### PR TITLE
fix(daemon): preserve bound-session recovery across restart

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -18,6 +18,7 @@ import {
   DAEMON_VERSION,
   DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD,
   DAEMON_NON_FINITE_ENCODED_PARAM,
+  DAEMON_SHUTTING_DOWN_ERROR_MESSAGE,
 } from "./constants";
 import { type BuildIdentity, getCurrentBuildIdentity } from "./buildIdentity";
 import { resolveMcpRequestTimeoutMs, ProgressExtendableDeadline } from "./mcpRequestTimeout";
@@ -37,6 +38,14 @@ export class DaemonUnavailableError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "DaemonUnavailableError";
+  }
+}
+
+/** Retryable response from a live daemon that has stopped admitting work. */
+export class DaemonShuttingDownError extends DaemonUnavailableError {
+  constructor() {
+    super(DAEMON_SHUTTING_DOWN_ERROR_MESSAGE);
+    this.name = "DaemonShuttingDownError";
   }
 }
 
@@ -606,7 +615,9 @@ export class DaemonClient {
               response.error || "Device-control transport failure",
               transportFailure,
             )
-          : new ActionableError(response.error || "Unknown error from daemon"),
+          : response.error === DAEMON_SHUTTING_DOWN_ERROR_MESSAGE
+            ? new DaemonShuttingDownError()
+            : new ActionableError(response.error || "Unknown error from daemon"),
       );
     }
   }

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -223,6 +223,9 @@ export const DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS = Math.min(
  */
 export const DAEMON_SHUTDOWN_TIMEOUT_MS = 10000;
 
+/** Stable control-socket error used to signal a retryable shutdown transition. */
+export const DAEMON_SHUTTING_DOWN_ERROR_MESSAGE = "Daemon is shutting down";
+
 /**
  * Minimum age (ms since startedAt) before the proxy will restart a daemon on
  * version mismatch. Prevents thrash when concurrent agents on different versions

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -2460,11 +2460,18 @@ export class Daemon {
     await runShutdownCleanupStages(
       [
         {
-          // Fence a request that was admitted before shutdown but outlives the
-          // socket server's bounded handler drain. Its eventual pool assignment
-          // must roll back instead of publishing after the release snapshot.
-          name: "device session admission",
-          run: () => this.sessionManager.stopAcceptingSessionCreations(),
+          // Quiesce the control socket synchronously before fencing session
+          // publication. Established clients then receive the stable retryable
+          // shutdown response instead of entering SessionManager during the
+          // cleanup stages below. A request admitted before this barrier may
+          // still outlive the bounded handler drain, so fence its eventual pool
+          // assignment before awaiting that drain.
+          name: "Unix socket and device session admission",
+          run: async () => {
+            const quiescing = this.socketServer?.quiesce();
+            this.sessionManager.stopAcceptingSessionCreations();
+            await quiescing;
+          },
         },
         {
           // Quiesce new recording work and stop owned children before any
@@ -2524,17 +2531,6 @@ export class Daemon {
             // after the transport snapshot below. The later HTTP server stage
             // awaits this same close once active transports have been closed.
             void this.closeHttpListener().catch(() => {});
-          },
-        },
-        {
-          // Reject new control-socket work and drain admitted requests, but keep
-          // subscribed sockets connected until active sessions publish their
-          // daemon-shutdown release below (issue #6336).
-          name: "Unix socket admission",
-          run: async () => {
-            if (this.socketServer) {
-              await this.socketServer.quiesce();
-            }
           },
         },
         { name: "video recording socket server", run: stopVideoRecordingSocketServer },

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -295,8 +295,10 @@ export class Daemon {
   private shutdownHandlersRegistered: boolean = false;
   private shutdownInProgress: boolean = false;
   private shutdownSessionReleasesDrained = true;
-  /** Session IDs whose release callback fired while shutdown sockets were preserved. */
+  /** Session IDs whose normal callback emitted the daemon-shutdown reason. */
   private shutdownReleaseNotifications: Set<string> | null = null;
+  /** Session IDs emitted by the shutdown fallback before their normal callback completed. */
+  private shutdownFallbackReleaseNotifications: Set<string> | null = null;
   /** Identities captured before concurrent shutdown release begins. */
   private shutdownSessionIds: string[] = [];
 
@@ -394,10 +396,12 @@ export class Daemon {
     // for every released key — base and derived `${base}:${label}` alike; the
     // proxy matches its bound (base) UUID by exact equality (issue #4610).
     this.sessionManager.onSessionRelease((sessionId, _deviceId, releaseReason, snapshot) => {
-      if (this.shutdownReleaseNotifications?.has(sessionId)) {
+      if (this.shutdownFallbackReleaseNotifications?.has(sessionId)) {
         return;
       }
-      this.shutdownReleaseNotifications?.add(sessionId);
+      if (releaseReason === "daemon-shutdown") {
+        this.shutdownReleaseNotifications?.add(sessionId);
+      }
       SessionReleaseBroadcaster.emit(sessionId, releaseReason, snapshot);
     });
     this.installedAppsRepository = installedAppsRepository ?? new InstalledAppsRepository();
@@ -2444,6 +2448,7 @@ export class Daemon {
   async stop(): Promise<void> {
     logger.info("Stopping daemon...");
     this.shutdownReleaseNotifications = new Set();
+    this.shutdownFallbackReleaseNotifications = new Set();
     this.shutdownSessionIds = [];
 
     const heartbeatMonitor = this.heartbeatMonitor;
@@ -2665,6 +2670,7 @@ export class Daemon {
     await Promise.resolve();
     const drained = await this.sessionManager.drainReleasePromises(
       SESSION_RELEASE_DRAIN_TIMEOUT_MS,
+      releases,
     );
     if (!drained) {
       this.shutdownSessionReleasesDrained = false;
@@ -2685,14 +2691,15 @@ export class Daemon {
    */
   private publishMissingShutdownReleaseNotifications(): void {
     const notified = this.shutdownReleaseNotifications;
-    if (!notified) {
+    const fallbacks = this.shutdownFallbackReleaseNotifications;
+    if (!(notified && fallbacks)) {
       return;
     }
     for (const sessionId of this.shutdownSessionIds) {
-      if (notified.has(sessionId)) {
+      if (notified.has(sessionId) || fallbacks.has(sessionId)) {
         continue;
       }
-      notified.add(sessionId);
+      fallbacks.add(sessionId);
       SessionReleaseBroadcaster.emit(sessionId, "daemon-shutdown");
     }
   }

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -295,6 +295,10 @@ export class Daemon {
   private shutdownHandlersRegistered: boolean = false;
   private shutdownInProgress: boolean = false;
   private shutdownSessionReleasesDrained = true;
+  /** Session IDs whose release callback fired while shutdown sockets were preserved. */
+  private shutdownReleaseNotifications: Set<string> | null = null;
+  /** Identities captured before concurrent shutdown release begins. */
+  private shutdownSessionIds: string[] = [];
 
   constructor(
     options: DaemonOptions = {},
@@ -390,6 +394,10 @@ export class Daemon {
     // for every released key — base and derived `${base}:${label}` alike; the
     // proxy matches its bound (base) UUID by exact equality (issue #4610).
     this.sessionManager.onSessionRelease((sessionId, _deviceId, releaseReason, snapshot) => {
+      if (this.shutdownReleaseNotifications?.has(sessionId)) {
+        return;
+      }
+      this.shutdownReleaseNotifications?.add(sessionId);
       SessionReleaseBroadcaster.emit(sessionId, releaseReason, snapshot);
     });
     this.installedAppsRepository = installedAppsRepository ?? new InstalledAppsRepository();
@@ -2435,6 +2443,8 @@ export class Daemon {
    */
   async stop(): Promise<void> {
     logger.info("Stopping daemon...");
+    this.shutdownReleaseNotifications = new Set();
+    this.shutdownSessionIds = [];
 
     const heartbeatMonitor = this.heartbeatMonitor;
     this.heartbeatMonitor = null;
@@ -2444,6 +2454,13 @@ export class Daemon {
     this.deviceDisconnectMonitor = null;
     await runShutdownCleanupStages(
       [
+        {
+          // Fence a request that was admitted before shutdown but outlives the
+          // socket server's bounded handler drain. Its eventual pool assignment
+          // must roll back instead of publishing after the release snapshot.
+          name: "device session admission",
+          run: () => this.sessionManager.stopAcceptingSessionCreations(),
+        },
         {
           // Quiesce new recording work and stop owned children before any
           // potentially blocking socket teardown consumes the shutdown budget.
@@ -2505,10 +2522,13 @@ export class Daemon {
           },
         },
         {
-          name: "Unix socket server",
+          // Reject new control-socket work and drain admitted requests, but keep
+          // subscribed sockets connected until active sessions publish their
+          // daemon-shutdown release below (issue #6336).
+          name: "Unix socket admission",
           run: async () => {
             if (this.socketServer) {
-              await this.socketServer.close();
+              await this.socketServer.quiesce();
             }
           },
         },
@@ -2547,6 +2567,19 @@ export class Daemon {
           run: () => this.closeHttpListener(),
         },
         { name: "active device sessions", run: () => this.releaseActiveSessionsForShutdown() },
+        {
+          // Session release broadcasts must be written while subscribed proxy
+          // sockets are still connected; closing first degrades the exact
+          // daemon-shutdown reason into session-not-found after reconnect.
+          name: "Unix socket server",
+          run: async () => {
+            if (this.socketServer) {
+              this.publishMissingShutdownReleaseNotifications();
+              await this.socketServer.drainSessionReleaseNotifications();
+              await this.socketServer.close();
+            }
+          },
+        },
         { name: "managed ADB server", run: this.stopManagedAdbServer },
         {
           name: "database write drain",
@@ -2615,6 +2648,7 @@ export class Daemon {
 
   private async releaseActiveSessionsForShutdown(): Promise<void> {
     const sessionIds = this.sessionManager.getAllKnownSessionIds();
+    this.shutdownSessionIds = sessionIds;
     const releases = sessionIds.map((sessionId) =>
       this.cancelAndReleaseSession(sessionId, "daemon-shutdown", true),
     );
@@ -2641,6 +2675,26 @@ export class Daemon {
       return;
     }
     reportFailures(await settled);
+  }
+
+  /**
+   * Preserve a recovery signal when a pre-existing terminal release remains
+   * blocked past the bounded persistence drain. Normal release callbacks win;
+   * only snapshot identities that have not emitted anything receive this
+   * daemon-shutdown fallback before notification sockets close.
+   */
+  private publishMissingShutdownReleaseNotifications(): void {
+    const notified = this.shutdownReleaseNotifications;
+    if (!notified) {
+      return;
+    }
+    for (const sessionId of this.shutdownSessionIds) {
+      if (notified.has(sessionId)) {
+        continue;
+      }
+      notified.add(sessionId);
+      SessionReleaseBroadcaster.emit(sessionId, "daemon-shutdown");
+    }
   }
 
   private getDaemonFileCleanupOptions(): {

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -718,6 +718,7 @@ export class DaemonMcpProxy {
   private readonly releasedSessionEpochs = new Map<string, number>();
   private readonly releasedSessionReasons = new Map<string, string>();
   private readonly activeReleaseEpochReferences = new Map<string, number>();
+  private readonly activeAcquisitionReleaseEpochs = new Map<number, number>();
   // Monotonic counter bumped whenever a daemon push invalidates a discovery cache
   // or the session binding mid-flight (list_changed nulls a cache; a bound-session
   // release changes the session scope). A `tools/list` / `resources/list` captures
@@ -1066,6 +1067,12 @@ export class DaemonMcpProxy {
       return;
     }
     this.recordSessionReleased(releasedSessionUuid, notification.reason);
+    if (notification.reason === "daemon-shutdown") {
+      // Daemon shutdown is connection-wide. Arm the successor barrier even when
+      // this UUID belongs to an unresolved acquisition result that has not become
+      // the current binding yet.
+      this.waitForDaemonShutdownDisconnect();
+    }
     // A released session is no longer owned: drop it so a later fresh-screenshot
     // read stops owner-routing to it and falls back to the live binding (which the
     // daemon denies), matching the "released session remains denied" guarantee
@@ -1080,9 +1087,6 @@ export class DaemonMcpProxy {
         notification.reason ?? "released",
         notification.release,
       );
-      if (notification.reason === "daemon-shutdown") {
-        this.waitForDaemonShutdownDisconnect();
-      }
     }
   }
 
@@ -1750,6 +1754,7 @@ export class DaemonMcpProxy {
     // UNRELATED session bumps the global epoch but not the forwarded UUID's entry,
     // so it does not block remembering the session this call forwarded.
     const callReleaseEpoch = this.releaseEpoch;
+    this.retainAcquisitionReleaseEpoch(isSessionAcquisition, callReleaseEpoch);
     if (progressToken !== undefined && onProgress) {
       this.progressListeners.set(progressToken, onProgress);
     }
@@ -1770,7 +1775,7 @@ export class DaemonMcpProxy {
       }
       this.rememberToolSelectionProfile(name, args, result);
       if (isSessionAcquisition) {
-        await this.bindResultMintedDeviceSession(name, result);
+        await this.bindResultMintedDeviceSession(name, result, callReleaseEpoch);
         return result;
       }
       // Remember what was actually forwarded, not the caller's raw args. An
@@ -1807,6 +1812,7 @@ export class DaemonMcpProxy {
       throw error;
     } finally {
       this.releaseReleaseEpochReference(forwardedSessionUuid);
+      this.releaseAcquisitionReleaseEpoch(isSessionAcquisition, callReleaseEpoch);
       if (progressToken !== undefined) {
         this.progressListeners.delete(progressToken);
       }
@@ -2153,7 +2159,10 @@ export class DaemonMcpProxy {
       return;
     }
     this.releaseEpoch += 1;
-    if (!this.activeReleaseEpochReferences.has(normalizedSessionUuid)) {
+    if (
+      !this.activeReleaseEpochReferences.has(normalizedSessionUuid) &&
+      this.activeAcquisitionReleaseEpochs.size === 0
+    ) {
       return;
     }
     this.releasedSessionEpochs.set(normalizedSessionUuid, this.releaseEpoch);
@@ -2180,8 +2189,54 @@ export class DaemonMcpProxy {
       return;
     }
     this.activeReleaseEpochReferences.delete(sessionUuid);
-    this.releasedSessionEpochs.delete(sessionUuid);
-    this.releasedSessionReasons.delete(sessionUuid);
+    const releasedAtEpoch = this.releasedSessionEpochs.get(sessionUuid);
+    if (
+      releasedAtEpoch === undefined ||
+      !this.isReleaseNeededByActiveAcquisition(releasedAtEpoch)
+    ) {
+      this.releasedSessionEpochs.delete(sessionUuid);
+      this.releasedSessionReasons.delete(sessionUuid);
+    }
+  }
+
+  private retainAcquisitionReleaseEpoch(isSessionAcquisition: boolean, epoch: number): void {
+    if (!isSessionAcquisition) {
+      return;
+    }
+    this.activeAcquisitionReleaseEpochs.set(
+      epoch,
+      (this.activeAcquisitionReleaseEpochs.get(epoch) ?? 0) + 1,
+    );
+  }
+
+  private releaseAcquisitionReleaseEpoch(isSessionAcquisition: boolean, epoch: number): void {
+    if (!isSessionAcquisition) {
+      return;
+    }
+    const references = (this.activeAcquisitionReleaseEpochs.get(epoch) ?? 0) - 1;
+    if (references > 0) {
+      this.activeAcquisitionReleaseEpochs.set(epoch, references);
+    } else {
+      this.activeAcquisitionReleaseEpochs.delete(epoch);
+    }
+    for (const [sessionUuid, releasedAtEpoch] of this.releasedSessionEpochs) {
+      if (
+        !this.activeReleaseEpochReferences.has(sessionUuid) &&
+        !this.isReleaseNeededByActiveAcquisition(releasedAtEpoch)
+      ) {
+        this.releasedSessionEpochs.delete(sessionUuid);
+        this.releasedSessionReasons.delete(sessionUuid);
+      }
+    }
+  }
+
+  private isReleaseNeededByActiveAcquisition(releasedAtEpoch: number): boolean {
+    for (const acquisitionEpoch of this.activeAcquisitionReleaseEpochs.keys()) {
+      if (releasedAtEpoch > acquisitionEpoch) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private forwardedSessionReleaseReasonSince(
@@ -2189,10 +2244,24 @@ export class DaemonMcpProxy {
     forwardEpoch: number,
   ): string | undefined {
     const forwardedUuid = this.sessionUuidFromArgs(forwardedArgs);
-    if (!forwardedUuid || (this.releasedSessionEpochs.get(forwardedUuid) ?? 0) <= forwardEpoch) {
+    if (!forwardedUuid) {
       return undefined;
     }
-    return this.releasedSessionReasons.get(forwardedUuid) ?? "released";
+    return this.sessionReleaseReasonSince(forwardedUuid, forwardEpoch);
+  }
+
+  private sessionReleaseReasonSince(sessionUuid: string, forwardEpoch: number): string | undefined {
+    if ((this.releasedSessionEpochs.get(sessionUuid) ?? 0) <= forwardEpoch) {
+      return undefined;
+    }
+    return this.releasedSessionReasons.get(sessionUuid) ?? "released";
+  }
+
+  private throwIfSessionReleasedSince(sessionUuid: string, forwardEpoch: number): void {
+    const releaseReason = this.sessionReleaseReasonSince(sessionUuid, forwardEpoch);
+    if (releaseReason) {
+      throw new DaemonBoundSessionExpiredError(sessionUuid, releaseReason);
+    }
   }
 
   private fenceReleasedForwardedSession(
@@ -2230,7 +2299,11 @@ export class DaemonMcpProxy {
   // for a result-minted session and reaps it under the pre-first-heartbeat grace
   // (issue #5689). Acquisition also clears any terminal fence: the connection is
   // usable again once a fresh session is established (AC2).
-  private async bindResultMintedDeviceSession(name: string, result: unknown): Promise<void> {
+  private async bindResultMintedDeviceSession(
+    name: string,
+    result: unknown,
+    acquisitionReleaseEpoch: number,
+  ): Promise<void> {
     if (!isDeviceSessionAcquisitionTool(name)) {
       return;
     }
@@ -2238,12 +2311,16 @@ export class DaemonMcpProxy {
     if (!mintedSessionUuid || mintedSessionUuid === this.boundSessionUuid) {
       return;
     }
+    this.throwIfSessionReleasedSince(mintedSessionUuid, acquisitionReleaseEpoch);
     // A prior binding's keeper must not outlive the rebind to a fresh session.
     // (A terminal fence already stopped it; this covers re-acquiring over a live
     // binding.)
     if (this.heartbeatKeeperStarted) {
       await this.stopBoundSessionHeartbeat();
     }
+    // Stopping the previous binding's keeper may yield. Recheck before publishing
+    // the new binding so a release delivered during that await cannot be missed.
+    this.throwIfSessionReleasedSince(mintedSessionUuid, acquisitionReleaseEpoch);
     this.terminalBoundSession = undefined;
     this.boundSessionUuid = mintedSessionUuid;
     this.boundSessionUuidAt = this.timer.now();

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -2362,6 +2362,10 @@ export class DaemonMcpProxy {
     // daemon records ownership before the pre-first-heartbeat grace fires
     // (mirrors the establishment guarantee in issue #5637).
     await this.establishBoundSessionHeartbeat();
+    // The first heartbeat is an awaited daemon round-trip. A shutdown release
+    // can arrive while it is in flight, fence and clear the binding, and make
+    // this acquisition result stale before it reaches the caller.
+    this.throwIfSessionReleasedSince(mintedSessionUuid, acquisitionReleaseEpoch);
   }
 
   // Called with the FORWARDED args (post-withBoundSessionUuid), so an implicit

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -649,6 +649,13 @@ export class DaemonMcpProxy {
   private readonly clientAssetVersion: string | null;
   private connecting: Promise<void> | null = null;
   private connectionCloseReject: ((reason?: unknown) => void) | null = null;
+  /**
+   * A `daemon-shutdown` release arrives before the old daemon closes its socket.
+   * Calls admitted for replacement acquisition wait on this peer-close barrier
+   * instead of reconnecting to the still-reachable but quiesced incarnation.
+   */
+  private daemonShutdownDisconnect: Promise<void> | null = null;
+  private resolveDaemonShutdownDisconnect: (() => void) | null = null;
   private connected: boolean = false;
   private closing: boolean = false;
   // The daemon clears socket-local state when its RPC connection drops. Keep this
@@ -802,6 +809,13 @@ export class DaemonMcpProxy {
   async ensureConnected(): Promise<void> {
     if (this.closing) {
       throw new DaemonUnavailableError("MCP proxy is closing");
+    }
+    const daemonShutdownDisconnect = this.daemonShutdownDisconnect;
+    if (daemonShutdownDisconnect) {
+      await daemonShutdownDisconnect;
+      if (this.closing) {
+        throw new DaemonUnavailableError("MCP proxy is closing");
+      }
     }
     if (this.connected && this.client) {
       return;
@@ -1068,7 +1082,29 @@ export class DaemonMcpProxy {
         notification.reason ?? "released",
         notification.release,
       );
+      if (notification.reason === "daemon-shutdown") {
+        this.waitForDaemonShutdownDisconnect();
+      }
     }
+  }
+
+  private waitForDaemonShutdownDisconnect(): void {
+    if (this.daemonShutdownDisconnect || !this.client) {
+      return;
+    }
+    const disconnect = Promise.withResolvers<void>();
+    this.daemonShutdownDisconnect = disconnect.promise;
+    this.resolveDaemonShutdownDisconnect = disconnect.resolve;
+    // Keep the old client attached long enough to observe peer EOF, but prevent
+    // ensureConnected() from treating this quiesced incarnation as reusable.
+    this.connected = false;
+  }
+
+  private completeDaemonShutdownDisconnect(): void {
+    const resolve = this.resolveDaemonShutdownDisconnect;
+    this.daemonShutdownDisconnect = null;
+    this.resolveDaemonShutdownDisconnect = null;
+    resolve?.();
   }
 
   /**
@@ -1524,6 +1560,7 @@ export class DaemonMcpProxy {
     this.connectionClosedUnsubscribe = client.onConnectionClosed(() => {
       if (this.client === client) {
         void this.resetConnection();
+        this.completeDaemonShutdownDisconnect();
       }
     });
   }
@@ -2496,6 +2533,7 @@ export class DaemonMcpProxy {
    */
   async close(): Promise<void> {
     this.closing = true;
+    this.completeDaemonShutdownDisconnect();
     this.cancelBackgroundConnectRetry();
     this.connectionCloseReject?.(new DaemonUnavailableError("MCP proxy is closing"));
     await this.stopBoundSessionHeartbeat();

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1095,8 +1095,20 @@ export class DaemonMcpProxy {
       return;
     }
     const disconnect = Promise.withResolvers<void>();
-    this.daemonShutdownDisconnect = disconnect.promise;
+    const barrier = disconnect.promise
+      .then(() => this.waitForDaemonShutdownRestartWindow())
+      .catch((error) => {
+        // Readiness is re-checked by doConnect; this barrier only prevents the
+        // deterministic stale-PID/no-startup-lock gap from racing that path.
+        logger.warn(`[DaemonMcpProxy] Failed while awaiting daemon restart transition: ${error}`);
+      });
+    this.daemonShutdownDisconnect = barrier;
     this.resolveDaemonShutdownDisconnect = disconnect.resolve;
+    void barrier.then(() => {
+      if (this.daemonShutdownDisconnect === barrier) {
+        this.daemonShutdownDisconnect = null;
+      }
+    });
     // Keep the old client attached long enough to observe peer EOF, but prevent
     // ensureConnected() from treating this quiesced incarnation as reusable.
     this.connected = false;
@@ -1104,9 +1116,23 @@ export class DaemonMcpProxy {
 
   private completeDaemonShutdownDisconnect(): void {
     const resolve = this.resolveDaemonShutdownDisconnect;
-    this.daemonShutdownDisconnect = null;
     this.resolveDaemonShutdownDisconnect = null;
     resolve?.();
+  }
+
+  private async waitForDaemonShutdownRestartWindow(): Promise<void> {
+    const socketPath = this.config.socketPath ?? SOCKET_PATH;
+    const deadline = this.timer.now() + DAEMON_STARTUP_TIMEOUT_MS;
+    while (!this.closing && this.timer.now() < deadline) {
+      if (await DaemonClient.isAvailable(socketPath)) {
+        return;
+      }
+      const status = await this.daemonManager.status();
+      if (!status.running || this.daemonManager.isStartupLockHeldByLiveProcess()) {
+        return;
+      }
+      await this.timer.sleep(Math.min(100, deadline - this.timer.now()));
+    }
   }
 
   /**

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -2,6 +2,7 @@ import { errorMessage } from "../utils/describeUnknownError";
 import { shellQuote } from "../utils/shellQuote";
 import {
   DaemonClient,
+  DaemonShuttingDownError,
   DaemonUnavailableError,
   type DaemonClientLike,
   type DaemonClientFactory,
@@ -18,6 +19,7 @@ import {
   DAEMON_TOOL_SELECTION_PROFILE_PARAM,
   DAEMON_BOUND_SESSION_PARAM,
   DAEMON_RELEASED_SESSION_PARAM,
+  DAEMON_SHUTDOWN_TIMEOUT_MS,
 } from "./constants";
 import { PROGRESS_NOTIFICATION_METHOD, type DaemonNotification, type DaemonOptions } from "./types";
 import { listChangedKindForMethod, type ListChangedKind } from "../server/listChangedBroadcast";
@@ -1095,15 +1097,32 @@ export class DaemonMcpProxy {
       return;
     }
     const disconnect = Promise.withResolvers<void>();
+    let peerDisconnected = false;
+    const completeDisconnect = (): void => {
+      peerDisconnected = true;
+      disconnect.resolve();
+    };
+    const timeoutHandle = this.timer.setTimeout(disconnect.resolve, DAEMON_SHUTDOWN_TIMEOUT_MS);
     const barrier = disconnect.promise
-      .then(() => this.waitForDaemonShutdownRestartWindow())
+      .then(async () => {
+        this.timer.clearTimeout(timeoutHandle);
+        if (!peerDisconnected) {
+          if (this.resolveDaemonShutdownDisconnect === completeDisconnect) {
+            this.resolveDaemonShutdownDisconnect = null;
+          }
+          // A stalled transport must not remain attached after the bounded EOF
+          // wait. resetConnection detaches it synchronously before closing it.
+          void this.resetConnection();
+        }
+        await this.waitForDaemonShutdownRestartWindow();
+      })
       .catch((error) => {
         // Readiness is re-checked by doConnect; this barrier only prevents the
         // deterministic stale-PID/no-startup-lock gap from racing that path.
         logger.warn(`[DaemonMcpProxy] Failed while awaiting daemon restart transition: ${error}`);
       });
     this.daemonShutdownDisconnect = barrier;
-    this.resolveDaemonShutdownDisconnect = disconnect.resolve;
+    this.resolveDaemonShutdownDisconnect = completeDisconnect;
     void barrier.then(() => {
       if (this.daemonShutdownDisconnect === barrier) {
         this.daemonShutdownDisconnect = null;
@@ -1112,12 +1131,21 @@ export class DaemonMcpProxy {
     // Keep the old client attached long enough to observe peer EOF, but prevent
     // ensureConnected() from treating this quiesced incarnation as reusable.
     this.connected = false;
+    if (typeof this.client.onConnectionClosed !== "function") {
+      // This client cannot report peer EOF. Begin detaching now; the timeout
+      // still bounds a custom close() implementation that never settles.
+      void this.resetConnection();
+    }
   }
 
-  private completeDaemonShutdownDisconnect(): void {
-    const resolve = this.resolveDaemonShutdownDisconnect;
+  private completeDaemonShutdownDisconnect(
+    expectedResolve: (() => void) | null = this.resolveDaemonShutdownDisconnect,
+  ): void {
+    if (this.resolveDaemonShutdownDisconnect !== expectedResolve) {
+      return;
+    }
     this.resolveDaemonShutdownDisconnect = null;
-    resolve?.();
+    expectedResolve?.();
   }
 
   private async waitForDaemonShutdownRestartWindow(): Promise<void> {
@@ -1505,6 +1533,9 @@ export class DaemonMcpProxy {
       logger.warn(
         `[DaemonMcpProxy] Daemon session is stale, reconnecting and retrying once: ${errorMessage(error)}`,
       );
+      if (error instanceof DaemonShuttingDownError) {
+        this.waitForDaemonShutdownDisconnect();
+      }
       await this.resetConnection();
       this.throwIfBoundSessionFenced(allowReleasedSession);
       await this.ensureConnected();
@@ -1560,6 +1591,7 @@ export class DaemonMcpProxy {
   }
 
   private async resetConnection(): Promise<void> {
+    const shutdownDisconnectResolve = this.resolveDaemonShutdownDisconnect;
     const staleClient = this.client;
     this.connected = false;
     this.client = null;
@@ -1570,7 +1602,7 @@ export class DaemonMcpProxy {
     this.invalidateCache();
 
     if (!staleClient) {
-      this.completeDaemonShutdownDisconnect();
+      this.completeDaemonShutdownDisconnect(shutdownDisconnectResolve);
       return;
     }
 
@@ -1582,7 +1614,7 @@ export class DaemonMcpProxy {
     // resetConnection deliberately unregisters the peer-close callback before
     // closing the stale client. Resolve an armed shutdown barrier explicitly so
     // the retry cannot wait forever for a callback that can no longer fire.
-    this.completeDaemonShutdownDisconnect();
+    this.completeDaemonShutdownDisconnect(shutdownDisconnectResolve);
   }
 
   private subscribeToClientConnectionClosed(client: DaemonClientLike): void {

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1544,6 +1544,7 @@ export class DaemonMcpProxy {
     this.invalidateCache();
 
     if (!staleClient) {
+      this.completeDaemonShutdownDisconnect();
       return;
     }
 
@@ -1552,6 +1553,10 @@ export class DaemonMcpProxy {
     } catch (error) {
       logger.warn(`[DaemonMcpProxy] Failed to close stale daemon client: ${error}`);
     }
+    // resetConnection deliberately unregisters the peer-close callback before
+    // closing the stale client. Resolve an armed shutdown barrier explicitly so
+    // the retry cannot wait forever for a callback that can no longer fire.
+    this.completeDaemonShutdownDisconnect();
   }
 
   private subscribeToClientConnectionClosed(client: DaemonClientLike): void {

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -899,13 +899,17 @@ export class DaemonMcpProxy {
     }
     logger.info("[DaemonMcpProxy] Connected to daemon");
 
-    // Deliver the ownership heartbeat FIRST — before the best-effort notification
-    // subscription (issue #5637). subscribeToNotifications() is a daemon RPC that
-    // can stall up to the connection timeout; awaiting it before the heartbeat
-    // would let the pre-first-heartbeat reclaim reap a bound session near the
-    // grace edge before the heartbeat is even sent. The notification handler is
-    // already registered above (before connect), so a session-released frame is
-    // still handled during the heartbeat even without the opt-in subscription.
+    // Start notification opt-in BEFORE awaiting the ownership heartbeat so a
+    // shutdown that releases the initial binding during that round trip cannot
+    // publish to an unsubscribed socket (#6336). Do not await the subscription
+    // yet: it is a best-effort daemon RPC that can stall up to the connection
+    // timeout, while the time-critical first heartbeat must still be dispatched
+    // immediately to beat the pre-first-heartbeat reclaim grace (#5637).
+    const notificationSubscription = supportsNotifications
+      ? client.subscribeToNotifications!().catch((error) => {
+          logger.warn(`[DaemonMcpProxy] Failed to subscribe to daemon notifications: ${error}`);
+        })
+      : Promise.resolve();
     //
     // On the FIRST establishment mark the proxy `connected` only AFTER the
     // establishment heartbeat lands (issue #5643). ensureConnected()'s fast path
@@ -929,16 +933,10 @@ export class DaemonMcpProxy {
     this.connected = true;
     this.cancelBackgroundConnectRetry();
 
-    if (supportsNotifications) {
-      try {
-        await client.subscribeToNotifications!();
-      } catch (error) {
-        // Best-effort: without the subscription the proxy degrades to the old
-        // cached behavior instead of failing the connection. Unexpected against
-        // a same-version daemon (the handshake gate pins versions), so warn.
-        logger.warn(`[DaemonMcpProxy] Failed to subscribe to daemon notifications: ${error}`);
-      }
-    }
+    // Connection establishment still waits for the already-running subscription
+    // so callers do not race later requests ahead of notification opt-in. Failure
+    // was converted to a warning above and preserves the prior best-effort policy.
+    await notificationSubscription;
 
     // If a client `tools/list` was served statically before this connection
     // existed (issue #5879), prompt it to re-fetch now that the daemon can

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -379,6 +379,8 @@ export class SessionManager {
   private readonly networkConditionMutationQueues: Map<string, Promise<unknown>> = new Map();
   /** Creation writes that must finish before a session becomes visible to callers. */
   private readonly pendingSessionCreations: Map<string, PendingSessionCreation> = new Map();
+  /** False once daemon shutdown fences acquisitions that outlive request quiescence. */
+  private acceptingSessionCreations = true;
   /** Automatic device assignments that have not yet started their creation write. */
   private readonly pendingSessionAssignments: Map<string, Promise<Session>> = new Map();
   /** Releases received before an assignment has published its session. */
@@ -515,6 +517,11 @@ export class SessionManager {
     timeoutMs?: number,
     heartbeatTimeoutMs?: number,
   ): Promise<Session> {
+    if (!this.acceptingSessionCreations) {
+      throw new ActionableError(
+        `Cannot create device session ${sessionId}: the daemon is shutting down.`,
+      );
+    }
     this.assertTerminalReleaseAdmission(sessionId, this.sessions.get(sessionId));
     let terminalRelease = this.terminalReleaseSnapshots.get(sessionId);
     if (terminalRelease) {
@@ -568,6 +575,18 @@ export class SessionManager {
         this.pendingSessionCreations.delete(sessionId);
       }
     }
+  }
+
+  /**
+   * Fence new session publication before daemon shutdown snapshots active work.
+   *
+   * A control-socket handler can outlive the bounded quiesce wait while preparing
+   * a device. Its eventual DevicePool binding still reaches createSession(), so
+   * this synchronous fence makes that assignment roll back instead of publishing
+   * a session after the shutdown release snapshot.
+   */
+  stopAcceptingSessionCreations(): void {
+    this.acceptingSessionCreations = false;
   }
 
   private async persistAndPublishSession(session: Session): Promise<Session> {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -595,7 +595,9 @@ export class SessionManager {
       this.terminalReleaseSnapshots.set(session.sessionId, persistedTerminalRelease);
       throw new TerminalSessionError(session.sessionId, persistedTerminalRelease);
     }
+    await this.rejectCreationAfterShutdownFence(session);
     await this.persistSession(session);
+    await this.rejectCreationAfterShutdownFence(session);
     this.assertTerminalReleaseAdmission(session.sessionId, session);
     const terminalRelease = this.terminalReleaseSnapshots.get(session.sessionId);
     if (terminalRelease) {
@@ -609,6 +611,29 @@ export class SessionManager {
     this.notifySessionCreated(session);
     logger.info(`Created session ${session.sessionId} with device ${session.assignedDevice}`);
     return session;
+  }
+
+  private async rejectCreationAfterShutdownFence(session: Session): Promise<void> {
+    if (this.acceptingSessionCreations) {
+      return;
+    }
+    const releasedAtMs = this.timer.now();
+    const snapshot: SessionReleaseSnapshot = {
+      sessionId: session.sessionId,
+      deviceId: session.assignedDevice,
+      releaseReason: "daemon-shutdown",
+      releasedAtMs,
+      terminal: true,
+      heartbeat: {
+        lastHeartbeatMs: session.lastHeartbeat,
+        hasReceivedHeartbeat: session.hasReceivedHeartbeat,
+        timeoutMs: session.heartbeatTimeoutMs,
+        ageMs: Math.max(0, releasedAtMs - session.lastHeartbeat),
+      },
+    };
+    await this.persistTerminalReleaseIfNeeded(snapshot);
+    this.notifySessionRelease(snapshot);
+    throw new TerminalSessionError(session.sessionId, snapshot);
   }
 
   private async getPersistedTerminalRelease(
@@ -1403,9 +1428,15 @@ export class SessionManager {
     );
   }
 
-  /** Wait a bounded amount of time for releases already started by monitors. */
-  async drainReleasePromises(timeoutMs: number): Promise<boolean> {
-    const releases = Array.from(this.activeReleasePromises, (release) => release.promise);
+  /** Wait a bounded amount of time for active and caller-started release work. */
+  async drainReleasePromises(
+    timeoutMs: number,
+    additionalReleases: ReadonlyArray<Promise<unknown>> = [],
+  ): Promise<boolean> {
+    const releases = [
+      ...Array.from(this.activeReleasePromises, (release) => release.promise),
+      ...additionalReleases,
+    ];
     if (releases.length === 0) {
       return true;
     }
@@ -1545,6 +1576,10 @@ export class SessionManager {
     if (reason.value === "device-killed") {
       return;
     }
+    if (candidate === "daemon-shutdown" && !isTerminalReleaseReason(reason.value)) {
+      reason.value = candidate;
+      return;
+    }
     if (!isTerminalReleaseReason(reason.value) && isTerminalReleaseReason(candidate)) {
       reason.value = candidate;
     }
@@ -1593,16 +1628,20 @@ export class SessionManager {
       return snapshot;
     }
     await this.persistSessionRelease(snapshot);
-    if (!isTerminalReleaseReason(reason.value)) {
+    if (reason.value === snapshot.releaseReason) {
       reason.finalizedSnapshot = snapshot;
       return snapshot;
     }
     const upgradedSnapshot = this.withReleaseReason(snapshot, reason.value, session);
     reason.finalizedSnapshot = upgradedSnapshot;
     this.recordFinalizedSessionRelease(session, reason);
-    this.terminalReleaseReasonStates.set(upgradedSnapshot.sessionId, reason);
-    await this.persistTerminalReleaseIfNeeded(upgradedSnapshot);
-    reason.terminalPersisted = true;
+    if (upgradedSnapshot.terminal) {
+      this.terminalReleaseReasonStates.set(upgradedSnapshot.sessionId, reason);
+      await this.persistTerminalReleaseIfNeeded(upgradedSnapshot);
+      reason.terminalPersisted = true;
+    } else {
+      await this.persistSessionRelease(upgradedSnapshot);
+    }
     return upgradedSnapshot;
   }
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -460,6 +460,7 @@ class McpClientReconnectDeadlineError extends Error {
 
 export class UnixSocketServer {
   private server: NetServer | null = null;
+  private serverClosePromise: Promise<void> | null = null;
   private closing = false;
   private acceptingRequests = false;
   private lifecycleGeneration = 0;
@@ -613,6 +614,7 @@ export class UnixSocketServer {
   async start(): Promise<void> {
     this.closing = false;
     this.acceptingRequests = true;
+    this.serverClosePromise = null;
     this.lifecycleGeneration += 1;
     // Owner-only (0o700) socket directory so the control socket is not
     // world-traversable. On macOS socket-file permission bits are not reliably
@@ -719,6 +721,12 @@ export class UnixSocketServer {
    * Handle a new client connection
    */
   private handleConnection(socket: Socket): void {
+    if (!this.acceptingRequests) {
+      // An accept callback can already be queued when quiesce closes the
+      // listener. End that late connection before it can bind or issue work.
+      socket.end();
+      return;
+    }
     const sessionId = this.idGenerator.next();
     const session: SessionContext = {
       sessionId,
@@ -4814,6 +4822,16 @@ export class UnixSocketServer {
    */
   async quiesce(): Promise<void> {
     this.acceptingRequests = false;
+    // Stop new connections immediately while keeping established notification
+    // subscribers alive long enough to receive session-release frames. Any
+    // connection that has not opted in cannot receive the shutdown reason, so
+    // close it now and let its proxy reconnect to the successor daemon.
+    void this.closeListeningServer(this.isOwnedSocketFile());
+    for (const [sessionId, socket] of this.clientSockets) {
+      if (!this.notificationSubscribers.has(sessionId) && !socket.destroyed) {
+        socket.end();
+      }
+    }
     await this.drainActiveRequestHandlers();
   }
 
@@ -4911,6 +4929,9 @@ export class UnixSocketServer {
   }
 
   private closeListeningServer(ownsSocketPath: boolean): Promise<void> {
+    if (this.serverClosePromise) {
+      return this.serverClosePromise;
+    }
     if (!this.server) {
       return Promise.resolve();
     }
@@ -4921,12 +4942,13 @@ export class UnixSocketServer {
       this.server.unref();
       return Promise.resolve();
     }
-    return new Promise((resolve) => {
+    this.serverClosePromise = new Promise((resolve) => {
       this.server!.close(() => {
         logger.info("Unix socket server closed");
         resolve();
       });
     });
+    return this.serverClosePromise;
   }
 
   private destroyClientSockets(clientSockets: Socket[]): void {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -132,6 +132,8 @@ import {
 const MCP_CLIENT_IDLE_CLOSE_MS = 5 * 60 * 1000;
 /** Keep shutdown bounded if a request handler ignores its disconnected peer. */
 const DAEMON_REQUEST_HANDLER_DRAIN_TIMEOUT_MS = 1_000;
+/** Keep shutdown bounded if a client cannot flush a release notification. */
+const DAEMON_NOTIFICATION_WRITE_DRAIN_TIMEOUT_MS = 1_000;
 
 /**
  * Bound on the observation-only liveness probe a LOCK-LESS bind runs against an
@@ -459,6 +461,7 @@ class McpClientReconnectDeadlineError extends Error {
 export class UnixSocketServer {
   private server: NetServer | null = null;
   private closing = false;
+  private acceptingRequests = false;
   private lifecycleGeneration = 0;
   private socketFileIdentity: SocketFileIdentity | null = null;
   private readonly adbClientFactory: AdbClientFactory;
@@ -469,6 +472,8 @@ export class UnixSocketServer {
   private activeRequestHandlers: Set<Promise<void>> = new Set();
   /** Socket sessions that opted in to server-pushed notifications. */
   private notificationSubscribers: Set<string> = new Set();
+  /** Session-release frames written but not yet flushed to their client sockets. */
+  private pendingSessionReleaseWrites: Set<Promise<void>> = new Set();
   private listChangedUnsubscribe: (() => void) | null = null;
   private sessionReleaseUnsubscribe: (() => void) | null = null;
   private socketPath: string;
@@ -607,6 +612,7 @@ export class UnixSocketServer {
    */
   async start(): Promise<void> {
     this.closing = false;
+    this.acceptingRequests = true;
     this.lifecycleGeneration += 1;
     // Owner-only (0o700) socket directory so the control socket is not
     // world-traversable. On macOS socket-file permission bits are not reliably
@@ -844,7 +850,12 @@ export class UnixSocketServer {
       if (!socket) {
         continue;
       }
-      this.writeFrame(socket, sessionId, notification);
+      const pending = Promise.withResolvers<void>();
+      this.pendingSessionReleaseWrites.add(pending.promise);
+      this.writeFrame(socket, sessionId, notification, () => {
+        this.pendingSessionReleaseWrites.delete(pending.promise);
+        pending.resolve();
+      });
     }
   }
 
@@ -896,18 +907,21 @@ export class UnixSocketServer {
     socket: Socket,
     sessionId: string,
     frame: DaemonResponse | DaemonNotification,
+    onFlushed?: () => void,
   ): void {
     if (socket.destroyed) {
+      onFlushed?.();
       return;
     }
     try {
-      const ok = socket.write(JSON.stringify(frame) + "\n");
+      const ok = socket.write(JSON.stringify(frame) + "\n", onFlushed);
       if (!ok) {
         logger.debug(
           `Daemon RPC socket ${sessionId} backpressured; awaiting drain (idle timeout still armed)`,
         );
       }
     } catch (error) {
+      onFlushed?.();
       logger.warn(`Daemon RPC write failed for ${sessionId}: ${error}`);
       if (!socket.destroyed) {
         socket.destroy();
@@ -930,6 +944,15 @@ export class UnixSocketServer {
         type: "mcp_response",
         success: false,
         error: "Session not found",
+      };
+    }
+
+    if (!this.acceptingRequests) {
+      return {
+        id: request.id,
+        type: "mcp_response",
+        success: false,
+        error: "Daemon is shutting down",
       };
     }
 
@@ -4784,11 +4807,54 @@ export class UnixSocketServer {
   }
 
   /**
+   * Stop admitting control-socket work while preserving connected notification
+   * subscribers. Daemon shutdown uses this barrier before releasing device
+   * sessions, so no new request can mint or refresh a session after the shutdown
+   * snapshot while each bound proxy can still receive its exact release reason.
+   */
+  async quiesce(): Promise<void> {
+    this.acceptingRequests = false;
+    await this.drainActiveRequestHandlers();
+  }
+
+  /** Wait for release frames to flush to client sockets, bounded for shutdown. */
+  async drainSessionReleaseNotifications(): Promise<void> {
+    const pendingWrites = Array.from(this.pendingSessionReleaseWrites);
+    if (pendingWrites.length === 0) {
+      return;
+    }
+
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const timeout = new Promise<boolean>((resolve) => {
+      timeoutHandle = this.timer.setTimeout(
+        () => resolve(false),
+        DAEMON_NOTIFICATION_WRITE_DRAIN_TIMEOUT_MS,
+      );
+    });
+    try {
+      const drained = await Promise.race([
+        Promise.allSettled(pendingWrites).then(() => true),
+        timeout,
+      ]);
+      if (!drained) {
+        logger.warn(
+          `Timed out waiting for ${pendingWrites.length} session-release notification(s) to flush during shutdown`,
+        );
+      }
+    } finally {
+      if (timeoutHandle !== undefined) {
+        this.timer.clearTimeout(timeoutHandle);
+      }
+    }
+  }
+
+  /**
    * Stop the Unix socket server
    */
   async close(): Promise<void> {
     logger.info("Closing Unix socket server...");
     this.closing = true;
+    this.acceptingRequests = false;
     this.lifecycleGeneration += 1;
 
     // Stop receiving list-changed events (mirrors the subscribe in start()).
@@ -4866,7 +4932,16 @@ export class UnixSocketServer {
   private destroyClientSockets(clientSockets: Socket[]): void {
     for (const socket of clientSockets) {
       if (!socket.destroyed) {
-        socket.destroy();
+        // `destroy()` may discard a just-flushed session-release frame and reset
+        // the peer before it can read the exact daemon-shutdown reason. End the
+        // writable side and destroy only after its buffer drains, with a bounded
+        // fallback for a non-reading peer.
+        const forceClose = this.timer.setTimeout(
+          () => socket.destroy(),
+          DAEMON_NOTIFICATION_WRITE_DRAIN_TIMEOUT_MS,
+        );
+        socket.once("close", () => this.timer.clearTimeout(forceClose));
+        socket.end();
       }
     }
   }

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -35,6 +35,7 @@ import {
   INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
   INTERNAL_MCP_REQUEST_DEADLINE_PARAM,
   INTERNAL_LIVE_DEADLINE_KEY_PARAM,
+  DAEMON_SHUTTING_DOWN_ERROR_MESSAGE,
 } from "./constants";
 import { registerLiveDeadline, unregisterLiveDeadline } from "./liveDeadlineRegistry";
 import {
@@ -960,7 +961,7 @@ export class UnixSocketServer {
         id: request.id,
         type: "mcp_response",
         success: false,
-        error: "Daemon is shutting down",
+        error: DAEMON_SHUTTING_DOWN_ERROR_MESSAGE,
       };
     }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -896,6 +896,11 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
               "Call getAndroid, getApple, or startDevice to acquire a new device session.",
             sessionUuid: error.sessionUuid,
             reason: error.release.releaseReason,
+            retryable: true,
+            recovery: {
+              action: "acquire_replacement_session",
+              tools: ["getAndroid", "getApple", "startDevice"],
+            },
             release: error.release,
           },
         };

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -42,6 +42,11 @@ function sessionOwnershipLostPayload(error: DaemonBoundSessionExpiredError) {
         "Call getAndroid, getApple, or startDevice to acquire a new device session.",
       sessionUuid: error.sessionUuid,
       reason: error.reason,
+      retryable: true,
+      recovery: {
+        action: "acquire_replacement_session",
+        tools: ["getAndroid", "getApple", "startDevice"],
+      },
       ...(error.release ? { release: error.release } : {}),
     },
   };
@@ -74,6 +79,11 @@ function noActiveDeviceSessionPayload(error: DaemonConnectionSessionReleasedErro
       code: "no_active_device_session",
       message: error.message,
       reason: error.reason,
+      retryable: true,
+      recovery: {
+        action: "acquire_replacement_session",
+        tools: ["getAndroid", "getApple", "startDevice"],
+      },
     },
   };
 }

--- a/test/daemon/clientRequestIdGenerator.test.ts
+++ b/test/daemon/clientRequestIdGenerator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import { Duplex } from "node:stream";
-import { DaemonClient } from "../../src/daemon/client";
+import { DaemonClient, DaemonShuttingDownError } from "../../src/daemon/client";
+import { DAEMON_SHUTTING_DOWN_ERROR_MESSAGE } from "../../src/daemon/constants";
 import { CountingIdGenerator } from "../../src/utils/IdGenerator";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -73,5 +74,26 @@ describe("DaemonClient request id comes from the injected IdGenerator", () => {
 
     await client.close();
     await pending;
+  });
+
+  test("classifies a quiescing daemon response as retryable", async () => {
+    const idGenerator = new CountingIdGenerator("req");
+    const writes: string[] = [];
+    const client = createConnectedClient(fakeTimer, idGenerator, writes);
+
+    const pending = client.callTool("tapOn", {});
+    (client as any).handleData(
+      Buffer.from(
+        JSON.stringify({
+          id: "req-1",
+          type: "mcp_response",
+          success: false,
+          error: DAEMON_SHUTTING_DOWN_ERROR_MESSAGE,
+        }) + "\n",
+      ),
+    );
+
+    await expect(pending).rejects.toBeInstanceOf(DaemonShuttingDownError);
+    await client.close();
   });
 });

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../src/daemon/daemonMcpProxy";
 import {
   DaemonClient,
+  DaemonShuttingDownError,
   DaemonUnavailableError,
   type DaemonClientLike,
 } from "../../src/daemon/client";
@@ -1913,6 +1914,54 @@ describe("DaemonMcpProxy", () => {
         expect(freshClient.connectCallCount).toBe(1);
         expect(freshClient.callToolCalls).toEqual([
           { toolName: "observe", params: { deviceId: "device-1" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("waits through quiescence before retrying a shutdown response (#6336)", async () => {
+      const recoveredResult = { content: [{ type: "text", text: "recovered after shutdown" }] };
+      const quiescedClient = new ScriptedDaemonClient({
+        toolError: new DaemonShuttingDownError(),
+      });
+      const freshClient = new ScriptedDaemonClient({
+        toolResult: recoveredResult,
+      });
+      const clients = [quiescedClient, freshClient];
+      const manager = matchingDaemonManager();
+      const timer = new FakeTimer();
+      let availabilityChecks = 0;
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockImplementation(async () => {
+        availabilityChecks += 1;
+        return availabilityChecks === 1;
+      });
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        daemonManager: manager,
+        autoStartDaemon: true,
+        timer,
+      });
+
+      try {
+        const recovery = proxy.callTool("tapOn", { text: "Button" });
+        for (let i = 0; i < 20 && timer.getPendingSleepCount() === 0; i++) {
+          await Promise.resolve();
+        }
+
+        expect(timer.getPendingSleeps()).toEqual([100]);
+        expect(freshClient.connectCallCount).toBe(0);
+
+        manager.statusResult = { running: false };
+        await timer.advanceTimeAsync(100);
+
+        await expect(recovery).resolves.toEqual(recoveredResult);
+        expect(quiescedClient.closeCallCount).toBe(1);
+        expect(manager.startCalled).toBe(true);
+        expect(freshClient.callToolCalls).toEqual([
+          { toolName: "tapOn", params: { text: "Button" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();

--- a/test/daemon/daemonShutdownSessionRelease.test.ts
+++ b/test/daemon/daemonShutdownSessionRelease.test.ts
@@ -472,11 +472,7 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
 
     try {
-      await sessionManager.createSession(
-        "blocked-terminal-session",
-        "emulator-5560",
-        "android",
-      );
+      await sessionManager.createSession("blocked-terminal-session", "emulator-5560", "android");
       const terminalRelease = sessionManager.releaseSession(
         "blocked-terminal-session",
         "heartbeat-timeout",
@@ -495,9 +491,9 @@ describe("Daemon shutdown session release (issue #5303)", () => {
       persistence.resolve();
       await terminalRelease;
       expect(events.filter((event) => event === fallback)).toHaveLength(1);
-      expect(events.filter((event) => event.startsWith("release:blocked-terminal-session:"))).toEqual(
-        [fallback],
-      );
+      expect(
+        events.filter((event) => event.startsWith("release:blocked-terminal-session:")),
+      ).toEqual([fallback]);
     } finally {
       persistence.resolve();
       markReleasedSpy.mockRestore();

--- a/test/daemon/daemonShutdownSessionRelease.test.ts
+++ b/test/daemon/daemonShutdownSessionRelease.test.ts
@@ -10,6 +10,7 @@ import {
   DeviceSessionRepository,
 } from "../../src/db/deviceSessionRepository";
 import type { DeviceSessionStatus } from "../../src/db/types";
+import { SessionReleaseBroadcaster } from "../../src/server/sessionReleaseBroadcast";
 import {
   KeepScreenAwakeManager,
   type KeepScreenAwakeState,
@@ -50,6 +51,14 @@ class FakeDeviceSessionRepository {
   }
 
   async markStaleActiveSessionsExpired(): Promise<void> {}
+}
+
+interface DaemonSocketServerInternals {
+  socketServer: {
+    quiesce(): Promise<void>;
+    drainSessionReleaseNotifications(): Promise<void>;
+    close(): Promise<void>;
+  } | null;
 }
 
 describe("Daemon shutdown session release (issue #5303)", () => {
@@ -274,6 +283,107 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     }
   });
 
+  test("publishes each concurrent bound-session shutdown before closing the control socket (#6336)", async () => {
+    const timer = new FakeTimer();
+    const repository = new FakeDeviceSessionRepository();
+    const daemon = new Daemon(
+      {},
+      new FakeInstalledAppsRepository(),
+      timer,
+      repository as unknown as DeviceSessionRepository,
+    );
+    const sessionManager = daemon.getSessionManager();
+    const events: string[] = [];
+    const unsubscribe = SessionReleaseBroadcaster.subscribe((sessionId, reason) => {
+      events.push(`release:${sessionId}:${reason}`);
+    });
+    (daemon as unknown as DaemonSocketServerInternals).socketServer = {
+      quiesce: async () => {
+        events.push("socket:quiesce");
+      },
+      drainSessionReleaseNotifications: async () => {
+        events.push("socket:drain-releases");
+      },
+      close: async () => {
+        events.push("socket:close");
+      },
+    };
+    const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
+
+    try {
+      await sessionManager.createSession("session-a", "emulator-5554", "android");
+      await sessionManager.createSession("session-b", "emulator-5556", "android");
+
+      await daemon.stop();
+
+      expect(events[0]).toBe("socket:quiesce");
+      expect(events.filter((event) => event === "release:session-a:daemon-shutdown")).toHaveLength(
+        1,
+      );
+      expect(events.filter((event) => event === "release:session-b:daemon-shutdown")).toHaveLength(
+        1,
+      );
+      const drainIndex = events.indexOf("socket:drain-releases");
+      expect(drainIndex).toBeGreaterThan(events.indexOf("release:session-a:daemon-shutdown"));
+      expect(drainIndex).toBeGreaterThan(events.indexOf("release:session-b:daemon-shutdown"));
+      expect(events.indexOf("socket:close")).toBeGreaterThan(drainIndex);
+      expect(sessionManager.getSession("session-a")).toBeNull();
+      expect(sessionManager.getSession("session-b")).toBeNull();
+    } finally {
+      unsubscribe();
+      loggerCloseSpy.mockRestore();
+    }
+  });
+
+  test("rejects a session creation that outlives control-socket quiescence (#6336)", async () => {
+    const timer = new FakeTimer();
+    const repository = new FakeDeviceSessionRepository();
+    const daemon = new Daemon(
+      {},
+      new FakeInstalledAppsRepository(),
+      timer,
+      repository as unknown as DeviceSessionRepository,
+    );
+    const sessionManager = daemon.getSessionManager();
+    const continueAcquisition = Promise.withResolvers<void>();
+    const lateCreation = (async () => {
+      await continueAcquisition.promise;
+      return await sessionManager.createSession(
+        "late-shutdown-session",
+        "emulator-5558",
+        "android",
+      );
+    })();
+    const lateCreationOutcome = lateCreation.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    (daemon as unknown as DaemonSocketServerInternals).socketServer = {
+      quiesce: async () => {
+        continueAcquisition.resolve();
+        await Promise.resolve();
+      },
+      drainSessionReleaseNotifications: async () => {},
+      close: async () => {},
+    };
+    const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
+
+    try {
+      await daemon.stop();
+
+      expect(await lateCreationOutcome).toEqual(
+        expect.objectContaining({
+          message:
+            "Cannot create device session late-shutdown-session: the daemon is shutting down.",
+        }),
+      );
+      expect(sessionManager.getSession("late-shutdown-session")).toBeNull();
+      expect(repository.sessions.has("late-shutdown-session")).toBe(false);
+    } finally {
+      loggerCloseSpy.mockRestore();
+    }
+  });
+
   test("drains a monitor release that removed its session before shutdown snapshots it", async () => {
     const timer = new FakeTimer();
     const repository = new FakeDeviceSessionRepository();
@@ -321,6 +431,77 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     } finally {
       markReleasedSpy.mockRestore();
       closeDatabaseSpy.mockRestore();
+      loggerCloseSpy.mockRestore();
+    }
+  });
+
+  test("publishes a shutdown fallback when terminal persistence outlives the drain (#6336)", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const repository = new FakeDeviceSessionRepository();
+    const daemon = new Daemon(
+      {},
+      new FakeInstalledAppsRepository(),
+      timer,
+      repository as unknown as DeviceSessionRepository,
+    );
+    const sessionManager = daemon.getSessionManager();
+    const events: string[] = [];
+    const persistence = Promise.withResolvers<void>();
+    const persistenceStarted = Promise.withResolvers<void>();
+    const originalMarkReleased = repository.markReleased.bind(repository);
+    const markReleasedSpy = spyOn(repository, "markReleased").mockImplementation(
+      async (...args) => {
+        persistenceStarted.resolve();
+        await persistence.promise;
+        await originalMarkReleased(...args);
+      },
+    );
+    const unsubscribe = SessionReleaseBroadcaster.subscribe((sessionId, reason) => {
+      events.push(`release:${sessionId}:${reason}`);
+    });
+    (daemon as unknown as DaemonSocketServerInternals).socketServer = {
+      quiesce: async () => {},
+      drainSessionReleaseNotifications: async () => {
+        events.push("socket:drain-releases");
+      },
+      close: async () => {
+        events.push("socket:close");
+      },
+    };
+    const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
+
+    try {
+      await sessionManager.createSession(
+        "blocked-terminal-session",
+        "emulator-5560",
+        "android",
+      );
+      const terminalRelease = sessionManager.releaseSession(
+        "blocked-terminal-session",
+        "heartbeat-timeout",
+      );
+      await persistenceStarted.promise;
+
+      await daemon.stop();
+
+      const fallback = "release:blocked-terminal-session:daemon-shutdown";
+      expect(events.filter((event) => event === fallback)).toHaveLength(1);
+      expect(events.indexOf("socket:drain-releases")).toBeGreaterThan(events.indexOf(fallback));
+      expect(events.indexOf("socket:close")).toBeGreaterThan(
+        events.indexOf("socket:drain-releases"),
+      );
+
+      persistence.resolve();
+      await terminalRelease;
+      expect(events.filter((event) => event === fallback)).toHaveLength(1);
+      expect(events.filter((event) => event.startsWith("release:blocked-terminal-session:"))).toEqual(
+        [fallback],
+      );
+    } finally {
+      persistence.resolve();
+      markReleasedSpy.mockRestore();
+      unsubscribe();
       loggerCloseSpy.mockRestore();
     }
   });

--- a/test/daemon/daemonShutdownSessionRelease.test.ts
+++ b/test/daemon/daemonShutdownSessionRelease.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { Daemon } from "../../src/daemon/daemon";
+import type { SessionDeviceAssigner } from "../../src/daemon/sessionManager";
 import { DaemonState } from "../../src/daemon/daemonState";
 import * as daemonFilesModule from "../../src/daemon/daemonFiles";
 import * as databaseModule from "../../src/db";
@@ -384,6 +385,61 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     }
   });
 
+  test("bounds shutdown while a pending assignment cannot settle (#6336)", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const repository = new FakeDeviceSessionRepository();
+    const daemon = new Daemon(
+      {},
+      new FakeInstalledAppsRepository(),
+      timer,
+      repository as unknown as DeviceSessionRepository,
+    );
+    const sessionManager = daemon.getSessionManager();
+    const finishAssignment = Promise.withResolvers<void>();
+    const assignmentStarted = Promise.withResolvers<void>();
+    const devicePool: SessionDeviceAssigner = {
+      async assignDeviceToSession(): Promise<string> {
+        assignmentStarted.resolve();
+        await finishAssignment.promise;
+        throw new Error("assignment stopped with daemon");
+      },
+    };
+    const assignment = sessionManager.getOrCreateSession("pending-shutdown-assignment", devicePool);
+    const assignmentOutcome = assignment.catch((error: unknown) => error);
+    await assignmentStarted.promise;
+    const events: string[] = [];
+    const unsubscribe = SessionReleaseBroadcaster.subscribe((sessionId, reason) => {
+      events.push(`release:${sessionId}:${reason}`);
+    });
+    (daemon as unknown as DaemonSocketServerInternals).socketServer = {
+      quiesce: async () => {},
+      drainSessionReleaseNotifications: async () => {
+        events.push("socket:drain-releases");
+      },
+      close: async () => {
+        events.push("socket:close");
+      },
+    };
+    const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
+
+    try {
+      await daemon.stop();
+
+      const fallback = "release:pending-shutdown-assignment:daemon-shutdown";
+      expect(events.filter((event) => event === fallback)).toHaveLength(1);
+      expect(events.indexOf("socket:drain-releases")).toBeGreaterThan(events.indexOf(fallback));
+      expect(events.indexOf("socket:close")).toBeGreaterThan(
+        events.indexOf("socket:drain-releases"),
+      );
+    } finally {
+      finishAssignment.resolve();
+      await assignmentOutcome;
+      unsubscribe();
+      loggerCloseSpy.mockRestore();
+    }
+  });
+
   test("drains a monitor release that removed its session before shutdown snapshots it", async () => {
     const timer = new FakeTimer();
     const repository = new FakeDeviceSessionRepository();
@@ -497,6 +553,75 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     } finally {
       persistence.resolve();
       markReleasedSpy.mockRestore();
+      unsubscribe();
+      loggerCloseSpy.mockRestore();
+    }
+  });
+
+  test("publishes a daemon-shutdown reason upgrade after an ordinary release callback (#6336)", async () => {
+    const timer = new FakeTimer();
+    const repository = new FakeDeviceSessionRepository();
+    const daemon = new Daemon(
+      {},
+      new FakeInstalledAppsRepository(),
+      timer,
+      repository as unknown as DeviceSessionRepository,
+    );
+    const sessionManager = daemon.getSessionManager();
+    const persistence = Promise.withResolvers<void>();
+    const persistenceStarted = Promise.withResolvers<void>();
+    const originalMarkReleased = repository.markReleased.bind(repository);
+    const markReleasedSpy = spyOn(repository, "markReleased").mockImplementation(
+      async (...args) => {
+        if (args[3] === "explicit-release") {
+          persistenceStarted.resolve();
+          await persistence.promise;
+        }
+        await originalMarkReleased(...args);
+      },
+    );
+    const shutdownReleaseStarted = Promise.withResolvers<void>();
+    const originalRelease = sessionManager.releaseSession.bind(sessionManager);
+    const releaseSpy = spyOn(sessionManager, "releaseSession").mockImplementation(
+      async (sessionId, reason, allowExpired) => {
+        if (reason === "daemon-shutdown") {
+          shutdownReleaseStarted.resolve();
+        }
+        return await originalRelease(sessionId, reason, allowExpired);
+      },
+    );
+    const events: string[] = [];
+    const unsubscribe = SessionReleaseBroadcaster.subscribe((sessionId, reason) => {
+      events.push(`release:${sessionId}:${reason}`);
+    });
+    let ordinaryRelease: Promise<string | null> | undefined;
+    (daemon as unknown as DaemonSocketServerInternals).socketServer = {
+      quiesce: async () => {
+        ordinaryRelease = sessionManager.releaseSession("upgraded-release", "explicit-release");
+        await persistenceStarted.promise;
+      },
+      drainSessionReleaseNotifications: async () => {},
+      close: async () => {},
+    };
+    const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
+
+    try {
+      await sessionManager.createSession("upgraded-release", "emulator-5562", "android");
+      const stop = daemon.stop();
+      await shutdownReleaseStarted.promise;
+      persistence.resolve();
+      await Promise.all([ordinaryRelease!, stop]);
+
+      expect(
+        events.filter((event) => event === "release:upgraded-release:explicit-release"),
+      ).toHaveLength(1);
+      expect(
+        events.filter((event) => event === "release:upgraded-release:daemon-shutdown"),
+      ).toHaveLength(1);
+    } finally {
+      persistence.resolve();
+      markReleasedSpy.mockRestore();
+      releaseSpy.mockRestore();
       unsubscribe();
       loggerCloseSpy.mockRestore();
     }

--- a/test/daemon/daemonShutdownSessionRelease.test.ts
+++ b/test/daemon/daemonShutdownSessionRelease.test.ts
@@ -295,6 +295,15 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     );
     const sessionManager = daemon.getSessionManager();
     const events: string[] = [];
+    const stopAcceptingSessionCreations =
+      sessionManager.stopAcceptingSessionCreations.bind(sessionManager);
+    const stopAcceptingSessionCreationsSpy = spyOn(
+      sessionManager,
+      "stopAcceptingSessionCreations",
+    ).mockImplementation(() => {
+      events.push("session:fence");
+      stopAcceptingSessionCreations();
+    });
     const unsubscribe = SessionReleaseBroadcaster.subscribe((sessionId, reason) => {
       events.push(`release:${sessionId}:${reason}`);
     });
@@ -318,6 +327,7 @@ describe("Daemon shutdown session release (issue #5303)", () => {
       await daemon.stop();
 
       expect(events[0]).toBe("socket:quiesce");
+      expect(events[1]).toBe("session:fence");
       expect(events.filter((event) => event === "release:session-a:daemon-shutdown")).toHaveLength(
         1,
       );
@@ -332,6 +342,7 @@ describe("Daemon shutdown session release (issue #5303)", () => {
       expect(sessionManager.getSession("session-b")).toBeNull();
     } finally {
       unsubscribe();
+      stopAcceptingSessionCreationsSpy.mockRestore();
       loggerCloseSpy.mockRestore();
     }
   });

--- a/test/daemon/proxyBoundSessionFirstHeartbeat.test.ts
+++ b/test/daemon/proxyBoundSessionFirstHeartbeat.test.ts
@@ -518,23 +518,31 @@ describe("proxy-bound session first heartbeat (issue #5637)", () => {
     }
   });
 
-  // AC1: the ownership heartbeat is delivered before the best-effort notification
-  // subscription — subscribeToNotifications() is a daemon RPC that can stall, and
-  // must not delay the time-critical first heartbeat past the reclaim grace.
-  test("delivers the first heartbeat before subscribing to notifications", async () => {
+  // AC1 + #6336: start notification opt-in before the heartbeat so shutdown
+  // release signals cannot land in an unsubscribed window, but do not await the
+  // potentially-stalled subscription before dispatching the time-critical
+  // heartbeat.
+  test("starts notification subscription without delaying the first heartbeat", async () => {
     await sessionManager.createSession(BOUND_SESSION, "emulator-5554", "android", 60_000);
 
-    let subscribeCallsAtHeartbeat = -1;
-    const clientRef: { current: FakeDaemonClient | null } = { current: null };
+    const releaseSubscription = Promise.withResolvers<void>();
+    let subscriptionStarted = false;
+    let subscriptionStartedAtHeartbeat = false;
+    let heartbeatObserved = false;
     const fakeClient = new FakeDaemonClient({
       onCallDaemonMethod: (method, params) => {
         if (method === "daemon/heartbeat" && typeof params.sessionId === "string") {
-          subscribeCallsAtHeartbeat = clientRef.current!.subscribeToNotificationsCalls;
+          heartbeatObserved = true;
+          subscriptionStartedAtHeartbeat = subscriptionStarted;
           sessionManager.recordHeartbeat(params.sessionId);
         }
       },
     });
-    clientRef.current = fakeClient;
+    fakeClient.subscribeToNotifications = async () => {
+      fakeClient.subscribeToNotificationsCalls += 1;
+      subscriptionStarted = true;
+      await releaseSubscription.promise;
+    };
     const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
     const proxy = new DaemonMcpProxy({
       initialSessionUuid: BOUND_SESSION,
@@ -545,12 +553,97 @@ describe("proxy-bound session first heartbeat (issue #5637)", () => {
     });
 
     try {
-      await proxy.ensureConnected();
-      // The heartbeat ran while the subscription had not yet been requested.
-      expect(subscribeCallsAtHeartbeat).toBe(0);
-      // The subscription still happens (best-effort), just after the heartbeat.
+      let connected = false;
+      const connection = proxy.ensureConnected().then(() => {
+        connected = true;
+      });
+      for (let i = 0; i < 50 && !heartbeatObserved; i++) {
+        await Promise.resolve();
+      }
+
+      expect(subscriptionStartedAtHeartbeat).toBe(true);
+      expect(heartbeatObserved).toBe(true);
+      expect(connected).toBe(false);
       expect(fakeClient.subscribeToNotificationsCalls).toBe(1);
       expect(sessionManager.getSession(BOUND_SESSION)?.hasReceivedHeartbeat).toBe(true);
+
+      releaseSubscription.resolve();
+      await connection;
+      expect(connected).toBe(true);
+    } finally {
+      releaseSubscription.resolve();
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  test("captures initial-binding shutdown during the first heartbeat and waits for EOF (#6336)", async () => {
+    await sessionManager.createSession(BOUND_SESSION, "emulator-5554", "android", 60_000);
+
+    let subscriptionStarted = false;
+    const oldDaemonRef: { current: FakeDaemonClient | null } = { current: null };
+    const oldDaemon = new FakeDaemonClient({
+      onCallDaemonMethod: (method) => {
+        if (method === "daemon/heartbeat" && subscriptionStarted) {
+          oldDaemonRef.current!.emitNotification(
+            SESSION_RELEASED_NOTIFICATION_METHOD,
+            BOUND_SESSION,
+            "daemon-shutdown",
+          );
+        }
+      },
+    });
+    oldDaemonRef.current = oldDaemon;
+    oldDaemon.subscribeToNotifications = async () => {
+      oldDaemon.subscribeToNotificationsCalls += 1;
+      subscriptionStarted = true;
+    };
+    const replacementDaemon = new FakeDaemonClient({
+      toolResultFor: (toolName) =>
+        toolName === "getAndroid"
+          ? {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({ sessionUuid: "replacement-session" }),
+                },
+              ],
+            }
+          : undefined,
+    });
+    const clients: DaemonClientLike[] = [oldDaemon, replacementDaemon];
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      initialSessionUuid: BOUND_SESSION,
+      clientFactory: () => clients.shift()!,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      await proxy.ensureConnected();
+      const reacquired = proxy.callTool("getAndroid", { avdName: "am-api34-ga-arm64" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(subscriptionStarted).toBe(true);
+      expect(oldDaemon.callToolCalls).toEqual([]);
+      expect(replacementDaemon.callToolCalls).toEqual([]);
+
+      oldDaemon.emitConnectionClosed();
+
+      await expect(reacquired).resolves.toEqual({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ sessionUuid: "replacement-session" }),
+          },
+        ],
+      });
+      expect(replacementDaemon.callToolCalls).toEqual([
+        { toolName: "getAndroid", params: { avdName: "am-api34-ga-arm64" } },
+      ]);
     } finally {
       isAvailableSpy.mockRestore();
       await proxy.close();

--- a/test/daemon/proxyResultMintedSession.test.ts
+++ b/test/daemon/proxyResultMintedSession.test.ts
@@ -248,6 +248,65 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
     }
   });
 
+  test("rejects a result-minted session released before binding and waits for EOF (#6336)", async () => {
+    const acquisitionStarted = Promise.withResolvers<void>();
+    const finishAcquisition = Promise.withResolvers<void>();
+    const oldDaemon = new FakeDaemonClient({
+      onCallTool: async (toolName) => {
+        if (toolName === "getAndroid") {
+          acquisitionStarted.resolve();
+          await finishAcquisition.promise;
+        }
+      },
+      toolResultFor: (toolName) =>
+        toolName === "getAndroid" ? deviceStartResult("released-before-result") : undefined,
+    });
+    const replacementDaemon = acquiringClient(sessionManager, ["replacement-after-race"]);
+    let clientFactoryCalls = 0;
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => {
+        clientFactoryCalls += 1;
+        return clientFactoryCalls === 1 ? oldDaemon : replacementDaemon.client;
+      },
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      const staleAcquisition = proxy.callTool("getAndroid", {
+        avdName: "am-api34-ga-arm64",
+      });
+      await acquisitionStarted.promise;
+      oldDaemon.emitNotification(
+        SESSION_RELEASED_NOTIFICATION_METHOD,
+        "released-before-result",
+        "daemon-shutdown",
+      );
+      finishAcquisition.resolve();
+
+      await expect(staleAcquisition).rejects.toMatchObject({
+        sessionUuid: "released-before-result",
+        reason: "daemon-shutdown",
+      });
+
+      const replacement = proxy.callTool("getAndroid", {
+        avdName: "am-api34-ga-arm64",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(replacementDaemon.nextIndex()).toBe(0);
+
+      oldDaemon.emitConnectionClosed();
+
+      await expect(replacement).resolves.toEqual(deviceStartResult("replacement-after-race"));
+      expect(replacementDaemon.nextIndex()).toBe(1);
+    } finally {
+      finishAcquisition.resolve();
+      await proxy.close();
+    }
+  });
+
   // AC3: a sessionless call on a fenced connection whose binding was result-minted
   // (never named by the client) fails naming the CURRENT state — directing to
   // re-acquire — rather than reporting the stale uuid the caller never referenced.

--- a/test/daemon/proxyResultMintedSession.test.ts
+++ b/test/daemon/proxyResultMintedSession.test.ts
@@ -207,6 +207,47 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
     }
   });
 
+  test("waits for the shutting-down daemon to disconnect before reacquiring (#6336)", async () => {
+    const M1 = "shutdown-session";
+    const M2 = "replacement-session";
+    const oldDaemon = acquiringClient(sessionManager, [M1, "wrong-old-daemon-session"]);
+    const replacementDaemon = acquiringClient(sessionManager, [M2]);
+    let clientFactoryCalls = 0;
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => {
+        clientFactoryCalls += 1;
+        return clientFactoryCalls === 1 ? oldDaemon.client : replacementDaemon.client;
+      },
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      await proxy.callTool("getAndroid", { avdName: "am-api34-ga-arm64" });
+      oldDaemon.client.emitNotification(
+        SESSION_RELEASED_NOTIFICATION_METHOD,
+        M1,
+        "daemon-shutdown",
+      );
+
+      const reacquired = proxy.callTool("getAndroid", { avdName: "am-api34-ga-arm64" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(oldDaemon.nextIndex()).toBe(1);
+      expect(replacementDaemon.nextIndex()).toBe(0);
+
+      oldDaemon.client.emitConnectionClosed();
+
+      await expect(reacquired).resolves.toEqual(deviceStartResult(M2));
+      expect(replacementDaemon.nextIndex()).toBe(1);
+      expect(sessionManager.getSession(M2)?.hasReceivedHeartbeat).toBe(true);
+    } finally {
+      await proxy.close();
+    }
+  });
+
   // AC3: a sessionless call on a fenced connection whose binding was result-minted
   // (never named by the client) fails naming the CURRENT state — directing to
   // re-acquire — rather than reporting the stale uuid the caller never referenced.

--- a/test/daemon/proxyResultMintedSession.test.ts
+++ b/test/daemon/proxyResultMintedSession.test.ts
@@ -212,19 +212,23 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
     const M2 = "replacement-session";
     const oldDaemon = acquiringClient(sessionManager, [M1, "wrong-old-daemon-session"]);
     const replacementDaemon = acquiringClient(sessionManager, [M2]);
+    const manager = matchingDaemonManager();
+    let daemonAvailable = true;
+    isAvailableSpy!.mockImplementation(async () => daemonAvailable);
     let clientFactoryCalls = 0;
     const proxy = new DaemonMcpProxy({
       clientFactory: () => {
         clientFactoryCalls += 1;
         return clientFactoryCalls === 1 ? oldDaemon.client : replacementDaemon.client;
       },
-      daemonManager: matchingDaemonManager(),
-      autoStartDaemon: false,
+      daemonManager: manager,
+      autoStartDaemon: true,
       timer,
     });
 
     try {
       await proxy.callTool("getAndroid", { avdName: "am-api34-ga-arm64" });
+      daemonAvailable = false;
       oldDaemon.client.emitNotification(
         SESSION_RELEASED_NOTIFICATION_METHOD,
         M1,
@@ -239,8 +243,22 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
       expect(replacementDaemon.nextIndex()).toBe(0);
 
       oldDaemon.client.emitConnectionClosed();
+      for (let i = 0; i < 20 && timer.getPendingSleepCount() === 0; i++) {
+        await Promise.resolve();
+      }
+
+      // Peer EOF precedes DaemonManager.restart() clearing the old PID record
+      // and taking the startup lock. Do not run doConnect in that deterministic
+      // gap: it would see running=true with no lock holder and reject recovery.
+      expect(timer.getPendingSleeps()).toEqual([100]);
+      expect(manager.startCalled).toBe(false);
+      expect(replacementDaemon.nextIndex()).toBe(0);
+
+      manager.statusResult = { running: false };
+      await timer.advanceTimeAsync(100);
 
       await expect(reacquired).resolves.toEqual(deviceStartResult(M2));
+      expect(manager.startCalled).toBe(true);
       expect(replacementDaemon.nextIndex()).toBe(1);
       expect(sessionManager.getSession(M2)?.hasReceivedHeartbeat).toBe(true);
     } finally {

--- a/test/daemon/proxyResultMintedSession.test.ts
+++ b/test/daemon/proxyResultMintedSession.test.ts
@@ -4,7 +4,7 @@ import { DaemonClient, DaemonUnavailableError } from "../../src/daemon/client";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { SessionHeartbeatMonitor } from "../../src/daemon/SessionHeartbeatMonitor";
 import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../../src/server/sessionReleaseBroadcast";
-import { DAEMON_VERSION } from "../../src/daemon/constants";
+import { DAEMON_SHUTDOWN_TIMEOUT_MS, DAEMON_VERSION } from "../../src/daemon/constants";
 import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
 import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -310,6 +310,51 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
     }
   });
 
+  test("bounds a missing shutdown EOF before reacquiring (#6336)", async () => {
+    const M1 = "shutdown-without-eof";
+    const M2 = "replacement-after-timeout";
+    const oldDaemon = acquiringClient(sessionManager, [M1]);
+    const replacementDaemon = acquiringClient(sessionManager, [M2]);
+    const manager = matchingDaemonManager();
+    let availabilityChecks = 0;
+    isAvailableSpy!.mockImplementation(async () => {
+      availabilityChecks += 1;
+      return availabilityChecks === 1;
+    });
+    const clients = [oldDaemon.client, replacementDaemon.client];
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => clients.shift()!,
+      daemonManager: manager,
+      autoStartDaemon: true,
+      timer,
+    });
+
+    try {
+      await proxy.callTool("getAndroid", { avdName: "am-api34-ga-arm64" });
+      oldDaemon.client.emitNotification(
+        SESSION_RELEASED_NOTIFICATION_METHOD,
+        M1,
+        "daemon-shutdown",
+      );
+
+      const reacquired = proxy.callTool("getAndroid", {
+        avdName: "am-api34-ga-arm64",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(replacementDaemon.nextIndex()).toBe(0);
+
+      manager.statusResult = { running: false };
+      await timer.advanceTimeAsync(DAEMON_SHUTDOWN_TIMEOUT_MS);
+
+      await expect(reacquired).resolves.toEqual(deviceStartResult(M2));
+      expect(manager.startCalled).toBe(true);
+      expect(replacementDaemon.nextIndex()).toBe(1);
+    } finally {
+      await proxy.close();
+    }
+  });
+
   test("rejects a result-minted session released before binding and waits for EOF (#6336)", async () => {
     const acquisitionStarted = Promise.withResolvers<void>();
     const finishAcquisition = Promise.withResolvers<void>();
@@ -402,12 +447,9 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
         avdName: "am-api34-ga-arm64",
       });
       await oldClientClosed.promise;
-      for (let i = 0; i < 20 && replacementDaemon.nextIndex() === 0; i++) {
-        await Promise.resolve();
-      }
 
-      expect(replacementDaemon.nextIndex()).toBe(1);
       await expect(recovery).resolves.toEqual(deviceStartResult("replacement-after-reset"));
+      expect(replacementDaemon.nextIndex()).toBe(1);
     } finally {
       await proxy.close();
     }

--- a/test/daemon/proxyResultMintedSession.test.ts
+++ b/test/daemon/proxyResultMintedSession.test.ts
@@ -139,6 +139,50 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
     }
   });
 
+  test("rejects a result-minted session released during its first heartbeat (#6336)", async () => {
+    const MINTED = "released-during-first-heartbeat";
+    const heartbeatStarted = Promise.withResolvers<void>();
+    const finishHeartbeat = Promise.withResolvers<void>();
+    const client = new FakeDaemonClient({
+      onCallTool: async (toolName) => {
+        if (toolName === "getAndroid") {
+          await sessionManager.createSession(MINTED, "emulator-5554", "android", 60_000);
+        }
+      },
+      toolResultFor: (toolName) =>
+        toolName === "getAndroid" ? deviceStartResult(MINTED) : undefined,
+      onCallDaemonMethod: async (method, params) => {
+        if (method === "daemon/heartbeat" && params.sessionId === MINTED) {
+          heartbeatStarted.resolve();
+          await finishHeartbeat.promise;
+        }
+      },
+    });
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => client,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      const acquisition = proxy.callTool("getAndroid", {
+        avdName: "am-api34-ga-arm64",
+      });
+      await heartbeatStarted.promise;
+      client.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, MINTED, "daemon-shutdown");
+      finishHeartbeat.resolve();
+
+      await expect(acquisition).rejects.toMatchObject({
+        sessionUuid: MINTED,
+        reason: "daemon-shutdown",
+      });
+    } finally {
+      finishHeartbeat.resolve();
+      await proxy.close();
+    }
+  });
+
   // AC1 (regression of the exact repro): without binding, the minted session is
   // reaped after ~5s idle. With the fix it survives a 20s idle window and a later
   // sessionless call still routes to it.

--- a/test/daemon/proxyResultMintedSession.test.ts
+++ b/test/daemon/proxyResultMintedSession.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, spyOn, beforeEach, afterEach } from "bun:test";
 import { DaemonMcpProxy } from "../../src/daemon/daemonMcpProxy";
-import { DaemonClient } from "../../src/daemon/client";
+import { DaemonClient, DaemonUnavailableError } from "../../src/daemon/client";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { SessionHeartbeatMonitor } from "../../src/daemon/SessionHeartbeatMonitor";
 import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../../src/server/sessionReleaseBroadcast";
@@ -303,6 +303,50 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
       expect(replacementDaemon.nextIndex()).toBe(1);
     } finally {
       finishAcquisition.resolve();
+      await proxy.close();
+    }
+  });
+
+  test("resolves the shutdown barrier when an in-flight acquisition resets its client (#6336)", async () => {
+    const oldClientClosed = Promise.withResolvers<void>();
+    const oldClientRef: { current: FakeDaemonClient | null } = { current: null };
+    const oldDaemon = new FakeDaemonClient({
+      onCallTool: (toolName) => {
+        if (toolName === "getAndroid") {
+          oldClientRef.current!.emitNotification(
+            SESSION_RELEASED_NOTIFICATION_METHOD,
+            "released-during-acquisition",
+            "daemon-shutdown",
+          );
+          throw new DaemonUnavailableError("Daemon socket connection lost");
+        }
+      },
+    });
+    oldClientRef.current = oldDaemon;
+    oldDaemon.close = async () => {
+      oldClientClosed.resolve();
+    };
+    const replacementDaemon = acquiringClient(sessionManager, ["replacement-after-reset"]);
+    const clients = [oldDaemon, replacementDaemon.client];
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => clients.shift()!,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      const recovery = proxy.callTool("getAndroid", {
+        avdName: "am-api34-ga-arm64",
+      });
+      await oldClientClosed.promise;
+      for (let i = 0; i < 20 && replacementDaemon.nextIndex() === 0; i++) {
+        await Promise.resolve();
+      }
+
+      expect(replacementDaemon.nextIndex()).toBe(1);
+      await expect(recovery).resolves.toEqual(deviceStartResult("replacement-after-reset"));
+    } finally {
       await proxy.close();
     }
   });

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -233,6 +233,43 @@ describe("SessionManager", () => {
       }
     });
 
+    test("terminally rejects a creation whose persistence outlives the shutdown fence", async () => {
+      const repository = new DeferredDeviceSessionPersistence();
+      const manager = new SessionManager(fakeTimer, repository);
+      const releaseReasons: string[] = [];
+      manager.onSessionRelease((_sessionId, _deviceId, reason) => {
+        releaseReasons.push(reason);
+      });
+
+      try {
+        repository.deferNextUpsert();
+        const creating = manager.createSession(
+          "persisting-during-shutdown",
+          "emulator-5554",
+          "android",
+        );
+        await repository.waitForUpsert();
+
+        manager.stopAcceptingSessionCreations();
+        repository.finishUpsert();
+
+        await expect(creating).rejects.toMatchObject({
+          sessionUuid: "persisting-during-shutdown",
+          release: expect.objectContaining({ releaseReason: "daemon-shutdown" }),
+        });
+        expect(manager.getSession("persisting-during-shutdown")).toBeNull();
+        expect(manager.getSessionForDevice("emulator-5554")).toBeNull();
+        expect(manager.getTerminalReleaseSnapshot("persisting-during-shutdown")).toMatchObject({
+          releaseReason: "daemon-shutdown",
+          terminal: true,
+        });
+        expect(releaseReasons).toEqual(["daemon-shutdown"]);
+      } finally {
+        repository.finishUpsert();
+        manager.stopCleanupTimer();
+      }
+    });
+
     test("keeps ownership unpublished while a creation write is pending", async () => {
       let rejectFirstWrite!: (error: Error) => void;
       const firstWrite = new Promise<void>((_resolve, reject) => {

--- a/test/daemon/socketServerNotifications.integration.test.ts
+++ b/test/daemon/socketServerNotifications.integration.test.ts
@@ -211,6 +211,37 @@ describe("UnixSocketServer notification broadcast", () => {
     });
   });
 
+  test("quiesce rejects new work while preserving concurrent shutdown releases (#6336)", async () => {
+    const subscriberA = await connectedClient();
+    const subscriberB = await connectedClient();
+    subscriberA.send(DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD);
+    subscriberB.send(DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD);
+    await Promise.all([subscriberA.waitForFrames(1), subscriberB.waitForFrames(1)]);
+
+    await server.quiesce();
+    subscriberA.send("daemon/refreshDevices");
+    await subscriberA.waitForFrames(2);
+    SessionReleaseBroadcaster.emit("session-a", "daemon-shutdown");
+    SessionReleaseBroadcaster.emit("session-b", "daemon-shutdown");
+    await server.drainSessionReleaseNotifications();
+    await server.close();
+    await Promise.all([subscriberA.waitForFrames(4), subscriberB.waitForFrames(3)]);
+
+    expect(subscriberA.frames[1]).toMatchObject({
+      type: "mcp_response",
+      success: false,
+      error: "Daemon is shutting down",
+    });
+    const expectedReleases = ["session-a", "session-b"].map((sessionId) => ({
+      type: "daemon_notification",
+      method: SESSION_RELEASED_NOTIFICATION_METHOD,
+      sessionId,
+      reason: "daemon-shutdown",
+    }));
+    expect(subscriberA.frames.slice(2)).toEqual(expectedReleases);
+    expect(subscriberB.frames.slice(1)).toEqual(expectedReleases);
+  });
+
   test("close() unsubscribes from the session-release broadcaster too (issue #4610)", async () => {
     const subscriber = await connectedClient();
     subscriber.send(DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD);

--- a/test/daemon/socketServerNotifications.integration.test.ts
+++ b/test/daemon/socketServerNotifications.integration.test.ts
@@ -38,11 +38,13 @@ class FrameCollectingClient {
   private socket = new Socket();
   private buffer = "";
   private frameWaiters: Array<() => void> = [];
+  private readonly closed = Promise.withResolvers<void>();
 
   connect(socketPath: string): Promise<void> {
     return new Promise((resolve, reject) => {
       this.socket.connect(socketPath, resolve);
       this.socket.on("error", reject);
+      this.socket.on("close", () => this.closed.resolve());
       this.socket.on("data", (data) => {
         this.buffer += data.toString();
         const lines = this.buffer.split("\n");
@@ -88,6 +90,26 @@ class FrameCollectingClient {
 
   close(): void {
     this.socket.destroy();
+  }
+
+  async waitForClose(deadlineMs: number = 10_000): Promise<void> {
+    let timeout: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        this.closed.promise,
+        new Promise<never>((_resolve, reject) => {
+          timeout = defaultTimer.setTimeout(
+            () => reject(new Error(`Socket did not close within ${deadlineMs}ms`)),
+            deadlineMs,
+          );
+          timeout.unref();
+        }),
+      ]);
+    } finally {
+      if (timeout !== undefined) {
+        defaultTimer.clearTimeout(timeout);
+      }
+    }
   }
 }
 
@@ -240,6 +262,30 @@ describe("UnixSocketServer notification broadcast", () => {
     }));
     expect(subscriberA.frames.slice(2)).toEqual(expectedReleases);
     expect(subscriberB.frames.slice(1)).toEqual(expectedReleases);
+  });
+
+  test("quiesce closes unsubscribed connections and stops accepting new clients (#6336)", async () => {
+    const subscriber = await connectedClient();
+    const unsubscribed = await connectedClient();
+    subscriber.send(DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD);
+    await subscriber.waitForFrames(1);
+
+    await server.quiesce();
+    await unsubscribed.waitForClose();
+
+    const lateClient = new FrameCollectingClient();
+    clients.push(lateClient);
+    await expect(lateClient.connect(socketPath)).rejects.toBeDefined();
+
+    SessionReleaseBroadcaster.emit("session-a", "daemon-shutdown");
+    await server.drainSessionReleaseNotifications();
+    await subscriber.waitForFrames(2);
+    expect(subscriber.frames[1]).toMatchObject({
+      type: "daemon_notification",
+      method: SESSION_RELEASED_NOTIFICATION_METHOD,
+      sessionId: "session-a",
+      reason: "daemon-shutdown",
+    });
   });
 
   test("close() unsubscribes from the session-release broadcaster too (issue #4610)", async () => {

--- a/test/daemon/socketServerSessionIdGenerator.test.ts
+++ b/test/daemon/socketServerSessionIdGenerator.test.ts
@@ -41,6 +41,10 @@ describe("UnixSocketServer session id comes from the injected IdGenerator", () =
       idGenerator,
     );
 
+    // handleConnection is only entered after start() enables admission in
+    // production. This unit drives the private hook directly, so mirror that
+    // lifecycle state before asserting the injected ID sequence.
+    (server as any).acceptingRequests = true;
     (server as any).handleConnection(createFakeSocket());
     (server as any).handleConnection(createFakeSocket());
 

--- a/test/server/deviceLossOutcomeWire.integration.test.ts
+++ b/test/server/deviceLossOutcomeWire.integration.test.ts
@@ -350,6 +350,11 @@ describe("device loss MCP outcome", () => {
           "Call getAndroid, getApple, or startDevice to acquire a new device session.",
         sessionUuid: "device-session-a",
         reason: "heartbeat-timeout",
+        retryable: true,
+        recovery: {
+          action: "acquire_replacement_session",
+          tools: ["getAndroid", "getApple", "startDevice"],
+        },
         release,
       },
     });

--- a/test/server/proxyServerSessionOwnership.test.ts
+++ b/test/server/proxyServerSessionOwnership.test.ts
@@ -77,6 +77,11 @@ describe("proxy server session ownership errors", () => {
                   "Call getAndroid, getApple, or startDevice to acquire a new device session.",
                 sessionUuid: "session-123",
                 reason: "heartbeat-timeout",
+                retryable: true,
+                recovery: {
+                  action: "acquire_replacement_session",
+                  tools: ["getAndroid", "getApple", "startDevice"],
+                },
                 release: {
                   sessionId: "session-123",
                   deviceId: "emulator-5554",
@@ -143,6 +148,108 @@ describe("proxy server session ownership errors", () => {
         expect(client.readResource({ uri: "automobile:devices/booted" })).rejects.toThrow(
           ownershipLoss,
         ),
+      ]);
+    } finally {
+      await client.close();
+      await server.close();
+      await proxy.close();
+    }
+  });
+
+  test("marks daemon-shutdown loss retryable and binds an in-band replacement session (#6336)", async () => {
+    isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const originalClient = new FakeDaemonClient({
+      daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+      toolResultFor: (toolName) =>
+        toolName === "getAndroid"
+          ? {
+              content: [{ type: "text", text: JSON.stringify({ sessionId: "shutdown-session" }) }],
+            }
+          : undefined,
+    });
+    const replacementClient = new FakeDaemonClient({
+      daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+      toolResultFor: (toolName) =>
+        toolName === "getAndroid"
+          ? {
+              content: [
+                { type: "text", text: JSON.stringify({ sessionId: "replacement-session" }) },
+              ],
+            }
+          : undefined,
+    });
+    let clientFactoryCalls = 0;
+    const daemonManager = new FakeDaemonManager();
+    daemonManager.statusResult = {
+      ...daemonManager.statusResult,
+      version: DAEMON_VERSION,
+    };
+    const { server, proxy } = createProxyMcpServer({
+      proxyConfig: {
+        clientFactory: () => {
+          clientFactoryCalls += 1;
+          return clientFactoryCalls === 1 ? originalClient : replacementClient;
+        },
+        daemonManager,
+        autoStartDaemon: false,
+      },
+    });
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "shutdown-recovery-client", version: "0.0.1" });
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+      await proxy.listTools();
+      await client.callTool({ name: "getAndroid", arguments: {} });
+      originalClient.emitNotification(
+        SESSION_RELEASED_NOTIFICATION_METHOD,
+        "shutdown-session",
+        "daemon-shutdown",
+      );
+
+      const loss = await client.callTool({
+        name: "observe",
+        arguments: { deviceId: "emulator-5554" },
+      });
+      expect(loss).toMatchObject({
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: {
+                code: "no_active_device_session",
+                message:
+                  "This MCP connection has no active device session " +
+                  "(the previous session was released: daemon-shutdown). " +
+                  "Call getAndroid, getApple, or startDevice to acquire a new device session.",
+                reason: "daemon-shutdown",
+                retryable: true,
+                recovery: {
+                  action: "acquire_replacement_session",
+                  tools: ["getAndroid", "getApple", "startDevice"],
+                },
+              },
+            }),
+          },
+        ],
+      });
+
+      originalClient.emitConnectionClosed();
+      await client.callTool({ name: "getAndroid", arguments: {} });
+      await client.callTool({
+        name: "observe",
+        arguments: { deviceId: "emulator-5554" },
+      });
+
+      expect(originalClient.callToolCalls).toEqual([{ toolName: "getAndroid", params: {} }]);
+      expect(replacementClient.callToolCalls).toEqual([
+        { toolName: "getAndroid", params: {} },
+        {
+          toolName: "observe",
+          params: { deviceId: "emulator-5554", sessionUuid: "replacement-session" },
+        },
       ]);
     } finally {
       await client.close();


### PR DESCRIPTION
## Summary

Preserve each bound device session's exact `daemon-shutdown` release signal when the shared daemon exits. Shutdown now quiesces new control-socket work, releases active sessions while subscribers remain connected, emits one fallback for any pre-existing release still blocked past the bounded persistence drain, drains those release frames, and only then closes the socket.

The structured ownership-loss payload now explicitly declares that recovery is retryable and names the in-band replacement action and tools. Initial bindings start notification opt-in before their first heartbeat without delaying that heartbeat, closing the shutdown-during-establishment race. Recovery calls wait for the shutting-down daemon's peer EOF before connecting to its successor, then `getAndroid`, `getApple`, or `startDevice` can bind a newly minted session on the same MCP transport.

Shutdown's five-second release bound now includes pending assignments and creations, reason upgrades remain observable without duplicating fallback frames, and a creation cannot publish after its persistence crosses the shutdown fence. Quiescing closes the listener and any unsubscribed sockets while preserving subscribed notification clients. A release delivered before an acquisition result binds is retained by epoch, rejects that stale result, and establishes the same EOF successor barrier; resetting that stale client explicitly completes the barrier.

## Linked Issue

Closes #6336

## Bug / Regression Context

- **Prior attempts:** [Issue #2599](https://github.com/kaeawc/auto-mobile/issues/2599) and [PR #2604](https://github.com/kaeawc/auto-mobile/pull/2604) recovered stale transport sessions, but did not preserve device-ownership release reasons across daemon replacement.
- **Observed symptom:** daemon shutdown closed notification sockets before releasing device sessions, so connected clients lost the `daemon-shutdown` event and later reported opaque `session-not-found` ownership loss.
- **Repro steps / conditions:** bind multiple MCP clients to separate Android sessions, stop and replace the shared daemon, then issue another device operation from each existing client.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (35/35)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run turbo:validate`
- [x] Focused daemon shutdown, late-acquisition fencing, notification, socket close, direct/proxy ownership, and replacement-session tests
- [x] New time-dependent behavior uses the existing injected `Timer`; focused unit tests remain under 100ms
- [x] No new dependency or generic helper
- [x] Based on current `origin/main`

## Follow-ups

None.

