### PR TITLE
fix(db): performance_live_metrics migration down() uses sql.raw

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -22,8 +22,6 @@ src/db/logEventRepository.ts: error TS2322: Type '{ deviceId: null | string; tim
 src/db/migrations/2026_01_27_000_failures.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
 src/db/migrations/2026_01_27_000_failures.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
 src/db/migrations/2026_01_27_000_failures.ts: error TS2769: No overload matches this call.
-src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2339: Property 'raw' does not exist on type 'Kysely<unknown>'.
-src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2339: Property 'raw' does not exist on type 'Kysely<unknown>'.
 src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'DataTypeExpression'.
 src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
 src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
@@ -237,7 +235,6 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 7 :: src/server/interactionTools.ts: error TS2322: Type 'SwipeDirection | undefined' is not assignable to type 'SwipeDirection'.
 # swap-fp: 7,13,55,56,63 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 # swap-fp: 7,7,7,7,9,9,9,9 :: src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
-# swap-fp: 8,8 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2339: Property 'raw' does not exist on type 'Kysely<unknown>'.
 # swap-fp: 85 :: src/daemon/socketServer.ts: error TS2554: Expected 1-2 arguments, but got 3.
 # swap-fp: 9 :: src/daemon/manager.ts: error TS18048: 'signal' is possibly 'undefined'.
 # swap-fp: 9 :: src/features/action/LaunchApp.ts: error TS2322: Type 'boolean | null' is not assignable to type 'boolean'.

--- a/src/db/migrations/2026_01_30_000_performance_live_metrics.ts
+++ b/src/db/migrations/2026_01_30_000_performance_live_metrics.ts
@@ -82,27 +82,21 @@ export async function down(db: Kysely<unknown>): Promise<void> {
     .execute();
 
   // Copy data to backup
-  await db.executeQuery(
-    db
-      .raw(`
-      INSERT INTO performance_audit_results_backup
-      SELECT id, device_id, session_id, package_name, timestamp, passed,
-             p50_ms, p90_ms, p95_ms, p99_ms, jank_count, missed_vsync_count,
-             slow_ui_thread_count, frame_deadline_missed_count, cpu_usage_percent,
-             touch_latency_ms, diagnostics_json, created_at
-      FROM performance_audit_results
-    `)
-      .compile(db),
-  );
+  await sql`
+    INSERT INTO performance_audit_results_backup
+    SELECT id, device_id, session_id, package_name, timestamp, passed,
+           p50_ms, p90_ms, p95_ms, p99_ms, jank_count, missed_vsync_count,
+           slow_ui_thread_count, frame_deadline_missed_count, cpu_usage_percent,
+           touch_latency_ms, diagnostics_json, created_at
+    FROM performance_audit_results
+  `.execute(db);
 
   // Drop original table
   await db.schema.dropTable("performance_audit_results").execute();
 
   // Rename backup to original
-  await db.executeQuery(
-    db
-      .raw("ALTER TABLE performance_audit_results_backup RENAME TO performance_audit_results")
-      .compile(db),
+  await sql`ALTER TABLE performance_audit_results_backup RENAME TO performance_audit_results`.execute(
+    db,
   );
 
   // Recreate original index

--- a/test/db/performanceLiveMetricsMigration.integration.test.ts
+++ b/test/db/performanceLiveMetricsMigration.integration.test.ts
@@ -24,11 +24,7 @@ const LIVE_METRIC_COLUMNS = [
   "node_id",
 ];
 
-async function columnExists(
-  db: Kysely<unknown>,
-  table: string,
-  column: string,
-): Promise<boolean> {
+async function columnExists(db: Kysely<unknown>, table: string, column: string): Promise<boolean> {
   const result = await sql<{ name: string }>`
     SELECT name FROM pragma_table_info(${table}) WHERE name = ${column}
   `.execute(db);
@@ -96,7 +92,12 @@ describe("2026_01_30_000_performance_live_metrics migration", () => {
 
     await liveMetricsDown(db);
 
-    const rows = await sql<{ device_id: string; session_id: string; passed: number; p50_ms: number }>`
+    const rows = await sql<{
+      device_id: string;
+      session_id: string;
+      passed: number;
+      p50_ms: number;
+    }>`
       SELECT device_id, session_id, passed, p50_ms
       FROM performance_audit_results
       ORDER BY device_id

--- a/test/db/performanceLiveMetricsMigration.integration.test.ts
+++ b/test/db/performanceLiveMetricsMigration.integration.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely, sql } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { up as thresholdsUp } from "../../src/db/migrations/2025_12_30_000_performance_thresholds";
+import {
+  up as liveMetricsUp,
+  down as liveMetricsDown,
+} from "../../src/db/migrations/2026_01_30_000_performance_live_metrics";
+
+/**
+ * Migration coverage for #6324. The live-metrics migration's `down()` originally
+ * called `db.raw(...)` — a method that does not exist on Kysely's `Kysely`
+ * instance at runtime; the API is the `sql` template tag (`sql.raw` for dynamic
+ * strings). The bug was latent only because no caller wires up rollback today.
+ * These tests exercise `down()` end-to-end so the raw-SQL copy/rename path can
+ * never silently regress to a non-existent method again.
+ */
+
+const LIVE_METRIC_COLUMNS = [
+  "time_to_first_frame_ms",
+  "time_to_interactive_ms",
+  "frame_rate_fps",
+  "node_id",
+];
+
+async function columnExists(
+  db: Kysely<unknown>,
+  table: string,
+  column: string,
+): Promise<boolean> {
+  const result = await sql<{ name: string }>`
+    SELECT name FROM pragma_table_info(${table}) WHERE name = ${column}
+  `.execute(db);
+  return result.rows.length > 0;
+}
+
+async function indexExists(db: Kysely<unknown>, name: string): Promise<boolean> {
+  const result = await sql<{ name: string }>`
+    SELECT name FROM sqlite_master WHERE type = 'index' AND name = ${name}
+  `.execute(db);
+  return result.rows.length > 0;
+}
+
+describe("2026_01_30_000_performance_live_metrics migration", () => {
+  let bunDb: BunDatabase;
+  let db: Kysely<unknown>;
+
+  beforeEach(async () => {
+    bunDb = new BunDatabase(":memory:");
+    db = new Kysely<unknown>({ dialect: new BunSqliteDialect({ database: bunDb }) });
+    // Base schema: performance_thresholds + performance_audit_results.
+    await thresholdsUp(db);
+    await liveMetricsUp(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("up added the live-metric columns and indexes", async () => {
+    for (const column of LIVE_METRIC_COLUMNS) {
+      expect(await columnExists(db, "performance_audit_results", column)).toBe(true);
+    }
+    expect(await indexExists(db, "idx_performance_audit_results_node_id")).toBe(true);
+    expect(await indexExists(db, "idx_performance_audit_results_package_timestamp")).toBe(true);
+  });
+
+  test("down() runs without throwing (raw copy/rename uses sql, not db.raw)", async () => {
+    // The regression guard: db.raw does not exist at runtime, so the original
+    // down() threw TypeError as soon as the copy step executed.
+    await expect(liveMetricsDown(db)).resolves.toBeUndefined();
+  });
+
+  test("down() drops the live-metric columns and their indexes", async () => {
+    await liveMetricsDown(db);
+
+    for (const column of LIVE_METRIC_COLUMNS) {
+      expect(await columnExists(db, "performance_audit_results", column)).toBe(false);
+    }
+    expect(await indexExists(db, "idx_performance_audit_results_node_id")).toBe(false);
+    expect(await indexExists(db, "idx_performance_audit_results_package_timestamp")).toBe(false);
+    // The original device+timestamp index is recreated.
+    expect(await indexExists(db, "idx_performance_audit_results_device_timestamp")).toBe(true);
+  });
+
+  test("down() preserves existing row data through the table rebuild", async () => {
+    await sql`
+      INSERT INTO performance_audit_results
+        (device_id, session_id, package_name, timestamp, passed,
+         p50_ms, p95_ms, node_id, frame_rate_fps)
+      VALUES
+        ('dev-1', 'sess-1', 'com.example', '2026-01-30T00:00:00Z', 1, 12.5, 30.0, 42, 60.0),
+        ('dev-2', 'sess-2', 'com.example', '2026-01-30T00:01:00Z', 0, 20.0, 55.0, 7, 45.5)
+    `.execute(db);
+
+    await liveMetricsDown(db);
+
+    const rows = await sql<{ device_id: string; session_id: string; passed: number; p50_ms: number }>`
+      SELECT device_id, session_id, passed, p50_ms
+      FROM performance_audit_results
+      ORDER BY device_id
+    `.execute(db);
+
+    expect(rows.rows).toEqual([
+      { device_id: "dev-1", session_id: "sess-1", passed: 1, p50_ms: 12.5 },
+      { device_id: "dev-2", session_id: "sess-2", passed: 0, p50_ms: 20.0 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

The `down()` in `src/db/migrations/2026_01_30_000_performance_live_metrics.ts` called `db.raw(...)` — a method that does not exist on Kysely's `Kysely` instance at runtime; the API is the `sql` template tag (`sql.raw` for dynamic strings). The bug was latent because no caller wires up migration rollback today, so the code never executed. It was flagged as an inert follow-up in [#6274](https://github.com/kaeawc/auto-mobile/pull/6274).

## Fix

Both `db.executeQuery(db.raw(...).compile(db))` calls in `down()` (the backup-table `INSERT ... SELECT` copy and the `ALTER TABLE ... RENAME`) now use the established `` sql`...`.execute(db) `` primitive, matching how every other migration in `src/db/migrations/` runs raw SQL.

## Test

Added `test/db/performanceLiveMetricsMigration.integration.test.ts` — an in-memory `BunSqliteDialect` harness that builds the base schema, applies `up()`, then exercises `down()` end-to-end: it runs without throwing, drops the live-metric columns/indexes, recreates the original index, and preserves existing row data through the table rebuild. Verified the test fails against the pre-fix `db.raw` version (3 of 4 cases throw) and passes after.

Also ratcheted `scripts/typecheck-baseline.txt` down by the two now-resolved `TS2339: Property 'raw' does not exist` errors (147 -> 145).

Closes #6324
