### PR TITLE
fix(deviceMatcher): multi-letter codename ordering + canonical release-table cross-check

### DIFF
--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -63,6 +63,19 @@ export function apiLevelToVersion(apiLevel: number): string | undefined {
   return API_LEVEL_TO_VERSION[apiLevel];
 }
 
+/**
+ * The canonical Android release table ({@link API_LEVEL_TO_VERSION}) as a list
+ * ordered ascending by API level. This is the single source of truth for the
+ * relative ordering of shipped release versions; the device matcher's
+ * `compareVersions` is cross-checked against it so the two modules can never
+ * disagree on, say, whether "12L" sorts above "12" and below "13" (#6326).
+ */
+export function canonicalReleaseVersionsByApiLevel(): { apiLevel: number; version: string }[] {
+  return Object.entries(API_LEVEL_TO_VERSION)
+    .map(([apiLevel, version]) => ({ apiLevel: Number(apiLevel), version }))
+    .sort((a, b) => a.apiLevel - b.apiLevel);
+}
+
 interface ParsedReleaseVersion {
   major: number;
   minor?: number;

--- a/src/utils/deviceMatcher.ts
+++ b/src/utils/deviceMatcher.ts
@@ -22,13 +22,19 @@ export interface DeviceMatcher {
 
 export interface ParsedDeviceVersion {
   components: number[];
-  /** A trailing single-letter release qualifier, e.g. Android 12L's "L" (#6132 follow-up). */
+  /**
+   * A trailing alphabetic release qualifier, uppercased. A single letter
+   * covers the shipped cases (Android 12L's "L", #6132 follow-up); the parser
+   * also accepts a multi-letter qualifier (e.g. a hypothetical "12Lv2"-style
+   * codename) so those order deterministically instead of failing to parse and
+   * degrading to a NaN comparison (#6326).
+   */
   letter?: string;
   qpr?: number;
 }
 
 function parseDeviceVersion(version: string): ParsedDeviceVersion | null {
-  const match = /^(\d+(?:\.\d+)*)([A-Za-z])?(?:-QPR(\d+))?$/i.exec(version.trim());
+  const match = /^(\d+(?:\.\d+)*)([A-Za-z]+)?(?:-QPR(\d+))?$/i.exec(version.trim());
   if (!match) {
     return null;
   }
@@ -51,12 +57,15 @@ function compareParsedVersions(partsA: number[], partsB: number[]): number {
 }
 
 /**
- * Orders a trailing release-qualifier letter such as Android 12L's "L": a
- * release with no letter sorts before one with a letter at the same numeric
- * components (Android 12 < 12L), and letters otherwise sort alphabetically.
- * This is a generic string-ordering rule, not an Android-specific codename
- * table -- it works for any single trailing letter without knowing what it
- * means.
+ * Orders a trailing release-qualifier such as Android 12L's "L": a release
+ * with no letter sorts before one with a letter at the same numeric components
+ * (Android 12 < 12L), and letters otherwise sort lexicographically. This is a
+ * generic string-ordering rule, not an Android-specific codename table -- it
+ * works for any trailing qualifier, single- or multi-letter (#6326), without
+ * knowing what it means. Lexicographic comparison stays a correct total order
+ * over multi-letter qualifiers too (e.g. "L" < "LA" < "LB"), so no separate
+ * length rule is needed to keep the relation reflexive, antisymmetric and
+ * transitive.
  */
 function compareLetterQualifier(letterA: string | undefined, letterB: string | undefined): number {
   if (letterA === letterB) {

--- a/test/server/deviceMatcher.test.ts
+++ b/test/server/deviceMatcher.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "bun:test";
 import { DefaultDeviceMatcher, compareVersions } from "../../src/server/deviceMatcher";
 import type { BootedDevice, DeviceInfo } from "../../src/models";
+import {
+  canonicalReleaseVersionsByApiLevel,
+  versionToApiLevelRange,
+} from "../../src/utils/android-cmdline-tools/AvdConfigReader";
 import { SeededRandom } from "../fakes/SeededRandom";
 
 const matcher = new DefaultDeviceMatcher();
@@ -98,6 +102,65 @@ describe("compareVersions", () => {
     expect(compareVersions("12L-QPR1", "12L-QPR2")).toBeLessThan(0);
     expect(compareVersions("12L-QPR1", "12L")).toBeGreaterThan(0);
     expect(compareVersions("12L-QPR1", "12")).toBeGreaterThan(0);
+  });
+
+  it("parses and totally orders a multi-letter codename qualifier (#6326)", () => {
+    // Multi-letter qualifiers previously failed to parse and degraded to a NaN
+    // comparison; they must now order like any other trailing qualifier.
+    expect(compareVersions("12", "12LA")).toBeLessThan(0);
+    expect(compareVersions("12LA", "13")).toBeLessThan(0);
+    // Lexicographic order over the qualifier string, including the prefix case
+    // (a shorter qualifier that prefixes a longer one sorts first).
+    expect(compareVersions("12L", "12LA")).toBeLessThan(0);
+    expect(compareVersions("12LA", "12LB")).toBeLessThan(0);
+    expect(compareVersions("12LB", "12LA")).toBeGreaterThan(0);
+    expect(compareVersions("12LA", "12LA")).toBe(0);
+    // Case-insensitive, like the single-letter qualifier.
+    expect(compareVersions("12la", "12LA")).toBe(0);
+  });
+
+  it("orders a multi-letter qualifier with a QPR suffix (#6326)", () => {
+    expect(compareVersions("12LA-QPR1", "12LA-QPR2")).toBeLessThan(0);
+    expect(compareVersions("12LA-QPR1", "12LA")).toBeGreaterThan(0);
+    expect(compareVersions("12LA-QPR2", "12LB")).toBeLessThan(0);
+  });
+});
+
+describe("compareVersions cross-checked against the canonical release table (#6326)", () => {
+  const canonical = canonicalReleaseVersionsByApiLevel();
+
+  it("orders every adjacent canonical release pair by ascending API level", () => {
+    for (let i = 1; i < canonical.length; i++) {
+      const lower = canonical[i - 1];
+      const higher = canonical[i];
+      expect(compareVersions(lower.version, higher.version)).toBeLessThan(0);
+      expect(compareVersions(higher.version, lower.version)).toBeGreaterThan(0);
+    }
+  });
+
+  it("agrees with AvdConfigReader's API-level ranges for every canonical pair", () => {
+    // For any two shipped releases whose API-level ranges do not overlap, the
+    // matcher's ordering must match the API-level ordering. This ties
+    // compareVersions directly to AvdConfigReader.versionToApiLevelRange so the
+    // canonical table stays the single source of truth (e.g. "12L" -> API 32
+    // must sort above "12" -> API 31 and below "13" -> API 33).
+    for (const a of canonical) {
+      for (const b of canonical) {
+        const rangeA = versionToApiLevelRange(a.version);
+        const rangeB = versionToApiLevelRange(b.version);
+        expect(rangeA).toBeDefined();
+        expect(rangeB).toBeDefined();
+        if (!rangeA || !rangeB) {
+          continue;
+        }
+        const sign = Math.sign(compareVersions(a.version, b.version));
+        if (rangeA.max < rangeB.min) {
+          expect(sign).toBe(-1);
+        } else if (rangeB.max < rangeA.min) {
+          expect(sign).toBe(1);
+        }
+      }
+    }
   });
 });
 

--- a/test/utils/deviceMatcher.property.test.ts
+++ b/test/utils/deviceMatcher.property.test.ts
@@ -88,7 +88,11 @@ describe("compareVersions (property-based)", () => {
 // oracle over the full (components, letter, qpr) triple, rather than only
 // example-based tests, per the tracking issue's explicit ask -- the
 // interactions between the three parts are easy to under-specify by hand.
-const letterOrUndefined = fc.option(fc.constantFrom("A", "L", "Q", "Z"), { nil: undefined });
+// Single- and multi-letter qualifiers (#6326): multi-letter codenames must
+// order under the same total-order contract as the single trailing letter.
+const letterOrUndefined = fc.option(fc.constantFrom("A", "L", "Q", "Z", "LA", "LB", "SV", "LZ"), {
+  nil: undefined,
+});
 const qprOrUndefined = fc.option(fc.nat(5), { nil: undefined });
 const releaseQualifier = fc.record({
   parts: versionParts,


### PR DESCRIPTION
Closes #6326

## Summary

Follow-up to [#6281](https://github.com/kaeawc/auto-mobile/pull/6281), which explicitly scoped out two items. This PR ships both:

1. **Multi-letter codename ordering.** The release-qualifier parser only captured a single trailing letter (`([A-Za-z])?`), so a multi-letter qualifier (e.g. a hypothetical `12Lv2`-style codename) failed to parse, fell through to the non-numeric branch, and degraded to a `NaN` comparison — silently unordered. The parser now accepts a multi-letter trailing qualifier (`([A-Za-z]+)?`); lexicographic comparison over the qualifier string is already a correct total order (`"L" < "LA" < "LB"`), so the relation stays reflexive, antisymmetric and transitive with no separate length rule.

2. **Canonical/shared release-ordering table, cross-checked against `AvdConfigReader.versionToApiLevelRange`.** `AvdConfigReader` now exports `canonicalReleaseVersionsByApiLevel()` — the `API_LEVEL_TO_VERSION` table as a list ordered ascending by API level, the single source of truth for release order. Tests tie `deviceMatcher`'s `compareVersions` to it, so the two modules can never disagree on relative release order (e.g. `12L` → API 32 must sort above `12` → API 31 and below `13` → API 33).

## Changes

- `src/utils/deviceMatcher.ts`: widen the trailing-qualifier capture to one-or-more letters; update the `letter` field and `compareLetterQualifier` docs to note the multi-letter total-order guarantee.
- `src/utils/android-cmdline-tools/AvdConfigReader.ts`: export `canonicalReleaseVersionsByApiLevel()`.

## Tests

- `test/server/deviceMatcher.test.ts`: example cases for multi-letter parsing/ordering (`12 < 12LA < 13`, prefix ordering `12L < 12LA`, case-insensitivity, multi-letter + QPR), plus a cross-check suite asserting `compareVersions` orders every adjacent canonical release pair by ascending API level and agrees with `versionToApiLevelRange` for every non-overlapping pair.
- `test/utils/deviceMatcher.property.test.ts`: extend the qualifier generator with multi-letter values so reflexivity, antisymmetry, transitivity, and the independent-oracle agreement properties now cover multi-letter qualifiers too.

## Validation

- `bun test test/server/deviceMatcher.test.ts test/utils/deviceMatcher.property.test.ts test/utils/android-cmdline-tools/AvdConfigReader.test.ts` — 145 pass
- Full `bun test` suite — 5937 pass, 0 fail
- `bun run typecheck` — no new baseline errors
- `bun run lint` — no new ratchet violations; boundary-checks pass
- `bun run format:check` — clean
- `bunx turbo run build` — succeeds
- `BUN_TEST_TIMING_BASE_REF=origin/main bash scripts/validate-bun-test-timings.sh` — exit 0
