### PR TITLE
fix(provisioning): exclude Android release bounds below CtrlProxy APK minSdk (24)

### DIFF
--- a/src/utils/deviceProvisioning.ts
+++ b/src/utils/deviceProvisioning.ts
@@ -206,6 +206,18 @@ function abiRank(abi: string, preferences: string[]): number {
 const LOWEST_KNOWN_API_LEVEL = 21;
 
 /**
+ * Minimum API level the AutoMobile CtrlProxy runner APK can install on. This
+ * mirrors `build-android-minSdk` in `android/gradle/libs.versions.toml` (the
+ * value `android/control-proxy/build.gradle.kts` compiles the APK with). The
+ * `startDevice` flow installs the runner APK during readiness prep, so an AVD
+ * provisioned below this level boots but can never install the runner and
+ * become automation-ready — provisioning must never select a sub-24 image
+ * (#6187). Keep this in sync with the gradle version catalog if the APK's
+ * `minSdk` ever changes.
+ */
+export const CTRL_PROXY_APK_MIN_SDK = 24;
+
+/**
  * A bound shaped exactly like a release version `versionToApiLevelRange`
  * knows how to parse: an integer major, optional dotted point-release
  * components, and an optional single trailing release letter (`"17"`,
@@ -286,11 +298,28 @@ export function pickAndroidSystemImage(
   criteria: Pick<DeviceMatchCriteria, "minOsVersion" | "maxOsVersion">,
   architecture: string,
 ): SystemImage {
-  const min = resolveApiLevelBound(criteria.minOsVersion, "min");
+  const requestedMin = resolveApiLevelBound(criteria.minOsVersion, "min");
   const max = resolveApiLevelBound(criteria.maxOsVersion, "max");
 
+  // Fail fast when the requested upper bound cannot host the runner APK
+  // (minSdk 24): an older AVD would boot but never install the runner during
+  // startDevice readiness prep, so it could never become automation-ready.
+  // Rejecting here beats creating an unusable AVD that only fails later (#6187).
+  if (max !== undefined && max < CTRL_PROXY_APK_MIN_SDK) {
+    throw new ActionableError(
+      `Requested Android maxOsVersion ${describeBound(criteria.maxOsVersion, max)} is below API ` +
+        `${CTRL_PROXY_APK_MIN_SDK}, the minimum SDK the AutoMobile CtrlProxy runner APK supports. ` +
+        "A lower AVD would boot but never install the runner and become automation-ready. " +
+        "Request Android 7.0 (API 24) or newer.",
+    );
+  }
+
+  // The runner-APK floor also raises the effective minimum, so a sub-24 image is
+  // never selected even when no (or a lower) minOsVersion was requested (#6187).
+  const min = Math.max(requestedMin ?? CTRL_PROXY_APK_MIN_SDK, CTRL_PROXY_APK_MIN_SDK);
+
   const inRange = images.filter((image) => {
-    if (min !== undefined && image.apiLevel < min) {
+    if (image.apiLevel < min) {
       return false;
     }
     if (max !== undefined && image.apiLevel > max) {
@@ -300,9 +329,16 @@ export function pickAndroidSystemImage(
   });
 
   if (inRange.length === 0) {
+    // When the runner-APK floor (not an explicit minOsVersion) is what excluded
+    // every image, describe the floor honestly rather than echoing a lower or
+    // absent requested bound.
+    const minDescription =
+      requestedMin !== undefined && requestedMin >= CTRL_PROXY_APK_MIN_SDK
+        ? describeBound(criteria.minOsVersion, min)
+        : `API ${CTRL_PROXY_APK_MIN_SDK} (CtrlProxy runner minSdk)`;
     throw new ActionableError(
       "No installed Android system image matches the requested API range " +
-        `(min=${describeBound(criteria.minOsVersion, min)}, max=${describeBound(criteria.maxOsVersion, max)}). ` +
+        `(min=${minDescription}, max=${describeBound(criteria.maxOsVersion, max)}). ` +
         `Installed images: ${images.map((image) => image.packageName).join(", ") || "none"}. ` +
         "Install one with 'sdkmanager \"system-images;android-<api>;google_apis;<abi>\"'.",
     );

--- a/test/utils/deviceProvisioning.test.ts
+++ b/test/utils/deviceProvisioning.test.ts
@@ -213,6 +213,53 @@ describe("pickAndroidSystemImage", () => {
     expect(preferredAbis("arm64")[0]).toBe("arm64-v8a");
     expect(preferredAbis("x64")[0]).toBe("x86_64");
   });
+
+  describe("CtrlProxy runner-APK minSdk floor (#6187)", () => {
+    // The runner APK targets minSdk 24; provisioning must never hand back a
+    // sub-24 image that would boot an AVD the runner can never install onto.
+    const withLegacy = [
+      systemImage(21, "google_apis", "x86_64"),
+      systemImage(23, "google_apis", "x86_64"),
+      systemImage(24, "google_apis", "x86_64"),
+      systemImage(34, "google_apis", "x86_64"),
+    ];
+
+    it("never selects an image below API 24 even without an explicit min bound", () => {
+      // API 21 is newest-by-nothing here only because 24/34 also exist; ensure a
+      // catalog whose only options are sub-24 is rejected rather than selected.
+      const onlyLegacy = [
+        systemImage(21, "google_apis", "x86_64"),
+        systemImage(23, "google_apis", "x86_64"),
+      ];
+      expect(() => pickAndroidSystemImage(onlyLegacy, {}, "x64")).toThrow(
+        /No installed Android system image.*CtrlProxy runner minSdk/,
+      );
+    });
+
+    it("clamps a below-floor min bound up to API 24 without touching valid picks", () => {
+      // minOsVersion "5.0" is Android 5.0 (API 21) — below the runner floor. The
+      // API 21/23 images stay excluded; the newest at-or-above 24 is chosen.
+      expect(pickAndroidSystemImage(withLegacy, { minOsVersion: "5.0" }, "x64").apiLevel).toBe(34);
+    });
+
+    it("fails fast when the requested max cannot host the runner APK", () => {
+      // maxOsVersion "6" is Android 6.0 (API 23): creating that AVD would fail
+      // APK install later, so provisioning rejects it up front.
+      expect(() => pickAndroidSystemImage(withLegacy, { maxOsVersion: "6" }, "x64")).toThrow(
+        ActionableError,
+      );
+      expect(() => pickAndroidSystemImage(withLegacy, { maxOsVersion: "6" }, "x64")).toThrow(
+        /below API 24.*CtrlProxy runner APK/,
+      );
+    });
+
+    it("leaves a valid at-or-above-floor bound unaffected", () => {
+      // A normal request that already sits at/above the floor selects exactly as
+      // before — the guard adds no behavior for in-support bounds.
+      expect(pickAndroidSystemImage(withLegacy, { minOsVersion: "7.0" }, "x64").apiLevel).toBe(34);
+      expect(pickAndroidSystemImage(withLegacy, { maxOsVersion: "7.0" }, "x64").apiLevel).toBe(24);
+    });
+  });
 });
 
 describe("DefaultDeviceProvisioner", () => {


### PR DESCRIPTION
## Summary

Device/AVD provisioning could pick an installed Android system image **below API 24** — the [CtrlProxy runner APK's `minSdk`](android/control-proxy/build.gradle.kts) (`build-android-minSdk` in `android/gradle/libs.versions.toml`). Now that release→API bound mapping is correct (#6176), a `maxOsVersion` like `"6"` (Android 6.0 / API 23), or an installed sub‑24 image with no bound, would provision an AVD that boots but can never install the runner during `startDevice` readiness prep — so the device never becomes automation-ready.

This is a provisioning-guard concern independent of the release-vs-API bound semantics fixed in #6176.

## Fix

`pickAndroidSystemImage` (`src/utils/deviceProvisioning.ts`) now:

- **Raises the effective floor** to the runner `minSdk`, so a sub‑24 image is never selected even when no `minOsVersion` (or a lower one) was requested.
- **Fails fast with an actionable error** when the requested `maxOsVersion` cannot host the runner APK, rather than creating an unusable AVD that only fails APK install later.

The floor reuses a single canonical constant, `CTRL_PROXY_APK_MIN_SDK = 24`, documented as mirroring the gradle version catalog (`build-android-minSdk`) — the source of truth the APK compiles with.

## Tests

Added a focused `describe("CtrlProxy runner-APK minSdk floor (#6187)")` block in `test/utils/deviceProvisioning.test.ts`:

- Never selects an image below API 24 when only sub‑24 images are installed (actionable error).
- Clamps a below-floor `minOsVersion` (`"5.0"` / API 21) up to 24 while still choosing the newest valid image.
- Fails fast when `maxOsVersion` (`"6"` / API 23) cannot host the runner APK.
- Leaves a valid at-or-above-floor bound unaffected (regression guard).

## Validation

- `bun test` on `deviceProvisioning`, `exactDeviceProvisioning`, `deviceBootService`, `deviceTools.createIfMissing`, `deviceTools.teardownDevice`, `ciIosBootRecovery` — all green.
- `bun run typecheck` — no new type errors.
- `bun run lint` — no new ratchet violations; boundary checks pass.
- `bun run build` — success.
- `BUN_TEST_TIMING_BASE_REF=origin/main scripts/validate-bun-test-timings.sh` — exit 0 (no timing regression).

Closes #6187
