### PR TITLE
fix(desktop-core): remove UnsafeCallOnNullableType Detekt regression in KeyValueInspector

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/storage/KeyValueInspector.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/storage/KeyValueInspector.kt
@@ -413,17 +413,17 @@ fun KeyValueInspector(
                             .pointerHoverIcon(PointerIcon.Hand),
                       )
                     }
-                    if (saveError != null) {
+                    saveError?.let { error ->
                       Text(
-                        saveError!!,
+                        error,
                         fontSize = 9.sp,
                         color = Color(0xFFE57373),
                         modifier = Modifier.padding(top = 2.dp),
                       )
                     }
-                    if (saveWarning != null) {
+                    saveWarning?.let { warning ->
                       Text(
-                        saveWarning!!,
+                        warning,
                         fontSize = 9.sp,
                         color = Color(0xFFFFB74D),
                         modifier = Modifier.padding(top = 2.dp),


### PR DESCRIPTION
## Problem

`:desktop-core:detektMain` has failed with "Analysis failed with 1 issues" on every On-Merge run for ~24h, keeping main red. The failure is an `UnsafeCallOnNullableType` violation in `KeyValueInspector.kt` (`!!` on the nullable Compose state `saveWarning`, with the sibling `saveError!!` the same latent pattern). Detekt is not a required PR check, so this merged red.

This **fixes the Detekt regression introduced by #6308** (issue #6292, storage inspection).

## Fix

Both `saveError` and `saveWarning` are declared as `var ... by remember { mutableStateOf<String?>(null) }`. A smart-cast on such a delegated property does not hold across the `Text()` call, so the code reached for `!!`. Replaced the `if (x != null) { Text(x!!, ...) }` blocks with idiomatic null-safe `x?.let { ... }`:

```kotlin
// before
if (saveError != null) { Text(saveError!!, ...) }
if (saveWarning != null) { Text(saveWarning!!, ...) }
// after
saveError?.let { error -> Text(error, ...) }
saveWarning?.let { warning -> Text(warning, ...) }
```

Behavior-preserving: same non-null branch condition, same rendered text, same styling — only the unsafe assertion is removed. No rule suppression, no new `!!`.

## Validation

- `./gradlew :desktop-core:detektMain` → **BUILD SUCCESSFUL**, 0 issues (was: "Analysis failed with 1 issues").
- ktfmt 0.64 `--google-style` on the file → no changes (clean).
- `:desktop-core:compileKotlin` runs clean as a detekt dependency.