### PR TITLE
fix(storage): fall back for SDK 'mutations disabled' SharedPreferences branch (#6347)

### DIFF
--- a/src/features/storage/AndroidSharedPreferencesKeyValueFile.ts
+++ b/src/features/storage/AndroidSharedPreferencesKeyValueFile.ts
@@ -162,6 +162,35 @@ export function isSharedPreferencesInspectionDisabledError(error: unknown): bool
   return /SharedPreferences inspection is disabled/i.test(errorMessage(error));
 }
 
+/**
+ * True when `error` is the SDK's *mutation* policy gate
+ * (`SharedPreferencesError.MutationNotAllowed` →
+ * `"SharedPreferences mutations are disabled by SDK policy"`), a distinct refusal from the
+ * inspection gate above. Like inspection, this policy only constrains the SDK
+ * ContentProvider route — it never touches the on-device `shared_prefs/<file>.xml`, which
+ * `setPreference` edits directly — so a mutation refused here is still reachable through the
+ * direct-file fallback (issue #6347).
+ */
+export function isSharedPreferencesMutationDisabledError(error: unknown): boolean {
+  return /SharedPreferences mutations are disabled by SDK policy/i.test(errorMessage(error));
+}
+
+/**
+ * True when a key-value mutation failed for a reason the direct-file fallback resolves:
+ * either the SDK's inspection capability is disabled (issue #6292) or its mutation policy
+ * disables writes (issue #6347). Both gates constrain only the SDK ContentProvider route,
+ * not the `adb shell run-as` XML edit that `setPreference`/`getPreference` always use, so the
+ * fallback restores write/delete/clear symmetry with `setPreference` in either case. A
+ * failure that is neither (a genuine transport/argument error, or the direct-file fallback
+ * itself failing on a non-debuggable app) is NOT matched, so its real cause still surfaces.
+ */
+export function isSharedPreferencesDirectFileFallbackError(error: unknown): boolean {
+  return (
+    isSharedPreferencesInspectionDisabledError(error) ||
+    isSharedPreferencesMutationDisabledError(error)
+  );
+}
+
 /** Outcome of {@link withAndroidSharedPreferencesInspectionFallback}. */
 export interface SharedPreferencesInspectionFallbackResult {
   /**
@@ -174,20 +203,22 @@ export interface SharedPreferencesInspectionFallbackResult {
 
 /**
  * Runs an Android SharedPreferences key-value mutation through the SDK ContentProvider
- * (`viaSdk`) and, if that fails specifically because SharedPreferences inspection is
- * disabled on the app, falls back to the same direct-file `adb shell run-as` XML edit
- * that `setPreference`/`getPreference` always use (`viaDirectFile`).
+ * (`viaSdk`) and, if that fails specifically because the SDK route is gated — SharedPreferences
+ * inspection is disabled (issue #6292) OR the SDK's mutation policy disables writes (issue
+ * #6347) — falls back to the same direct-file `adb shell run-as` XML edit that
+ * `setPreference`/`getPreference` always use (`viaDirectFile`).
  *
  * This keeps write/delete/clear reachability consistent for the same app + SharedPreferences
- * file (issue #6292) across BOTH mutation entry points — the MCP `setKeyValue`/`removeKeyValue`/
+ * file across BOTH mutation entry points — the MCP `setKeyValue`/`removeKeyValue`/
  * `clearKeyValueFile` tools and the desktop Storage pane's `ide/*` daemon-socket routes — so a
  * caller who can write a preference through `setPreference` can also delete or clear it, instead
- * of the delete/clear paths being wrongly gated behind a capability the write path never needed.
+ * of the delete/clear paths being wrongly gated behind a capability (or a policy) the write path
+ * never needed.
  *
- * A failure that is NOT the "inspection disabled" gate (e.g. a genuine transport error, or the
- * direct-file fallback itself failing because the app is not debuggable) is surfaced as-is so the
- * caller sees the real, actionable cause rather than a misleading fallback error. `createAdb` is
- * only invoked when the fallback actually runs, so no adb client is created on the happy path.
+ * A failure that is neither gate (e.g. a genuine transport error, or the direct-file fallback
+ * itself failing because the app is not debuggable) is surfaced as-is so the caller sees the real,
+ * actionable cause rather than a misleading fallback error. `createAdb` is only invoked when the
+ * fallback actually runs, so no adb client is created on the happy path.
  */
 export async function withAndroidSharedPreferencesInspectionFallback(
   appId: string,
@@ -200,11 +231,11 @@ export async function withAndroidSharedPreferencesInspectionFallback(
     await viaSdk();
     return { usedDirectFileFallback: false };
   } catch (error) {
-    if (!isSharedPreferencesInspectionDisabledError(error)) {
+    if (!isSharedPreferencesDirectFileFallbackError(error)) {
       throw error;
     }
     logger.info(
-      `[storage] SharedPreferences inspection is disabled for ${appId}; falling back to direct-file access for ${fileName} (issue #6292)`,
+      `[storage] SharedPreferences SDK route is disabled for ${appId} (inspection or mutation policy); falling back to direct-file access for ${fileName} (issues #6292, #6347)`,
     );
     const adb = createAdb();
     await viaDirectFile(adb);
@@ -223,8 +254,8 @@ export async function withAndroidSharedPreferencesInspectionFallback(
  */
 export function directFileFallbackRelaunchWarning(appId: string, fileName: string): string {
   return (
-    `Edited ${appId}'s "${fileName}" SharedPreferences file on disk directly because ` +
-    "inspection is disabled. If the app is running it may keep the old value in memory and " +
+    `Edited ${appId}'s "${fileName}" SharedPreferences file on disk directly because the ` +
+    "SDK route is disabled. If the app is running it may keep the old value in memory and " +
     "overwrite this change on its next commit — relaunch the app (or let it clear its " +
     "in-memory cache) for the change to take effect reliably."
   );

--- a/test/features/storage/AndroidSharedPreferencesKeyValueFile.test.ts
+++ b/test/features/storage/AndroidSharedPreferencesKeyValueFile.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
   clearAndroidKeyValueFileDirect,
+  isSharedPreferencesDirectFileFallbackError,
   isSharedPreferencesInspectionDisabledError,
+  isSharedPreferencesMutationDisabledError,
   removeAndroidKeyValueDirect,
   setAndroidKeyValueDirect,
 } from "../../../src/features/storage/AndroidSharedPreferencesKeyValueFile";
@@ -46,6 +48,65 @@ describe("isSharedPreferencesInspectionDisabledError", () => {
 
   test("does not match a non-Error thrown value", () => {
     expect(isSharedPreferencesInspectionDisabledError("boom")).toBe(false);
+  });
+
+  test("does NOT match the distinct mutations-disabled policy error (#6347)", () => {
+    // The inspection gate and the mutation-policy gate are separate SDK refusals; only the
+    // combined predicate below should span both.
+    expect(
+      isSharedPreferencesInspectionDisabledError(
+        new Error("SharedPreferences mutations are disabled by SDK policy"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isSharedPreferencesMutationDisabledError (#6347)", () => {
+  test("matches the SDK's disabled-mutation policy error text", () => {
+    expect(
+      isSharedPreferencesMutationDisabledError(
+        new Error(
+          "Failed to remove key-value entry: Error: SharedPreferences mutations are disabled by SDK policy",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  test("does not match the inspection-disabled error", () => {
+    expect(
+      isSharedPreferencesMutationDisabledError(
+        new Error("SharedPreferences inspection is disabled"),
+      ),
+    ).toBe(false);
+  });
+
+  test("does not match an unrelated error or a non-Error value", () => {
+    expect(isSharedPreferencesMutationDisabledError(new Error("WebSocket not connected"))).toBe(
+      false,
+    );
+    expect(isSharedPreferencesMutationDisabledError("boom")).toBe(false);
+  });
+});
+
+describe("isSharedPreferencesDirectFileFallbackError (#6292, #6347)", () => {
+  test("matches BOTH the inspection-disabled and mutations-disabled SDK gates", () => {
+    expect(
+      isSharedPreferencesDirectFileFallbackError(
+        new Error("SharedPreferences inspection is disabled"),
+      ),
+    ).toBe(true);
+    expect(
+      isSharedPreferencesDirectFileFallbackError(
+        new Error("SharedPreferences mutations are disabled by SDK policy"),
+      ),
+    ).toBe(true);
+  });
+
+  test("does not match a genuine transport/argument failure", () => {
+    expect(
+      isSharedPreferencesDirectFileFallbackError(new Error("run-as: package not debuggable")),
+    ).toBe(false);
+    expect(isSharedPreferencesDirectFileFallbackError("boom")).toBe(false);
   });
 });
 

--- a/test/server/storageTools.androidInspectionFallback.test.ts
+++ b/test/server/storageTools.androidInspectionFallback.test.ts
@@ -30,28 +30,40 @@ const APP_ID = "dev.jasonpearson.automobile.playground";
 const FILE_NAME = "settings";
 
 const INSPECTION_DISABLED_ERROR = () => new Error("SharedPreferences inspection is disabled");
+// Issue #6347: a distinct SDK refusal (SharedPreferencesError.MutationNotAllowed) that the
+// original #6292 fallback (keyed only on "inspection is disabled") did not match, re-opening the
+// setPreference/removeKeyValue asymmetry whenever the app's SDK policy disables mutations.
+const MUTATION_DISABLED_ERROR = () =>
+  new Error("SharedPreferences mutations are disabled by SDK policy");
 
-function inspectionDisabledClient(
+function disabledClient(
+  makeError: () => Error,
   overrides: Partial<AndroidKeyValueClient> = {},
 ): AndroidKeyValueClient {
   return {
     setPreference: async () => {
-      throw INSPECTION_DISABLED_ERROR();
+      throw makeError();
     },
     removePreference: async () => {
-      throw INSPECTION_DISABLED_ERROR();
+      throw makeError();
     },
     clearPreferenceStore: async () => {
-      throw INSPECTION_DISABLED_ERROR();
+      throw makeError();
     },
     listDataStores: async () => {
-      throw INSPECTION_DISABLED_ERROR();
+      throw makeError();
     },
     getDataStore: async () => {
-      throw INSPECTION_DISABLED_ERROR();
+      throw makeError();
     },
     ...overrides,
   };
+}
+
+function inspectionDisabledClient(
+  overrides: Partial<AndroidKeyValueClient> = {},
+): AndroidKeyValueClient {
+  return disabledClient(INSPECTION_DISABLED_ERROR, overrides);
 }
 
 function singleAdbFactory(adb: FakeAdbExecutor): AdbClientFactory {
@@ -228,6 +240,80 @@ describe("storageTools Android SharedPreferences-inspection fallback (#6292)", (
         key: "probeA",
       }),
     ).rejects.toThrow(/debuggable\/test build/);
+  });
+
+  test("setKeyValue falls back to the direct-file path when the SDK reports mutations disabled by policy (#6347)", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setCommandResponse(`cat shared_prefs/${FILE_NAME}.xml`, createExecResult("<map/>", ""));
+
+    setStorageToolsDependenciesForTesting({
+      androidClientFactory: () => disabledClient(MUTATION_DISABLED_ERROR),
+      adbClientFactory: singleAdbFactory(adb),
+    });
+
+    const result = await toolHandler("setKeyValue")(ANDROID_DEVICE, {
+      appId: APP_ID,
+      name: FILE_NAME,
+      key: "probeB",
+      value: "2",
+      type: "STRING",
+    });
+
+    const parsed = JSON.parse((result as any).content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.warning).toMatch(/relaunch/i);
+    expect(parsed.warning).toContain(APP_ID);
+
+    const writeCommand = adb
+      .getExecutedCommands()
+      .find((cmd) => cmd.includes(`base64 -d > shared_prefs/${FILE_NAME}.xml`));
+    expect(writeCommand).toBeDefined();
+  });
+
+  test("removeKeyValue falls back and removes a key when the SDK reports mutations disabled by policy (#6347)", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setCommandResponseSequence(`cat shared_prefs/${FILE_NAME}.xml`, [
+      createExecResult('<map><string name="probeA">1</string></map>', ""),
+    ]);
+
+    setStorageToolsDependenciesForTesting({
+      androidClientFactory: () => disabledClient(MUTATION_DISABLED_ERROR),
+      adbClientFactory: singleAdbFactory(adb),
+    });
+
+    const result = await toolHandler("removeKeyValue")(ANDROID_DEVICE, {
+      appId: APP_ID,
+      name: FILE_NAME,
+      key: "probeA",
+    });
+
+    const parsed = JSON.parse((result as any).content[0].text);
+    expect(parsed.success).toBe(true);
+
+    const writeCommand = adb
+      .getExecutedCommands()
+      .find((cmd) => cmd.includes(`base64 -d > shared_prefs/${FILE_NAME}.xml`));
+    expect(writeCommand).toBeDefined();
+    const match = writeCommand!.match(/([A-Za-z0-9+/=]{24,})/);
+    const writtenXml = Buffer.from(match![1], "base64").toString("utf8");
+    expect(writtenXml).not.toContain("probeA");
+  });
+
+  test("clearKeyValueFile falls back when the SDK reports mutations disabled by policy (#6347)", async () => {
+    const adb = new FakeAdbExecutor();
+
+    setStorageToolsDependenciesForTesting({
+      androidClientFactory: () => disabledClient(MUTATION_DISABLED_ERROR),
+      adbClientFactory: singleAdbFactory(adb),
+    });
+
+    const result = await toolHandler("clearKeyValueFile")(ANDROID_DEVICE, {
+      appId: APP_ID,
+      name: FILE_NAME,
+    });
+
+    const parsed = JSON.parse((result as any).content[0].text);
+    expect(parsed.success).toBe(true);
   });
 
   test("listDataStores rewrites the disabled-inspection error with actionable guidance (no filesystem fallback exists for DataStore)", async () => {


### PR DESCRIPTION
## Summary

[#6308](https://github.com/kaeawc/auto-mobile/pull/6308) (closing [#6292](https://github.com/kaeawc/auto-mobile/issues/6292)) gave the SharedPreferences key-value tools (`setKeyValue`/`removeKeyValue`/`clearKeyValueFile`) a direct-file fallback, but keyed it only on the SDK's `SharedPreferences inspection is disabled` message. The Android SDK has a **second, distinct** refusal — `SharedPreferences mutations are disabled by SDK policy` (`SharedPreferencesError.MutationNotAllowed`) — which that predicate never matched. So the exact `setPreference`/`removeKeyValue` asymmetry #6292 fixed survived verbatim whenever an app's SDK policy disables *mutations* rather than *inspection*.

## Root cause

`isSharedPreferencesInspectionDisabledError` (`src/features/storage/AndroidSharedPreferencesKeyValueFile.ts`) matched only `/SharedPreferences inspection is disabled/i`, and `withAndroidSharedPreferencesInspectionFallback` gated the direct-file fallback on it. `setPreference` writes `shared_prefs/<file>.xml` directly via `run-as` and never touches SDK policy, so writes kept working while delete/clear through the SDK route were refused.

## Fix (TS-side)

- Add `isSharedPreferencesMutationDisabledError` matching the SDK's mutation-policy branch (`SharedPreferences mutations are disabled by SDK policy`).
- Add a combined `isSharedPreferencesDirectFileFallbackError` (inspection-disabled OR mutation-disabled) and key `withAndroidSharedPreferencesInspectionFallback` on it, so all three key-value tools fall back to the same direct-file XML edit on **both** gates — restoring symmetry with `setPreference` across the MCP tools and the desktop `ide/*` daemon-socket routes.
- The DataStore paths keep the narrow inspection-disabled predicate: they have no direct-file fallback, and a mutation-policy refusal doesn't apply to those read operations.
- Generalized the fallback log line and the relaunch warning wording (no longer says "inspection is disabled" specifically).

## Tests

- `test/features/storage/AndroidSharedPreferencesKeyValueFile.test.ts`: unit coverage for the new predicates — the mutation-disabled matcher, the two gates staying distinct, and the combined predicate spanning both.
- `test/server/storageTools.androidInspectionFallback.test.ts`: `setKeyValue`, `removeKeyValue`, and `clearKeyValueFile` each fall back and succeed when the fake SDK client raises the mutations-disabled policy error, alongside the existing inspection-disabled fixtures.

## Validation

- `bun test` (affected storage suites): 47 pass / 0 fail.
- `bun run build`, `bun run lint` (ratchet: no new violations), `bun run typecheck` (no new type errors), `bun run format:check`: all green.
- `BUN_TEST_TIMING_BASE_REF=origin/main scripts/validate-bun-test-timings.sh`: 357 pass / 0 fail, exit 0.
- Pre-existing (unrelated) reds in `test/daemon/socketServerKeyValue.integration.test.ts` fail identically on `origin/main` without this change.

Closes #6347
