### PR TITLE
fix(localization): stop changeLocalization lying on Android API < 33

### DIFF
--- a/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
+++ b/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
@@ -3,6 +3,7 @@ import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interface
 import { readAndroidDeviceApiLevel } from "../../../utils/android-cmdline-tools/readAndroidDeviceApiLevel";
 import { logger } from "../../../utils/logger";
 import { shellQuote } from "../../../utils/shellQuote";
+import { defaultTimer, type Timer } from "../../../utils/SystemTimer";
 import { AndroidCtrlProxyClient } from "../../observe/android/AndroidCtrlProxyClient";
 import type { SettingsNamespace } from "../../observe/android";
 import type {
@@ -30,6 +31,14 @@ import {
 type TextDirectionSettingKey = "debug.force_rtl" | "force_rtl";
 const MIN_APP_LOCALE_API_LEVEL = 33;
 
+// Bounds for waiting on the framework to come back after the legacy (<33)
+// `stop; start` restart. We poll `sys.boot_completed` rather than racing the
+// read-back against an in-progress restart (issue #6346). Values are generous
+// enough for a real cold framework restart but injected via the Timer seam so
+// unit tests drive them deterministically without real sleeps.
+const FRAMEWORK_RESTART_READY_TIMEOUT_MS = 60_000;
+const FRAMEWORK_RESTART_POLL_INTERVAL_MS = 2_000;
+
 /**
  * Android implementation of {@link SystemConfigurationAdapter}. Uses
  * ADB shell commands (with an accessibility-service fast path for
@@ -45,6 +54,7 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
   constructor(
     private readonly device: BootedDevice,
     private readonly adb: AdbExecutor,
+    private readonly timer: Timer = defaultTimer,
   ) {}
 
   async setLocale(languageTag: string, options: BroadcastOptions): Promise<SetLocaleResult> {
@@ -65,7 +75,10 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
     options: BroadcastOptions,
     method: string,
   ): Promise<SetLocaleResult> {
-    const previousLanguageTag = await this.getCurrentLocaleTag();
+    // The legacy path can only change the whole device, so the previous value we
+    // record for restore is the persisted system prop we are about to overwrite —
+    // not `getCurrentLocaleTag()`, which can resolve to a per-app override.
+    const previousLanguageTag = await this.readSetting("shell getprop persist.sys.locale");
 
     try {
       await this.runShellCommand(`shell setprop persist.sys.locale ${shellQuote(languageTag)}`);
@@ -76,18 +89,37 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
         success: false,
         languageTag,
         previousLanguageTag,
-        error: `Failed to set locale: ${errorMsg}`,
+        localeScope: "system",
+        error: `Failed to set device-wide locale: ${errorMsg}`,
       };
     }
 
-    const effectiveLanguageTag = await this.getEffectiveLocaleTag();
-    if (!this.localeTagsMatch(effectiveLanguageTag, languageTag)) {
+    // Wait (bounded, via the injected Timer) for the framework to finish
+    // restarting before reading anything back. Racing the read-back against an
+    // in-progress `stop; start` is what made this path report success:false for a
+    // change it had actually applied, and wedged concurrent tools (issue #6346).
+    const frameworkReady = await this.waitForFrameworkReady();
+
+    // Read back the exact prop we wrote. `persist.sys.locale` is a plain system
+    // property, readable even while the framework is still coming up, so this
+    // never races the restart the way the old `am get-config` read-back did.
+    const persistedLanguageTag = await this.readSetting("shell getprop persist.sys.locale");
+    if (!this.localeTagsMatch(persistedLanguageTag, languageTag)) {
       return {
         success: false,
         languageTag,
         previousLanguageTag,
-        error: `Read-back verification failed: expected "${languageTag}" but got "${effectiveLanguageTag ?? "null"}"`,
+        localeScope: "system",
+        error: `Read-back verification failed: expected persist.sys.locale "${languageTag}" but got "${persistedLanguageTag ?? "null"}"`,
       };
+    }
+
+    if (!frameworkReady) {
+      logger.warn(
+        `[SystemConfigurationManager] Device-wide locale ${languageTag} was applied and persisted, ` +
+          `but the framework did not report boot_completed within ${FRAMEWORK_RESTART_READY_TIMEOUT_MS}ms after stop; start. ` +
+          "Subsequent tools may briefly see the device as not fully booted.",
+      );
     }
 
     const broadcasted = options.broadcast === false ? false : await this.broadcastLocaleChange();
@@ -97,8 +129,42 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
       languageTag,
       previousLanguageTag,
       method,
+      localeScope: "system",
       broadcasted,
     };
+  }
+
+  /**
+   * Poll `sys.boot_completed` until the framework reports it is back up after a
+   * `stop; start`, or the bounded timeout elapses. Uses the injected {@link Timer}
+   * so tests drive the restart timing deterministically instead of sleeping.
+   * Returns `true` if the framework became ready, `false` on timeout.
+   */
+  private async waitForFrameworkReady(): Promise<boolean> {
+    const deadline = this.timer.now() + FRAMEWORK_RESTART_READY_TIMEOUT_MS;
+    for (;;) {
+      let bootCompleted: string | null = null;
+      try {
+        const result = await this.adb.executeCommand(
+          "shell getprop sys.boot_completed",
+          undefined,
+          undefined,
+          true,
+        );
+        bootCompleted = normalizeSettingValue(result.stdout);
+      } catch (error) {
+        // Expected while the framework is mid-restart: the shell may briefly
+        // reject commands. Swallow and keep polling until the deadline.
+        logger.debug(`[SystemConfigurationManager] boot_completed probe failed: ${error}`);
+      }
+      if (bootCompleted === "1") {
+        return true;
+      }
+      if (this.timer.now() >= deadline) {
+        return false;
+      }
+      await this.timer.sleep(FRAMEWORK_RESTART_POLL_INTERVAL_MS);
+    }
   }
 
   private async setTargetAppLocale(
@@ -157,6 +223,7 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
       languageTag,
       previousLanguageTag,
       method: `cmd locale set-app-locales ${appId} --user ${targetUserId}`,
+      localeScope: "app",
       broadcasted,
     };
   }

--- a/src/models/SetLocaleResult.ts
+++ b/src/models/SetLocaleResult.ts
@@ -6,4 +6,16 @@ export interface SetLocaleResult {
   method?: string;
   broadcasted?: boolean;
   error?: string;
+  /**
+   * Scope the locale change was actually applied at.
+   *
+   * `"app"` means the change was scoped to a single app (Android 13+ / iOS
+   * per-app). `"system"` means it changed the whole device — which is what the
+   * legacy Android (< 13) path is forced to do even when a per-app change was
+   * requested, because the app-scoped `cmd locale` service does not exist there.
+   *
+   * Callers use this to know whether a per-app request was silently widened to
+   * the entire device (issue #6346) so they can restore global state afterwards.
+   */
+  localeScope?: "app" | "system";
 }

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -602,8 +602,15 @@ export function registerUtilityTools() {
       const result = await manager.setLocale(args.locale, localeOptions);
       if (result.success) {
         changes.locale = result.languageTag;
+        // Prefer the scope the adapter reports directly (issue #6346): on
+        // Android < 13 a per-app request is forced device-wide, and the adapter
+        // says so via localeScope: "system" rather than us inferring it from the
+        // method string.
+        const localeScope =
+          result.localeScope ??
+          (result.method?.startsWith("cmd locale set-app-locales") ? "app" : "system");
         localeMetadata = {
-          localeScope: result.method?.startsWith("cmd locale set-app-locales") ? "app" : "system",
+          localeScope,
           ...(args.appId && device.platform === "android" ? { localeAppId: args.appId } : {}),
           ...(result.method ? { localeMethod: result.method } : {}),
         };

--- a/test/features/utility/SystemConfigurationAdapter.test.ts
+++ b/test/features/utility/SystemConfigurationAdapter.test.ts
@@ -5,6 +5,7 @@ import { IosSystemConfigurationAdapter } from "../../../src/features/utility/sys
 import { createSystemConfigurationAdapter } from "../../../src/features/utility/system-configuration/createSystemConfigurationAdapter";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeProcessExecutor } from "../../fakes/FakeProcessExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
 import type { BootedDevice, ExecResult } from "../../../src/models";
 import type { SystemConfigurationAdapter } from "../../../src/utils/interfaces/SystemConfigurationAdapter";
 
@@ -210,14 +211,19 @@ describe("SystemConfigurationAdapter", () => {
       ).toBe(true);
     });
 
-    it("uses root-backed system locale after adb root below Android 13", async () => {
+    it("uses root-backed system locale after adb root below Android 13 and reports system scope", async () => {
       const adb = new FakeAdbClient();
       adb.setCommandResult("shell getprop ro.build.version.sdk", "32");
       adb.setCommandResult("root", "restarting adbd as root\n");
       adb.setCommandResult("wait-for-device", "");
       adb.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
-      adb.setCommandResult("shell settings get system system_locales", "en-US");
-      adb.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
+      // persist.sys.locale is read once for the previous value, then again for the
+      // race-free read-back after the framework restart.
+      adb.setCommandResultSequence("shell getprop persist.sys.locale", [
+        { stdout: "en-US", stderr: "" },
+        { stdout: "ja-JP", stderr: "" },
+      ]);
+      adb.setCommandResult("shell getprop sys.boot_completed", "1");
       const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
       const result = await adapter.setLocale("ja-JP", {
         broadcast: false,
@@ -226,10 +232,15 @@ describe("SystemConfigurationAdapter", () => {
 
       expect(result.success).toBe(true);
       expect(result.method).toBe("setprop persist.sys.locale + stop/start after adb root");
+      expect(result.localeScope).toBe("system");
+      expect(result.previousLanguageTag).toBe("en-US");
       expect(adb.wasCommandExecuted("root")).toBe(true);
       expect(adb.wasCommandExecuted("shell id")).toBe(true);
       expect(adb.wasCommandExecuted("cmd locale set-app-locales")).toBe(false);
       expect(adb.wasCommandExecuted("setprop persist.sys.locale 'ja-JP'")).toBe(true);
+      // Read-back verifies the prop we actually wrote, never `am get-config`,
+      // which would race the in-progress framework restart (issue #6346).
+      expect(adb.wasCommandExecuted("shell am get-config")).toBe(false);
     });
 
     it("returns a root-capability error below Android 13 when adb root fails", async () => {
@@ -323,20 +334,111 @@ describe("SystemConfigurationAdapter", () => {
       expect(adb.wasCommandExecuted("cmd locale set-app-locales")).toBe(false);
     });
 
-    it("returns false when legacy root-backed verification reads the old effective locale", async () => {
+    it("returns false with system scope when the legacy setprop read-back does not take", async () => {
       const adb = new FakeAdbClient();
       adb.setCommandResult("shell getprop ro.build.version.sdk", "32");
       adb.setCommandResult("root", "restarting adbd as root\n");
       adb.setCommandResult("wait-for-device", "");
       adb.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
-      adb.setCommandResult("shell settings get system system_locales", "en-US");
-      adb.setCommandResult("shell am get-config", "config: mcc310-mnc260-en-rUS-sw411dp\n");
+      // setprop silently no-ops (e.g. read-only prop): persist.sys.locale keeps
+      // its old value on read-back, so we honestly report failure.
+      adb.setCommandResult("shell getprop persist.sys.locale", "en-US");
+      adb.setCommandResult("shell getprop sys.boot_completed", "1");
       const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
       const result = await adapter.setLocale("ja-JP", { appId: "com.example.app" });
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Read-back verification failed: expected "ja-JP" but got "en-US"');
+      expect(result.localeScope).toBe("system");
+      expect(result.previousLanguageTag).toBe("en-US");
+      expect(result.error).toBe(
+        'Read-back verification failed: expected persist.sys.locale "ja-JP" but got "en-US"',
+      );
       expect(adb.wasCommandExecuted("am broadcast")).toBe(false);
+    });
+
+    it("reports app scope on the Android 13+ app-scoped path (issue #6346)", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop ro.build.version.sdk", "36");
+      adb.setCommandResultSequence("shell cmd locale get-app-locales 'com.example.app' --user 0", [
+        { stdout: "Locales for com.example.app for user 0 are []\n", stderr: "" },
+        { stdout: "Locales for com.example.app for user 0 are [ja-JP]\n", stderr: "" },
+      ]);
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setLocale("ja-JP", {
+        broadcast: false,
+        appId: "com.example.app",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.localeScope).toBe("app");
+      expect(adb.wasCommandExecuted("setprop persist.sys.locale")).toBe(false);
+    });
+
+    it("waits for the framework restart before the legacy read-back instead of racing it (issue #6346)", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop ro.build.version.sdk", "31");
+      adb.setCommandResult("root", "restarting adbd as root\n");
+      adb.setCommandResult("wait-for-device", "");
+      adb.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
+      // Previous value, then the value after the restart settles.
+      adb.setCommandResultSequence("shell getprop persist.sys.locale", [
+        { stdout: "en-US", stderr: "" },
+        { stdout: "es-ES", stderr: "" },
+      ]);
+      // The framework is still restarting for the first two polls (empty
+      // boot_completed) before it comes back up — mirroring the wedge in #6346.
+      adb.setCommandResultSequence("shell getprop sys.boot_completed", [
+        { stdout: "", stderr: "" },
+        { stdout: "", stderr: "" },
+        { stdout: "1", stderr: "" },
+      ]);
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any, timer);
+
+      const result = await adapter.setLocale("es-ES", {
+        broadcast: false,
+        appId: "com.android.settings",
+      });
+
+      // Result and reality agree: the change applied device-wide and we say so.
+      expect(result.success).toBe(true);
+      expect(result.localeScope).toBe("system");
+      expect(result.languageTag).toBe("es-ES");
+      expect(result.previousLanguageTag).toBe("en-US");
+      // We polled boot_completed until it returned "1" (did not read back on the
+      // first, racing, poll) and slept between polls via the injected timer.
+      expect(adb.getCommandCount("shell getprop sys.boot_completed")).toBe(3);
+      expect(timer.getSleepCallCount()).toBeGreaterThanOrEqual(2);
+      expect(adb.wasCommandExecuted("shell am get-config")).toBe(false);
+    });
+
+    it("returns success once the legacy prop is applied even if the framework never reports ready (issue #6346)", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop ro.build.version.sdk", "28");
+      adb.setCommandResult("root", "restarting adbd as root\n");
+      adb.setCommandResult("wait-for-device", "");
+      adb.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
+      adb.setCommandResultSequence("shell getprop persist.sys.locale", [
+        { stdout: "en-US", stderr: "" },
+        { stdout: "es-ES", stderr: "" },
+      ]);
+      // boot_completed never flips to "1"; the readiness wait times out but the
+      // prop-based read-back still confirms the change was applied.
+      adb.setCommandResult("shell getprop sys.boot_completed", "");
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any, timer);
+
+      const result = await adapter.setLocale("es-ES", {
+        broadcast: false,
+        appId: "com.android.settings",
+      });
+
+      // The change applied and persisted, so we must not report success:false.
+      expect(result.success).toBe(true);
+      expect(result.localeScope).toBe("system");
+      expect(result.previousLanguageTag).toBe("en-US");
     });
 
     it("ignores no-op user_locale when reading Android localization settings", async () => {

--- a/test/features/utility/SystemConfigurationManager.test.ts
+++ b/test/features/utility/SystemConfigurationManager.test.ts
@@ -630,16 +630,17 @@ describe("SystemConfigurationManager", () => {
       fakeAdbClient.setCommandResult("root", "restarting adbd as root\n");
       fakeAdbClient.setCommandResult("wait-for-device", "");
       fakeAdbClient.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
-      fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US");
-      fakeAdbClient.setCommandResult(
-        "shell am get-config",
-        "config: mcc310-mnc260-ja-rJP-sw411dp\n",
-      );
+      fakeAdbClient.setCommandResultSequence("shell getprop persist.sys.locale", [
+        { stdout: "en-US", stderr: "" },
+        { stdout: "ja-JP", stderr: "" },
+      ]);
+      fakeAdbClient.setCommandResult("shell getprop sys.boot_completed", "1");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setLocale("ja-JP", { appId: "com.example.app" });
 
       expect(result.success).toBe(true);
       expect(result.method).toBe("setprop persist.sys.locale + stop/start after adb root");
+      expect(result.localeScope).toBe("system");
       expect(fakeExec.getExecutedCommands()).toHaveLength(0);
       expect(fakeAdbClient.wasCommandExecuted("root")).toBe(true);
       expect(fakeAdbClient.wasCommandExecuted("setprop persist.sys.locale 'ja-JP'")).toBe(true);
@@ -944,21 +945,22 @@ describe("SystemConfigurationManager", () => {
       expect(fakeAdbClient.wasCommandExecuted("cmd locale set-app-locales")).toBe(false);
     });
 
-    test("sets system locale with persist.sys.locale on Android 12 after adb root and verifies am get-config", async () => {
+    test("sets system locale with persist.sys.locale on Android 12 after adb root and verifies the persisted prop", async () => {
       fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "32");
       fakeAdbClient.setCommandResult("root", "restarting adbd as root\n");
       fakeAdbClient.setCommandResult("wait-for-device", "");
       fakeAdbClient.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
-      fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US");
-      fakeAdbClient.setCommandResult(
-        "shell am get-config",
-        "config: mcc310-mnc260-ja-rJP-sw411dp\n",
-      );
+      fakeAdbClient.setCommandResultSequence("shell getprop persist.sys.locale", [
+        { stdout: "en-US", stderr: "" },
+        { stdout: "ja-JP", stderr: "" },
+      ]);
+      fakeAdbClient.setCommandResult("shell getprop sys.boot_completed", "1");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setLocale("ja-JP", { appId: "com.example.app" });
 
       expect(result.success).toBe(true);
       expect(result.method).toBe("setprop persist.sys.locale + stop/start after adb root");
+      expect(result.localeScope).toBe("system");
       expect(result.previousLanguageTag).toBe("en-US");
       expect(fakeAdbClient.wasCommandExecuted("root")).toBe(true);
       expect(fakeAdbClient.wasCommandExecuted("setprop persist.sys.locale 'ja-JP'")).toBe(true);
@@ -967,23 +969,24 @@ describe("SystemConfigurationManager", () => {
       expect(fakeAdbClient.wasCommandExecuted("settings put system user_locale ja-JP")).toBe(false);
     });
 
-    test("returns false when legacy root-backed command succeeds but effective locale is unchanged", async () => {
+    test("returns false with system scope when the legacy setprop is silently ignored", async () => {
       fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "32");
       fakeAdbClient.setCommandResult("root", "restarting adbd as root\n");
       fakeAdbClient.setCommandResult("wait-for-device", "");
       fakeAdbClient.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
-      fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US");
-      fakeAdbClient.setCommandResult(
-        "shell am get-config",
-        "config: mcc310-mnc260-en-rUS-sw411dp\n",
-      );
+      // persist.sys.locale keeps its old value: the setprop did not take.
+      fakeAdbClient.setCommandResult("shell getprop persist.sys.locale", "en-US");
+      fakeAdbClient.setCommandResult("shell getprop sys.boot_completed", "1");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setLocale("ja-JP", { appId: "com.example.app" });
 
       expect(result.success).toBe(false);
       expect(result.languageTag).toBe("ja-JP");
       expect(result.previousLanguageTag).toBe("en-US");
-      expect(result.error).toBe('Read-back verification failed: expected "ja-JP" but got "en-US"');
+      expect(result.localeScope).toBe("system");
+      expect(result.error).toBe(
+        'Read-back verification failed: expected persist.sys.locale "ja-JP" but got "en-US"',
+      );
     });
 
     test("returns command error when root-backed locale write is denied", async () => {
@@ -1000,21 +1003,22 @@ describe("SystemConfigurationManager", () => {
       const result = await mgr.setLocale("ja-JP", { appId: "com.example.app" });
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain("Failed to set locale");
+      expect(result.error).toContain("Failed to set device-wide locale");
       expect(result.error).toContain("permission denied");
     });
 
-    test("reads previous locale from system_locales without consulting user_locale", async () => {
+    test("reads previous locale from persist.sys.locale without consulting user_locale", async () => {
       fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "32");
       fakeAdbClient.setCommandResult("root", "restarting adbd as root\n");
       fakeAdbClient.setCommandResult("wait-for-device", "");
       fakeAdbClient.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
-      fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US,fr-FR");
       fakeAdbClient.setCommandResult("shell settings get system user_locale", "ja-JP");
-      fakeAdbClient.setCommandResult(
-        "shell am get-config",
-        "config: mcc310-mnc260-ja-rJP-sw411dp\n",
-      );
+      // The legacy path restores from the device-wide prop it overwrites.
+      fakeAdbClient.setCommandResultSequence("shell getprop persist.sys.locale", [
+        { stdout: "en-US", stderr: "" },
+        { stdout: "ja-JP", stderr: "" },
+      ]);
+      fakeAdbClient.setCommandResult("shell getprop sys.boot_completed", "1");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setLocale("ja-JP", { appId: "com.example.app" });
 


### PR DESCRIPTION
## Summary

Closes #6346.

On Android API < 33, `changeLocalization` cannot make a *per-app* locale change
(the `cmd locale` LocaleManager service does not exist), so it falls back to a
*device-wide* `setprop persist.sys.locale` plus a framework `stop; start`. Two
bugs made that path lie:

1. It read the change back with `am get-config` **immediately** after
   `stop; start`, racing the still-restarting framework. The read returned
   `null`, so the tool reported `success: false` — even though the prop had
   already been written and persisted. Nothing restored it, so the device was
   left in the new locale with the caller believing nothing happened, and the
   in-progress framework restart wedged every concurrent tool for 1–2 minutes
   as a misleading "device may not be fully booted".
2. It never reported that a per-app request had been silently widened to the
   whole device, unlike the API 33+ and iOS paths which report their scope
   honestly.

## Contract implemented

Per the issue's "Expected" (apply the system-wide change **and say so**, with
`success: true` and a restorable `previousLanguageTag`):

- **Result and reality agree.** The legacy read-back now verifies the exact
  property we wrote — `getprop persist.sys.locale` — which is readable even
  while the framework is still coming up, so it never races the restart. If the
  prop took, we return `success: true`; if a silent no-op left the old value,
  we return `success: false` honestly (nothing was applied).
- **No racing the restart.** After `stop; start` we wait, bounded, for
  `sys.boot_completed == 1` before returning, via the injected `Timer` seam
  (no raw sleeps). If the framework never reports ready within the bound we
  still return the truthful prop-based result (and log a warning) rather than
  hanging or lying.
- **Honest scope.** `SetLocaleResult` gains a `localeScope: "app" | "system"`
  field. The legacy path reports `"system"` (even on the failure branch, so a
  caller knows global state may have changed and can restore from
  `previousLanguageTag`); the API 33+ app path reports `"app"`. The
  `changeLocalization` tool now surfaces the adapter's reported scope directly
  instead of inferring it from the method string, so a per-app request that had
  to go device-wide is never silently presented as app-scoped.

API 33+ and iOS paths are unchanged in behavior.

## Files

- `src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts`
  — prop-based race-free read-back, bounded `waitForFrameworkReady()` via the
  injected `Timer`, `localeScope` on every return, honest previous-value read.
- `src/models/SetLocaleResult.ts` — add `localeScope`.
- `src/server/utilityTools.ts` — prefer the adapter's reported `localeScope`.

## Tests

Unit tests use the executor + `FakeTimer` fakes (no real device, no real
sleeps):

- legacy `< 33` path returns `success: true` + `localeScope: "system"` +
  restorable `previousLanguageTag`, and never calls `am get-config`;
- the read-back waits for the framework restart (drives a fake
  `boot_completed` sequence `"","","1"` and asserts the poll count + timer
  sleeps) instead of racing it;
- when the framework never reports ready, the prop-based read-back still yields
  a truthful `success: true`;
- a silently-ignored `setprop` yields an honest `success: false` with
  `localeScope: "system"`;
- the app-scoped path reports `localeScope: "app"`.

## Validation

`bun test` (adapter + manager suites) green; `bun run typecheck` (no new
errors), `bun run lint` (no new ratchet violations), `bun run build` all pass.

On-device confirmation on an API 28/31 emulator is still ideal since this is
device-behavior, but the racing read-back and scope dishonesty are fully
reproduced and pinned by the fakes.
