### PR TITLE
feat(rotate): support persistent orientation locks

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -8018,6 +8018,10 @@
           "type": "string",
           "enum": ["portrait", "landscape"]
         },
+        "lockOrientation": {
+          "description": "Android only. true keeps the requested orientation locked after rotation; false explicitly restores automatic rotation after a persistent request. Omit to preserve the existing behavior.",
+          "type": "boolean"
+        },
         "platform": {
           "type": "string",
           "enum": ["android", "ios"]

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -390,11 +390,27 @@ export class Rotate extends BaseVisualChange {
     orientation: "portrait" | "landscape",
     value: number,
     currentOrientation: string,
-  ): Promise<RotateResult> {
+  ): Promise<RotateResult | null> {
+    const liveRotation = await this.readLiveRotation();
+    if (liveRotation === null) {
+      // The normal rotation path can still establish the requested orientation
+      // when the exact live rotation is temporarily unavailable.
+      return null;
+    }
+    const liveOrientation = liveRotation === 0 || liveRotation === 2 ? "portrait" : "landscape";
+    if (liveOrientation !== orientation) {
+      // The display changed after the initial read; perform a normal requested
+      // rotation instead of locking a now-opposite orientation.
+      return null;
+    }
+
     try {
-      // Do not write user_rotation here: an already-applied reverse
-      // orientation (mRotation 2 or 3) must remain reverse when locked.
+      // Android applies user_rotation when auto-rotate is disabled. Persist
+      // the exact live value before the lock so stale settings cannot rotate
+      // an already-matching (including reverse) display.
+      await this.writeSystemSetting("user_rotation", String(liveRotation));
       await this.writeSystemSetting("accelerometer_rotation", "0");
+      await this.awaitIdle.waitForRotation(liveRotation);
     } catch (error) {
       logger.warn(`Failed to lock the current ${orientation} orientation: ${error}`, error);
       return {
@@ -411,17 +427,24 @@ export class Rotate extends BaseVisualChange {
     }
 
     const orientationLockState = await this.getOrientationLockState();
-    if (orientationLockState !== "locked") {
+    const confirmedRotation = await this.readLiveRotation();
+    if (orientationLockState !== "locked" || confirmedRotation !== liveRotation) {
+      const achievedOrientation =
+        confirmedRotation === null
+          ? "unknown"
+          : confirmedRotation === 0 || confirmedRotation === 2
+            ? "portrait"
+            : "landscape";
       return {
         success: false,
         orientation,
         value,
-        currentOrientation,
+        currentOrientation: achievedOrientation,
         previousOrientation: currentOrientation,
         rotationPerformed: false,
         orientationLockHandled: false,
         orientationLockState,
-        error: `Device is already in ${orientation} orientation, but the persistent orientation lock could not be confirmed (auto-rotate is ${orientationLockState}).`,
+        error: `Device was already in ${orientation} orientation, but its exact locked rotation could not be confirmed (auto-rotate is ${orientationLockState}).`,
       };
     }
 

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -1,7 +1,7 @@
 import { Mutex } from "async-mutex";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { BaseVisualChange } from "./BaseVisualChange";
-import { BootedDevice, RotateResult } from "../../models";
+import { BootedDevice, OrientationLockState, RotateResult } from "../../models";
 import { logger } from "../../utils/logger";
 import { ProgressCallback } from "./BaseVisualChange";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
@@ -378,6 +378,187 @@ export class Rotate extends BaseVisualChange {
     return parseInt(val, 10) === 0 ? "locked" : "enabled";
   }
 
+  private async getOrientationLockState(): Promise<OrientationLockState> {
+    const autoRotateState = await this.getAutoRotateState();
+    if (autoRotateState === "unknown") {
+      return "unknown";
+    }
+    return autoRotateState === "locked" ? "locked" : "unlocked";
+  }
+
+  private async handleAlreadyAppliedOrientation(
+    orientation: "portrait" | "landscape",
+    value: number,
+    currentOrientation: string,
+    autoRotateState: "locked" | "enabled" | "unknown",
+    preserveLock: boolean,
+    restoreAutomaticRotation: boolean,
+  ): Promise<RotateResult | null> {
+    if (currentOrientation !== orientation) {
+      return null;
+    }
+
+    const initialOrientationLockState: OrientationLockState =
+      autoRotateState === "locked"
+        ? "locked"
+        : autoRotateState === "enabled"
+          ? "unlocked"
+          : "unknown";
+    if (
+      (preserveLock && initialOrientationLockState === "locked") ||
+      (restoreAutomaticRotation && initialOrientationLockState === "unlocked") ||
+      (!preserveLock && !restoreAutomaticRotation)
+    ) {
+      return {
+        success: true,
+        orientation,
+        value,
+        currentOrientation,
+        previousOrientation: currentOrientation,
+        rotationPerformed: false,
+        orientationLockHandled: false,
+        orientationLockState: initialOrientationLockState,
+        message: `Device is already in ${orientation} orientation`,
+      };
+    }
+
+    if (!restoreAutomaticRotation) {
+      return null;
+    }
+
+    const { achievedOrientation, warning } =
+      await this.restoreAutoRotateAndConfirmOrientation(orientation);
+    const orientationLockState = await this.getOrientationLockState();
+    if (orientationLockState !== "unlocked") {
+      return {
+        success: false,
+        orientation,
+        value,
+        currentOrientation: achievedOrientation,
+        previousOrientation: currentOrientation,
+        rotationPerformed: false,
+        orientationLockHandled: true,
+        orientationLockState,
+        error: `Automatic rotation could not be confirmed as restored (orientation lock is ${orientationLockState}).`,
+      };
+    }
+    return {
+      success: true,
+      orientation,
+      value,
+      currentOrientation: achievedOrientation,
+      previousOrientation: currentOrientation,
+      rotationPerformed: false,
+      orientationLockHandled: true,
+      orientationLockState,
+      warning,
+      message: `Restored automatic rotation; device is currently ${achievedOrientation}.`,
+    };
+  }
+
+  private resolveAutoRotatePlan(
+    autoRotateState: "locked" | "enabled" | "unknown",
+    lockOrientation: boolean | undefined,
+  ): {
+    preserveLock: boolean;
+    restoreAutomaticRotation: boolean;
+    wasAutoRotateEnabled: boolean;
+    shouldRestoreAutoRotate: boolean;
+    canForceAutoRotateOff: boolean;
+  } {
+    const preserveLock = lockOrientation === true;
+    const restoreAutomaticRotation = lockOrientation === false;
+    const wasAutoRotateEnabled = autoRotateState === "enabled";
+    return {
+      preserveLock,
+      restoreAutomaticRotation,
+      wasAutoRotateEnabled,
+      shouldRestoreAutoRotate: restoreAutomaticRotation || (wasAutoRotateEnabled && !preserveLock),
+      // The default preserves the #6199 guard against mutating an
+      // unconfirmed setting. Explicit requests deliberately own the
+      // resulting state, so they can force auto-rotate off first.
+      canForceAutoRotateOff: lockOrientation !== undefined || autoRotateState !== "unknown",
+    };
+  }
+
+  private logAutoRotatePlan(
+    autoRotateState: "locked" | "enabled" | "unknown",
+    preserveLock: boolean,
+    restoreAutomaticRotation: boolean,
+  ): void {
+    if (preserveLock) {
+      logger.info("Keeping the requested orientation locked after rotation");
+    } else if (restoreAutomaticRotation) {
+      logger.info("Rotating before explicitly restoring automatic rotation");
+    } else if (autoRotateState === "locked") {
+      logger.info("Orientation is locked; forcing the requested rotation");
+    } else if (autoRotateState === "enabled") {
+      logger.info("Auto-rotate is on; temporarily disabling it to force rotation");
+    } else {
+      logger.info(
+        "accelerometer_rotation is unreadable; setting user_rotation only, without forcing accelerometer_rotation (no confirmed prior state to restore)",
+      );
+    }
+  }
+
+  private async finalizeAndroidRotation(
+    orientation: "portrait" | "landscape",
+    value: number,
+    currentOrientation: string,
+    achievedOrientation: string,
+    warning: string | undefined,
+    restoreConfirmed: boolean,
+    preserveLock: boolean,
+    restoreAutomaticRotation: boolean,
+    wasAutoRotateEnabled: boolean,
+  ): Promise<RotateResult> {
+    const orientationLockState = await this.getOrientationLockState();
+    if (preserveLock && orientationLockState !== "locked") {
+      return {
+        success: false,
+        orientation,
+        value,
+        currentOrientation: orientation,
+        previousOrientation: currentOrientation,
+        rotationPerformed: true,
+        orientationLockHandled: false,
+        orientationLockState,
+        error: `Rotated to ${orientation}, but the persistent orientation lock could not be confirmed (auto-rotate is ${orientationLockState}).`,
+      };
+    }
+    if (restoreAutomaticRotation && orientationLockState !== "unlocked") {
+      return {
+        success: false,
+        orientation,
+        value,
+        currentOrientation: achievedOrientation,
+        previousOrientation: currentOrientation,
+        rotationPerformed: true,
+        orientationLockHandled: true,
+        orientationLockState,
+        error: `Rotated to ${orientation}, but automatic rotation could not be confirmed as restored (orientation lock is ${orientationLockState}).`,
+      };
+    }
+    return {
+      success: true,
+      orientation,
+      value,
+      currentOrientation: achievedOrientation,
+      previousOrientation: currentOrientation,
+      rotationPerformed: true,
+      orientationLockHandled: wasAutoRotateEnabled,
+      orientationLockState,
+      warning,
+      message: this.buildRotationMessage(
+        orientation,
+        currentOrientation,
+        achievedOrientation,
+        warning,
+        restoreConfirmed,
+      ),
+    };
+  }
+
   /**
    * Check if orientation is locked
    * @returns Promise with boolean indicating if auto-rotation is disabled
@@ -403,6 +584,7 @@ export class Rotate extends BaseVisualChange {
   async execute(
     orientation: "portrait" | "landscape",
     progress?: ProgressCallback,
+    lockOrientation?: boolean,
   ): Promise<RotateResult> {
     const perf = createGlobalPerformanceTracker();
     perf.serial("rotate");
@@ -411,7 +593,7 @@ export class Rotate extends BaseVisualChange {
       case "ios":
         return this.executeIosRotation(orientation, progress, perf);
       case "android":
-        return this.executeAndroidRotation(orientation, progress, perf);
+        return this.executeAndroidRotation(orientation, progress, perf, lockOrientation);
       default:
         throw new Error(`Unsupported platform: ${this.device.platform}`);
     }
@@ -469,6 +651,7 @@ export class Rotate extends BaseVisualChange {
     orientation: "portrait" | "landscape",
     progress: ProgressCallback | undefined,
     perf: ReturnType<typeof createGlobalPerformanceTracker>,
+    lockOrientation: boolean | undefined,
   ): Promise<RotateResult> {
     return this.observedInteraction(
       // The read-auto-rotate -> disable -> rotate -> restore-auto-rotate
@@ -478,7 +661,9 @@ export class Rotate extends BaseVisualChange {
       // (#6199 review). Different devices use independent locks and never
       // wait on each other.
       () =>
-        this.getRotationLock().runExclusive(() => this.performAndroidRotation(orientation, perf)),
+        this.getRotationLock().runExclusive(() =>
+          this.performAndroidRotation(orientation, perf, lockOrientation),
+        ),
       {
         changeExpected: true,
         timeoutMs: 5000,
@@ -499,6 +684,7 @@ export class Rotate extends BaseVisualChange {
   private async performAndroidRotation(
     orientation: "portrait" | "landscape",
     perf: ReturnType<typeof createGlobalPerformanceTracker>,
+    lockOrientation: boolean | undefined,
   ): Promise<RotateResult> {
     const value = orientation === "portrait" ? 0 : 1;
 
@@ -507,45 +693,35 @@ export class Rotate extends BaseVisualChange {
       Promise.all([this.getCurrentOrientation(), this.getAutoRotateState()]),
     );
 
-    // Check if device is already in the desired orientation
-    if (currentOrientation === orientation) {
-      return {
-        success: true,
-        orientation,
-        value,
-        currentOrientation,
-        previousOrientation: currentOrientation,
-        rotationPerformed: false,
-        orientationLockHandled: false,
-        message: `Device is already in ${orientation} orientation`,
-      };
+    const {
+      preserveLock,
+      restoreAutomaticRotation,
+      wasAutoRotateEnabled,
+      shouldRestoreAutoRotate,
+      canForceAutoRotateOff,
+    } = this.resolveAutoRotatePlan(autoRotateState, lockOrientation);
+    const alreadyApplied = await this.handleAlreadyAppliedOrientation(
+      orientation,
+      value,
+      currentOrientation,
+      autoRotateState,
+      preserveLock,
+      restoreAutomaticRotation,
+    );
+    if (alreadyApplied) {
+      return alreadyApplied;
     }
 
     // Auto-rotate must be off for `user_rotation` writes to take effect,
     // regardless of whether it was already off beforehand. Remember the
     // pre-existing value so it can be restored once the forced rotation
     // completes, instead of leaving auto-rotate permanently disabled
-    // (#6129). Only restore when we CONFIRMED auto-rotate was on beforehand
-    // — an unreadable/malformed reading must never be fabricated into a
-    // state to restore (#6199 review).
-    const wasAutoRotateEnabled = autoRotateState === "enabled";
-    // When the prior state is unconfirmed, do not touch accelerometer_rotation
-    // at all: forcing it to 0 would be a real mutation of device state we
-    // have no confirmed value to restore afterward. Only write user_rotation
-    // in that case and let waitForRotation report honestly whether it took
-    // effect (#6199 review).
-    const canForceAutoRotateOff = autoRotateState !== "unknown";
+    // (#6129). An explicit persistent request takes ownership of this state,
+    // while explicit false restores automatic rotation even after a previous
+    // persistent request.
 
     try {
-      if (autoRotateState === "locked") {
-        logger.info("Orientation is locked; forcing the requested rotation");
-      } else if (autoRotateState === "enabled") {
-        logger.info("Auto-rotate is on; temporarily disabling it to force rotation");
-      } else {
-        logger.info(
-          "accelerometer_rotation is unreadable; setting user_rotation only, without forcing accelerometer_rotation (no confirmed prior state to restore)",
-        );
-      }
+      this.logAutoRotatePlan(autoRotateState, preserveLock, restoreAutomaticRotation);
 
       await perf.track("setRotation", async () => {
         if (canForceAutoRotateOff) {
@@ -571,31 +747,26 @@ export class Rotate extends BaseVisualChange {
       let warning: string | undefined;
       let restoreConfirmed = true;
 
-      if (wasAutoRotateEnabled) {
+      if (shouldRestoreAutoRotate) {
         ({ achievedOrientation, warning, restoreConfirmed } =
           await this.restoreAutoRotateAndConfirmOrientation(orientation));
       }
 
-      return {
-        success: true,
+      return this.finalizeAndroidRotation(
         orientation,
         value,
-        currentOrientation: achievedOrientation,
-        previousOrientation: currentOrientation,
-        rotationPerformed: true,
-        orientationLockHandled: wasAutoRotateEnabled,
+        currentOrientation,
+        achievedOrientation,
         warning,
-        message: this.buildRotationMessage(
-          orientation,
-          currentOrientation,
-          achievedOrientation,
-          warning,
-          restoreConfirmed,
-        ),
-      };
+        restoreConfirmed,
+        preserveLock,
+        restoreAutomaticRotation,
+        wasAutoRotateEnabled,
+      );
     } catch (error) {
-      // Restore auto-rotate if it was on before this call
-      if (wasAutoRotateEnabled) {
+      // Restore auto-rotate on a failed temporary/explicit-unlock operation.
+      // A persistent request intentionally leaves its lock in place.
+      if (shouldRestoreAutoRotate) {
         try {
           await this.writeSystemSetting("accelerometer_rotation", "1");
           logger.info("Restored auto-rotate after error");

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -10,6 +10,13 @@ import { IOSCtrlProxyClient } from "../observe/ios";
 import { AndroidCtrlProxyClient } from "../observe/android/AndroidCtrlProxyClient";
 import { parseWindowManagerRotation } from "../../utils/android-cmdline-tools/parseWindowManagerRotation";
 
+type AlreadyAppliedOrientationDecision =
+  | { kind: "handled"; result: RotateResult }
+  | {
+      kind: "requires-rotation";
+      reason: "orientation-differs" | "live-rotation-unavailable" | "live-orientation-changed";
+    };
+
 export class Rotate extends BaseVisualChange {
   // Serializes the read-auto-rotate -> disable -> rotate -> restore-auto-rotate
   // critical section per device, so two concurrent rotations against the SAME
@@ -390,18 +397,18 @@ export class Rotate extends BaseVisualChange {
     orientation: "portrait" | "landscape",
     value: number,
     currentOrientation: string,
-  ): Promise<RotateResult | null> {
+  ): Promise<AlreadyAppliedOrientationDecision> {
     const liveRotation = await this.readLiveRotation();
     if (liveRotation === null) {
       // The normal rotation path can still establish the requested orientation
       // when the exact live rotation is temporarily unavailable.
-      return null;
+      return { kind: "requires-rotation", reason: "live-rotation-unavailable" };
     }
     const liveOrientation = liveRotation === 0 || liveRotation === 2 ? "portrait" : "landscape";
     if (liveOrientation !== orientation) {
       // The display changed after the initial read; perform a normal requested
       // rotation instead of locking a now-opposite orientation.
-      return null;
+      return { kind: "requires-rotation", reason: "live-orientation-changed" };
     }
 
     try {
@@ -414,15 +421,18 @@ export class Rotate extends BaseVisualChange {
     } catch (error) {
       logger.warn(`Failed to lock the current ${orientation} orientation: ${error}`, error);
       return {
-        success: false,
-        orientation,
-        value,
-        currentOrientation,
-        previousOrientation: currentOrientation,
-        rotationPerformed: false,
-        orientationLockHandled: false,
-        orientationLockState: await this.getOrientationLockState(),
-        error: `Failed to lock the device in its current ${orientation} orientation: ${error}`,
+        kind: "handled",
+        result: {
+          success: false,
+          orientation,
+          value,
+          currentOrientation,
+          previousOrientation: currentOrientation,
+          rotationPerformed: false,
+          orientationLockHandled: false,
+          orientationLockState: await this.getOrientationLockState(),
+          error: `Failed to lock the device in its current ${orientation} orientation: ${error}`,
+        },
       };
     }
 
@@ -436,28 +446,34 @@ export class Rotate extends BaseVisualChange {
             ? "portrait"
             : "landscape";
       return {
-        success: false,
-        orientation,
-        value,
-        currentOrientation: achievedOrientation,
-        previousOrientation: currentOrientation,
-        rotationPerformed: false,
-        orientationLockHandled: false,
-        orientationLockState,
-        error: `Device was already in ${orientation} orientation, but its exact locked rotation could not be confirmed (auto-rotate is ${orientationLockState}).`,
+        kind: "handled",
+        result: {
+          success: false,
+          orientation,
+          value,
+          currentOrientation: achievedOrientation,
+          previousOrientation: currentOrientation,
+          rotationPerformed: false,
+          orientationLockHandled: false,
+          orientationLockState,
+          error: `Device was already in ${orientation} orientation, but its exact locked rotation could not be confirmed (auto-rotate is ${orientationLockState}).`,
+        },
       };
     }
 
     return {
-      success: true,
-      orientation,
-      value,
-      currentOrientation,
-      previousOrientation: currentOrientation,
-      rotationPerformed: false,
-      orientationLockHandled: true,
-      orientationLockState,
-      message: `Locked device orientation to ${orientation}.`,
+      kind: "handled",
+      result: {
+        success: true,
+        orientation,
+        value,
+        currentOrientation,
+        previousOrientation: currentOrientation,
+        rotationPerformed: false,
+        orientationLockHandled: true,
+        orientationLockState,
+        message: `Locked device orientation to ${orientation}.`,
+      },
     };
   }
 
@@ -480,9 +496,9 @@ export class Rotate extends BaseVisualChange {
     autoRotateState: "locked" | "enabled" | "unknown",
     preserveLock: boolean,
     restoreAutomaticRotation: boolean,
-  ): Promise<RotateResult | null> {
+  ): Promise<AlreadyAppliedOrientationDecision> {
     if (currentOrientation !== orientation) {
-      return null;
+      return { kind: "requires-rotation", reason: "orientation-differs" };
     }
 
     const initialOrientationLockState: OrientationLockState =
@@ -499,15 +515,18 @@ export class Rotate extends BaseVisualChange {
       )
     ) {
       return {
-        success: true,
-        orientation,
-        value,
-        currentOrientation,
-        previousOrientation: currentOrientation,
-        rotationPerformed: false,
-        orientationLockHandled: false,
-        orientationLockState: initialOrientationLockState,
-        message: `Device is already in ${orientation} orientation`,
+        kind: "handled",
+        result: {
+          success: true,
+          orientation,
+          value,
+          currentOrientation,
+          previousOrientation: currentOrientation,
+          rotationPerformed: false,
+          orientationLockHandled: false,
+          orientationLockState: initialOrientationLockState,
+          message: `Device is already in ${orientation} orientation`,
+        },
       };
     }
 
@@ -516,7 +535,7 @@ export class Rotate extends BaseVisualChange {
     }
 
     if (!restoreAutomaticRotation) {
-      return null;
+      return { kind: "requires-rotation", reason: "orientation-differs" };
     }
 
     const { achievedOrientation, warning } =
@@ -524,7 +543,24 @@ export class Rotate extends BaseVisualChange {
     const orientationLockState = await this.getOrientationLockState();
     if (orientationLockState !== "unlocked") {
       return {
-        success: false,
+        kind: "handled",
+        result: {
+          success: false,
+          orientation,
+          value,
+          currentOrientation: achievedOrientation,
+          previousOrientation: currentOrientation,
+          rotationPerformed: false,
+          orientationLockHandled: true,
+          orientationLockState,
+          error: `Automatic rotation could not be confirmed as restored (orientation lock is ${orientationLockState}).`,
+        },
+      };
+    }
+    return {
+      kind: "handled",
+      result: {
+        success: true,
         orientation,
         value,
         currentOrientation: achievedOrientation,
@@ -532,20 +568,9 @@ export class Rotate extends BaseVisualChange {
         rotationPerformed: false,
         orientationLockHandled: true,
         orientationLockState,
-        error: `Automatic rotation could not be confirmed as restored (orientation lock is ${orientationLockState}).`,
-      };
-    }
-    return {
-      success: true,
-      orientation,
-      value,
-      currentOrientation: achievedOrientation,
-      previousOrientation: currentOrientation,
-      rotationPerformed: false,
-      orientationLockHandled: true,
-      orientationLockState,
-      warning,
-      message: `Restored automatic rotation; device is currently ${achievedOrientation}.`,
+        warning,
+        message: `Restored automatic rotation; device is currently ${achievedOrientation}.`,
+      },
     };
   }
 
@@ -804,9 +829,12 @@ export class Rotate extends BaseVisualChange {
       preserveLock,
       restoreAutomaticRotation,
     );
-    if (alreadyApplied) {
-      return alreadyApplied;
+    if (alreadyApplied.kind === "handled") {
+      return alreadyApplied.result;
     }
+    logger.debug(
+      `[Rotate] Continuing with requested rotation: ${alreadyApplied.reason.replaceAll("-", " ")}`,
+    );
 
     // Auto-rotate must be off for `user_rotation` writes to take effect,
     // regardless of whether it was already off beforehand. Remember the

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -386,6 +386,70 @@ export class Rotate extends BaseVisualChange {
     return autoRotateState === "locked" ? "locked" : "unlocked";
   }
 
+  private async lockAlreadyAppliedOrientation(
+    orientation: "portrait" | "landscape",
+    value: number,
+    currentOrientation: string,
+  ): Promise<RotateResult> {
+    try {
+      // Do not write user_rotation here: an already-applied reverse
+      // orientation (mRotation 2 or 3) must remain reverse when locked.
+      await this.writeSystemSetting("accelerometer_rotation", "0");
+    } catch (error) {
+      logger.warn(`Failed to lock the current ${orientation} orientation: ${error}`, error);
+      return {
+        success: false,
+        orientation,
+        value,
+        currentOrientation,
+        previousOrientation: currentOrientation,
+        rotationPerformed: false,
+        orientationLockHandled: false,
+        orientationLockState: await this.getOrientationLockState(),
+        error: `Failed to lock the device in its current ${orientation} orientation: ${error}`,
+      };
+    }
+
+    const orientationLockState = await this.getOrientationLockState();
+    if (orientationLockState !== "locked") {
+      return {
+        success: false,
+        orientation,
+        value,
+        currentOrientation,
+        previousOrientation: currentOrientation,
+        rotationPerformed: false,
+        orientationLockHandled: false,
+        orientationLockState,
+        error: `Device is already in ${orientation} orientation, but the persistent orientation lock could not be confirmed (auto-rotate is ${orientationLockState}).`,
+      };
+    }
+
+    return {
+      success: true,
+      orientation,
+      value,
+      currentOrientation,
+      previousOrientation: currentOrientation,
+      rotationPerformed: false,
+      orientationLockHandled: true,
+      orientationLockState,
+      message: `Locked device orientation to ${orientation}.`,
+    };
+  }
+
+  private shouldReturnAlreadyAppliedOrientation(
+    preserveLock: boolean,
+    restoreAutomaticRotation: boolean,
+    initialOrientationLockState: OrientationLockState,
+  ): boolean {
+    return (
+      (preserveLock && initialOrientationLockState === "locked") ||
+      (restoreAutomaticRotation && initialOrientationLockState === "unlocked") ||
+      (!preserveLock && !restoreAutomaticRotation)
+    );
+  }
+
   private async handleAlreadyAppliedOrientation(
     orientation: "portrait" | "landscape",
     value: number,
@@ -405,9 +469,11 @@ export class Rotate extends BaseVisualChange {
           ? "unlocked"
           : "unknown";
     if (
-      (preserveLock && initialOrientationLockState === "locked") ||
-      (restoreAutomaticRotation && initialOrientationLockState === "unlocked") ||
-      (!preserveLock && !restoreAutomaticRotation)
+      this.shouldReturnAlreadyAppliedOrientation(
+        preserveLock,
+        restoreAutomaticRotation,
+        initialOrientationLockState,
+      )
     ) {
       return {
         success: true,
@@ -420,6 +486,10 @@ export class Rotate extends BaseVisualChange {
         orientationLockState: initialOrientationLockState,
         message: `Device is already in ${orientation} orientation`,
       };
+    }
+
+    if (preserveLock) {
+      return this.lockAlreadyAppliedOrientation(orientation, value, currentOrientation);
     }
 
     if (!restoreAutomaticRotation) {

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -513,6 +513,7 @@ export class Rotate extends BaseVisualChange {
     wasAutoRotateEnabled: boolean,
   ): Promise<RotateResult> {
     const orientationLockState = await this.getOrientationLockState();
+    const rotationPerformed = currentOrientation !== orientation;
     if (preserveLock && orientationLockState !== "locked") {
       return {
         success: false,
@@ -520,10 +521,10 @@ export class Rotate extends BaseVisualChange {
         value,
         currentOrientation: orientation,
         previousOrientation: currentOrientation,
-        rotationPerformed: true,
+        rotationPerformed,
         orientationLockHandled: false,
         orientationLockState,
-        error: `Rotated to ${orientation}, but the persistent orientation lock could not be confirmed (auto-rotate is ${orientationLockState}).`,
+        error: `${rotationPerformed ? `Rotated to ${orientation}` : `Device is already in ${orientation} orientation`}, but the persistent orientation lock could not be confirmed (auto-rotate is ${orientationLockState}).`,
       };
     }
     if (restoreAutomaticRotation && orientationLockState !== "unlocked") {
@@ -533,7 +534,7 @@ export class Rotate extends BaseVisualChange {
         value,
         currentOrientation: achievedOrientation,
         previousOrientation: currentOrientation,
-        rotationPerformed: true,
+        rotationPerformed,
         orientationLockHandled: true,
         orientationLockState,
         error: `Rotated to ${orientation}, but automatic rotation could not be confirmed as restored (orientation lock is ${orientationLockState}).`,
@@ -545,17 +546,19 @@ export class Rotate extends BaseVisualChange {
       value,
       currentOrientation: achievedOrientation,
       previousOrientation: currentOrientation,
-      rotationPerformed: true,
+      rotationPerformed,
       orientationLockHandled: wasAutoRotateEnabled,
       orientationLockState,
       warning,
-      message: this.buildRotationMessage(
-        orientation,
-        currentOrientation,
-        achievedOrientation,
-        warning,
-        restoreConfirmed,
-      ),
+      message: rotationPerformed
+        ? this.buildRotationMessage(
+            orientation,
+            currentOrientation,
+            achievedOrientation,
+            warning,
+            restoreConfirmed,
+          )
+        : `Locked device orientation to ${orientation}.`,
     };
   }
 

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -725,13 +725,16 @@ export class Rotate extends BaseVisualChange {
 
       await perf.track("setRotation", async () => {
         if (canForceAutoRotateOff) {
-          await Promise.all([
-            this.writeSystemSetting("accelerometer_rotation", "0"),
-            this.writeSystemSetting("user_rotation", String(value)),
-          ]);
+          // user_rotation is honored only after automatic rotation is disabled.
+          // Keeping these writes ordered avoids a target write racing ahead of
+          // the lock on devices where the settings provider completes slowly.
+          await this.writeSystemSetting("accelerometer_rotation", "0");
         } else {
-          await this.writeSystemSetting("user_rotation", String(value));
+          logger.debug(
+            "[Rotate] accelerometer_rotation is unconfirmed; writing user_rotation without changing the lock state",
+          );
         }
+        await this.writeSystemSetting("user_rotation", String(value));
       });
 
       // Wait for rotation to complete (also serves as verification)
@@ -783,6 +786,7 @@ export class Rotate extends BaseVisualChange {
         previousOrientation: currentOrientation,
         rotationPerformed: false,
         orientationLockHandled: wasAutoRotateEnabled,
+        orientationLockState: await this.getOrientationLockState(),
         error: `Failed to change device orientation: ${error}`,
       };
     }

--- a/src/models/RotateResult.ts
+++ b/src/models/RotateResult.ts
@@ -1,6 +1,12 @@
 import { BaseActionResult } from "./BaseActionResult";
 
 /**
+ * Whether Android automatic rotation is disabled, enabled, or could not be
+ * confirmed after a rotation operation.
+ */
+export type OrientationLockState = "locked" | "unlocked" | "unknown";
+
+/**
  * Result of a rotate operation
  */
 export interface RotateResult extends BaseActionResult {
@@ -12,6 +18,11 @@ export interface RotateResult extends BaseActionResult {
   previousOrientation?: string;
   rotationPerformed?: boolean;
   orientationLockHandled?: boolean;
+  /**
+   * Android automatic-rotation state after the operation. A persistent
+   * rotation succeeds only when this is confirmed as "locked".
+   */
+  orientationLockState?: OrientationLockState;
   message?: string;
   warning?: string;
 }

--- a/src/server/interactionToolTypes.ts
+++ b/src/server/interactionToolTypes.ts
@@ -202,6 +202,11 @@ export interface RecentAppsArgs {
 
 export interface RotateArgs {
   orientation: "portrait" | "landscape";
+  /**
+   * Android only. `true` keeps the requested orientation locked; `false`
+   * explicitly restores automatic rotation; omit to preserve prior behavior.
+   */
+  lockOrientation?: boolean;
   platform?: Platform;
 }
 

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -41,6 +41,7 @@ import {
   type DragAndDropResult,
   type ImeActionResult,
   type PressButtonResult,
+  type RotateResult,
   type SelectAllTextResult,
   type TapOnElementResult,
   type TapOnSelectedElement,
@@ -1536,6 +1537,51 @@ export async function imeActionHandler(
   }
 }
 
+// Injection seam for the rotate handler. In particular, persistent-orientation
+// failures must reach MCP clients as errors rather than success-shaped results.
+export type RotateLike = Pick<Rotate, "execute">;
+
+let rotateFactory: (device: BootedDevice) => RotateLike = (device) => new Rotate(device);
+
+export function setRotateFactory(factory: (device: BootedDevice) => RotateLike): void {
+  rotateFactory = factory;
+}
+
+export function resetRotateFactory(): void {
+  rotateFactory = (device) => new Rotate(device);
+}
+
+export function formatRotateMessage(
+  result: Pick<RotateResult, "success" | "orientation" | "error" | "message">,
+): string {
+  if (!result.success) {
+    return `Failed to rotate device: ${result.error || "unknown error"}`;
+  }
+  return result.message ?? `Rotated device to ${result.orientation} orientation`;
+}
+
+export async function rotateHandler(
+  device: BootedDevice,
+  args: RotateArgs,
+  progress?: ProgressCallback,
+) {
+  try {
+    if (args.lockOrientation !== undefined && device.platform !== "android") {
+      throw new ActionableError("lockOrientation is supported only on Android devices.");
+    }
+    const rotate = rotateFactory(device);
+    const result = await rotate.execute(args.orientation, progress, args.lockOrientation);
+    const response = createJSONToolResponse({
+      observation: result.observation,
+      ...result,
+      message: formatRotateMessage(result),
+    });
+    return result.success ? response : { ...response, isError: true as const };
+  } catch (error) {
+    throw new ActionableError(`Failed to rotate device: ${error}`);
+  }
+}
+
 // ============================================================================
 // Tool Registration
 // ============================================================================
@@ -1959,29 +2005,6 @@ export function registerInteractionTools() {
       });
     } catch (error) {
       throw new ActionableError(`Failed to go to home screen: ${error}`);
-    }
-  };
-
-  // Rotate handler
-  const rotateHandler = async (
-    device: BootedDevice,
-    args: RotateArgs,
-    progress?: ProgressCallback,
-  ) => {
-    try {
-      if (args.lockOrientation !== undefined && device.platform !== "android") {
-        throw new ActionableError("lockOrientation is supported only on Android devices.");
-      }
-      const rotate = new Rotate(device);
-      const result = await rotate.execute(args.orientation, progress, args.lockOrientation);
-
-      return createJSONToolResponse({
-        message: `Rotated device to ${args.orientation} orientation`,
-        observation: result.observation,
-        ...result,
-      });
-    } catch (error) {
-      throw new ActionableError(`Failed to rotate device: ${error}`);
     }
   };
 

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -896,6 +896,12 @@ export const homeScreenSchema = addDeviceTargetingToSchema(
 export const rotateSchema = addDeviceTargetingToSchema(
   z.object({
     orientation: z.enum(["portrait", "landscape"]),
+    lockOrientation: z
+      .boolean()
+      .optional()
+      .describe(
+        "Android only. true keeps the requested orientation locked after rotation; false explicitly restores automatic rotation after a persistent request. Omit to preserve the existing behavior.",
+      ),
     // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
     // not required — a device handle from getAndroid/getApple is sufficient on
     // its own.
@@ -1963,8 +1969,11 @@ export function registerInteractionTools() {
     progress?: ProgressCallback,
   ) => {
     try {
+      if (args.lockOrientation !== undefined && device.platform !== "android") {
+        throw new ActionableError("lockOrientation is supported only on Android devices.");
+      }
       const rotate = new Rotate(device);
-      const result = await rotate.execute(args.orientation, progress);
+      const result = await rotate.execute(args.orientation, progress, args.lockOrientation);
 
       return createJSONToolResponse({
         message: `Rotated device to ${args.orientation} orientation`,

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -494,6 +494,7 @@ describe("Rotate", () => {
       expect(result.success).toBe(true);
       expect(result.rotationPerformed).toBe(true);
       expect(result.orientationLockHandled).toBe(true);
+      expect(result.orientationLockState).toBe("unlocked");
       expect(result.warning).toBeUndefined();
       // Auto-rotate must be forced off to apply user_rotation, then restored.
       expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 0")).toBe(
@@ -507,6 +508,97 @@ describe("Rotate", () => {
         .getExecutedCommands()
         .filter((cmd) => cmd.includes("settings put system accelerometer_rotation"));
       expect(accelWrites.at(-1)).toContain("accelerometer_rotation 1");
+    });
+
+    test("keeps a requested portrait locked when the sensor prefers landscape (#6350)", async () => {
+      // The device begins physically landscape with auto-rotate on. A durable
+      // portrait request must leave accelerometer_rotation disabled instead of
+      // restoring it and letting the sensor snap back to landscape.
+      fakeAdb.setCommandResponseSequence("shell settings get system accelerometer_rotation", [
+        createExecResult("1"),
+        createExecResult("0"),
+      ]);
+      fakeAdb.setCommandResponse(
+        'shell dumpsys window | grep -i "mRotation="',
+        createExecResult("mRotation=1"),
+      );
+
+      const result = await rotate.execute("portrait", undefined, true);
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      expect(result.currentOrientation).toBe("portrait");
+      expect(result.orientationLockState).toBe("locked");
+      expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 1")).toBe(
+        false,
+      );
+      expect(fakeAwaitIdle.wasMethodCalled("waitForRotation(0")).toBe(true);
+    });
+
+    test("keeps a requested landscape locked when the sensor prefers portrait (#6350)", async () => {
+      fakeAdb.setCommandResponseSequence("shell settings get system accelerometer_rotation", [
+        createExecResult("1"),
+        createExecResult("0"),
+      ]);
+      fakeAdb.setCommandResponse(
+        'shell dumpsys window | grep -i "mRotation="',
+        createExecResult("mRotation=0"),
+      );
+
+      const result = await rotate.execute("landscape", undefined, true);
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      expect(result.currentOrientation).toBe("landscape");
+      expect(result.orientationLockState).toBe("locked");
+      expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 1")).toBe(
+        false,
+      );
+      expect(fakeAwaitIdle.wasMethodCalled("waitForRotation(1")).toBe(true);
+    });
+
+    test("reports a persistent rotation as unconfirmed when the lock cannot be verified (#6350)", async () => {
+      // The rotation itself is confirmed by waitForRotation, but the
+      // authoritative setting read still reports auto-rotate enabled.
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      fakeAdb.setCommandResponse(
+        'shell dumpsys window | grep -i "mRotation="',
+        createExecResult("mRotation=1"),
+      );
+
+      const result = await rotate.execute("portrait", undefined, true);
+
+      expect(result.success).toBe(false);
+      expect(result.rotationPerformed).toBe(true);
+      expect(result.currentOrientation).toBe("portrait");
+      expect(result.orientationLockState).toBe("unlocked");
+      expect(result.error ?? "").toMatch(/persistent.*could not be confirmed/i);
+    });
+
+    test("explicitly restores automatic rotation after a persistent request (#6350)", async () => {
+      // This is the documented inverse of lockOrientation: true. The desired
+      // orientation is already applied, so the operation must still re-enable
+      // automatic rotation rather than taking the existing no-op return path.
+      fakeAdb.setCommandResponseSequence("shell settings get system accelerometer_rotation", [
+        createExecResult("0"),
+        createExecResult("1"),
+      ]);
+      fakeAdb.setCommandResponse(
+        'shell dumpsys window | grep -i "mRotation="',
+        createExecResult("mRotation=0"),
+      );
+
+      const result = await rotate.execute("portrait", undefined, false);
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(false);
+      expect(result.orientationLockState).toBe("unlocked");
+      expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 1")).toBe(
+        true,
+      );
     });
 
     test("should not mutate accelerometer_rotation at all when it is unreadable (#6199)", async () => {

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -446,6 +446,50 @@ describe("Rotate", () => {
       expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 1")).toBe(true);
     });
 
+    test("disables auto-rotate before writing a persistent target rotation (#6350)", async () => {
+      fakeAdb.setCommandResponseSequence("shell settings get system accelerometer_rotation", [
+        createExecResult("1"),
+        createExecResult("0"),
+      ]);
+      fakeAdb.setCommandResponse(
+        'shell dumpsys window | grep -i "mRotation="',
+        createExecResult("mRotation=0"),
+      );
+
+      let releaseDisableWrite: (() => void) | undefined;
+      let disableWriteStarted = false;
+      let userRotationWriteStarted = false;
+      const disableWriteGate = new Promise<void>((resolve) => {
+        releaseDisableWrite = resolve;
+      });
+      const originalExecuteCommand = fakeAdb.executeCommand.bind(fakeAdb);
+      fakeAdb.executeCommand = (async (command: string, ...rest: unknown[]) => {
+        if (command.includes("settings put system accelerometer_rotation 0")) {
+          disableWriteStarted = true;
+          await disableWriteGate;
+        }
+        if (command.includes("settings put system user_rotation 1")) {
+          userRotationWriteStarted = true;
+        }
+        return (originalExecuteCommand as (...args: unknown[]) => Promise<ExecResult>)(
+          command,
+          ...rest,
+        );
+      }) as typeof fakeAdb.executeCommand;
+
+      const rotation = rotate.execute("landscape", undefined, true);
+      for (let i = 0; i < 50 && !disableWriteStarted; i++) {
+        await Promise.resolve();
+      }
+
+      expect(disableWriteStarted).toBe(true);
+      expect(userRotationWriteStarted).toBe(false);
+
+      releaseDisableWrite!();
+      const result = await rotation;
+      expect(result.success).toBe(true);
+    });
+
     test("should rotate directly (without unlocking) when orientation is already locked", async () => {
       // Setup: device is landscape with orientation locked
       fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("1"));
@@ -576,6 +620,31 @@ describe("Rotate", () => {
       expect(result.currentOrientation).toBe("portrait");
       expect(result.orientationLockState).toBe("unlocked");
       expect(result.error ?? "").toMatch(/persistent.*could not be confirmed/i);
+    });
+
+    test("reports the remaining lock state after a persistent target write fails (#6350)", async () => {
+      // Disabling auto-rotate can succeed before the target write fails. The
+      // failure result must expose that the device remains locked rather than
+      // leaving callers unable to determine which cleanup action is needed.
+      fakeAdb.setCommandResponseSequence("shell settings get system accelerometer_rotation", [
+        createExecResult("1"),
+        createExecResult("0"),
+      ]);
+      fakeAdb.setCommandResponse(
+        'shell dumpsys window | grep -i "mRotation="',
+        createExecResult("mRotation=1"),
+      );
+      fakeAdb.setCommandError(
+        "shell settings put system user_rotation 0",
+        new Error("settings provider unavailable"),
+      );
+
+      const result = await rotate.execute("portrait", undefined, true);
+
+      expect(result.success).toBe(false);
+      expect(result.rotationPerformed).toBe(false);
+      expect(result.orientationLockState).toBe("locked");
+      expect(result.error ?? "").toContain("settings provider unavailable");
     });
 
     test("explicitly restores automatic rotation after a persistent request (#6350)", async () => {

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -619,12 +619,18 @@ describe("Rotate", () => {
       expect(result.rotationPerformed).toBe(false);
       expect(result.orientationLockState).toBe("locked");
       expect(result.message).toBe("Locked device orientation to landscape.");
+      const commands = fakeAdb.getExecutedCommands();
+      expect(commands.indexOf("shell settings put system user_rotation 1")).toBeGreaterThan(-1);
+      expect(commands.indexOf("shell settings put system user_rotation 1")).toBeLessThan(
+        commands.indexOf("shell settings put system accelerometer_rotation 0"),
+      );
+      expect(fakeAwaitIdle.wasMethodCalled("waitForRotation(1")).toBe(true);
     });
 
     test("locks reverse portrait without forcing canonical portrait rotation (#6350)", async () => {
       // mRotation=2 is reverse portrait. Locking it must preserve the exact
-      // live rotation, rather than writing canonical user_rotation=0 and
-      // rotating the display by 180 degrees.
+      // live rotation by saving user_rotation=2 before disabling auto-rotate,
+      // rather than writing canonical user_rotation=0 and rotating 180 degrees.
       fakeAdb.setCommandResponseSequence("shell settings get system accelerometer_rotation", [
         createExecResult("1"),
         createExecResult("0"),
@@ -639,8 +645,9 @@ describe("Rotate", () => {
       expect(result.success).toBe(true);
       expect(result.rotationPerformed).toBe(false);
       expect(result.orientationLockState).toBe("locked");
+      expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 2")).toBe(true);
       expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 0")).toBe(false);
-      expect(fakeAwaitIdle.wasMethodCalled("waitForRotation(")).toBe(false);
+      expect(fakeAwaitIdle.wasMethodCalled("waitForRotation(2")).toBe(true);
     });
 
     test("reports a persistent rotation as unconfirmed when the lock cannot be verified (#6350)", async () => {

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -621,6 +621,28 @@ describe("Rotate", () => {
       expect(result.message).toBe("Locked device orientation to landscape.");
     });
 
+    test("locks reverse portrait without forcing canonical portrait rotation (#6350)", async () => {
+      // mRotation=2 is reverse portrait. Locking it must preserve the exact
+      // live rotation, rather than writing canonical user_rotation=0 and
+      // rotating the display by 180 degrees.
+      fakeAdb.setCommandResponseSequence("shell settings get system accelerometer_rotation", [
+        createExecResult("1"),
+        createExecResult("0"),
+      ]);
+      fakeAdb.setCommandResponse(
+        'shell dumpsys window | grep -i "mRotation="',
+        createExecResult("mRotation=2"),
+      );
+
+      const result = await rotate.execute("portrait", undefined, true);
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(false);
+      expect(result.orientationLockState).toBe("locked");
+      expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 0")).toBe(false);
+      expect(fakeAwaitIdle.wasMethodCalled("waitForRotation(")).toBe(false);
+    });
+
     test("reports a persistent rotation as unconfirmed when the lock cannot be verified (#6350)", async () => {
       // The rotation itself is confirmed by waitForRotation, but the
       // authoritative setting read still reports auto-rotate enabled.

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -601,6 +601,26 @@ describe("Rotate", () => {
       expect(fakeAwaitIdle.wasMethodCalled("waitForRotation(1")).toBe(true);
     });
 
+    test("reports a lock-only request without claiming a rotation (#6350)", async () => {
+      // The display is already landscape, but auto-rotate must still be
+      // disabled to make that orientation persistent.
+      fakeAdb.setCommandResponseSequence("shell settings get system accelerometer_rotation", [
+        createExecResult("1"),
+        createExecResult("0"),
+      ]);
+      fakeAdb.setCommandResponse(
+        'shell dumpsys window | grep -i "mRotation="',
+        createExecResult("mRotation=1"),
+      );
+
+      const result = await rotate.execute("landscape", undefined, true);
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(false);
+      expect(result.orientationLockState).toBe("locked");
+      expect(result.message).toBe("Locked device orientation to landscape.");
+    });
+
     test("reports a persistent rotation as unconfirmed when the lock cannot be verified (#6350)", async () => {
       // The rotation itself is confirmed by waitForRotation, but the
       // authoritative setting read still reports auto-rotate enabled.

--- a/test/server/interactionTools.actionHandlersIsError.test.ts
+++ b/test/server/interactionTools.actionHandlersIsError.test.ts
@@ -8,13 +8,16 @@ import {
   resetDragAndDropFactory,
   resetImeActionFactory,
   resetPressButtonFactory,
+  resetRotateFactory,
   resetSelectAllTextFactory,
   resetTapAnyElementFactory,
+  rotateHandler,
   selectAllTextHandler,
   setClearTextFactory,
   setDragAndDropFactory,
   setImeActionFactory,
   setPressButtonFactory,
+  setRotateFactory,
   setSelectAllTextFactory,
   setTapAnyElementFactory,
   tapAnyHandler,
@@ -24,6 +27,7 @@ import type {
   DragAndDropArgs,
   ImeActionArgs,
   PressButtonArgs,
+  RotateArgs,
   SelectAllTextArgs,
   TapAnyArgs,
 } from "../../src/server/interactionToolTypes";
@@ -33,6 +37,7 @@ import type {
   DragAndDropResult,
   ImeActionResult,
   PressButtonResult,
+  RotateResult,
   SelectAllTextResult,
   TapOnElementResult,
 } from "../../src/models";
@@ -272,5 +277,57 @@ describe("imeActionHandler (registered handler wiring)", () => {
     const response = (await imeActionHandler(fakeDevice, args)) as ToolResponse;
     expect(response.isError).toBeUndefined();
     expect(parsePayload(response).message).toBe('Executed IME action "done"');
+  });
+});
+
+describe("rotateHandler (registered handler wiring)", () => {
+  const args: RotateArgs = {
+    orientation: "portrait",
+    lockOrientation: true,
+    platform: "android",
+  };
+
+  afterEach(() => {
+    resetRotateFactory();
+  });
+
+  const fakeResult = (overrides: Partial<RotateResult>): RotateResult => ({
+    success: false,
+    orientation: "portrait",
+    value: 0,
+    ...overrides,
+  });
+
+  test("a persistent-lock failure is an MCP error, not a successful rotation", async () => {
+    setRotateFactory(() => ({
+      execute: async () =>
+        fakeResult({
+          error: "Rotated to portrait, but the persistent orientation lock could not be confirmed.",
+          orientationLockState: "unlocked",
+        }),
+    }));
+
+    const response = (await rotateHandler(fakeDevice, args)) as ToolResponse;
+
+    expect(response.isError).toBe(true);
+    expect(parsePayload(response).success).toBe(false);
+    expect(parsePayload(response).message).toContain(
+      "Failed to rotate device: Rotated to portrait",
+    );
+  });
+
+  test("forwards lockOrientation to the rotate implementation", async () => {
+    let receivedLockOrientation: boolean | undefined;
+    setRotateFactory(() => ({
+      execute: async (_orientation, _progress, lockOrientation) => {
+        receivedLockOrientation = lockOrientation;
+        return fakeResult({ success: true });
+      },
+    }));
+
+    const response = (await rotateHandler(fakeDevice, args)) as ToolResponse;
+
+    expect(response.isError).toBeUndefined();
+    expect(receivedLockOrientation).toBe(true);
   });
 });

--- a/test/server/toolSchemaHelpers.test.ts
+++ b/test/server/toolSchemaHelpers.test.ts
@@ -400,7 +400,44 @@ describe("appId aliases on tool schemas", () => {
   });
 });
 
+describe("rotateSchema", () => {
+  test("documents opt-in persistent locking and explicit automatic-rotation restoration", () => {
+    const persistent = rotateSchema.safeParse({
+      orientation: "landscape",
+      lockOrientation: true,
+      platform: "android",
+    });
+    const restoreAutomatic = rotateSchema.safeParse({
+      orientation: "landscape",
+      lockOrientation: false,
+      platform: "android",
+    });
+    const defaultBehavior = rotateSchema.safeParse({
+      orientation: "landscape",
+      platform: "android",
+    });
+
+    expect(persistent.success).toBe(true);
+    expect(restoreAutomatic.success).toBe(true);
+    expect(defaultBehavior.success).toBe(true);
+  });
+});
+
 describe("generated tool definitions", () => {
+  test("rotate generated schema documents persistent locking and restoration", () => {
+    const schemas = JSON.parse(readFileSync("schemas/tool-definitions.json", "utf8")) as Array<{
+      name: string;
+      inputSchema?: { properties?: Record<string, unknown> };
+    }>;
+    const rotate = schemas.find((schema) => schema.name === "rotate");
+
+    expect(rotate?.inputSchema?.properties?.lockOrientation).toEqual({
+      description:
+        "Android only. true keeps the requested orientation locked after rotation; false explicitly restores automatic rotation after a persistent request. Omit to preserve the existing behavior.",
+      type: "boolean",
+    });
+  });
+
   test("changeLocalization generated schema conditionally requires appId for Android locale changes", () => {
     const schemas = JSON.parse(readFileSync("schemas/tool-definitions.json", "utf8")) as Array<{
       name: string;


### PR DESCRIPTION
## Summary

Adds `rotate.lockOrientation` for Android:

- `true` keeps the requested portrait or landscape orientation locked after live rotation verification.
- `false` explicitly restores automatic rotation, including after a prior persistent request.
- Omitting the field preserves the prior restore-the-original-auto-rotate behavior.

The result now reports `orientationLockState` as `locked`, `unlocked`, or `unknown`. A persistent request returns a typed failure when the resulting lock cannot be confirmed.

## Linked Issue

Closes [#6350](https://github.com/kaeawc/auto-mobile/issues/6350).

## Validation

- [x] `bun test test/features/action/Rotate.test.ts test/server/toolSchemaHelpers.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] Generated `schemas/tool-definitions.json`
- [x] New tests use existing fakes and `FakeTimer`

## Risk

Android-only behavior using the existing system-setting and live-window-manager rotation paths. No CtrlProxy runner or platform artifact changes.
