### PR TITLE
fix(rotate): report live orientation when persistent locking fails

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -168,6 +168,26 @@ fresh CtrlProxy can use `sendKeys` after explicitly enabling it.
 | 🔔 <code>getNotificationPolicy</code> / 🔔 <code>setNotificationPolicy</code>  | Reads or changes app notification and Do Not Disturb policy.                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | 🛂 <code>getAppPermissions</code> / 🛂 <code>setAppPermissions</code>          | Reads or changes app permissions.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
+### Keeping an Android orientation locked
+
+`rotate` preserves its existing behavior when `lockOrientation` is omitted: it
+temporarily disables auto-rotate when necessary, then restores the prior
+setting. To keep portrait or landscape orientation in effect for subsequent
+actions, pass `lockOrientation: true`:
+
+```json
+{ "orientation": "landscape", "lockOrientation": true }
+```
+
+The result reports `orientationLockState` as `locked`, `unlocked`, or `unknown`.
+A persistent request succeeds only after live rotation and the lock are
+confirmed. If lock verification fails, `currentOrientation` reports the latest
+confirmed live orientation, or `unknown` when it cannot be read.
+
+To restore automatic rotation, pass `lockOrientation: false`, for example
+`{ "orientation": "landscape", "lockOrientation": false }`. These lock options
+are supported only on Android.
+
 ### Acquiring a device: `avdName`, `udid`, and the `deviceId` alias
 
 `getAndroid` and `getApple` each accept two ways to name a target; pass one.

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -633,11 +633,14 @@ export class Rotate extends BaseVisualChange {
     const orientationLockState = await this.getOrientationLockState();
     const rotationPerformed = currentOrientation !== orientation;
     if (preserveLock && orientationLockState !== "locked") {
+      // Auto-rotate may already have restored the sensor-held orientation.
+      // Reuse the bounded live read; stale user_rotation cannot confirm it.
+      const confirmation = await this.confirmOrientationAfterAutoRotateRestore(orientation, false);
       return {
         success: false,
         orientation,
         value,
-        currentOrientation: orientation,
+        currentOrientation: confirmation.achievedOrientation,
         previousOrientation: currentOrientation,
         rotationPerformed,
         orientationLockHandled: false,

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -650,26 +650,34 @@ describe("Rotate", () => {
       expect(fakeAwaitIdle.wasMethodCalled("waitForRotation(2")).toBe(true);
     });
 
-    test("reports a persistent rotation as unconfirmed when the lock cannot be verified (#6350)", async () => {
-      // The rotation itself is confirmed by waitForRotation, but the
-      // authoritative setting read still reports auto-rotate enabled.
-      fakeAdb.setCommandResponse(
-        "shell settings get system accelerometer_rotation",
-        createExecResult("1"),
-      );
-      fakeAdb.setCommandResponse(
-        'shell dumpsys window | grep -i "mRotation="',
-        createExecResult("mRotation=1"),
-      );
+    test.each([
+      { liveRotation: "mRotation=3", expectedOrientation: "landscape" },
+      { liveRotation: "unavailable", expectedOrientation: "unknown" },
+    ])(
+      "reports $expectedOrientation after persistent lock verification fails (#6350)",
+      async ({ liveRotation, expectedOrientation }) => {
+        // waitForRotation confirmed the requested portrait, but auto-rotate is
+        // still enabled: the sensor may already have restored landscape.
+        fakeAdb.setCommandResponse(
+          "shell settings get system accelerometer_rotation",
+          createExecResult("1"),
+        );
+        fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+          createExecResult("mRotation=1"),
+          createExecResult(liveRotation),
+          createExecResult(liveRotation),
+          createExecResult(liveRotation),
+        ]);
 
-      const result = await rotate.execute("portrait", undefined, true);
+        const result = await rotate.execute("portrait", undefined, true);
 
-      expect(result.success).toBe(false);
-      expect(result.rotationPerformed).toBe(true);
-      expect(result.currentOrientation).toBe("portrait");
-      expect(result.orientationLockState).toBe("unlocked");
-      expect(result.error ?? "").toMatch(/persistent.*could not be confirmed/i);
-    });
+        expect(result.success).toBe(false);
+        expect(result.rotationPerformed).toBe(true);
+        expect(result.currentOrientation).toBe(expectedOrientation);
+        expect(result.orientationLockState).toBe("unlocked");
+        expect(result.error ?? "").toMatch(/persistent.*could not be confirmed/i);
+      },
+    );
 
     test("reports the remaining lock state after a persistent target write fails (#6350)", async () => {
       // Disabling auto-rotate can succeed before the target write fails. The


### PR DESCRIPTION
When an Android persistent orientation lock cannot be confirmed, the sensor may already have restored the opposite orientation. The failure response previously reported the requested orientation as current. It now reuses the bounded live rotation check and reports the confirmed orientation, or `unknown` when that check cannot read it.

This is a narrow follow-up to [PR 6358](https://github.com/kaeawc/auto-mobile/pull/6358) and [issue 6350](https://github.com/kaeawc/auto-mobile/issues/6350). It retains the merged persistent-lock implementation, including reverse-orientation and already-applied handling, and adds usage documentation for lock/unlock requests. No new dependency or runner artifact is required.

Validation:

- The sensor-reversion case failed against main and passed with the fix; regression coverage also checks unreadable live rotation.
- All 51 Rotate tests pass, including existing reverse-orientation and default-behavior cases.
- `bun run turbo:validate`: all seven tasks passed.
- `scripts/all_fast_validate_checks.sh`: 35 passed.
- `bun run typecheck` and `bun run format:check`: passed.
- `BUN_TEST_TIMING_BASE_REF=origin/main bash scripts/validate-bun-test-timings.sh`: passed.

Validation uses existing fakes and FakeTimer; no on-device test is claimed.
