### PR TITLE
test: repair storage routing and Windows logging regressions

### DIFF
--- a/test/daemon/socketServerKeyValue.integration.test.ts
+++ b/test/daemon/socketServerKeyValue.integration.test.ts
@@ -127,6 +127,7 @@ describe("UnixSocketServer key-value mutation platform routing (#4708)", () => {
       null,
       { sessionToolSelectionService: profileService },
       undefined,
+      {},
       adbClientFactory,
     );
     await server.start();

--- a/test/utils/logPruner.test.ts
+++ b/test/utils/logPruner.test.ts
@@ -484,6 +484,8 @@ describe("logPruner daemon-discovery caching per sweep (issue #6194)", () => {
         ownPrefix: "stdio-111",
         maxOwnFiles: 10,
         abandonedMaxAgeMs: -1,
+        // Windows file mtimes can be ahead of Date.now(); age is not under test.
+        now: Date.now() + 60_000,
         isProcessAlive: () => false, // every spawning manager AND discovered pid is dead
         daemonPidFiles: () => {
           enumerateCalls += 1;

--- a/test/utils/logger-sink-degradation.test.ts
+++ b/test/utils/logger-sink-degradation.test.ts
@@ -357,6 +357,15 @@ describe("logger degrades the record itself under a persistent write failure (Co
     // ENOSPC failures rather than a synchronous constructor throw.
     const targetLogFile = join(logDir, `stdio-${process.pid}.log`);
     mkdirSync(targetLogFile);
+    // flush() waits for write callbacks, but Windows may deliver the stream's
+    // error/close afterward. Keep teardown outside that failure window.
+    const streamClosures: Promise<void>[] = [];
+    const realCreateWriteStream = fs.createWriteStream;
+    const createWriteStream = spyOn(fs, "createWriteStream").mockImplementation((...args) => {
+      const stream = realCreateWriteStream(...args);
+      streamClosures.push(new Promise<void>((resolve) => stream.once("close", resolve)));
+      return stream;
+    });
     const stderr = spyStderr();
 
     let mod: typeof import("../../src/utils/logger") | undefined;
@@ -373,8 +382,10 @@ describe("logger degrades the record itself under a persistent write failure (Co
       mod.logger.info("third record");
       await mod.logger.flush();
     } finally {
-      stderr.restore();
+      await Promise.all(streamClosures);
       await mod?.logger.closeAfterFlush();
+      stderr.restore();
+      createWriteStream.mockRestore();
       rmSync(logDir, { recursive: true, force: true });
     }
 

--- a/test/utils/logger-sink-degradation.test.ts
+++ b/test/utils/logger-sink-degradation.test.ts
@@ -388,8 +388,20 @@ describe("logger degrades the record itself under a persistent write failure (Co
 
   test("does not double-emit the same record to stderr in `both` mode when the file write also fails", async () => {
     const logDir = mkdtempSync(join(tmpdir(), "am-logger-eisdir-both-"));
-    const targetLogFile = join(logDir, `stdio-${process.pid}.log`);
-    mkdirSync(targetLogFile);
+    // Drive callback + error delivery deterministically. Real Windows EISDIR
+    // may arrive during teardown, making this assertion about OS event timing.
+    const stream = new AsyncFailStream();
+    const failedWrite = spyOn(stream, "write").mockImplementation((_chunk, callback) => {
+      queueMicrotask(() => {
+        const error = new Error("EISDIR: write failed");
+        callback?.(error);
+        stream.emit("error", error);
+      });
+      return true;
+    });
+    const createWriteStream = spyOn(fs, "createWriteStream").mockReturnValue(
+      stream as unknown as fs.WriteStream,
+    );
     const stderr = spyStderr();
 
     let mod: typeof import("../../src/utils/logger") | undefined;
@@ -400,14 +412,16 @@ describe("logger degrades the record itself under a persistent write failure (Co
       mod.logger.info("both-mode record");
       await mod.logger.flush();
     } finally {
-      stderr.restore();
       await mod?.logger.closeAfterFlush();
+      stderr.restore();
+      createWriteStream.mockRestore();
       rmSync(logDir, { recursive: true, force: true });
     }
 
     // `both` already emits every record via writeToConfiguredStderr regardless
     // of file-sink health; the failed file write must not additionally
     // duplicate that exact line.
+    expect(failedWrite).toHaveBeenCalledTimes(1);
     const matches = stderr.lines.filter((line) => line.includes("both-mode record"));
     expect(matches.length).toBe(1);
   });


### PR DESCRIPTION
## Summary

Repair the remaining test failures reported in [issue #6344](https://github.com/kaeawc/auto-mobile/issues/6344). The SharedPreferences socket tests now pass their fake ADB factory in the correct constructor position, so fallback writes are observed by the fake. The Windows logging tests use a controlled asynchronous write failure and the existing injected pruning clock to keep their assertions independent of filesystem event timing.

## Linked Issue

Closes [#6344](https://github.com/kaeawc/auto-mobile/issues/6344)

## Bug / Regression Context

- The socket constructor gained a bind-guard argument before the ADB factory. These tests still passed the factory in that slot, causing real ADB access and three failing fallback assertions on every OS. All existing route-success, relaunch-warning, XML-write, and no-fallback assertions remain intact.
- The Windows log-pruner failure retained the last two newly created files while its discovery-count assertions passed. Advancing the injected sweep clock removes the filesystem-mtime race from this discovery-caching test, matching existing neighboring tests.
- The Windows logger failure surfaced EISDIR during stream teardown. Reusing the existing stream fake controls callback/error delivery while checking that a file write actually failed and the ordinary record appears exactly once on stderr. The neighboring real-filesystem persistent-failure test retains its real EISDIR coverage and awaits stream closure before teardown, preventing the same late-error race.
- The Kotlin Detekt violation is already fixed on main by [PR #6351](https://github.com/kaeawc/auto-mobile/pull/6351). The SDK mutation-policy fix in [PR #6353](https://github.com/kaeawc/auto-mobile/pull/6353) did not correct this test's misplaced factory argument. No production changes are needed here.

## Validation

- Reproduced all three socket fallback failures before the fix; all 14 routing tests pass afterward.
- All 32 tests in the two logging suites pass locally.
- `bun run turbo:validate` passes all seven tasks (lint, build, unit tests, and boundary checks).
- `bun run typecheck` passes with no new errors.
- Formatting and whitespace checks pass.
- The first PR CI run passed both originally reported Windows unit tests and the Linux/Windows host integration suites; it exposed the same teardown race in the neighboring real-filesystem test, now repaired and revalidated locally. Final Windows CI is pending.
- The final full local gate passes with four workers. One higher-concurrency run timed out in an unrelated FileDownloader test; its targeted rerun and the full gate both pass without changing that test.
