### PR TITLE
fix(session): preserve live autolock ownership on warm acquisition

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -4891,6 +4891,7 @@ export class DevicePool {
     >,
     stableRuntimeName = expectedIdentity.name,
     verifiedAndroidAvdName?: string,
+    autolockClient?: { mcpSessionId?: string },
   ): Promise<DeviceReadinessReservation> {
     // The stable-name reservation exists to bridge an Android emulator changing
     // serials across a reboot. iOS UDIDs are stable, so a name reservation there
@@ -4904,6 +4905,9 @@ export class DevicePool {
     await this.assignmentMutex.runExclusive(async () => {
       const pooled = this.devices.get(deviceId);
       if (pooled) {
+        // Acquisition may reboot a device during readiness recovery. Prove
+        // ownership before reserving it or beginning those side effects.
+        this.getOwnedAutolockSession(pooled, autolockClient);
         if (this.hasTransportOnlyIdentityChange(pooled, expectedIdentity)) {
           await this.replacePooledDeviceForRuntimeIdentity(pooled, expectedIdentity);
         } else {
@@ -5532,14 +5536,14 @@ export class DevicePool {
   /**
    * Lock a device with an autolock session ID.
    *
-   * Generates a new session UUID bound to the device. When autolock is enabled,
+   * Creates a session UUID or reuses the proven caller's live autolock. When enabled,
    * subsequent tool calls from the same MCP session can resolve this UUID
    * implicitly; other clients must include it explicitly. The session has a
    * configurable idle timeout (AUTO_MOBILE_DEVICE_POOL_TIMEOUT).
    *
    * @param deviceId - The device to lock
    * @param platform - Device platform
-   * @returns The generated session ID, or undefined if autolock is disabled
+   * @returns The assigned session ID, or undefined if autolock is disabled
    */
   async autolockDevice(
     deviceId: string,
@@ -5701,6 +5705,32 @@ export class DevicePool {
     mcpSessionId: string | undefined,
     achievedReadiness: DeviceReadinessLevel,
   ): Promise<string | undefined> {
+    const session = this.getOwnedAutolockSession(device, { mcpSessionId });
+    if (!session) {
+      return undefined;
+    }
+    const refreshed = await this.sessionManager.getOrCreateSession(session.sessionId);
+    // Release can finish while activity persistence yields, even under the
+    // assignment mutex. Do not report success for a retired ownership identity.
+    if (
+      refreshed !== session ||
+      !this.isSessionAssignmentCurrent(device, session) ||
+      !this.sessionManager.isAdmittedForAutomation(session)
+    ) {
+      throw new ActionableError(`Device '${device.id}' was released during autolock acquisition.`);
+    }
+    this.sessionManager.setDeviceReadiness(session.sessionId, achievedReadiness);
+    return session.sessionId;
+  }
+
+  private getOwnedAutolockSession(
+    device: PooledDevice,
+    client: { mcpSessionId?: string } | undefined,
+  ): Session | undefined {
+    if (!client) {
+      return undefined;
+    }
+    const { mcpSessionId } = client;
     const session = device.sessionId ? this.sessionManager.getSession(device.sessionId) : null;
     if (!session) {
       return undefined;
@@ -5717,18 +5747,7 @@ export class DevicePool {
           "Acquire a different device or wait for its owner to release it.",
       );
     }
-    const refreshed = await this.sessionManager.getOrCreateSession(session.sessionId);
-    // Release can finish while activity persistence yields, even under the
-    // assignment mutex. Do not report success for a retired ownership identity.
-    if (
-      refreshed !== session ||
-      !this.isSessionAssignmentCurrent(device, session) ||
-      !this.sessionManager.isAdmittedForAutomation(session)
-    ) {
-      throw new ActionableError(`Device '${device.id}' was released during autolock acquisition.`);
-    }
-    this.sessionManager.setDeviceReadiness(session.sessionId, achievedReadiness);
-    return session.sessionId;
+    return session;
   }
 
   private throwIfFreshStartAlreadyBound(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5581,7 +5581,6 @@ export class DevicePool {
     verifiedAndroidAvdIdentity?: DeviceInfo,
     achievedReadiness: DeviceReadinessLevel = "automationReady",
   ): Promise<string> {
-    const sessionId = this.idGenerator.next();
     const androidAvdIdentity = verifiedAndroidAvdIdentity ?? sourceImage;
 
     // Ensure device is in the pool (it may have been freshly booted)
@@ -5646,6 +5645,16 @@ export class DevicePool {
       readinessReservationOwners,
     );
 
+    const reusedSessionId = await this.reuseOwnedAutolockSession(
+      device,
+      mcpSessionId,
+      achievedReadiness,
+    );
+    if (reusedSessionId) {
+      return reusedSessionId;
+    }
+
+    const sessionId = this.idGenerator.next();
     const assignmentSnapshot = this.snapshotSessionAssignment(device);
     device.sessionId = sessionId;
     device.status = "busy";
@@ -5684,6 +5693,42 @@ export class DevicePool {
       `Autolocked device ${deviceId} with session ${sessionId} (timeout: ${timeoutMs}ms)`,
     );
     return sessionId;
+  }
+
+  /** Warm acquisition must prove ownership before reusing a live autolock. */
+  private async reuseOwnedAutolockSession(
+    device: PooledDevice,
+    mcpSessionId: string | undefined,
+    achievedReadiness: DeviceReadinessLevel,
+  ): Promise<string | undefined> {
+    const session = device.sessionId ? this.sessionManager.getSession(device.sessionId) : null;
+    if (!session) {
+      return undefined;
+    }
+    if (
+      !mcpSessionId ||
+      this.mcpSessionAutolockMap.get(mcpSessionId) !== session.sessionId ||
+      device.autolockSessionId !== session.sessionId ||
+      !this.isSessionAssignmentCurrent(device, session) ||
+      !this.sessionManager.isAdmittedForAutomation(session)
+    ) {
+      throw new ActionableError(
+        `Device '${device.id}' is already assigned to another session. ` +
+          "Acquire a different device or wait for its owner to release it.",
+      );
+    }
+    const refreshed = await this.sessionManager.getOrCreateSession(session.sessionId);
+    // Release can finish while activity persistence yields, even under the
+    // assignment mutex. Do not report success for a retired ownership identity.
+    if (
+      refreshed !== session ||
+      !this.isSessionAssignmentCurrent(device, session) ||
+      !this.sessionManager.isAdmittedForAutomation(session)
+    ) {
+      throw new ActionableError(`Device '${device.id}' was released during autolock acquisition.`);
+    }
+    this.sessionManager.setDeviceReadiness(session.sessionId, achievedReadiness);
+    return session.sessionId;
   }
 
   private throwIfFreshStartAlreadyBound(

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -3612,6 +3612,7 @@ async function reserveInitialDeviceForReadiness(
   daemonState: DaemonState,
   boot: DeviceBootResult,
   releaseReadinessReservations: DeviceReadinessReservation[],
+  mcpSessionId: string | undefined,
 ): Promise<void> {
   const devicePool = getStartDevicePool(daemonState);
   if (!devicePool) {
@@ -3622,6 +3623,8 @@ async function reserveInitialDeviceForReadiness(
       boot.device.deviceId,
       boot.device,
       boot.sourceImage?.name ?? boot.device.name,
+      undefined,
+      isDevicePoolAutolockEnabled() ? { mcpSessionId } : undefined,
     ),
   );
 }
@@ -5013,7 +5016,12 @@ export function registerDeviceTools() {
           }
         : undefined);
     const daemonState = DaemonState.getInstance();
-    await reserveInitialDeviceForReadiness(daemonState, state.boot, releaseReadinessReservations);
+    await reserveInitialDeviceForReadiness(
+      daemonState,
+      state.boot,
+      releaseReadinessReservations,
+      args.__mcpSessionId,
+    );
 
     // A new incarnation must not inherit a prior intentional-shutdown marker
     // while its per-device runner setup is in flight.
@@ -5082,18 +5090,23 @@ export function registerDeviceTools() {
         state.boot,
         sourceImage,
       );
+      // Recovery must revalidate the caller through the same autolock path;
+      // a preserved UUID alone is not proof that this client owns the session.
       const boundSessionId =
-        readinessResult.preservedSessionId ??
-        (await bindBootedDeviceSession(
-          state.boot.device,
-          args,
-          state.boot.source === "cold-boot" ? sourceImage : undefined,
-          state.boot.processHandle,
-          new Set(releaseReadinessReservations.map((reservation) => reservation.owner)),
-          verifiedWarmAndroidAvdIdentity,
-        ));
+        readinessResult.preservedSessionId && !isDevicePoolAutolockEnabled()
+          ? readinessResult.preservedSessionId
+          : await bindBootedDeviceSession(
+              state.boot.device,
+              args,
+              state.boot.source === "cold-boot" && !readinessResult.preservedSessionId
+                ? sourceImage
+                : undefined,
+              state.boot.processHandle,
+              new Set(releaseReadinessReservations.map((reservation) => reservation.owner)),
+              verifiedWarmAndroidAvdIdentity,
+            );
       if (readinessResult.preservedSessionId) {
-        // #6227 round 7: the System UI ANR recovery path above bypasses
+        // #6227 round 7: without autolock, System UI ANR recovery bypasses
         // `bindBootedDeviceSession` (and therefore its own
         // `recordAcquiredSessionReadiness` call) entirely when a preserved
         // session is being reused. But by this point

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -5101,7 +5101,8 @@ export function registerDeviceTools() {
               state.boot.source === "cold-boot" && !readinessResult.preservedSessionId
                 ? sourceImage
                 : undefined,
-              state.boot.processHandle,
+              // Recovery already registered this process and its output tail.
+              readinessResult.preservedSessionId ? undefined : state.boot.processHandle,
               new Set(releaseReadinessReservations.map((reservation) => reservation.owner)),
               verifiedWarmAndroidAvdIdentity,
             );

--- a/test/daemon/devicePoolAutolockOwnership.test.ts
+++ b/test/daemon/devicePoolAutolockOwnership.test.ts
@@ -1,0 +1,245 @@
+import { expect, spyOn, test } from "bun:test";
+import { Database as Sqlite } from "bun:sqlite";
+import { Kysely } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { up } from "../../src/db/migrations/2026_04_02_000_device_sessions";
+import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
+import type { Database } from "../../src/db/types";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { FakeTimer } from "../../test/fakes/FakeTimer";
+import { FakeIdGenerator } from "../../test/fakes/FakeIdGenerator";
+import { FakeDeviceManager } from "../../test/fakes/FakeDeviceManager";
+import { FakeInstalledAppsRepository } from "../../test/fakes/FakeInstalledAppsRepository";
+import { FakeDbWriteBarrier } from "../../test/fakes/FakeDbWriteBarrier";
+import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
+import { InMemoryVirtualDeviceLifecycleCoordinator } from "../../src/utils/virtualDeviceLifecycleCoordinator";
+import { FakeDeviceMatcher } from "../../test/fakes/FakeDeviceMatcher";
+import { FakeDeviceUtils } from "../../test/fakes/FakeDeviceUtils";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import {
+  registerDeviceTools,
+  resetDeviceToolsDependencies,
+  setDeviceToolsDependencies,
+} from "../../src/server/deviceTools";
+import { getDeviceSessionIdFromResult } from "../../src/server/deviceSessionResult";
+
+async function harness() {
+  const db = new Kysely<Database>({
+    dialect: new BunSqliteDialect({ database: new Sqlite(":memory:") }),
+  });
+  await up(db as Kysely<unknown>);
+  const repository = new DeviceSessionRepository(db);
+  const timer = new FakeTimer();
+  const barrier = new FakeDbWriteBarrier();
+  const manager = new SessionManager(timer, repository, () => barrier);
+  const devices = new FakeDeviceManager(
+    [],
+    [{ deviceId: "emulator-5554", name: "Agent A AVD", platform: "android" }],
+  );
+  const pool = new DevicePool(
+    manager,
+    "hunt-daemon",
+    timer,
+    new FakeInstalledAppsRepository(),
+    devices,
+    new DefaultRetryExecutor(timer),
+    repository,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    { onLoss: false, maxAttempts: 2 },
+    undefined,
+    undefined,
+    undefined,
+    new FakeIdGenerator(),
+    new InMemoryVirtualDeviceLifecycleCoordinator(timer),
+  );
+  await pool.initializeWithDevices(devices.bootedDevices);
+  return {
+    db,
+    repository,
+    timer,
+    manager,
+    devices,
+    pool,
+    close: async () => {
+      manager.stopCleanupTimer();
+      await db.destroy();
+    },
+  };
+}
+
+async function withAutolock(work: () => Promise<void>): Promise<void> {
+  const previous = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+  process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+  try {
+    await work();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+    } else {
+      process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = previous;
+    }
+  }
+}
+
+test.each(["agent-B", undefined])(
+  "rejects a competing or unidentified autolock client: %s",
+  async (client) => {
+    await withAutolock(async () => {
+      const h = await harness();
+      try {
+        const first = (await h.pool.autolockDevice("emulator-5554", "android", "agent-A"))!;
+        const original = await h.repository.getSession(first);
+        await expect(h.pool.autolockDevice("emulator-5554", "android", client)).rejects.toThrow(
+          "already assigned",
+        );
+        expect(h.pool.getDevice("emulator-5554")?.sessionId).toBe(first);
+        expect(h.manager.getSessionForDevice("emulator-5554")).toBe(first);
+        expect(h.manager.getSession(first)?.assignedDevice).toBe("emulator-5554");
+        expect(h.pool.resolveAutolockSessionForMcpSession("agent-A")).toBe(first);
+        expect(() => h.pool.assertAutolockAccess("emulator-5554", first)).not.toThrow();
+        expect(await h.repository.getSession(first)).toEqual(original);
+        expect(await h.db.selectFrom("device_sessions").selectAll().execute()).toHaveLength(1);
+      } finally {
+        await h.close();
+      }
+    });
+  },
+);
+
+test("same MCP client reuses its live autolock without rotating ownership", async () => {
+  await withAutolock(async () => {
+    const h = await harness();
+    try {
+      const first = (await h.pool.autolockDevice("emulator-5554", "android", "agent-A"))!;
+      const original = await h.repository.getSession(first);
+      h.timer.advanceTime(1000);
+      expect(await h.pool.autolockDevice("emulator-5554", "android", "agent-A")).toBe(first);
+      expect(h.pool.getDevice("emulator-5554")?.assignmentCount).toBe(1);
+      expect(h.manager.getSessionForDevice("emulator-5554")).toBe(first);
+      expect(h.pool.resolveAutolockSessionForMcpSession("agent-A")).toBe(first);
+      expect(h.manager.getDeviceReadiness(first)).toBe("automationReady");
+      const row = await h.repository.getSession(first);
+      expect(row?.mcp_session_id).toBe(original?.mcp_session_id);
+      expect(row?.autolock_enabled).toBe(1);
+      expect(row?.last_used_at_ms).toBe(h.timer.now());
+      expect(await h.db.selectFrom("device_sessions").selectAll().execute()).toHaveLength(1);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+test("concurrent clients cannot both acquire the same autolock", async () => {
+  await withAutolock(async () => {
+    const h = await harness();
+    try {
+      const results = await Promise.allSettled([
+        h.pool.autolockDevice("emulator-5554", "android", "agent-A"),
+        h.pool.autolockDevice("emulator-5554", "android", "agent-B"),
+      ]);
+      expect(results.map((result) => result.status)).toEqual(["fulfilled", "rejected"]);
+      expect(h.manager.getActiveSessionCount()).toBe(1);
+      expect(await h.db.selectFrom("device_sessions").selectAll().execute()).toHaveLength(1);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+test("does not return a reused UUID released during activity persistence", async () => {
+  await withAutolock(async () => {
+    const h = await harness();
+    const started = Promise.withResolvers<void>();
+    const finished = Promise.withResolvers<void>();
+    const recordActivity = h.repository.recordActivity.bind(h.repository);
+    const activity = spyOn(h.repository, "recordActivity");
+    try {
+      const first = (await h.pool.autolockDevice("emulator-5554", "android", "agent-A"))!;
+      activity.mockImplementationOnce(async (id, update) => {
+        started.resolve();
+        await finished.promise;
+        await recordActivity(id, update);
+      });
+      const reacquiring = h.pool
+        .autolockDevice("emulator-5554", "android", "agent-A")
+        .catch((error: unknown) => error);
+      await started.promise;
+      await h.manager.releaseSession(first);
+      await h.pool.releaseDevice("emulator-5554", first);
+      finished.resolve();
+      expect(await reacquiring).toMatchObject({
+        message: "Device 'emulator-5554' was released during autolock acquisition.",
+      });
+      expect(h.manager.getSession(first)).toBeNull();
+      expect(h.pool.getDevice("emulator-5554")?.sessionId).toBeNull();
+      expect((await h.repository.getSession(first))?.status).toBe("released");
+    } finally {
+      finished.resolve();
+      activity.mockRestore();
+      await h.close();
+    }
+  });
+});
+
+test("same-client reuse cannot bypass the fresh-start ownership guard", async () => {
+  await withAutolock(async () => {
+    const h = await harness();
+    try {
+      const first = (await h.pool.autolockDevice("emulator-5554", "android", "agent-A"))!;
+      await expect(
+        h.pool.autolockDevice("emulator-5554", "android", "agent-A", {
+          name: "Agent A AVD",
+          platform: "android",
+          isRunning: false,
+          source: "local",
+        }),
+      ).rejects.toThrow("Freshly started device");
+      expect(h.pool.getDevice("emulator-5554")?.sessionId).toBe(first);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+test("registered getAndroid preserves its caller's UUID and rejects a different client", async () => {
+  await withAutolock(async () => {
+    const h = await harness();
+    const matcher = new FakeDeviceMatcher();
+    const deviceUtils = new FakeDeviceUtils();
+    deviceUtils.setBootedDevices("android", h.devices.bootedDevices);
+    matcher.setBootedResult(h.devices.bootedDevices[0]);
+    DaemonState.getInstance().initialize(h.manager, h.pool);
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => deviceUtils,
+      deviceMatcherFactory: () => matcher,
+      ensureCtrlProxyReady: async () => {},
+      notifyResourcesChanged: async () => {},
+      timer: h.timer,
+      idGenerator: new FakeIdGenerator(),
+      lifecycleCoordinator: new InMemoryVirtualDeviceLifecycleCoordinator(h.timer),
+    });
+    registerDeviceTools();
+    try {
+      const handler = ToolRegistry.getTool("getAndroid")!.handler;
+      const args = { deviceId: "emulator-5554", __mcpSessionId: "agent-A" };
+      const first = getDeviceSessionIdFromResult(await handler(args));
+      expect(first).toBeDefined();
+      expect(getDeviceSessionIdFromResult(await handler(args))).toBe(first);
+      await expect(handler({ ...args, __mcpSessionId: "agent-B" })).rejects.toThrow(
+        "already assigned",
+      );
+      expect(h.pool.getDevice("emulator-5554")?.sessionId).toBe(first);
+      expect(h.manager.getActiveSessionCount()).toBe(1);
+    } finally {
+      resetDeviceToolsDependencies();
+      DaemonState.getInstance().reset();
+      ToolRegistry.clearTools();
+      await h.close();
+    }
+  });
+});

--- a/test/daemon/devicePoolAutolockOwnership.test.ts
+++ b/test/daemon/devicePoolAutolockOwnership.test.ts
@@ -24,8 +24,9 @@ import {
   setDeviceToolsDependencies,
 } from "../../src/server/deviceTools";
 import { getDeviceSessionIdFromResult } from "../../src/server/deviceSessionResult";
+import { SystemUiAnrRecoveryRequiredError } from "../../src/utils/RunnerReadinessService";
 
-async function harness() {
+async function harness(deviceUtils?: FakeDeviceUtils) {
   const db = new Kysely<Database>({
     dialect: new BunSqliteDialect({ database: new Sqlite(":memory:") }),
   });
@@ -43,7 +44,7 @@ async function harness() {
     "hunt-daemon",
     timer,
     new FakeInstalledAppsRepository(),
-    devices,
+    deviceUtils ?? devices,
     new DefaultRetryExecutor(timer),
     repository,
     undefined,
@@ -243,3 +244,79 @@ test("registered getAndroid preserves its caller's UUID and rejects a different 
     }
   });
 });
+
+test.each(["agent-B", "agent-A", "agent-A-reassigned"])(
+  "System UI recovery respects the requesting autolock owner: %s",
+  async (client) => {
+    await withAutolock(async () => {
+      const deviceUtils = new FakeDeviceUtils();
+      const h = await harness(deviceUtils);
+      const matcher = new FakeDeviceMatcher();
+      const device = h.devices.bootedDevices[0];
+      const image = { ...device, deviceId: "emulator-5556", isRunning: false };
+      deviceUtils.setBootedDevices("android", [device]);
+      deviceUtils.setDeviceImages("android", [image]);
+      matcher.setBootedResult(device);
+      matcher.setImageResult(image);
+      const kill = deviceUtils.killDevice.bind(deviceUtils);
+      deviceUtils.killDevice = async (target, options) => {
+        await kill(target, options);
+        deviceUtils.setBootedDevices("android", []);
+      };
+      let readinessAttempts = 0;
+      let secondOwner: string | undefined;
+      DaemonState.getInstance().initialize(h.manager, h.pool);
+      setDeviceToolsDependencies({
+        deviceManagerFactory: () => deviceUtils,
+        deviceMatcherFactory: () => matcher,
+        timer: h.timer,
+        notifyResourcesChanged: async () => {},
+        ensureCtrlProxyReady: async (request) => {
+          if (++readinessAttempts === 1) {
+            throw new SystemUiAnrRecoveryRequiredError("System UI ANR");
+          }
+          if (client === "agent-A-reassigned") {
+            const otherDevice = { ...device, deviceId: "emulator-5558", name: "Other AVD" };
+            deviceUtils.setBootedDevices("android", [request.device, otherDevice]);
+            await h.pool.addDevice(otherDevice);
+            secondOwner = await h.pool.autolockDevice(otherDevice.deviceId, "android", "agent-A");
+          }
+        },
+      });
+      registerDeviceTools();
+      try {
+        const owner = await h.pool.autolockDevice(device.deviceId, "android", "agent-A", image);
+        const acquiring = ToolRegistry.getTool("getAndroid")!.handler({
+          deviceId: device.deviceId,
+          __mcpSessionId: client === "agent-A-reassigned" ? "agent-A" : client,
+        });
+        if (client === "agent-B") {
+          await expect(acquiring).rejects.toThrow("another session");
+          expect(readinessAttempts).toBe(0);
+          expect(deviceUtils.getExecutedOperations()).not.toContain(`killDevice:${device.name}`);
+          expect(h.manager.getSession(owner!)?.assignedDevice).toBe(device.deviceId);
+        } else if (client === "agent-A") {
+          expect(getDeviceSessionIdFromResult(await acquiring)).toBe(owner);
+          expect(readinessAttempts).toBe(2);
+          expect(h.manager.getSession(owner!)?.assignedDevice).toBe(image.deviceId);
+          expect(h.manager.getDeviceReadiness(owner!)).toBe("automationReady");
+        } else {
+          await expect(acquiring).rejects.toThrow("another session");
+          expect(readinessAttempts).toBe(2);
+          expect(secondOwner).toBeDefined();
+          expect(h.manager.getSession(owner!)?.assignedDevice).toBe(image.deviceId);
+        }
+        expect(h.pool.resolveAutolockSessionForMcpSession("agent-A")).toBe(secondOwner ?? owner);
+        expect(h.pool.resolveAutolockSessionForMcpSession("agent-B")).toBeUndefined();
+        expect(await h.db.selectFrom("device_sessions").selectAll().execute()).toHaveLength(
+          secondOwner ? 2 : 1,
+        );
+      } finally {
+        resetDeviceToolsDependencies();
+        DaemonState.getInstance().reset();
+        ToolRegistry.clearTools();
+        await h.close();
+      }
+    });
+  },
+);

--- a/test/daemon/devicePoolAutolockOwnership.test.ts
+++ b/test/daemon/devicePoolAutolockOwnership.test.ts
@@ -1,6 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import { Database as Sqlite } from "bun:sqlite";
 import { Kysely } from "kysely";
+import type { ChildProcess } from "node:child_process";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import { up } from "../../src/db/migrations/2026_04_02_000_device_sessions";
 import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
@@ -16,6 +17,7 @@ import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
 import { InMemoryVirtualDeviceLifecycleCoordinator } from "../../src/utils/virtualDeviceLifecycleCoordinator";
 import { FakeDeviceMatcher } from "../../test/fakes/FakeDeviceMatcher";
 import { FakeDeviceUtils } from "../../test/fakes/FakeDeviceUtils";
+import { FakeChildProcess } from "../../test/fakes/FakeChildProcess";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import {
@@ -254,6 +256,8 @@ test.each(["agent-B", "agent-A", "agent-A-reassigned"])(
       const matcher = new FakeDeviceMatcher();
       const device = h.devices.bootedDevices[0];
       const image = { ...device, deviceId: "emulator-5556", isRunning: false };
+      const recoveredProcess = new FakeChildProcess(h.timer);
+      deviceUtils.setMockChildProcess(image.name, recoveredProcess as unknown as ChildProcess);
       deviceUtils.setBootedDevices("android", [device]);
       deviceUtils.setDeviceImages("android", [image]);
       matcher.setBootedResult(device);
@@ -264,6 +268,8 @@ test.each(["agent-B", "agent-A", "agent-A-reassigned"])(
         deviceUtils.setBootedDevices("android", []);
       };
       let readinessAttempts = 0;
+      let recoveredExitListeners = 0;
+      let recoveredOutputListeners = 0;
       let secondOwner: string | undefined;
       DaemonState.getInstance().initialize(h.manager, h.pool);
       setDeviceToolsDependencies({
@@ -275,6 +281,8 @@ test.each(["agent-B", "agent-A", "agent-A-reassigned"])(
           if (++readinessAttempts === 1) {
             throw new SystemUiAnrRecoveryRequiredError("System UI ANR");
           }
+          recoveredExitListeners = recoveredProcess.listenerCount("exit");
+          recoveredOutputListeners = recoveredProcess.stdout.listenerCount("data");
           if (client === "agent-A-reassigned") {
             const otherDevice = { ...device, deviceId: "emulator-5558", name: "Other AVD" };
             deviceUtils.setBootedDevices("android", [request.device, otherDevice]);
@@ -308,6 +316,11 @@ test.each(["agent-B", "agent-A", "agent-A-reassigned"])(
         }
         expect(h.pool.resolveAutolockSessionForMcpSession("agent-A")).toBe(secondOwner ?? owner);
         expect(h.pool.resolveAutolockSessionForMcpSession("agent-B")).toBeUndefined();
+        if (readinessAttempts > 1) {
+          expect(recoveredExitListeners).toBeGreaterThan(0);
+          expect(recoveredProcess.listenerCount("exit")).toBe(recoveredExitListeners);
+          expect(recoveredProcess.stdout.listenerCount("data")).toBe(recoveredOutputListeners);
+        }
         expect(await h.db.selectFrom("device_sessions").selectAll().execute()).toHaveLength(
           secondOwner ? 2 : 1,
         );

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -1451,7 +1451,7 @@ describe("startDevice handler", () => {
     expect(adopterSettled).toBe(false);
     releaseOwnerReadiness();
     const ownerResult = await ownerStart;
-    await expect(adopterStart).rejects.toThrow(/Freshly started device .* assigned to session/);
+    await expect(adopterStart).rejects.toThrow("already assigned to another session");
 
     expect(ownerResult.sessionUuid).toBeDefined();
     expect(childProcess.killed).toBe(false);


### PR DESCRIPTION
## Summary

Repeated warm device acquisition now preserves a live autolock only when the caller's MCP transport maps to its current owner. Competing or unidentified clients receive an actionable error before readiness or recovery can touch the device. Same-owner acquisition refreshes activity and readiness without rotating the UUID, and rejects a session released during that refresh. System UI recovery checks ownership before reboot and again before returning the preserved UUID.

## Linked Issue

Closes [#6363](https://github.com/kaeawc/auto-mobile/issues/6363)

## Bug / Regression Context

- **Observed symptom:** agent B could acquire agent A's warm Android device, overwrite its pool owner and reverse lookup, and leave A's session live.
- **Reproduction:** acquire one booted emulator through `getAndroid` as MCP client A, then acquire it again as B. Before this change both calls succeeded with different UUIDs.
- The existing assignment mutex, ownership identity checks, activity persistence, and readiness setter provide the fix. No new dependency or public API is needed.

## Validation

- [x] New regressions failed against the original behavior, then passed with the fix.
- [x] Ten ownership tests cover competing/unidentified clients, same-owner reuse and durable metadata, concurrent acquisition, release during activity persistence, fresh-start rejection, registered `getAndroid` calls, and System UI recovery before/after ownership changes.
- [x] All 69 focused ownership and start-device tests pass. The shared-cold-boot regression still proves rejected acquisition does not kill the owner's process.
- [x] `bun run turbo:validate` passes (all seven tasks, including lint/build/unit suite).
- [x] `bun run typecheck` reports no new errors (147 existing baseline errors).
- [x] Tests use existing fakes, FakeTimer, and an in-memory database; individual new tests complete under 100ms.
- [x] Rebased onto repaired `main` (`bc805d99caa4f75f1df68b1225a166fc56c82086`) and reran full validation and typecheck successfully.

## Review

Runtime, delivery, and ownership/persistence review passes completed. The final change closes the preserved-session recovery bypass and retains the recovery process's existing registration. Recovery tests cover ownership and unchanged process-exit/output listener counts. Full validation and typecheck pass after both fixes.

## Follow-ups

Persisted restart identity and pending-cleanup admission are tracked separately in [#6364](https://github.com/kaeawc/auto-mobile/issues/6364) and [#6365](https://github.com/kaeawc/auto-mobile/issues/6365).
