### PR TITLE
fix(performance): only report tapped coordinate from tapped samples (#6318)

### DIFF
--- a/src/features/performance/TouchLatencyTracker.ts
+++ b/src/features/performance/TouchLatencyTracker.ts
@@ -466,13 +466,17 @@ export class TouchLatencyTracker {
         logger.debug(`[TouchLatency] Taking sample ${i + 1}/${sampleCount}`);
 
         const sampleResult = await this.takeSample(packageName, touchLocation, maxWaitMs, perf, i);
-        reportedLocation = sampleResult.tapPoint;
 
         if (sampleResult.animating) {
           animatingCount++;
         } else if (sampleResult.obstructed) {
           obstructedCount++;
         } else if (sampleResult.latencyMs !== null) {
+          // Only samples that actually injected a tap update the reported
+          // coordinate. Animating/obstructed samples issue no `input tap` and
+          // return the untouched initial `touchLocation`, so reporting their
+          // point would surface a coordinate no sample ever tapped (#6318).
+          reportedLocation = sampleResult.tapPoint;
           measurements.push(sampleResult.latencyMs);
           logger.debug(`[TouchLatency] Sample ${i + 1}: ${sampleResult.latencyMs}ms`);
         } else {

--- a/test/features/performance/TouchLatencyTracker.test.ts
+++ b/test/features/performance/TouchLatencyTracker.test.ts
@@ -1162,6 +1162,58 @@ describe("TouchLatencyTracker - Unit Tests", function () {
       expect(result.touchCoordinates).toEqual({ x: 333, y: 444 });
     });
 
+    // Regression (#6318): a #6296 adversary finding. When the LAST sample is
+    // obstructed (resolver returns null → no tap issued, tapPoint falls back to
+    // the untouched initial location) but an EARLIER sample tapped and produced
+    // a real measurement, touchCoordinates must report the genuinely-tapped
+    // point, not the never-tapped initial selection.
+    test("touchCoordinates must not report the never-tapped initial point when the last sample is obstructed (#6318)", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      let tapsAtReset = 0;
+      let framesAfterTap = 0;
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command) => {
+        const taps = dynamicAdb.getExecutedCommands().filter((c) => c.includes("input tap")).length;
+        if (command.includes("reset")) {
+          tapsAtReset = taps;
+          framesAfterTap = 0;
+          return { stdout: "", stderr: "" };
+        }
+        const totalFrames = taps > tapsAtReset ? (framesAfterTap += 3) : 0;
+        return { stdout: `Total frames rendered: ${totalFrames}`, stderr: "" };
+      });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      // Sample 1 resolves a real inert point; sample 2 is obstructed (null).
+      const points: Array<{ x: number; y: number } | null> = [{ x: 333, y: 444 }, null];
+      let resolveCallCount = 0;
+      const resolver = {
+        resolveInertTouchPoint: async () => points[resolveCallCount++] ?? null,
+      };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer, resolver);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 2, maxWaitMs: 200, touchPoint: { x: 999, y: 888 } },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.sampleCount).toBe(1);
+      const tapCommands = dynamicAdb.getExecutedCommands().filter((c) => c.includes("input tap"));
+      expect(tapCommands).toHaveLength(1);
+      expect(tapCommands[0]).toContain("input tap 333 444");
+      // The obstructed final sample must NOT overwrite the reported coordinate
+      // with the untouched initial point.
+      expect(result.touchCoordinates).not.toEqual({ x: 999, y: 888 });
+      expect(result.touchCoordinates).toEqual({ x: 333, y: 444 });
+    });
+
     // Regression (#6228): when the freshly captured hierarchy has no
     // verified-inert point (a control now covers every candidate), the sample
     // must abort WITHOUT tapping rather than reuse a stale point.


### PR DESCRIPTION
Closes #6318

## Root cause

`TouchLatencyTracker.measureLatency` unconditionally overwrote `reportedLocation` with `sampleResult.tapPoint` on **every** loop iteration, including samples that never issued an `input tap`. On the obstructed path (`InertTouchPointResolver` returns `null`) and the animating path, `takeSample` issues no tap and returns `tapPoint: touchLocation` — the untouched initial/derived point.

So when the **last** sample was obstructed but an **earlier** sample tapped and produced a real measurement, `buildResult` reported `touchCoordinates` as the stale initial selection that no sample ever tapped — the exact outcome the [#6296](https://github.com/kaeawc/auto-mobile/pull/6296) / [#6228](https://github.com/kaeawc/auto-mobile/issues/6228) invariant set out to prevent.

## Fix

`src/features/performance/TouchLatencyTracker.ts` — move the `reportedLocation = sampleResult.tapPoint` assignment into the measured-sample branch (`latencyMs !== null`), so only samples that actually inject a tap update the reported coordinate. Obstructed/animating samples no longer clobber it. If no sample ever taps, `reportedLocation` correctly stays at the initial `touchLocation` fallback.

## Test

`test/features/performance/TouchLatencyTracker.test.ts` — added the reproducing regression (fakes + `FakeTimer`, ~0.3ms): sample 1 resolves `{333,444}` and taps; sample 2 is obstructed (`null`). Asserts `touchCoordinates` reports `{333,444}`, not the never-tapped initial `{999,888}`. Verified it **fails** on the pre-fix code and **passes** with the fix.

## Validation

- `bun test test/features/performance/TouchLatencyTracker.test.ts` — 29 pass
- `bun test test/features/observe/audits/PerformanceAuditor.test.ts` — 58 pass
- `bash scripts/all_fast_validate_checks.sh` — 35/35 pass
- `bun run lint` — ratchet green (no new violations); `bun run typecheck` — no new type errors
- `BUN_TEST_TIMING_BASE_REF=origin/main bash scripts/validate-bun-test-timings.sh` — 4042 pass, exit 0

## Provenance

This is a `needs-human` adversary finding (daily self-review routine, reproduced against HEAD). The reproducing failing test is the needs-human verification — it now passes with the fix.
