### PR TITLE
fix(navigation): do not report close-button dismissal when re-observation has no view hierarchy (#6319)

### DIFF
--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -512,6 +512,28 @@ export class DefaultUIStateSetup implements UIStateSetup {
   }
 
   /**
+   * Strict variant of {@link isModalDismissed} for the close-button success
+   * path. Unlike `isModalDismissed`, an unavailable observation (the
+   * re-observation returned no view hierarchy, or `observeScreen.execute`
+   * threw, so `getCurrentUIState` resolves to `undefined`) does NOT count as a
+   * confirmed dismissal (#6319): the modal's presence is genuinely
+   * unobservable, so there is zero positive evidence it closed. `tapCloseButton`
+   * promises a candidate succeeds only when it "genuinely dismissed the modal
+   * (verified by re-observing and checking the modal is no longer present)", so
+   * it must require an actual observation — the plain `!undefined?.…` negation
+   * would otherwise collapse to a false-positive `true`. An unverifiable outcome
+   * falls through to the next candidate (and, ultimately, the remaining
+   * dismissal strategies) instead of claiming success.
+   */
+  private async isModalConfirmedDismissed(modal: ModalState, platform: string): Promise<boolean> {
+    const currentState = await this.getCurrentUIState(platform);
+    if (!currentState) {
+      return false;
+    }
+    return !currentState.modalStack?.some((m) => m.windowId === modal.windowId);
+  }
+
+  /**
    * Try to tap a close/cancel button in the current view.
    *
    * Each candidate text is tried in turn, and a candidate only counts as
@@ -548,7 +570,7 @@ export class DefaultUIStateSetup implements UIStateSetup {
         throwIfInternalToolFailed(response, "tapOn", platform);
 
         await this.sleep(200);
-        if (await this.isModalDismissed(modal, platform)) {
+        if (await this.isModalConfirmedDismissed(modal, platform)) {
           logger.debug(`[UI_STATE_SETUP] Tapped close button: "${text}"`);
           return true;
         }

--- a/test/features/navigation/DefaultUIStateSetup.test.ts
+++ b/test/features/navigation/DefaultUIStateSetup.test.ts
@@ -511,5 +511,37 @@ describe("DefaultUIStateSetup", () => {
       // All prior candidates were attempted before the one that worked.
       expect(tappedTexts).toEqual(["Close", "Cancel", "Dismiss", "×", "✕"]);
     });
+
+    // Regression for issue #6319: an adversarial gap in the #6123 fix. The
+    // outcome check runs through the REAL getCurrentUIState/isModalDismissed
+    // path (not a stubbed getCurrentUIState). When the confirming re-observation
+    // returns no view hierarchy, getCurrentUIState resolves to `undefined`, so
+    // the modal's presence is genuinely unobservable. The old
+    // `!undefined?.modalStack?.some(...)` collapsed to `true`, reporting a
+    // confirmed dismissal with zero positive evidence the modal closed. An
+    // unavailable observation must fall through (no candidate confirms), so the
+    // whole loop returns false.
+    test("tap succeeds but re-observation yields no view hierarchy → must NOT report dismissal (#6319)", async () => {
+      const tappedTexts: string[] = [];
+
+      // Real getCurrentUIState runs: every observation returns a null
+      // hierarchy, so isModalDismissed can never confirm the modal is gone.
+      const setup = makeSetup(() => ({
+        execute: async () => ({ viewHierarchy: null }) as unknown as ObserveResult,
+      }));
+
+      ToolRegistry.register("tapOn", "tapOn", {}, async (args: any) => {
+        tappedTexts.push(args.selector.text);
+        // A real element was tapped (tool-wise success), but the outcome is
+        // unverifiable because the re-observation has no hierarchy.
+        return createStructuredToolResponse({ success: true });
+      });
+
+      const result = await tapCloseButtonOf(setup).call(setup, dialog, "android");
+
+      expect(result).toBe(false);
+      // No candidate could be confirmed, so all were attempted.
+      expect(tappedTexts).toEqual(["Close", "Cancel", "Dismiss", "×", "✕"]);
+    });
   });
 });


### PR DESCRIPTION
Closes #6319

## Root cause

`tapCloseButton` (`src/features/navigation/DefaultUIStateSetup.ts`) promises a candidate counts as success only when it BOTH tapped a real element AND "genuinely dismissed the modal (verified by re-observing and checking the modal is no longer present)." But its outcome check ran through `isModalDismissed`:

```ts
return !currentState?.modalStack?.some((m) => m.windowId === modal.windowId);
```

`getCurrentUIState` returns `undefined` whenever the re-observation yields no `viewHierarchy` (or `observeScreen.execute()` throws → caught → `undefined`). With `currentState === undefined`, the expression is `!undefined?.modalStack?.some(...)` === `!undefined` === **`true`**.

So a tap that was tool-wise successful but whose outcome is genuinely **unverifiable** (observation returned no hierarchy) was reported as a confirmed dismissal with zero positive evidence the modal closed. The false `true` propagated through `dismissWithCloseButton` → `dismissModal`, so downstream UI-state setup proceeded believing a possibly-still-present modal was gone.

## Fix

Added `isModalConfirmedDismissed`, a strict variant of `isModalDismissed` used **only on the close-button success path**: an unavailable observation (`getCurrentUIState() === undefined`) counts as NOT confirmed, so the candidate falls through to the next text (and ultimately the remaining dismissal strategies) rather than claiming success. `tapCloseButton` now verifies with this strict check.

Files:
- `src/features/navigation/DefaultUIStateSetup.ts` — new `isModalConfirmedDismissed`; `tapCloseButton` uses it.
- `test/features/navigation/DefaultUIStateSetup.test.ts` — reproducing regression test.

### Scope note (deliberately narrow)

The lenient `!undefined === true` pattern is shared: `isModalDismissed` (swipe/back/tap-outside paths) and the final back-button fallback (`dismissModal`, `!currentState?.modalStack?.some(...)`) both treat an unobservable state as dismissed. Multiple existing tests intentionally use a null-hierarchy observation and expect those *fallback* paths to still report dismissal (e.g. popup outside-tap recovery, iOS back recovery, bottom-sheet back fallback). Per the issue's own guidance ("treat an unavailable observation as not verified dismissed … **at least on the close-button success path**. Direction only — a human should confirm intended semantics"), this PR fixes only the path whose docstring makes the explicit "verified … no longer present" guarantee, and leaves the broader fallback leniency unchanged for human review.

## Test

`test/features/navigation/DefaultUIStateSetup.test.ts` — new case in the `tapCloseButton` (#6123) block, driving the **real** `getCurrentUIState`/verification path (not a stubbed `getCurrentUIState`):

- `tapOn` returns `{success:true}` (a real element tapped);
- every observation returns `{viewHierarchy: null}` (modal presence unobservable);
- asserts `tapCloseButton(dialog, "android")` returns **`false`** and all candidates were attempted.

Fakes + `FakeTimer` (auto-advance), no file-backed DB. Verified it **fails on the pre-fix source** (`Expected: false, Received: true`) and passes with the fix.

## Validation

- `bun test test/features/navigation/` — 566 pass / 0 fail
- `bash scripts/all_fast_validate_checks.sh` — 35 passed / 0 failed
- `BUN_TEST_TIMING_BASE_REF=origin/main bash scripts/validate-bun-test-timings.sh` — exit 0 (no timing regression)
- `bun run lint` — oxlint ratchet: no new violations; boundary-checks 13/13
- `bun run typecheck` — no new type errors
- `bun run build` — success

## needs-human (routine:adversary)

Filed by the adversary routine as `needs-human`. The reproducing failing test is the requested human verification. A reviewer should confirm the intended dismissal-verification semantics for the *other* lenient paths (shared `isModalDismissed` and the final back-button fallback) called out in the scope note above.
