### PR TITLE
fix(deviceMatcher): total order for long numeric components (#6321)

### DIFF
--- a/src/utils/deviceMatcher.ts
+++ b/src/utils/deviceMatcher.ts
@@ -21,7 +21,16 @@ export interface DeviceMatcher {
 }
 
 export interface ParsedDeviceVersion {
-  components: number[];
+  /**
+   * The dotted numeric components, kept as their raw digit strings rather than
+   * `number`s. The parser's `\d+` accepts a run of any length, and coercing a
+   * long-enough run through `Number()` overflows to `Infinity`, which makes the
+   * old subtraction-based comparison return `NaN` and falsifies the total-order
+   * contract (#6321). Digit strings are compared without precision loss
+   * (length-then-lexicographic), so the relation stays reflexive, antisymmetric
+   * and transitive over every input this parser accepts.
+   */
+  components: string[];
   /**
    * A trailing alphabetic release qualifier, uppercased. A single letter
    * covers the shipped cases (Android 12L's "L", #6132 follow-up); the parser
@@ -30,7 +39,8 @@ export interface ParsedDeviceVersion {
    * degrading to a NaN comparison (#6326).
    */
   letter?: string;
-  qpr?: number;
+  /** The QPR suffix as its raw digit string, compared precision-safely like a component (#6321). */
+  qpr?: string;
 }
 
 function parseDeviceVersion(version: string): ParsedDeviceVersion | null {
@@ -39,16 +49,37 @@ function parseDeviceVersion(version: string): ParsedDeviceVersion | null {
     return null;
   }
   return {
-    components: match[1].split(".").map(Number),
+    components: match[1].split("."),
     ...(match[2] === undefined ? {} : { letter: match[2].toUpperCase() }),
-    ...(match[3] === undefined ? {} : { qpr: Number(match[3]) }),
+    ...(match[3] === undefined ? {} : { qpr: match[3] }),
   };
 }
 
-function compareParsedVersions(partsA: number[], partsB: number[]): number {
+/**
+ * Compares two runs of decimal digits as non-negative integers without
+ * precision loss: leading zeros are ignored (so "08" equals "8" and "12.0"
+ * equals "12"), then a longer digit run is the larger number, and equal-length
+ * runs compare lexicographically. Returns a sign (-1, 0, 1). This never returns
+ * `NaN` for any `\d+` run the parser accepts, however long -- the fix for the
+ * `Number()`-overflow-to-`Infinity` defect that made `compareVersions` not a
+ * total order (#6321).
+ */
+function compareNumericComponent(a: string, b: string): number {
+  const trimmedA = a.replace(/^0+(?=\d)/, "");
+  const trimmedB = b.replace(/^0+(?=\d)/, "");
+  if (trimmedA.length !== trimmedB.length) {
+    return trimmedA.length < trimmedB.length ? -1 : 1;
+  }
+  if (trimmedA === trimmedB) {
+    return 0;
+  }
+  return trimmedA < trimmedB ? -1 : 1;
+}
+
+function compareParsedVersions(partsA: string[], partsB: string[]): number {
   const length = Math.max(partsA.length, partsB.length);
   for (let index = 0; index < length; index++) {
-    const delta = (partsA[index] ?? 0) - (partsB[index] ?? 0);
+    const delta = compareNumericComponent(partsA[index] ?? "0", partsB[index] ?? "0");
     if (delta !== 0) {
       return delta;
     }
@@ -87,7 +118,7 @@ export function compareStrictNumericVersions(a: string, b: string): number {
   ) {
     return Number.NaN;
   }
-  return compareParsedVersions(a.split(".").map(Number), b.split(".").map(Number));
+  return compareParsedVersions(a.split("."), b.split("."));
 }
 
 /**
@@ -99,9 +130,9 @@ export function compareStrictNumericVersions(a: string, b: string): number {
  * qualifier order against each other (#6182).
  */
 function compareComponentsThenLetter(
-  componentsA: number[],
+  componentsA: string[],
   letterA: string | undefined,
-  componentsB: number[],
+  componentsB: string[],
   letterB: string | undefined,
 ): number {
   const componentsDelta = compareParsedVersions(componentsA, componentsB);
@@ -132,7 +163,7 @@ export function compareReleaseQualifiers(a: ParsedDeviceVersion, b: ParsedDevice
   if (delta !== 0) {
     return delta;
   }
-  return (a.qpr ?? 0) - (b.qpr ?? 0);
+  return compareNumericComponent(a.qpr ?? "0", b.qpr ?? "0");
 }
 
 export function compareVersions(a: string, b: string): number {
@@ -247,7 +278,7 @@ function compareVersionToBound(version: string, bound: string, platform: Platfor
     if (parsedBound.qpr === undefined) {
       return 0;
     }
-    return (parsedVersion.qpr ?? 0) - parsedBound.qpr;
+    return compareNumericComponent(parsedVersion.qpr ?? "0", parsedBound.qpr);
   }
   return compareVersions(version, bound);
 }

--- a/test/server/deviceMatcher.test.ts
+++ b/test/server/deviceMatcher.test.ts
@@ -124,6 +124,36 @@ describe("compareVersions", () => {
     expect(compareVersions("12LA-QPR1", "12LA")).toBeGreaterThan(0);
     expect(compareVersions("12LA-QPR2", "12LB")).toBeLessThan(0);
   });
+
+  it("stays a total order for a long numeric component the parser accepts (#6321)", () => {
+    // `Number("9".repeat(400)) === Infinity`, so the previous subtraction-based
+    // comparison returned `Infinity - Infinity = NaN` -- neither reflexive nor
+    // total, even though `parseDeviceVersion`'s `\d+` accepts the run.
+    // (Guard against `Object.is(NaN, NaN) === true`: assert via `Number.isNaN`,
+    // not `.toBe(NaN)`.)
+    const huge = "9".repeat(400);
+    expect(compareVersions(huge, huge)).toBe(0);
+    expect(Number.isNaN(compareVersions("1" + huge, "2" + huge))).toBe(false);
+    // Digit strings compare by magnitude without precision loss: the two runs
+    // are distinguishable even though both overflow `Number()` to `Infinity`.
+    expect(compareVersions("1" + huge, "2" + huge)).toBeLessThan(0);
+    expect(compareVersions("2" + huge, "1" + huge)).toBeGreaterThan(0);
+    // A longer run is the larger number.
+    expect(compareVersions(huge, "9".repeat(399))).toBeGreaterThan(0);
+  });
+
+  it("stays a total order for a long QPR suffix the parser accepts (#6321)", () => {
+    const bigQpr = "9".repeat(400);
+    expect(compareVersions("14-QPR" + bigQpr, "14-QPR" + bigQpr)).toBe(0);
+    expect(Number.isNaN(compareVersions("14-QPR" + bigQpr, "14-QPR1"))).toBe(false);
+    expect(compareVersions("14-QPR" + bigQpr, "14-QPR1")).toBeGreaterThan(0);
+  });
+
+  it("ignores leading zeros in numeric components and QPR suffixes", () => {
+    expect(compareVersions("14", "014")).toBe(0);
+    expect(compareVersions("12.08", "12.8")).toBe(0);
+    expect(compareVersions("14-QPR01", "14-QPR1")).toBe(0);
+  });
 });
 
 describe("compareVersions cross-checked against the canonical release table (#6326)", () => {

--- a/test/utils/deviceMatcher.property.test.ts
+++ b/test/utils/deviceMatcher.property.test.ts
@@ -174,6 +174,91 @@ describe("compareVersions over lettered/QPR release qualifiers (property-based)"
   });
 });
 
+// Long numeric components (#6321). `parseDeviceVersion`'s `\d+` accepts a run
+// of any length, but coercing a run past ~308 digits through `Number()`
+// overflows to `Infinity`, which made the old subtraction comparison return
+// `NaN` -- not a total order. Generate components long enough to cross that
+// threshold and check against a BigInt oracle that never loses precision. Fewer
+// runs than RUN_OPTIONS: each case builds up to ~1.8KB of digits.
+const LONG_RUN_OPTIONS = { seed: 1_234_567, numRuns: 150 } as const;
+const bigComponent = fc
+  .array(fc.integer({ min: 0, max: 9 }), { minLength: 1, maxLength: 450 })
+  .map((digits) => digits.join(""));
+const bigVersionParts = fc.array(bigComponent, { minLength: 1, maxLength: 4 });
+const bigVersionOf = (parts: string[]): string => parts.join(".");
+
+// Independent oracle over arbitrary-length digit strings: exact integer
+// comparison via BigInt, missing trailing components treated as 0 (the same
+// contract compareVersions documents). BigInt ignores leading zeros, matching
+// the comparator.
+const refBigIntCompareSign = (a: string[], b: string[]): number => {
+  const length = Math.max(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    const av = BigInt(a[i] ?? "0");
+    const bv = BigInt(b[i] ?? "0");
+    if (av !== bv) {
+      return av < bv ? -1 : 1;
+    }
+  }
+  return 0;
+};
+
+describe("compareVersions over long numeric components (property-based, #6321)", () => {
+  test("is reflexive (never NaN) on a long component", () => {
+    fc.assert(
+      fc.property(
+        bigVersionParts,
+        (parts) => compareVersions(bigVersionOf(parts), bigVersionOf(parts)) === 0,
+      ),
+      LONG_RUN_OPTIONS,
+    );
+  });
+
+  test("returns a defined sign (never NaN) for any two accepted versions", () => {
+    fc.assert(
+      fc.property(bigVersionParts, bigVersionParts, (a, b) => {
+        return !Number.isNaN(compareVersions(bigVersionOf(a), bigVersionOf(b)));
+      }),
+      LONG_RUN_OPTIONS,
+    );
+  });
+
+  test("is sign-antisymmetric", () => {
+    fc.assert(
+      fc.property(bigVersionParts, bigVersionParts, (a, b) => {
+        const va = bigVersionOf(a);
+        const vb = bigVersionOf(b);
+        return Math.sign(compareVersions(va, vb)) === -Math.sign(compareVersions(vb, va));
+      }),
+      LONG_RUN_OPTIONS,
+    );
+  });
+
+  test("agrees in sign with a BigInt (precision-exact) oracle", () => {
+    fc.assert(
+      fc.property(bigVersionParts, bigVersionParts, (a, b) => {
+        return Math.sign(compareVersions(bigVersionOf(a), bigVersionOf(b))) === refBigIntCompareSign(a, b);
+      }),
+      LONG_RUN_OPTIONS,
+    );
+  });
+
+  test("ordering is transitive", () => {
+    fc.assert(
+      fc.property(bigVersionParts, bigVersionParts, bigVersionParts, (a, b, c) => {
+        const va = bigVersionOf(a);
+        const vb = bigVersionOf(b);
+        const vc = bigVersionOf(c);
+        return (
+          !(compareVersions(va, vb) <= 0 && compareVersions(vb, vc) <= 0) ||
+          compareVersions(va, vc) <= 0
+        );
+      }),
+      LONG_RUN_OPTIONS,
+    );
+  });
+});
+
 const platform = fc.constantFrom<Platform>("android", "ios");
 const device: fc.Arbitrary<BootedDevice> = fc.record({
   name: fc.string({ maxLength: 12 }),

--- a/test/utils/deviceMatcher.property.test.ts
+++ b/test/utils/deviceMatcher.property.test.ts
@@ -237,7 +237,10 @@ describe("compareVersions over long numeric components (property-based, #6321)",
   test("agrees in sign with a BigInt (precision-exact) oracle", () => {
     fc.assert(
       fc.property(bigVersionParts, bigVersionParts, (a, b) => {
-        return Math.sign(compareVersions(bigVersionOf(a), bigVersionOf(b))) === refBigIntCompareSign(a, b);
+        return (
+          Math.sign(compareVersions(bigVersionOf(a), bigVersionOf(b))) ===
+          refBigIntCompareSign(a, b)
+        );
       }),
       LONG_RUN_OPTIONS,
     );


### PR DESCRIPTION
Closes #6321.

## Root cause

`parseDeviceVersion`'s regex (`^(\d+(?:\.\d+)*)…-QPR(\d+)?$`) accepts a numeric
component — and a QPR suffix — of *any* length, but the comparator coerced each
component through `Number()` and compared with plain subtraction
(`(partsA[i] ?? 0) - (partsB[i] ?? 0)`). A digit run past ~308 characters
overflows to `Infinity`, so `Infinity - Infinity = NaN`, which is `!== 0`. The
comparator therefore returned `NaN` — neither reflexive nor total — for inputs
the parser accepts, falsifying the total-ordering contract #6281 states in its
own docstring ("reflexive, antisymmetric and transitive over every input this
parser accepts"). A `NaN`-returning comparator also yields implementation-defined
results under `Array.prototype.sort`.

Reproduced on HEAD (`huge = "9".repeat(400)`): `compareVersions(huge, huge)`
returned `NaN` instead of `0`.

## Fix (`src/utils/deviceMatcher.ts`)

Keep the numeric components and the QPR suffix as their raw digit strings
instead of coercing to `number`, and compare them without precision loss via a
new `compareNumericComponent`: leading zeros ignored (so `"12.0" == "12"`,
`"14-QPR01" == "14-QPR1"`), then a longer digit run is the larger number, else
lexicographic. This never returns `NaN` for any `\d+` run the parser accepts,
however long, and preserves the existing semantics on realistic versions
(magnitude was never used — every call site is sign-based). Builds on #6339's
multi-letter qualifier ordering (branched from latest `origin/main`); the letter
tiebreak is untouched.

## Tests

- `test/server/deviceMatcher.test.ts`: the `#6321` reproduction (reflexive on a
  400-digit component, defined sign for two overflowing-but-distinct versions),
  a long-QPR variant, and leading-zero equality. Guards use `Number.isNaN`, not
  `.toBe(NaN)` (`Object.is(NaN, NaN) === true` would false-pass).
- `test/utils/deviceMatcher.property.test.ts`: a long-component generator (runs
  up to 450 digits, crossing the `Number()` overflow threshold) checked for
  reflexivity, no-`NaN`, sign-antisymmetry, transitivity, and agreement with a
  BigInt (precision-exact) oracle.

## Validation

- `bun test` deviceMatcher suites: 76 pass.
- `bash scripts/all_fast_validate_checks.sh`: 35/35.
- `bun run typecheck` + `bun run lint`: ratchets green (no new violations).
- `BUN_TEST_TIMING_BASE_REF=origin/main bash scripts/validate-bun-test-timings.sh`:
  5488 pass, 0 fail; no new timing regressions.

## needs-human (adversary follow-up)

Filed by the daily self-review adversary routine as `needs-human`. The reporter
flagged this as low-severity / triage-first: no real device version is ~400
digits, so it is a contract-correctness / robustness defect, not field-reachable.
This PR hardens the contract the merged #6281 asserts in code (total order over
*every* parser-accepted input); a human should confirm that hardening the
contract — rather than closing as `not_planned` / treating the claim as
aspirational — is the intended resolution. The reproduced counterexample is the
needs-human verification.
