### PR TITLE
feat(server): per-page subscription identities for paginated resources

### DIFF
--- a/src/server/databaseResources.ts
+++ b/src/server/databaseResources.ts
@@ -322,14 +322,12 @@ async function getTableDataResource(params: Record<string, string>): Promise<Res
   const decodedTable = decodeURIComponent(table);
   // Always the canonical URI (no limit/offset), never the exact requested
   // URI. notifyDatabaseChanged / table-schema invalidation both fire
-  // notifyResourceUpdated against this canonical form, and
-  // ResourceRegistry.notifyResourceUpdated requires an exact
-  // subscriptions.has(uri) match — echoing a per-page URI here would leave a
-  // client subscribed to a paginated URI never notified after a mutating
-  // sqlQuery (issue #6188). limit/offset stay valid, optional read params
-  // (issue #6133); the resource's subscribable identity is just the table,
-  // not a page of it. Distinct per-page subscription identities would need a
-  // broader resource-subscription redesign, tracked separately.
+  // notifyResourceUpdated against this canonical form. The registry treats
+  // `limit`/`offset` as page-scoping params, so a canonical-URI change fans
+  // out to every subscriber sharing this table's page-independent identity —
+  // the whole-table subscriber and each per-page subscriber alike (issue
+  // #6198), each notified with its own page URI. limit/offset stay valid,
+  // optional read params (issue #6133).
   const uri = buildTableDataUri(deviceId, decodedPath, decodedTable, appId ?? "");
 
   try {
@@ -533,12 +531,18 @@ export function registerDatabaseResources(): void {
 
   // Register template for table data. appId, limit, and offset are all
   // optional and order-independent (issue #6133) — see the template comment.
+  // limit/offset are page-scoping params: a client may subscribe to a specific
+  // page (`&limit=10&offset=20`) as its own subscription identity, and a
+  // canonical-URI change (notifyDatabaseChanged / schema invalidation, which
+  // both fire against the no-limit/offset form) fans out to every per-page
+  // subscriber (issue #6198).
   ResourceRegistry.registerTemplate(
     DATABASE_RESOURCE_TEMPLATES.TABLE_DATA,
     "Table Data",
     "Get rows from a database table with pagination (default: 50 rows). Add &limit=N&offset=M for pagination.",
     "application/json",
     getTableDataResource,
+    ["limit", "offset"],
   );
 
   // Register template for table structure

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -61,9 +61,46 @@ interface ResourceTemplateMetadata {
   regex: RegExp;
   paramNames: string[];
   queryParamNames: string[];
+  // Query-param names that scope a *page* of an otherwise-shared resource
+  // rather than its identity (e.g. `limit`/`offset` on paginated table data).
+  // Two URIs that differ only in these params are distinct subscription
+  // identities but share one underlying resource, so a canonical-URI update
+  // fans out to every per-page subscriber (issue #6198). Empty for
+  // non-paginated templates, which keeps their exact-match notify behavior.
+  paginationParamNames: string[];
 }
 
 const requestedResourceUri = Symbol("requestedResourceUri");
+
+// Collapse a URI to its *page-independent* subscription identity by dropping
+// the declared pagination query params and normalizing the order of the
+// remaining query params. Two URIs that differ only in pagination (e.g.
+// `.../data?appId=x&limit=10&offset=0` vs `.../data?appId=x&limit=10&offset=10`)
+// map to the same identity, so a canonical-URI update fans out to every
+// per-page subscriber (issue #6198). With an empty pagination set this is just
+// query-order normalization — never used for non-paginated templates, whose
+// notify path stays exact-match.
+function computeSubscriptionIdentity(uri: string, paginationParamNames: string[]): string {
+  const queryStart = uri.indexOf("?");
+  if (queryStart < 0) {
+    return uri;
+  }
+  const path = uri.slice(0, queryStart);
+  const pagination = new Set(paginationParamNames);
+  const retained: Array<[string, string]> = [];
+  for (const [name, value] of new URLSearchParams(uri.slice(queryStart + 1))) {
+    if (pagination.has(name)) {
+      continue;
+    }
+    retained.push([name, value]);
+  }
+  if (retained.length === 0) {
+    return path;
+  }
+  retained.sort((a, b) => (a[0] === b[0] ? a[1].localeCompare(b[1]) : a[0].localeCompare(b[0])));
+  const normalizedQuery = retained.map(([name, value]) => `${name}=${value}`).join("&");
+  return `${path}?${normalizedQuery}`;
+}
 
 export function getRequestedResourceUri(params: Record<string, string>): string | undefined {
   return (params as Record<PropertyKey, unknown>)[requestedResourceUri] as string | undefined;
@@ -187,6 +224,7 @@ class ResourceRegistryClass {
     description: string,
     mimeType: string,
     handler: ResourceTemplateHandler,
+    paginationParams: string[] = [],
   ): void {
     const { regex, paramNames, queryParamNames } = compileUriTemplate(uriTemplate);
     this.templates.set(uriTemplate, {
@@ -198,6 +236,7 @@ class ResourceRegistryClass {
       regex,
       paramNames,
       queryParamNames,
+      paginationParamNames: paginationParams,
     });
   }
 
@@ -207,6 +246,7 @@ class ResourceRegistryClass {
     description: string,
     mimeType: string,
     handlerWithReadContext: ContextualResourceTemplateHandler,
+    paginationParams: string[] = [],
   ): void {
     const { regex, paramNames, queryParamNames } = compileUriTemplate(uriTemplate);
     this.templates.set(uriTemplate, {
@@ -218,6 +258,7 @@ class ResourceRegistryClass {
       regex,
       paramNames,
       queryParamNames,
+      paginationParamNames: paginationParams,
     });
   }
 
@@ -401,32 +442,69 @@ class ResourceRegistryClass {
     return new Set(this.subscriptions);
   }
 
-  // Send resource update notification (only if client is subscribed)
-  async notifyResourceUpdated(uri: string): Promise<void> {
-    if (!this.subscriptions.has(uri)) {
-      return;
+  // Resolve which subscribed URIs a change to `uri` should notify. Each
+  // returned URI is echoed verbatim in the notification so a client re-reads
+  // exactly the resource it subscribed to.
+  //
+  // - Exact resources and non-paginated templates keep exact-match semantics:
+  //   only a subscription on this exact URI is notified.
+  // - A paginated template (one that declared pagination params) fans the
+  //   canonical-URI change out to every subscription sharing its page-
+  //   independent identity — the whole-table subscriber plus each per-page
+  //   subscriber, each notified with its own page URI (issue #6198).
+  private resolveNotificationTargets(
+    uri: string,
+    resource: RegisteredResource | undefined,
+    templateMatch: { template: RegisteredResourceTemplate } | undefined,
+  ): string[] {
+    const paginationParamNames = resource
+      ? []
+      : (templateMatch?.template.paginationParamNames ?? []);
+    if (paginationParamNames.length === 0) {
+      return this.subscriptions.has(uri) ? [uri] : [];
     }
 
+    const changedIdentity = computeSubscriptionIdentity(uri, paginationParamNames);
+    const targets: string[] = [];
+    for (const subscribedUri of this.subscriptions) {
+      if (computeSubscriptionIdentity(subscribedUri, paginationParamNames) === changedIdentity) {
+        targets.push(subscribedUri);
+      }
+    }
+    return targets;
+  }
+
+  // Send resource update notification (only if client is subscribed)
+  async notifyResourceUpdated(uri: string): Promise<void> {
     const resource = this.getResource(uri);
     const templateMatch = resource ? undefined : this.matchTemplate(uri);
     if (!resource && !templateMatch) {
       return;
     }
 
+    const targetUris = this.resolveNotificationTargets(uri, resource, templateMatch);
+    if (targetUris.length === 0) {
+      return;
+    }
+
     // Subscriptions are tracked registry-wide, so every live session's server
     // gets the update (issue #3223) — best-effort per server.
     for (const server of this.servers) {
-      try {
-        // Send notification to clients that resource has changed
-        await server.server.notification({
-          method: "notifications/resources/updated",
-          params: {
-            uri: resource ? resource.uri : uri,
-          },
-        });
-      } catch (error) {
-        // Silently ignore notification errors (e.g., when transport is not connected during tests)
-        logger.debug(`[ResourceRegistry] Failed to notify resource update for ${uri}: ${error}`);
+      for (const targetUri of targetUris) {
+        try {
+          // Send notification to clients that resource has changed
+          await server.server.notification({
+            method: "notifications/resources/updated",
+            params: {
+              uri: targetUri,
+            },
+          });
+        } catch (error) {
+          // Silently ignore notification errors (e.g., when transport is not connected during tests)
+          logger.debug(
+            `[ResourceRegistry] Failed to notify resource update for ${targetUri}: ${error}`,
+          );
+        }
       }
     }
   }

--- a/test/server/resourceRegistryListChanged.test.ts
+++ b/test/server/resourceRegistryListChanged.test.ts
@@ -125,6 +125,153 @@ describe("ResourceRegistry list-changed fan-out (issue #3223)", () => {
   });
 });
 
+describe("ResourceRegistry per-page subscription identities (issue #6198)", () => {
+  const PAGINATED_TEMPLATE = "automobile:pages/{id}/data{?appId,limit,offset}";
+  const CANONICAL_URI = "automobile:pages/one/data?appId=x";
+  const PAGE_A = "automobile:pages/one/data?appId=x&limit=10&offset=0";
+  const PAGE_B = "automobile:pages/one/data?appId=x&limit=10&offset=10";
+
+  function urisNotified(server: FakeMcpServer): string[] {
+    return server.server.notifications
+      .filter((n) => n.method === "notifications/resources/updated")
+      .map((n) => (n.params as { uri: string }).uri);
+  }
+
+  async function subscribe(server: FakeMcpServer, uri: string): Promise<void> {
+    const handler = server.server.handlersBySchema.get(SubscribeRequestSchema);
+    await handler!({ params: { uri } });
+  }
+
+  beforeEach(() => {
+    ResourceRegistry.clearResources();
+    ResourceRegistry.clearServersForTesting();
+    ResourceRegistry.registerTemplate(
+      PAGINATED_TEMPLATE,
+      "Paginated",
+      "Paginated test resource",
+      "application/json",
+      async (params) => ({ uri: getRequestedResourceUri(params) ?? "", text: "{}" }),
+      ["limit", "offset"],
+    );
+  });
+
+  test("distinct per-page URIs are tracked as distinct subscription identities", async () => {
+    const server = new FakeMcpServer();
+    ResourceRegistry.registerWithServer(server as unknown as McpServer);
+    await subscribe(server, PAGE_A);
+    await subscribe(server, PAGE_B);
+
+    const subscriptions = ResourceRegistry.getSubscriptions();
+    expect(subscriptions.has(PAGE_A)).toBe(true);
+    expect(subscriptions.has(PAGE_B)).toBe(true);
+    expect(subscriptions.size).toBe(2);
+  });
+
+  test("a canonical-URI update fans out to every per-page subscriber, each with its own page URI", async () => {
+    const server = new FakeMcpServer();
+    ResourceRegistry.registerWithServer(server as unknown as McpServer);
+    await subscribe(server, PAGE_A);
+    await subscribe(server, PAGE_B);
+
+    await ResourceRegistry.notifyResourceUpdated(CANONICAL_URI);
+
+    expect(urisNotified(server).sort()).toEqual([PAGE_A, PAGE_B]);
+  });
+
+  test("the whole-table subscriber and per-page subscribers are all notified", async () => {
+    const server = new FakeMcpServer();
+    ResourceRegistry.registerWithServer(server as unknown as McpServer);
+    await subscribe(server, CANONICAL_URI);
+    await subscribe(server, PAGE_A);
+
+    await ResourceRegistry.notifyResourceUpdated(CANONICAL_URI);
+
+    expect(urisNotified(server).sort()).toEqual([CANONICAL_URI, PAGE_A].sort());
+  });
+
+  test("pagination-only difference is order-independent between subscription and canonical URI", async () => {
+    const server = new FakeMcpServer();
+    ResourceRegistry.registerWithServer(server as unknown as McpServer);
+    // offset before limit, still the same page-independent identity as CANONICAL_URI.
+    const reordered = "automobile:pages/one/data?offset=10&appId=x&limit=10";
+    await subscribe(server, reordered);
+
+    await ResourceRegistry.notifyResourceUpdated(CANONICAL_URI);
+
+    expect(urisNotified(server)).toEqual([reordered]);
+  });
+
+  test("does not fan out to a page of a different identity (differing non-pagination query)", async () => {
+    const server = new FakeMcpServer();
+    ResourceRegistry.registerWithServer(server as unknown as McpServer);
+    const otherApp = "automobile:pages/one/data?appId=y&limit=10&offset=0";
+    await subscribe(server, PAGE_A);
+    await subscribe(server, otherApp);
+
+    await ResourceRegistry.notifyResourceUpdated(CANONICAL_URI);
+
+    expect(urisNotified(server)).toEqual([PAGE_A]);
+  });
+
+  test("does not fan out to a page of a different path", async () => {
+    const server = new FakeMcpServer();
+    ResourceRegistry.registerWithServer(server as unknown as McpServer);
+    const otherRow = "automobile:pages/two/data?appId=x&limit=10&offset=0";
+    await subscribe(server, PAGE_A);
+    await subscribe(server, otherRow);
+
+    await ResourceRegistry.notifyResourceUpdated(CANONICAL_URI);
+
+    expect(urisNotified(server)).toEqual([PAGE_A]);
+  });
+
+  test("no subscribers means no notification even for a paginated template", async () => {
+    const server = new FakeMcpServer();
+    ResourceRegistry.registerWithServer(server as unknown as McpServer);
+
+    await ResourceRegistry.notifyResourceUpdated(CANONICAL_URI);
+
+    expect(urisNotified(server)).toEqual([]);
+  });
+
+  test("non-paginated resources keep exact-match notify semantics", async () => {
+    const server = new FakeMcpServer();
+    ResourceRegistry.registerWithServer(server as unknown as McpServer);
+    // A non-paginated template (no pagination params declared).
+    ResourceRegistry.registerTemplate(
+      "automobile:plain/{id}{?appId}",
+      "Plain",
+      "Non-paginated test resource",
+      "application/json",
+      async (params) => ({ uri: getRequestedResourceUri(params) ?? "", text: "{}" }),
+    );
+    // A subscription that differs only by a would-be pagination query key.
+    await subscribe(server, "automobile:plain/one?appId=x&limit=10");
+
+    // Firing against the canonical URI must NOT fan out — exact match only.
+    await ResourceRegistry.notifyResourceUpdated("automobile:plain/one?appId=x");
+
+    expect(urisNotified(server)).toEqual([]);
+
+    // The exact subscribed URI is still notified.
+    await ResourceRegistry.notifyResourceUpdated("automobile:plain/one?appId=x&limit=10");
+    expect(urisNotified(server)).toEqual(["automobile:plain/one?appId=x&limit=10"]);
+  });
+
+  test("fan-out reaches every registered server (issue #3223)", async () => {
+    const first = new FakeMcpServer();
+    const second = new FakeMcpServer();
+    ResourceRegistry.registerWithServer(first as unknown as McpServer);
+    ResourceRegistry.registerWithServer(second as unknown as McpServer);
+    await subscribe(first, PAGE_A);
+
+    await ResourceRegistry.notifyResourceUpdated(CANONICAL_URI);
+
+    expect(urisNotified(first)).toEqual([PAGE_A]);
+    expect(urisNotified(second)).toEqual([PAGE_A]);
+  });
+});
+
 describe("ResourceRegistry URI-template matching", () => {
   beforeEach(() => {
     ResourceRegistry.clearResources();


### PR DESCRIPTION
## Problem

Follow-up to #6188 / #6133.

`getTableDataResource` always echoes the **canonical** table-data URI (no `limit`/`offset`), and `notifyDatabaseChanged` / table-schema invalidation both fire `notifyResourceUpdated` against that same canonical form. Because `ResourceRegistry.notifyResourceUpdated` required an exact `subscriptions.has(uri)` match, a client that subscribed to a specific **page** (`?limit=10&offset=20`) was never notified after a mutating `sqlQuery` — its subscription identity did not match the canonical URI. A subscription was effectively to the table as a whole, not to a page of it.

## Fix

A general per-page fan-out in the resource registry (`src/server/resourceRegistry.ts`):

- A template may declare its page-scoping query params via a new optional `paginationParams` argument to `registerTemplate` / `registerTemplateWithReadContext`. It defaults to `[]`, so **every existing template keeps its exact-match notify behavior** unchanged.
- `computeSubscriptionIdentity(uri, paginationParamNames)` collapses a URI to its page-independent identity: the path plus the non-pagination query params, order-normalized. URIs differing only in pagination map to one identity.
- `notifyResourceUpdated`, when the changed URI matches a template that declared pagination params, fans the update out to **every subscription sharing that identity** — the whole-table subscriber and each per-page subscriber alike — echoing each subscriber's **own** page URI so it re-reads exactly the page it subscribed to. Exact resources and non-paginated templates keep exact-match semantics.
- The table-data template (`src/server/databaseResources.ts`) declares `["limit", "offset"]` as its pagination params.

Distinct pages remain distinct subscription identities; a different `appId` or table (differing non-pagination query / path) is never cross-notified.

## Tests

New `ResourceRegistry per-page subscription identities (issue #6198)` suite in `test/server/resourceRegistryListChanged.test.ts`:

- distinct per-page URIs tracked as distinct subscription identities
- canonical-URI update fans out to every per-page subscriber, each with its own page URI
- whole-table subscriber and per-page subscribers all notified
- pagination-only difference is order-independent
- no fan-out to a different identity (differing `appId`) or a different path
- empty-subscriber no-op for a paginated template
- **non-paginated resources keep exact-match notify semantics**
- fan-out reaches every registered server (#3223)

## Validation

- `bun test test/server/resourceRegistryListChanged.test.ts test/server/databaseResourcesPagination.test.ts` — 36 pass
- `bash scripts/all_fast_validate_checks.sh` — 35/35 pass
- `bun run lint` (oxlint ratchet), `bun run typecheck`, `bun run build` — green, no new violations
- `BUN_TEST_TIMING_BASE_REF=origin/main bash scripts/validate-bun-test-timings.sh` — exit 0, 5857 pass

No shared daemon/socket types were touched — the change is entirely within the resource-subscription identity code.

Closes #6198
