### PR TITLE
test(navigation): inject action/timer fakes into ExploreBlockerDetection tests

### DIFF
--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -65,6 +65,10 @@ import {
   isPermissionDialog,
   handlePermissionDialog,
 } from "./ExploreBlockerDetection";
+import type {
+  BlockerHandlerDeps,
+  DialogTapActionFactory,
+} from "./ExploreBlockerDetection";
 
 // Import validate mode functions
 import {
@@ -101,6 +105,7 @@ export class Explore extends BaseVisualChange {
   private currentTargetEdge: NavigationEdge | null = null;
   private currentElementConfidence: number = 0;
   private sessionUuid?: string;
+  private readonly tapActionFactory?: DialogTapActionFactory;
 
   // Constants for safety limits
   private static readonly MAX_CONSECUTIVE_BACKS = 5;
@@ -117,12 +122,25 @@ export class Explore extends BaseVisualChange {
     timer: Timer = defaultTimer,
     navigationManager?: NavigationGraphService,
     sessionUuid?: string,
+    tapActionFactory?: DialogTapActionFactory,
   ) {
     super(device, adb, timer);
     this.navigationManager = navigationManager ?? NavigationGraphManager.getInstance();
     this.exploredElements = new Map();
     this.elementParser = new DefaultElementParser();
     this.sessionUuid = sessionUuid;
+    this.tapActionFactory = tapActionFactory;
+  }
+
+  /**
+   * Dependencies threaded into the blocker handlers so exploration reuses this
+   * instance's injected `timer` (identical to `defaultTimer` in production) and
+   * lets a test substitute a fake tap action instead of spying on
+   * `TapOnElement.prototype`. `tapActionFactory` is left undefined in
+   * production, so the handlers fall back to constructing `TapOnElement`.
+   */
+  private blockerHandlerDeps(): BlockerHandlerDeps {
+    return { timer: this.timer, tapActionFactory: this.tapActionFactory };
   }
 
   /**
@@ -229,6 +247,7 @@ export class Explore extends BaseVisualChange {
           this.elementParser,
           (p) => this.handleDeadEnd(p),
           progress,
+          this.blockerHandlerDeps(),
         );
         if (blockerHandled) {
           // Re-observe after handling blocker
@@ -524,6 +543,7 @@ export class Explore extends BaseVisualChange {
       this.device,
       this.adb,
       progress,
+      this.blockerHandlerDeps(),
     );
     if (granted) {
       this.consecutiveNoChangeCount = 0;

--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -65,10 +65,7 @@ import {
   isPermissionDialog,
   handlePermissionDialog,
 } from "./ExploreBlockerDetection";
-import type {
-  BlockerHandlerDeps,
-  DialogTapActionFactory,
-} from "./ExploreBlockerDetection";
+import type { BlockerHandlerDeps, DialogTapActionFactory } from "./ExploreBlockerDetection";
 
 // Import validate mode functions
 import {

--- a/src/features/navigation/ExploreBlockerDetection.ts
+++ b/src/features/navigation/ExploreBlockerDetection.ts
@@ -2,10 +2,43 @@ import type { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import type { ProgressCallback } from "../action/BaseVisualChange";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
+import type { TapOnElementOptions } from "../../models/TapOnElementOptions";
 import { TapOnElement } from "../action/TapOnElement";
 import { logger } from "../../utils/logger";
 import { extractAllElements, tapSelectorFor } from "./ExploreElementExtraction";
-import { defaultTimer } from "../../utils/SystemTimer";
+import { defaultTimer, Timer } from "../../utils/SystemTimer";
+
+/**
+ * Minimal tap-action seam consumed by the blocker handlers. Only `execute`
+ * is used, and its result is ignored (the handlers just need the tap to fire),
+ * so this exposes exactly that (YAGNI). `TapOnElement` satisfies it directly.
+ */
+export interface DialogTapAction {
+  execute(options: TapOnElementOptions, progress?: ProgressCallback): Promise<unknown>;
+}
+
+/**
+ * Builds a {@link DialogTapAction} for a device/adb pair. Injecting the factory
+ * (rather than `new TapOnElement(...)` at the call site) lets tests substitute
+ * a fake instead of spying on `TapOnElement.prototype`.
+ */
+export type DialogTapActionFactory = (
+  device: BootedDevice,
+  adb: AdbExecutor | null,
+) => DialogTapAction;
+
+/**
+ * Injectable dependencies for the blocker handlers. Both are optional and
+ * default to production singletons, so every existing call site is unchanged
+ * and behavior is identical unless a caller (or a test) injects a fake.
+ */
+export interface BlockerHandlerDeps {
+  tapActionFactory?: DialogTapActionFactory;
+  timer?: Timer;
+}
+
+const defaultTapActionFactory: DialogTapActionFactory = (device, adb) =>
+  new TapOnElement(device, adb);
 
 /**
  * Normalized, lowercased text for an element.
@@ -364,7 +397,10 @@ export async function handlePermissionDialog(
   device: BootedDevice,
   adb: AdbExecutor | null,
   progress?: ProgressCallback,
+  deps: BlockerHandlerDeps = {},
 ): Promise<boolean> {
+  const tapActionFactory = deps.tapActionFactory ?? defaultTapActionFactory;
+  const timer = deps.timer ?? defaultTimer;
   for (const element of elements) {
     if (!element.clickable) {
       continue;
@@ -376,9 +412,9 @@ export async function handlePermissionDialog(
         continue;
       }
       try {
-        const tapOn = new TapOnElement(device, adb);
+        const tapOn = tapActionFactory(device, adb);
         await tapOn.execute({ ...selector, action: "tap" }, progress);
-        await defaultTimer.sleep(1000);
+        await timer.sleep(1000);
         return true;
       } catch (error) {
         logger.warn(`[Explore] Failed to handle permission dialog: ${error}`);
@@ -402,7 +438,10 @@ async function dismissDialog(
   device: BootedDevice,
   adb: AdbExecutor | null,
   progress?: ProgressCallback,
+  deps: BlockerHandlerDeps = {},
 ): Promise<boolean> {
+  const tapActionFactory = deps.tapActionFactory ?? defaultTapActionFactory;
+  const timer = deps.timer ?? defaultTimer;
   for (const element of elements) {
     if (!element.clickable) {
       continue;
@@ -414,9 +453,9 @@ async function dismissDialog(
         continue;
       }
       try {
-        const tapOn = new TapOnElement(device, adb);
+        const tapOn = tapActionFactory(device, adb);
         await tapOn.execute({ ...selector, action: "tap" }, progress);
-        await defaultTimer.sleep(1000);
+        await timer.sleep(1000);
         return true;
       } catch (error) {
         logger.warn(`[Explore] Failed to dismiss dialog: ${error}`);
@@ -442,6 +481,7 @@ export async function detectAndHandleBlockers(
   elementParser: ElementParser,
   handleDeadEnd: DeadEndHandler,
   progress?: ProgressCallback,
+  deps: BlockerHandlerDeps = {},
 ): Promise<boolean> {
   const viewHierarchy = observation.viewHierarchy;
   if (!viewHierarchy || viewHierarchy.hierarchy.error) {
@@ -454,7 +494,7 @@ export async function detectAndHandleBlockers(
   // Check for permission dialogs
   if (isPermissionDialog(elements)) {
     logger.info("[Explore] Detected permission dialog, attempting to dismiss");
-    return await handlePermissionDialog(elements, viewHierarchy, device, adb, progress);
+    return await handlePermissionDialog(elements, viewHierarchy, device, adb, progress, deps);
   }
 
   // Check for login/signup screens
@@ -467,7 +507,7 @@ export async function detectAndHandleBlockers(
   // Check for app rating/review dialogs
   if (isRatingDialog(elements)) {
     logger.info("[Explore] Detected rating dialog, attempting to dismiss");
-    return await dismissDialog(elements, viewHierarchy, device, adb, progress);
+    return await dismissDialog(elements, viewHierarchy, device, adb, progress, deps);
   }
 
   return false;

--- a/test/fakes/FakeDialogTapAction.ts
+++ b/test/fakes/FakeDialogTapAction.ts
@@ -1,0 +1,46 @@
+import type { BootedDevice } from "../../src/models";
+import type { AdbExecutor } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { ProgressCallback } from "../../src/features/action/BaseVisualChange";
+import type { TapOnElementOptions } from "../../src/models/TapOnElementOptions";
+import type {
+  DialogTapAction,
+  DialogTapActionFactory,
+} from "../../src/features/navigation/ExploreBlockerDetection";
+
+/**
+ * Fake {@link DialogTapAction} for the Explore blocker handlers.
+ *
+ * Replaces `spyOn(TapOnElement.prototype, "execute")`: the handlers construct
+ * their tap action through an injected {@link DialogTapActionFactory}, so a
+ * test passes {@link FakeDialogTapAction.factory} instead of patching a
+ * prototype. Records every `execute` call's options for assertions and the
+ * `(device, adb)` pairs the handler built actions for.
+ */
+export class FakeDialogTapAction implements DialogTapAction {
+  readonly calls: TapOnElementOptions[] = [];
+  readonly builtFor: Array<{ device: BootedDevice; adb: AdbExecutor | null }> = [];
+  private readonly result: unknown;
+  private readonly error?: Error;
+
+  constructor(options: { result?: unknown; error?: Error } = {}) {
+    this.result = options.result ?? { success: true, action: "tap" };
+    this.error = options.error;
+  }
+
+  async execute(options: TapOnElementOptions, _progress?: ProgressCallback): Promise<unknown> {
+    this.calls.push(options);
+    if (this.error) {
+      throw this.error;
+    }
+    return this.result;
+  }
+
+  /**
+   * Factory that records the device/adb pair and returns this recorder, so a
+   * single fake captures every tap the handler performs in a test.
+   */
+  readonly factory: DialogTapActionFactory = (device, adb) => {
+    this.builtFor.push({ device, adb });
+    return this;
+  };
+}

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -31,7 +31,7 @@ import type { ElementParser } from "../../../src/utils/interfaces/ElementParser"
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { TapOnElement } from "../../../src/features/action/TapOnElement";
 import { LaunchApp } from "../../../src/features/action/LaunchApp";
-import { defaultTimer } from "../../../src/utils/SystemTimer";
+import { FakeDialogTapAction } from "../../fakes/FakeDialogTapAction";
 
 // `dumpsys window windows` output parseable (by Window.parseActiveWindowModern)
 // as the launcher being foreground. Used to satisfy home-press verification
@@ -354,7 +354,13 @@ describe("Explore", () => {
     // forever until the timeout. The no-op must now be counted so the existing
     // stuck-screen accounting stops exploration (partially addresses #6169).
     test("does not loop indefinitely on a deny-only permission dialog", async () => {
-      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph);
+      // The deny control must never be tapped: inject a fake tap action and
+      // assert it is never invoked (issue #6191 — no more TapOnElement.prototype
+      // spy). The blocker handler's post-tap sleep runs on the injected
+      // auto-advancing fakeTimer, so the run stays fast without stubbing a
+      // module-level timer.
+      const fakeTap = new FakeDialogTapAction();
+      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph, undefined, fakeTap.factory);
 
       const denyOnlyDialog = createMockObservation([
         createMockViewHierarchyNode({
@@ -379,11 +385,6 @@ describe("Explore", () => {
         getMostRecentCachedObserveResult: async () => denyOnlyDialog,
       };
 
-      // The deny control must never be tapped.
-      const tapSpy = spyOn(TapOnElement.prototype, "execute").mockResolvedValue({
-        success: true,
-      } as never);
-
       // maxInteractions and timeout are set generously so the ONLY thing that
       // can terminate the run is the stuck-screen accounting; without the fix
       // this run would spin forever.
@@ -397,14 +398,13 @@ describe("Explore", () => {
       expect(result.stopReason).toContain("stuck");
       // Bounded by the stuck counter, not maxInteractions or the timeout.
       expect(observeCount).toBe(maxNoChange);
-      expect(tapSpy).not.toHaveBeenCalled();
-
-      tapSpy.mockRestore();
+      expect(fakeTap.calls).toEqual([]);
     });
 
     // A grantable permission dialog still taps "Allow" and exploration proceeds.
     test("grants a permission dialog and continues exploring", async () => {
-      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph);
+      const fakeTap = new FakeDialogTapAction();
+      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph, undefined, fakeTap.factory);
 
       const grantDialog = createMockObservation([
         createMockViewHierarchyNode({
@@ -430,12 +430,9 @@ describe("Explore", () => {
         getMostRecentCachedObserveResult: async () => normalScreen,
       };
 
-      const tapSpy = spyOn(TapOnElement.prototype, "execute").mockResolvedValue({
-        success: true,
-      } as never);
-      // handlePermissionDialog sleeps on the real timer after a grant; stub it
-      // so the test stays fast (<100ms).
-      const sleepSpy = spyOn(defaultTimer, "sleep").mockResolvedValue(undefined);
+      // handlePermissionDialog sleeps after a grant; that sleep now runs on the
+      // injected auto-advancing fakeTimer (issue #6191), so no defaultTimer stub
+      // is needed to keep the test fast.
       // Successful interactions advance the interaction counter so the run ends
       // deterministically at maxInteractions rather than via stuck detection.
       (explore as any).performInteraction = async () => true;
@@ -447,14 +444,11 @@ describe("Explore", () => {
       });
 
       // The "Allow" button was tapped exactly once, via the permission fast-path.
-      expect(tapSpy).toHaveBeenCalledTimes(1);
+      expect(fakeTap.calls).toHaveLength(1);
       // Exploration continued past the dialog rather than stalling on it.
       expect(result.stopReason).not.toContain("stuck");
       expect(result.interactionsPerformed).toBe(2);
       expect(observeCount).toBeGreaterThan(1);
-
-      tapSpy.mockRestore();
-      sleepSpy.mockRestore();
     });
 
     // Regression: a grant used to report "continue" without clearing the
@@ -464,7 +458,8 @@ describe("Explore", () => {
     // observation on the next prompt could immediately trip the stuck-screen
     // stop despite the intervening successful grant.
     test("resets the no-change streak after granting a permission", async () => {
-      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph);
+      const fakeTap = new FakeDialogTapAction();
+      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph, undefined, fakeTap.factory);
 
       const grantDialog = createMockObservation([
         createMockViewHierarchyNode({
@@ -480,11 +475,6 @@ describe("Explore", () => {
         }),
       ]);
 
-      const tapSpy = spyOn(TapOnElement.prototype, "execute").mockResolvedValue({
-        success: true,
-      } as never);
-      const sleepSpy = spyOn(defaultTimer, "sleep").mockResolvedValue(undefined);
-
       // Simulate a streak accrued by an earlier, unrelated ungrantable dialog.
       (explore as any).consecutiveNoChangeCount = 39;
 
@@ -492,10 +482,7 @@ describe("Explore", () => {
 
       expect(outcome).toBe("continue");
       expect((explore as any).consecutiveNoChangeCount).toBe(0);
-      expect(tapSpy).toHaveBeenCalledTimes(1);
-
-      tapSpy.mockRestore();
-      sleepSpy.mockRestore();
+      expect(fakeTap.calls).toHaveLength(1);
     });
 
     test("should detect login screens", async () => {

--- a/test/features/navigation/ExploreBlockerDetection.test.ts
+++ b/test/features/navigation/ExploreBlockerDetection.test.ts
@@ -1,7 +1,8 @@
-import { expect, describe, test, spyOn } from "bun:test";
+import { expect, describe, test } from "bun:test";
 import { Element } from "../../../src/models";
 import type { BootedDevice, ObserveResult, ViewHierarchyResult } from "../../../src/models";
 import type { ElementParser } from "../../../src/utils/interfaces/ElementParser";
+import type { TapOnElementOptions } from "../../../src/models/TapOnElementOptions";
 import {
   isPermissionDialog,
   isLoginScreen,
@@ -11,8 +12,9 @@ import {
   handlePermissionDialog,
   isPermissionDenyElement,
 } from "../../../src/features/navigation/ExploreBlockerDetection";
-import { TapOnElement } from "../../../src/features/action/TapOnElement";
-import { defaultTimer } from "../../../src/utils/SystemTimer";
+import type { BlockerHandlerDeps } from "../../../src/features/navigation/ExploreBlockerDetection";
+import { FakeDialogTapAction } from "../../fakes/FakeDialogTapAction";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 describe("ExploreBlockerDetection", () => {
   function createMockElement(overrides: Partial<Element> = {}): Element {
@@ -394,23 +396,22 @@ describe("ExploreBlockerDetection", () => {
     // TapOnElement.validateOptions rejects a call carrying both text and
     // elementId, so an Allow / dismiss button that has both must be tapped
     // with exactly one selector (issue #6121). The handlers hard-sleep 1s
-    // after a tap via defaultTimer, so that is stubbed to keep the test fast.
-    function captureTapOptions(): { calls: unknown[]; restore: () => void } {
-      const calls: unknown[] = [];
-      const tapSpy = spyOn(TapOnElement.prototype, "execute").mockImplementation(
-        async (options: unknown) => {
-          calls.push(options);
-          return { success: true, action: "tap" } as never;
-        },
-      );
-      const sleepSpy = spyOn(defaultTimer, "sleep").mockResolvedValue(undefined);
-      return {
-        calls,
-        restore: () => {
-          tapSpy.mockRestore();
-          sleepSpy.mockRestore();
-        },
-      };
+    // after a tap; a FakeTimer in auto-advance mode resolves that sleep
+    // immediately (and records it) so the test stays fast and deterministic.
+    //
+    // Injecting a FakeDialogTapAction + FakeTimer through the handler's `deps`
+    // seam replaces the former `spyOn(TapOnElement.prototype, "execute")` /
+    // `spyOn(defaultTimer, "sleep")` global spies (issue #6191): nothing global
+    // is patched, so there is nothing to restore between tests.
+    function captureTapOptions(): {
+      calls: TapOnElementOptions[];
+      timer: FakeTimer;
+      deps: BlockerHandlerDeps;
+    } {
+      const tap = new FakeDialogTapAction();
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      return { calls: tap.calls, timer, deps: { tapActionFactory: tap.factory, timer } };
     }
 
     const androidDevice = { deviceId: "emulator-5554", platform: "android" } as BootedDevice;
@@ -437,7 +438,7 @@ describe("ExploreBlockerDetection", () => {
     }
 
     test("handlePermissionDialog taps an Allow button with text and resource-id by id only", async () => {
-      const { calls, restore } = captureTapOptions();
+      const { calls, deps } = captureTapOptions();
       const elements = [
         createMockElement({ text: "Allow camera access?", clickable: false }),
         createMockElement({
@@ -446,17 +447,14 @@ describe("ExploreBlockerDetection", () => {
         }),
       ];
 
-      let handled: boolean;
-      try {
-        handled = await handlePermissionDialog(
-          elements,
-          hierarchyOf(elements),
-          androidDevice,
-          null,
-        );
-      } finally {
-        restore();
-      }
+      const handled = await handlePermissionDialog(
+        elements,
+        hierarchyOf(elements),
+        androidDevice,
+        null,
+        undefined,
+        deps,
+      );
 
       expect(handled).toBe(true);
       expect(calls).toEqual([
@@ -472,7 +470,7 @@ describe("ExploreBlockerDetection", () => {
     // if they were the dialog's Allow button, before a genuine "OK" was ever
     // reached.
     test("handlePermissionDialog skips 'ok'-substring buttons and taps the real OK button", async () => {
-      const { calls, restore } = captureTapOptions();
+      const { calls, deps } = captureTapOptions();
       const elements = [
         createMockElement({ text: "Bookmarks", "resource-id": "com.test:id/bookmarks" }),
         createMockElement({ text: "Cookies", "resource-id": "com.test:id/cookies" }),
@@ -480,40 +478,34 @@ describe("ExploreBlockerDetection", () => {
         createMockElement({ text: "OK", "resource-id": "com.test:id/ok_button" }),
       ];
 
-      let handled: boolean;
-      try {
-        handled = await handlePermissionDialog(
-          elements,
-          hierarchyOf(elements),
-          androidDevice,
-          null,
-        );
-      } finally {
-        restore();
-      }
+      const handled = await handlePermissionDialog(
+        elements,
+        hierarchyOf(elements),
+        androidDevice,
+        null,
+        undefined,
+        deps,
+      );
 
       expect(handled).toBe(true);
       expect(calls).toEqual([{ elementId: "com.test:id/ok_button", action: "tap" }]);
     });
 
     test("handlePermissionDialog does not tap when only 'ok'-substring buttons are present", async () => {
-      const { calls, restore } = captureTapOptions();
+      const { calls, deps } = captureTapOptions();
       const elements = [
         createMockElement({ text: "Bookmarks", "resource-id": "com.test:id/bookmarks" }),
         createMockElement({ text: "Cookies", "resource-id": "com.test:id/cookies" }),
       ];
 
-      let handled: boolean;
-      try {
-        handled = await handlePermissionDialog(
-          elements,
-          hierarchyOf(elements),
-          androidDevice,
-          null,
-        );
-      } finally {
-        restore();
-      }
+      const handled = await handlePermissionDialog(
+        elements,
+        hierarchyOf(elements),
+        androidDevice,
+        null,
+        undefined,
+        deps,
+      );
 
       expect(handled).toBe(false);
       expect(calls).toEqual([]);
@@ -525,7 +517,7 @@ describe("ExploreBlockerDetection", () => {
     // substring check accepted them.
     test("handlePermissionDialog taps machine-style 'ok_button'/'allow_button'/'ok.button' content-desc ids", async () => {
       for (const machineId of ["ok_button", "allow_button", "ok.button"]) {
-        const { calls, restore } = captureTapOptions();
+        const { calls, deps } = captureTapOptions();
         const elements = [
           createMockElement({
             text: "",
@@ -534,17 +526,14 @@ describe("ExploreBlockerDetection", () => {
           }),
         ];
 
-        let handled: boolean;
-        try {
-          handled = await handlePermissionDialog(
-            elements,
-            hierarchyOf(elements),
-            androidDevice,
-            null,
-          );
-        } finally {
-          restore();
-        }
+        const handled = await handlePermissionDialog(
+          elements,
+          hierarchyOf(elements),
+          androidDevice,
+          null,
+          undefined,
+          deps,
+        );
 
         expect(handled).toBe(true);
         expect(calls).toEqual([{ elementId: "com.test:id/ok_button", action: "tap" }]);
@@ -558,20 +547,17 @@ describe("ExploreBlockerDetection", () => {
     // affirmative keyword (tokenizes to ["okay"], distinct from "ok").
     test("handlePermissionDialog taps camelCase 'okButton'/'allowButton' content-desc ids and a genuine 'Okay' button", async () => {
       for (const text of ["okButton", "allowButton", "Okay"]) {
-        const { calls, restore } = captureTapOptions();
+        const { calls, deps } = captureTapOptions();
         const elements = [createMockElement({ text, "resource-id": "com.test:id/ok_button" })];
 
-        let handled: boolean;
-        try {
-          handled = await handlePermissionDialog(
-            elements,
-            hierarchyOf(elements),
-            androidDevice,
-            null,
-          );
-        } finally {
-          restore();
-        }
+        const handled = await handlePermissionDialog(
+          elements,
+          hierarchyOf(elements),
+          androidDevice,
+          null,
+          undefined,
+          deps,
+        );
 
         expect(handled).toBe(true);
         expect(calls).toEqual([{ elementId: "com.test:id/ok_button", action: "tap" }]);
@@ -584,22 +570,19 @@ describe("ExploreBlockerDetection", () => {
     // otherwise it tokenizes as a single "okbutton" token that matches
     // nothing.
     test("handlePermissionDialog taps acronym-prefixed camelCase 'OKButton' content-desc", async () => {
-      const { calls, restore } = captureTapOptions();
+      const { calls, deps } = captureTapOptions();
       const elements = [
         createMockElement({ text: "OKButton", "resource-id": "com.test:id/ok_button" }),
       ];
 
-      let handled: boolean;
-      try {
-        handled = await handlePermissionDialog(
-          elements,
-          hierarchyOf(elements),
-          androidDevice,
-          null,
-        );
-      } finally {
-        restore();
-      }
+      const handled = await handlePermissionDialog(
+        elements,
+        hierarchyOf(elements),
+        androidDevice,
+        null,
+        undefined,
+        deps,
+      );
 
       expect(handled).toBe(true);
       expect(calls).toEqual([{ elementId: "com.test:id/ok_button", action: "tap" }]);
@@ -613,7 +596,7 @@ describe("ExploreBlockerDetection", () => {
     // grant. The deny-exclusion set must skip "Don't allow" and tap the real
     // grant button that follows it.
     test("handlePermissionDialog taps the grant button, never 'Don't allow', when deny precedes grant", async () => {
-      const { calls, restore } = captureTapOptions();
+      const { calls, deps } = captureTapOptions();
       const elements = [
         createMockElement({
           text: "Don't allow",
@@ -626,17 +609,14 @@ describe("ExploreBlockerDetection", () => {
         }),
       ];
 
-      let handled: boolean;
-      try {
-        handled = await handlePermissionDialog(
-          elements,
-          hierarchyOf(elements),
-          androidDevice,
-          null,
-        );
-      } finally {
-        restore();
-      }
+      const handled = await handlePermissionDialog(
+        elements,
+        hierarchyOf(elements),
+        androidDevice,
+        null,
+        undefined,
+        deps,
+      );
 
       expect(handled).toBe(true);
       expect(calls).toEqual([
@@ -659,23 +639,20 @@ describe("ExploreBlockerDetection", () => {
     ])(
       "handlePermissionDialog excludes deny label %p and taps the affirmative option",
       async (denyText: string) => {
-        const { calls, restore } = captureTapOptions();
+        const { calls, deps } = captureTapOptions();
         const elements = [
           createMockElement({ text: denyText, "resource-id": "com.test:id/deny" }),
           createMockElement({ text: "Only this time", "resource-id": "com.test:id/allow" }),
         ];
 
-        let handled: boolean;
-        try {
-          handled = await handlePermissionDialog(
-            elements,
-            hierarchyOf(elements),
-            androidDevice,
-            null,
-          );
-        } finally {
-          restore();
-        }
+        const handled = await handlePermissionDialog(
+          elements,
+          hierarchyOf(elements),
+          androidDevice,
+          null,
+          undefined,
+          deps,
+        );
 
         expect(handled).toBe(true);
         expect(calls).toEqual([{ elementId: "com.test:id/allow", action: "tap" }]);
@@ -702,22 +679,19 @@ describe("ExploreBlockerDetection", () => {
     ])(
       "handlePermissionDialog does not tap when only a deny control %p is present",
       async (denyText: string) => {
-        const { calls, restore } = captureTapOptions();
+        const { calls, deps } = captureTapOptions();
         const elements = [
           createMockElement({ text: denyText, "resource-id": "com.test:id/deny_button" }),
         ];
 
-        let handled: boolean;
-        try {
-          handled = await handlePermissionDialog(
-            elements,
-            hierarchyOf(elements),
-            androidDevice,
-            null,
-          );
-        } finally {
-          restore();
-        }
+        const handled = await handlePermissionDialog(
+          elements,
+          hierarchyOf(elements),
+          androidDevice,
+          null,
+          undefined,
+          deps,
+        );
 
         expect(handled).toBe(false);
         expect(calls).toEqual([]);
@@ -727,7 +701,7 @@ describe("ExploreBlockerDetection", () => {
     // A "Blocked" label in one field must veto an "allow" token carried in the
     // other, so a mixed control is never treated as an affirmative grant.
     test("handlePermissionDialog does not tap a control mixing an allow token with 'Blocked'", async () => {
-      const { calls, restore } = captureTapOptions();
+      const { calls, deps } = captureTapOptions();
       const elements = [
         createMockElement({
           text: "Allow",
@@ -736,17 +710,14 @@ describe("ExploreBlockerDetection", () => {
         }),
       ];
 
-      let handled: boolean;
-      try {
-        handled = await handlePermissionDialog(
-          elements,
-          hierarchyOf(elements),
-          androidDevice,
-          null,
-        );
-      } finally {
-        restore();
-      }
+      const handled = await handlePermissionDialog(
+        elements,
+        hierarchyOf(elements),
+        androidDevice,
+        null,
+        undefined,
+        deps,
+      );
 
       expect(handled).toBe(false);
       expect(calls).toEqual([]);
@@ -771,7 +742,7 @@ describe("ExploreBlockerDetection", () => {
     ])(
       "handlePermissionDialog does not tap machine-form negative content-desc %p",
       async (denyContentDesc: string) => {
-        const { calls, restore } = captureTapOptions();
+        const { calls, deps } = captureTapOptions();
         const elements = [
           createMockElement({
             text: "",
@@ -780,17 +751,14 @@ describe("ExploreBlockerDetection", () => {
           }),
         ];
 
-        let handled: boolean;
-        try {
-          handled = await handlePermissionDialog(
-            elements,
-            hierarchyOf(elements),
-            androidDevice,
-            null,
-          );
-        } finally {
-          restore();
-        }
+        const handled = await handlePermissionDialog(
+          elements,
+          hierarchyOf(elements),
+          androidDevice,
+          null,
+          undefined,
+          deps,
+        );
 
         expect(handled).toBe(false);
         expect(calls).toEqual([]);
@@ -844,7 +812,7 @@ describe("ExploreBlockerDetection", () => {
     // The canonical modern layout (grant first, deny last) must keep working:
     // the grant button is tapped and the trailing "Don't allow" is ignored.
     test("handlePermissionDialog taps 'Allow' and ignores a trailing 'Don't allow'", async () => {
-      const { calls, restore } = captureTapOptions();
+      const { calls, deps } = captureTapOptions();
       const elements = [
         createMockElement({
           text: "Allow",
@@ -856,17 +824,14 @@ describe("ExploreBlockerDetection", () => {
         }),
       ];
 
-      let handled: boolean;
-      try {
-        handled = await handlePermissionDialog(
-          elements,
-          hierarchyOf(elements),
-          androidDevice,
-          null,
-        );
-      } finally {
-        restore();
-      }
+      const handled = await handlePermissionDialog(
+        elements,
+        hierarchyOf(elements),
+        androidDevice,
+        null,
+        undefined,
+        deps,
+      );
 
       expect(handled).toBe(true);
       expect(calls).toEqual([
@@ -878,7 +843,7 @@ describe("ExploreBlockerDetection", () => {
     });
 
     test("dismissDialog taps a Not now button with text and resource-id by id only", async () => {
-      const { calls, restore } = captureTapOptions();
+      const { calls, deps } = captureTapOptions();
       const elements = [
         createMockElement({ text: "Enjoying the app? Rate us!", clickable: false }),
         createMockElement({ text: "Not now", "resource-id": "com.test:id/dismiss_button" }),
@@ -888,18 +853,15 @@ describe("ExploreBlockerDetection", () => {
           elements.map((element, index) => ({ element, index, depth: 0 })),
       } as unknown as ElementParser;
 
-      let handled: boolean;
-      try {
-        handled = await detectAndHandleBlockers(
-          { viewHierarchy: hierarchyOf(elements) } as unknown as ObserveResult,
-          androidDevice,
-          null,
-          parser,
-          async () => {},
-        );
-      } finally {
-        restore();
-      }
+      const handled = await detectAndHandleBlockers(
+        { viewHierarchy: hierarchyOf(elements) } as unknown as ObserveResult,
+        androidDevice,
+        null,
+        parser,
+        async () => {},
+        undefined,
+        deps,
+      );
 
       expect(handled).toBe(true);
       expect(calls).toEqual([{ elementId: "com.test:id/dismiss_button", action: "tap" }]);
@@ -911,7 +873,7 @@ describe("ExploreBlockerDetection", () => {
     // Word-boundary matching must reject both while still accepting a
     // genuine "Skip" button — reverting to substring matching turns this red.
     test("dismissDialog does not tap 'close'/'skip' substrings but taps a genuine Skip button", async () => {
-      const { calls, restore } = captureTapOptions();
+      const { calls, deps } = captureTapOptions();
       const elements = [
         createMockElement({ text: "Enjoying the app? Rate us!", clickable: false }),
         createMockElement({ text: "Disclosed", "resource-id": "com.test:id/disclosed" }),
@@ -923,18 +885,15 @@ describe("ExploreBlockerDetection", () => {
           elements.map((element, index) => ({ element, index, depth: 0 })),
       } as unknown as ElementParser;
 
-      let handled: boolean;
-      try {
-        handled = await detectAndHandleBlockers(
-          { viewHierarchy: hierarchyOf(elements) } as unknown as ObserveResult,
-          androidDevice,
-          null,
-          parser,
-          async () => {},
-        );
-      } finally {
-        restore();
-      }
+      const handled = await detectAndHandleBlockers(
+        { viewHierarchy: hierarchyOf(elements) } as unknown as ObserveResult,
+        androidDevice,
+        null,
+        parser,
+        async () => {},
+        undefined,
+        deps,
+      );
 
       expect(handled).toBe(true);
       expect(calls).toEqual([{ elementId: "com.test:id/skip_button", action: "tap" }]);
@@ -944,7 +903,7 @@ describe("ExploreBlockerDetection", () => {
     // separators must still be tapped as dismiss buttons.
     test("dismissDialog taps machine-style 'not_now'/'skip-action'/'skip.action'/'notNow'/'skipAction' content-desc ids", async () => {
       for (const machineId of ["not_now", "skip-action", "skip.action", "notNow", "skipAction"]) {
-        const { calls, restore } = captureTapOptions();
+        const { calls, deps } = captureTapOptions();
         const elements = [
           createMockElement({ text: "Enjoying the app? Rate us!", clickable: false }),
           createMockElement({
@@ -958,18 +917,15 @@ describe("ExploreBlockerDetection", () => {
             elements.map((element, index) => ({ element, index, depth: 0 })),
         } as unknown as ElementParser;
 
-        let handled: boolean;
-        try {
-          handled = await detectAndHandleBlockers(
-            { viewHierarchy: hierarchyOf(elements) } as unknown as ObserveResult,
-            androidDevice,
-            null,
-            parser,
-            async () => {},
-          );
-        } finally {
-          restore();
-        }
+        const handled = await detectAndHandleBlockers(
+          { viewHierarchy: hierarchyOf(elements) } as unknown as ObserveResult,
+          androidDevice,
+          null,
+          parser,
+          async () => {},
+          undefined,
+          deps,
+        );
 
         expect(handled).toBe(true);
         expect(calls).toEqual([{ elementId: "com.test:id/dismiss_button", action: "tap" }]);
@@ -977,7 +933,7 @@ describe("ExploreBlockerDetection", () => {
     });
 
     test("dismissDialog does not tap when only 'close'/'skip' substrings are present", async () => {
-      const { calls, restore } = captureTapOptions();
+      const { calls, deps } = captureTapOptions();
       const elements = [
         createMockElement({ text: "Enjoying the app? Rate us!", clickable: false }),
         createMockElement({ text: "Disclosed", "resource-id": "com.test:id/disclosed" }),
@@ -988,18 +944,15 @@ describe("ExploreBlockerDetection", () => {
           elements.map((element, index) => ({ element, index, depth: 0 })),
       } as unknown as ElementParser;
 
-      let handled: boolean;
-      try {
-        handled = await detectAndHandleBlockers(
-          { viewHierarchy: hierarchyOf(elements) } as unknown as ObserveResult,
-          androidDevice,
-          null,
-          parser,
-          async () => {},
-        );
-      } finally {
-        restore();
-      }
+      const handled = await detectAndHandleBlockers(
+        { viewHierarchy: hierarchyOf(elements) } as unknown as ObserveResult,
+        androidDevice,
+        null,
+        parser,
+        async () => {},
+        undefined,
+        deps,
+      );
 
       expect(handled).toBe(false);
       expect(calls).toEqual([]);
@@ -1012,7 +965,7 @@ describe("ExploreBlockerDetection", () => {
     // label. Exact-token matching must reject this while still accepting a
     // genuine "Not now".
     test("dismissDialog does not tap a 'Notes now' false positive but taps a genuine 'Not now'", async () => {
-      const { calls: notesCalls, restore: restoreNotes } = captureTapOptions();
+      const { calls: notesCalls, deps: notesDeps } = captureTapOptions();
       const notesElements = [
         createMockElement({ text: "Enjoying the app? Rate us!", clickable: false }),
         createMockElement({ text: "Notes now", "resource-id": "com.test:id/notes_now" }),
@@ -1022,23 +975,20 @@ describe("ExploreBlockerDetection", () => {
           notesElements.map((element, index) => ({ element, index, depth: 0 })),
       } as unknown as ElementParser;
 
-      let notesHandled: boolean;
-      try {
-        notesHandled = await detectAndHandleBlockers(
-          { viewHierarchy: hierarchyOf(notesElements) } as unknown as ObserveResult,
-          androidDevice,
-          null,
-          notesParser,
-          async () => {},
-        );
-      } finally {
-        restoreNotes();
-      }
+      const notesHandled = await detectAndHandleBlockers(
+        { viewHierarchy: hierarchyOf(notesElements) } as unknown as ObserveResult,
+        androidDevice,
+        null,
+        notesParser,
+        async () => {},
+        undefined,
+        notesDeps,
+      );
 
       expect(notesHandled).toBe(false);
       expect(notesCalls).toEqual([]);
 
-      const { calls: genuineCalls, restore: restoreGenuine } = captureTapOptions();
+      const { calls: genuineCalls, deps: genuineDeps } = captureTapOptions();
       const genuineElements = [
         createMockElement({ text: "Enjoying the app? Rate us!", clickable: false }),
         createMockElement({ text: "Not now", "resource-id": "com.test:id/dismiss_button" }),
@@ -1048,18 +998,15 @@ describe("ExploreBlockerDetection", () => {
           genuineElements.map((element, index) => ({ element, index, depth: 0 })),
       } as unknown as ElementParser;
 
-      let genuineHandled: boolean;
-      try {
-        genuineHandled = await detectAndHandleBlockers(
-          { viewHierarchy: hierarchyOf(genuineElements) } as unknown as ObserveResult,
-          androidDevice,
-          null,
-          genuineParser,
-          async () => {},
-        );
-      } finally {
-        restoreGenuine();
-      }
+      const genuineHandled = await detectAndHandleBlockers(
+        { viewHierarchy: hierarchyOf(genuineElements) } as unknown as ObserveResult,
+        androidDevice,
+        null,
+        genuineParser,
+        async () => {},
+        undefined,
+        genuineDeps,
+      );
 
       expect(genuineHandled).toBe(true);
       expect(genuineCalls).toEqual([{ elementId: "com.test:id/dismiss_button", action: "tap" }]);


### PR DESCRIPTION
## What

Migrates the `ExploreBlockerDetection` tests off global prototype/module spies
(`spyOn(TapOnElement.prototype, "execute")`, `spyOn(defaultTimer, "sleep")`) to
the repo's Interface + Fake + FakeTimer convention, per
[#6191](https://github.com/kaeawc/auto-mobile/issues/6191) (raised by CodeRabbit
on #6190).

## Why the spies existed

`handlePermissionDialog` / `dismissDialog` constructed `new TapOnElement(...)`
at the call site and called `defaultTimer.sleep(1000)` directly — neither had a
seam to substitute a fake, so the tests reached for global spies.

## Production seams added (behavior-preserving)

Both dependencies are optional and default to the existing singletons, so every
current call site is equivalent at runtime.

- **`ExploreBlockerDetection.ts`** — a narrow `DialogTapAction` interface + a
  `DialogTapActionFactory`, and a `BlockerHandlerDeps` bag
  (`{ tapActionFactory, timer }`) threaded through `handlePermissionDialog`,
  `dismissDialog`, and `detectAndHandleBlockers`. Unset deps fall back to
  constructing `TapOnElement` and to `defaultTimer`.
- **`Explore.ts`** — an optional `tapActionFactory` constructor param and a
  private `blockerHandlerDeps()` helper that passes the instance's
  already-injected `timer` (identical to `defaultTimer` in production) and the
  factory into the handlers. In production the factory is `undefined` and the
  timer is `defaultTimer`, so behavior is unchanged.

## Tests

- New `test/fakes/FakeDialogTapAction.ts` records `execute()` options and the
  `(device, adb)` pairs it was built for.
- `ExploreBlockerDetection.test.ts` and `Explore.test.ts` inject the fake action
  + an auto-advancing `FakeTimer` instead of patching a prototype/module.
  Assertions are equivalent or stronger — the `FakeTimer` records the 1s
  post-tap sleep deterministically, and the deny-only test asserts the fake was
  never tapped.
- The out-of-scope `performInteraction` tap-selector spy in `Explore.test.ts` is
  left untouched (separate seam, not part of this issue).

## Validation

- `bun test` for both files: 189 pass, 0 fail (~480ms)
- `bash scripts/all_fast_validate_checks.sh`: 35/35 pass
- `bun run lint` (oxlint + ratchet): no new violations
- `bun run typecheck`: no new type errors
- `bun run build`: OK
- `BUN_TEST_TIMING_BASE_REF=origin/main bash scripts/validate-bun-test-timings.sh`: exit 0

Closes #6191
