### PR TITLE
fix(session): reject foreign sessionUuid on a connection that already owns a device (#6069)

### DIFF
--- a/src/server/SessionToolBinding.ts
+++ b/src/server/SessionToolBinding.ts
@@ -52,6 +52,24 @@ export class SessionToolBinding {
     return explicitSessionUuid ?? boundSessionUuid;
   }
 
+  /**
+   * #6069: The connection's live device-session binding, whether seeded at
+   * construction (`initialSessionUuid`) OR acquired mid-connection via `bind()`
+   * (getAndroid/getApple, or a device tool with a valid sessionUuid). Unlike
+   * {@link effectiveSessionUuid}'s cross-routing throw — which fires for every
+   * tool and so is deliberately kept to construction-seeded bindings to leave
+   * plain (non-device) tools free to carry any sessionUuid (e.g. a tool-selection
+   * profile) — this exposes the bound id so the caller can enforce ownership on
+   * the DEVICE-routing path only. Keying that throw on this instead of
+   * `initialSessionUuid` closes the residual bypass where a later device-tool
+   * call on a connection that already holds an active session passed a DIFFERENT
+   * (fabricated/typo'd/stale) `sessionUuid` and was auto-assigned a SECOND,
+   * foreign device (`#6019`/`#6045` behind an active-session precondition).
+   */
+  boundDeviceSessionUuid(mcpSessionId: string | undefined): string | undefined {
+    return this.boundSessionUuid(mcpSessionId);
+  }
+
   /** A released identity is not an authorization grant for a replacement session. */
   releasedResourceSessionUuid(mcpSessionId: string | undefined): string | undefined {
     if (this.boundSessionUuid(mcpSessionId)) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -552,6 +552,38 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     if (!tool) {
       throw new ActionableError(`Unknown tool: ${name}`);
     }
+
+    // #6069: enforce connection ownership on the DEVICE-routing path. If this
+    // connection already holds an active device session — whether seeded at
+    // construction or acquired mid-connection via getAndroid/getApple (recorded
+    // by `bind()`) — a device tool that names a DIFFERENT `sessionUuid` must be
+    // rejected, not routed. Without this, a later call carrying a fabricated,
+    // typo'd, or stale id on a connection that already owns a device was handed
+    // off to session admission/creation and auto-assigned a SECOND, foreign
+    // device (the residual #6019/#6045 bypass behind an active-session
+    // precondition). This is scoped to `requiresDevice` tools on purpose:
+    // `effectiveSessionUuid`'s own cross-routing throw fires for every tool and
+    // so is deliberately limited to construction-seeded bindings, leaving plain
+    // tools free to carry any sessionUuid (e.g. a tool-selection profile).
+    // Acquisition tools are excluded — they legitimately mint/rebind a session.
+    if (tool.requiresDevice && !isDeviceSessionAcquisitionTool(name)) {
+      const rawExplicitSessionUuid = (toolParams as Record<string, unknown>).sessionUuid;
+      const explicitSessionUuid =
+        typeof rawExplicitSessionUuid === "string" && rawExplicitSessionUuid.trim().length > 0
+          ? rawExplicitSessionUuid
+          : undefined;
+      const boundDeviceSessionUuid = sessionToolBinding.boundDeviceSessionUuid(sessionId);
+      if (
+        boundDeviceSessionUuid &&
+        explicitSessionUuid &&
+        explicitSessionUuid !== boundDeviceSessionUuid
+      ) {
+        throw new ActionableError(
+          `MCP connection is bound to device session ${boundDeviceSessionUuid}; ` +
+            `cannot route this call to ${explicitSessionUuid} until the binding is released.`,
+        );
+      }
+    }
     // An omitted selection target always belongs to an independent
     // transport-local profile, even after device routing binds. Device-session
     // release must not erase choices for a still-open MCP connection.

--- a/test/server/sessionToolDiscovery.test.ts
+++ b/test/server/sessionToolDiscovery.test.ts
@@ -54,6 +54,43 @@ describe("session-scoped tool discovery", () => {
     expect(binding.effectiveSessionUuid(undefined)).toBeUndefined();
   });
 
+  test("exposes a session acquired mid-connection as the bound device session (#6069)", () => {
+    // The connection is NOT seeded with an initial session; it acquires one
+    // mid-flight (getAndroid, or a device tool with a valid sessionUuid) which
+    // records the binding via bind(). `boundDeviceSessionUuid` must surface that
+    // id so the device-routing guard can reject a later call that names a
+    // DIFFERENT (fabricated/typo'd/stale) session — the residual #6019/#6045
+    // ownership bypass behind an active-session precondition. This is distinct
+    // from `effectiveSessionUuid`, whose cross-routing throw is deliberately kept
+    // to construction-seeded bindings so plain tools stay free to carry any id.
+    const binding = new SessionToolBinding();
+    expect(binding.boundDeviceSessionUuid("conn-1")).toBeUndefined();
+
+    expect(binding.bind("conn-1", "device-session-a")).toBe(true);
+    expect(binding.boundDeviceSessionUuid("conn-1")).toBe("device-session-a");
+    // A fabricated id on the SAME connection does NOT throw here (that guard now
+    // lives on the device path), but the connection's real binding is unchanged.
+    expect(binding.effectiveSessionUuid("conn-1", { sessionUuid: "kumquat-D" })).toBe("kumquat-D");
+    expect(binding.boundDeviceSessionUuid("conn-1")).toBe("device-session-a");
+
+    // Releasing the session clears the bound id.
+    expect(binding.unbindSession("device-session-a")).toBe(true);
+    expect(binding.boundDeviceSessionUuid("conn-1")).toBeUndefined();
+  });
+
+  test("exposes a mid-connection stdio (direct) binding as the bound device session (#6069)", () => {
+    const binding = new SessionToolBinding();
+    expect(binding.boundDeviceSessionUuid(undefined)).toBeUndefined();
+
+    expect(binding.bind(undefined, "device-session-a")).toBe(true);
+    expect(binding.boundDeviceSessionUuid(undefined)).toBe("device-session-a");
+  });
+
+  test("exposes a construction-seeded initial session as the bound device session (#6069)", () => {
+    const binding = new SessionToolBinding("device-session-a");
+    expect(binding.boundDeviceSessionUuid("recreated-transport")).toBe("device-session-a");
+  });
+
   test("seeds only a recreated transport's initial session binding", () => {
     const binding = new SessionToolBinding("device-session-a");
 

--- a/test/server/unissuedSessionBoundConnection.integration.test.ts
+++ b/test/server/unissuedSessionBoundConnection.integration.test.ts
@@ -141,6 +141,49 @@ describe("unissued sessionUuid on a bound connection (#6069)", () => {
     expect(sessionManager.getSession("S1")?.assignedDevice).toBe("emulator-5554");
   });
 
+  test("rejects routing to a FOREIGN live session once the connection is bound (#6069 red→green)", async () => {
+    const { client } = fixture!.getContext();
+
+    // The connection acquires and binds its own session S1 on emulator-5554.
+    await sessionManager.createSession("S1", "emulator-5554", "android");
+    const first = (await client.request(
+      { method: "tools/call", params: { name: "observeProbe", arguments: { sessionUuid: "S1" } } },
+      z.any(),
+    )) as { isError?: boolean };
+    expect(first.isError ?? false).toBe(false);
+    expect(handlerDevices).toEqual(["emulator-5554"]);
+
+    // A DIFFERENT, genuinely-issued session F1 exists on the OTHER pooled device
+    // (e.g. left by earlier fleet activity / another connection). Because it is a
+    // real live session, admitIssuedSessionForAutomation would happily admit it —
+    // so the #6045/#6079 admission guard does NOT reject this id. Before the fix,
+    // the connection bound to S1 could still route this call to F1 and run against
+    // emulator-5556, a device this connection never acquired.
+    await sessionManager.createSession("F1", "emulator-5556", "android");
+
+    let rejected = false;
+    let result: { isError?: boolean } | undefined;
+    try {
+      result = (await client.request(
+        {
+          method: "tools/call",
+          params: { name: "observeProbe", arguments: { sessionUuid: "F1" } },
+        },
+        z.any(),
+      )) as { isError?: boolean };
+    } catch {
+      rejected = true;
+    }
+
+    // The call must be rejected by the connection-binding guard...
+    expect(rejected || result?.isError === true).toBe(true);
+    // ...and must NOT have run on the foreign device the connection never bound.
+    expect(handlerDevices).toEqual(["emulator-5554"]);
+    // Both sessions keep their own devices; nothing was re-routed or re-assigned.
+    expect(sessionManager.getSession("S1")?.assignedDevice).toBe("emulator-5554");
+    expect(sessionManager.getSession("F1")?.assignedDevice).toBe("emulator-5556");
+  });
+
   test("rejects a fabricated sessionUuid while an autolock session is active on the connection", async () => {
     process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
     try {


### PR DESCRIPTION
## Summary

Closes #6069 — the residual ownership bypass from #6019/#6045: a device tool call carrying a **fabricated, typo'd, or stale `sessionUuid`** on an MCP connection that **already holds an active device session** was still handed to session admission/creation and **auto-assigned a SECOND, foreign device** — running against a device the caller never acquired.

## Root cause

The connection-ownership guard lived in `SessionToolBinding.effectiveSessionUuid`, whose cross-routing throw keyed only on a **construction-seeded** `initialSessionUuid`:

```ts
if (this.initialSessionUuid && explicitSessionUuid && explicitSessionUuid !== this.initialSessionUuid) { throw ... }
```

A connection that **acquired** its session mid-flight — `getAndroid`/`getApple`, or a device tool with a valid `sessionUuid` — records it via `bind()` into `boundDeviceSessions` / `directDeviceSessionUuid`, leaving `initialSessionUuid` `undefined`. So no ownership guard fired, and the different id flowed to the pool-minting fallback. #6045's admission guard also does **not** reject an id that resolves to a real (foreign) live session or a recoverable persisted `device_sessions` row — which matches the investigation's stale-persisted-row hypothesis in the issue thread.

The prior investigation modeled only never-issued ids (which `admit` rejects anyway), so it could not reproduce the bypass. The reproducible shape is a **different, genuinely-issued** session id on an already-bound connection.

## Fix

- `SessionToolBinding.boundDeviceSessionUuid()` exposes the connection's live binding (seeded **or** dynamically acquired).
- The request handler (`src/server/index.ts`) enforces ownership on the **device-routing path**, scoped to `requiresDevice` tools (acquisition tools excepted, since they legitimately mint/rebind). A device tool naming a different `sessionUuid` than the connection's bound session is rejected before any assignment.
- `effectiveSessionUuid` is left unchanged, so **plain (non-device) tools stay free to carry any `sessionUuid`** (e.g. a tool-selection profile) — preserving the deliberate binding-preservation behavior in `sessionToolBindingFailedCall.integration.test.ts`.

## Tests

- `test/server/sessionToolDiscovery.test.ts`: unit coverage for `boundDeviceSessionUuid` across construction-seeded, mid-connection `bind()`, and direct/stdio bindings.
- `test/server/unissuedSessionBoundConnection.integration.test.ts`: an integration **red→green** that binds a connection to session `S1` (emulator-5554), then routes a call to a **different genuinely-issued** session `F1` (emulator-5556). Fails on the pre-fix code (handler ran on the foreign device); rejected by the ownership guard after the fix. The existing never-issued-id guards still pass.

## Validation

- `bun test test/server/` (2531 pass) and `bun test test/daemon/` (2004 pass)
- `bash scripts/all_fast_validate_checks.sh` — 35/35 pass
- `bun run lint` (ratchet: no new violations), `bun run typecheck` (no new errors), `bun run format:check`, `bun run build`
- `BUN_TEST_TIMING_BASE_REF=origin/main bash scripts/validate-bun-test-timings.sh` — pass
