### PR TITLE
fix(observe): stabilize skeleton view-id against descendant text churn (#6230)

### DIFF
--- a/src/features/observe/android/StableNodeIdentity.ts
+++ b/src/features/observe/android/StableNodeIdentity.ts
@@ -17,11 +17,29 @@ import { createHash } from "crypto";
  *
  * This module rewrites those *generated* (UUID-shaped) `view-id`s at TS
  * ingest into a **content-derived** stable id: a Merkle-style SHA-256 over the
- * node's own stable content fields plus its children's content hashes —
+ * node's own stable content fields plus its children's *structural* hashes —
  * deliberately excluding everything a scroll or interaction perturbs (bounds,
  * sibling position, `extras`, focus/checked/occlusion state). The same row
  * therefore keeps the same id before and after a scroll, and two rows with
  * different content can never share one.
+ *
+ * Descendant text/content-desc stability (issue #6230). A node's id must not
+ * change merely because some *descendant's* `text`/`content-desc` ticked
+ * between captures — a row wrapping a live timer child ("1 second" → "2
+ * seconds") is still the same row, and the `s2-…` id an `observe(project:
+ * "skeleton")` emitted must still resolve on the fresh capture a later
+ * `tapOn`/`inputText` runs against. So a child contributes only its
+ * **structural** hash to an ancestor — class/className, `resource-id`,
+ * `test-tag`, and (recursively) its own children's structural hashes — with the
+ * volatile display fields (`text`, `content-desc`) omitted from that upward
+ * contribution. A node's *own* id still mixes in its own `text`/`content-desc`
+ * (a node's own text edit remains a new identity, matching
+ * `nodeKey`/`contentIdentityKey` semantics), so leaf text nodes stay distinct
+ * and the timer leaf's own id still churns — only its ancestors are shielded.
+ * Nodes that differ only by a descendant's display text share one structural
+ * identity (ordinal-suffixed as a duplicate group below); nodes differing in
+ * structure — a distinct `resource-id`, `class`, or `test-tag` anywhere in the
+ * subtree — still get distinct ids.
  *
  * Content-identical duplicates (repeated spacer rows, empty Compose click
  * surfaces) share a hash by construction, so the k-th duplicate (document
@@ -85,15 +103,27 @@ export const STABLE_VIEW_ID_PREFIX = "s2-";
 export const STABLE_VIEW_ID_HASH_LENGTH = 16;
 
 /**
- * Node fields that participate in the content hash: the stable, position-free
- * description of what the node *is*. Everything else is deliberately excluded:
- * `bounds` and sibling order shift on scroll; `focused` / `checked` /
- * `selected` / `enabled` flip on interaction (a toggle should surface as a
- * `changed` delta, not an identity change); `extras` and
- * `occlusionState`/`occludedBy`/`occludedByViewId` churn nondeterministically
- * between captures (#3051, #3519).
+ * Node fields that participate in a node's *own* identity: the stable,
+ * position-free description of what the node *is*, including its own display
+ * text. Everything else is deliberately excluded: `bounds` and sibling order
+ * shift on scroll; `focused` / `checked` / `selected` / `enabled` flip on
+ * interaction (a toggle should surface as a `changed` delta, not an identity
+ * change); `extras` and `occlusionState`/`occludedBy`/`occludedByViewId` churn
+ * nondeterministically between captures (#3051, #3519).
  */
 const CONTENT_FIELDS: readonly string[] = ["resource-id", "content-desc", "text", "test-tag"];
+
+/**
+ * Node fields a child contributes *upward* to its ancestors' ids (issue #6230):
+ * the structural identifiers that do not churn as displayed content updates.
+ * `text` and `content-desc` are deliberately omitted here — a descendant whose
+ * label ticks between captures (a timer, a live counter, streaming text) must
+ * not restamp its ancestors' ids, or the `s2-…` selector an `observe(project:
+ * "skeleton")` emitted stops resolving on the fresh capture a `tapOn` runs
+ * against. A node's own `text`/`content-desc` still count toward *its own* id
+ * via {@link CONTENT_FIELDS}; they are excluded only from the ancestor rollup.
+ */
+const STRUCTURAL_FIELDS: readonly string[] = ["resource-id", "test-tag"];
 
 /** Normalize the `node` child slot (absent / single object / array) to an array. */
 function toChildArray(node: Record<string, unknown>): Record<string, unknown>[] {
@@ -134,25 +164,45 @@ export function assignStableViewIds(root: unknown): Map<string, string> {
   }
   const rootNode = root as Record<string, unknown>;
 
-  // Pass 1 (bottom-up): Merkle content hash per node — own stable fields plus
-  // the *hashes* of the children, so cost stays O(n) instead of concatenating
-  // whole subtrees at every level.
+  // Pass 1 (bottom-up): two Merkle-style hashes per node, each rolling up the
+  // *hashes* of the children (not their raw subtrees) so cost stays O(n).
+  //
+  //  - structuralHash: class + STRUCTURAL_FIELDS + children's structuralHashes.
+  //    This is what a node contributes to its ANCESTORS, so it excludes the
+  //    volatile `text`/`content-desc` — a descendant's label ticking between
+  //    captures must not restamp any ancestor's id (#6230).
+  //  - contentHash (emitted): class + CONTENT_FIELDS (incl. the node's OWN
+  //    `text`/`content-desc`) + children's structuralHashes. The node's own
+  //    display text still defines its own identity, but descendants roll up
+  //    structurally only.
+  //
+  // Two nodes sharing a contentHash are content-identical up to descendant
+  // display text; they are ordinal-suffixed as a duplicate group in pass 2b
+  // exactly as fully-identical subtrees already were. Distinct structure
+  // anywhere in the subtree — a differing `resource-id`, `class`, or `test-tag`
+  // — still yields distinct structuralHashes and therefore distinct ids.
   const contentHash = new Map<Record<string, unknown>, string>();
-  const compute = (node: Record<string, unknown>): string => {
-    const childHashes = toChildArray(node).map(compute);
-    // JSON-encoding the field array keeps values from straddling separator
-    // boundaries (text can contain any delimiter we might pick by hand).
-    const canonical = JSON.stringify([
-      node["class"] ?? node.className ?? "",
-      ...CONTENT_FIELDS.map((field) => node[field] ?? ""),
-      childHashes,
-    ]);
-    const hash = createHash("sha256")
-      .update(canonical)
+  const hashCanonical = (
+    fields: readonly string[],
+    node: Record<string, unknown>,
+    kids: string[],
+  ): string =>
+    createHash("sha256")
+      // JSON-encoding the field array keeps values from straddling separator
+      // boundaries (text can contain any delimiter we might pick by hand).
+      .update(
+        JSON.stringify([
+          node["class"] ?? node.className ?? "",
+          ...fields.map((field) => node[field] ?? ""),
+          kids,
+        ]),
+      )
       .digest("hex")
       .slice(0, STABLE_VIEW_ID_HASH_LENGTH);
-    contentHash.set(node, hash);
-    return hash;
+  const compute = (node: Record<string, unknown>): string => {
+    const childStructuralHashes = toChildArray(node).map(compute);
+    contentHash.set(node, hashCanonical(CONTENT_FIELDS, node, childStructuralHashes));
+    return hashCanonical(STRUCTURAL_FIELDS, node, childStructuralHashes);
   };
   compute(rootNode);
 

--- a/test/features/observe/android/stableNodeIdentity.test.ts
+++ b/test/features/observe/android/stableNodeIdentity.test.ts
@@ -102,16 +102,57 @@ describe("assignStableViewIds (#3228)", () => {
     );
   });
 
-  test("different descendant content yields DIFFERENT ids (distinct rows never share)", () => {
+  test("structurally distinct rows yield DIFFERENT ids (distinct rows never share)", () => {
+    // Distinctness is structural: a differing resource-id / class / test-tag
+    // anywhere in the subtree keeps the ancestors' ids distinct (#6230), even
+    // though the volatile display text no longer participates in the rollup.
     const rowA = node({ "view-id": generatedUuid("a") }, [
-      node({ "view-id": generatedUuid("a1"), text: "Item 1" }),
+      node({
+        "view-id": generatedUuid("a1"),
+        "resource-id": "com.example:id/first",
+        text: "Item 1",
+      }),
     ]);
     const rowB = node({ "view-id": generatedUuid("b") }, [
-      node({ "view-id": generatedUuid("b1"), text: "Item 2" }),
+      node({
+        "view-id": generatedUuid("b1"),
+        "resource-id": "com.example:id/second",
+        text: "Item 2",
+      }),
     ]);
     assignStableViewIds(rowA);
     assignStableViewIds(rowB);
     expect(rowA["view-id"]).not.toEqual(rowB["view-id"]);
+    // The leaf nodes themselves still differ by their own resource-id/text.
+    expect((rowA.node as Record<string, unknown>)["view-id"]).not.toEqual(
+      (rowB.node as Record<string, unknown>)["view-id"],
+    );
+  });
+
+  test("a descendant's text/content-desc churn does NOT change an ancestor's id (#6230)", () => {
+    // A row wrapping a live timer child whose label ticks between the skeleton
+    // capture and the fresh capture a later tapOn resolves against. The row (and
+    // any other ancestor) must keep its id so the emitted selector still matches;
+    // only the timer leaf's own id may change, because its own content changed.
+    const rowWith = (label: string): Record<string, unknown> =>
+      node({ "view-id": generatedUuid("row"), "resource-id": "com.example:id/timerRow" }, [
+        node({ "view-id": generatedUuid("static"), text: "Elapsed" }),
+        node({ "view-id": generatedUuid("timer"), text: label }),
+      ]);
+    const before = rowWith("1 second");
+    const after = rowWith("2 seconds");
+    assignStableViewIds(before);
+    assignStableViewIds(after);
+    // Ancestor row id is stable across the descendant label tick…
+    expect(before["view-id"]).toEqual(after["view-id"]);
+    // …and the static sibling's own id is likewise stable…
+    expect((before.node as Record<string, unknown>[])[0]["view-id"]).toEqual(
+      (after.node as Record<string, unknown>[])[0]["view-id"],
+    );
+    // …while the timer leaf's OWN id changes, because its own text changed.
+    expect((before.node as Record<string, unknown>[])[1]["view-id"]).not.toEqual(
+      (after.node as Record<string, unknown>[])[1]["view-id"],
+    );
   });
 
   test("canonical class and legacy className participate equivalently in identity", () => {


### PR DESCRIPTION
Closes #6230

## Problem

`assignStableViewIds` (`src/features/observe/android/StableNodeIdentity.ts`) derived a node's synthetic `view-id` from a Merkle-style hash that folded in every descendant's **full content hash** — including the volatile `text`/`content-desc` fields. So a node's id depended on every descendant's displayed text, not just its own structure.

When any descendant's `text`/`content-desc` ticks between an `observe(project: "skeleton")` capture and the fresh capture a later `tapOn`/`inputText` resolves against — a live timer child ("1 second" → "2 seconds"), a counter, streaming text, a progress label — the **ancestor's** `s2-<hash>` id changed too, even though the ancestor is otherwise unchanged and still on screen. `ElementFinder`'s exact-match lookup then returned no match for the id observed a moment earlier: functionally a miss for a control the user meant to tap (the lower-severity sibling of #6229).

## Fix

Split the per-node hash into two Merkle-style rollups:

- **structuralHash** — `class`/`className` + `resource-id` + `test-tag` + children's structural hashes. This is what a child contributes **upward** to its ancestors, so `text`/`content-desc` are omitted from the rollup and a descendant's label tick can no longer restamp any ancestor's id.
- **contentHash (emitted id)** — the node's OWN `CONTENT_FIELDS` (incl. its own `text`/`content-desc`) + children's *structural* hashes.

A node's own display text still defines its own identity, so leaf-node identity and the own-text-edit-is-a-new-identity semantics (matching `nodeKey`/`contentIdentityKey`) are unchanged, and the timer leaf's own id still churns — only its ancestors are shielded.

Distinctness stays **structural**: a differing `resource-id`, `class`, or `test-tag` anywhere in the subtree still yields distinct ids. Nodes differing *only* by a descendant's display text now share one structural identity and are ordinal-suffixed as a duplicate group — exactly as fully content-identical subtrees already were, and consistent with the #6229 "every duplicate-group member gets an ordinal, bare form reserved for unique content" invariant.

## Tests

- New: **descendant text/content-desc churn does NOT change an ancestor's id** — a timer-row fixture ("1 second" → "2 seconds") asserts the row id and the static-sibling id are stable while the timer leaf's own id changes.
- Updated the distinctness guard to assert distinctness via **structure** (distinct child `resource-id`s → distinct ancestor ids, and the leaf nodes stay distinct), replacing the old assertion that encoded the now-fixed descendant-text coupling.
- All pre-existing guards retained and green: scroll survival, class/className equivalence, interaction-state flips, duplicate ordinals, idempotence, occlusion rewrites, and the real #3132 scroll-pair acceptance suite (`stableIdentityScrollDiff.test.ts`, incl. AC#3 no-false-merge).

## Validation

- `bun test test/features/observe/` — 2475 pass, 0 fail; `test/features/utility/` — 536 pass, 0 fail
- `bash scripts/all_fast_validate_checks.sh` — 35 passed, 0 failed
- `bun run lint` — oxlint ratchet: no new violations; boundary checks all pass
- `bun run typecheck` — no new type errors
- `BUN_TEST_TIMING_BASE_REF=origin/main bash scripts/validate-bun-test-timings.sh` — exit 0 (5604 pass)
- `bun run build` — success

## Scope note

Confined to the skeleton view-id synthesis module + its unit tests. `ElementFinder`/`SkeletonProjection`/`ObserveResultOutput` are unchanged: they read the emitted id as before. The broader provenance/positional-fallback redesign the issue sketches (directions a/b) is intentionally out of scope here.
