### PR TITLE
fix(redaction): spec-decode secretParameters key names (#6141)

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
@@ -1,6 +1,9 @@
 package dev.jasonpearson.automobile.junit
 
 import java.text.Normalizer
+import org.yaml.snakeyaml.LoaderOptions
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
 
 /**
  * Redacts sensitive plan-parameter values from any recovery context that leaves the process for a
@@ -13,13 +16,24 @@ import java.text.Normalizer
  * (issue #6029 review — an independent fixpoint could mismatch the executor's single ordered pass,
  * or blow up on a self-referential value). The executor hands over the concrete substituted secret
  * strings; this object expands each into its Unicode NFC/NFD forms and scrubs every occurrence. It
- * also scans the RAW plan for the declared secret key names with a placeholder-tolerant line
- * scanner (a full YAML load chokes on `${...}` in flow collections). `internal` — its only consumer
- * is the executor, and `SecretRedactorTest` unit-tests it. Mirrors the iOS `SecretRedaction` /
+ * also scans the RAW plan for the declared secret key names: `${...}` placeholders are swapped for
+ * YAML-safe sentinels so snakeyaml can spec-decode the key scalars (escapes, folding, CRLF), then
+ * the sentinels are mapped back — falling back to a placeholder-tolerant line scanner when the
+ * substituted plan is not loadable (issue #6141). `internal` — its only consumer is the executor,
+ * and `SecretRedactorTest` unit-tests it. Mirrors the iOS `SecretRedaction` /
  * `PlanMetadataParser.parseSecretParameterKeys`.
  */
 internal object SecretRedactor {
   const val PLACEHOLDER: String = "***REDACTED***"
+
+  /** Matches a `${...}` substitution placeholder (non-greedy, no nested braces). */
+  private val PLACEHOLDER_PATTERN = Regex("""\$\{[^}]*}""")
+
+  // A sentinel that survives YAML as a plain scalar (letters/digits only, no escapes) and is
+  // exceedingly unlikely to collide with a real key. The index keeps each placeholder distinct so
+  // it maps back to its exact original text.
+  private const val SENTINEL_PREFIX = "AMx6141xPLACEHOLDERx"
+  private const val SENTINEL_SUFFIX = "xEND"
 
   /**
    * Expand the executor-supplied concrete secret strings into the exact forms to scrub: each value
@@ -215,13 +229,88 @@ internal object SecretRedactor {
 
   /**
    * Scan a plan's top-level `secretParameters:` declaration for the sensitive key names, tolerating
-   * `${...}` placeholders anywhere (they are literal text to the scanner). MUST run on the RAW,
-   * pre-substitution plan: a substituted value can inject a newline that truncates the declaration,
-   * and a full YAML load throws on unquoted placeholders in flow collections (issue #6029 review).
-   * Non-throwing. Only the `secretParameters:` block is scanned, so unrelated `${...}` lists are
-   * ignored. Mirrors iOS `PlanMetadataParser.parseSecretParameterKeys`.
+   * `${...}` placeholders anywhere (they are literal text). MUST run on the RAW, pre-substitution
+   * plan: a substituted value can inject a newline that truncates the declaration (issue #6029
+   * review).
+   *
+   * Primary path (issue #6141): replace every `${...}` placeholder with a YAML-safe sentinel so a
+   * real YAML load does not choke on unquoted placeholders in flow collections, run the plan
+   * through snakeyaml — which decodes escapes (`\xNN`, `\uNNNN`, `\U........`, `\n`, `\t`, `\0`,
+   * `\/`, …), multi-line folding, and CRLF to the spec-correct key name — then map the sentinels
+   * back to their original `${...}` text. Falls back to the placeholder-tolerant line scanner
+   * ([parsePlanSecretKeysBestEffort]) whenever the substituted plan is not loadable as a mapping
+   * (e.g. a value injected a newline that truncated the document), so the redactor never drops a
+   * declared key. Non-throwing. Mirrors iOS `PlanMetadataParser.parseSecretParameterKeys`.
    */
   fun parsePlanSecretKeys(planContent: String): Set<String> {
+    val sentinels = mutableListOf<Pair<String, String>>()
+    val substituted =
+      PLACEHOLDER_PATTERN.replace(planContent) { match ->
+        val sentinel = "$SENTINEL_PREFIX${sentinels.size}$SENTINEL_SUFFIX"
+        sentinels.add(sentinel to match.value)
+        sentinel
+      }
+
+    val decoded = runCatching {
+      // SafeConstructor: build only maps/lists/scalars, never arbitrary Java types — a redactor
+      // must not become a YAML-deserialization gadget for untrusted plan content. Escapes and
+      // folding are resolved by the reader, so they still decode under SafeConstructor.
+      val root = Yaml(SafeConstructor(LoaderOptions())).load<Any?>(substituted)
+      val declaration = (root as? Map<*, *>)?.get("secretParameters")
+      extractKeyNames(declaration, sentinels)
+    }
+      .getOrNull()
+
+    // A null result means the substituted plan was not a loadable mapping (snakeyaml threw or the
+    // top level was not a map). Fall back to the best-effort scanner so a declared key is never
+    // dropped. A non-null empty set means the plan parsed cleanly with no `secretParameters:`.
+    return decoded ?: parsePlanSecretKeysBestEffort(planContent)
+  }
+
+  /**
+   * Turn a snakeyaml-decoded `secretParameters` value into its set of key names, mapping any
+   * substitution sentinel back to its original `${...}` text. A scalar declaration is treated as a
+   * single key; a sequence contributes each stringified element. Returns null when the declaration
+   * is absent so the caller can distinguish "no secrets" (empty set) from "not a mapping"
+   * (fallback).
+   */
+  private fun extractKeyNames(
+    declaration: Any?,
+    sentinels: List<Pair<String, String>>,
+  ): Set<String> {
+    val keys = LinkedHashSet<String>()
+    when (declaration) {
+      null -> {}
+      is List<*> ->
+        for (element in declaration) {
+          if (element == null) continue
+          val key = restorePlaceholders(parameterStringValue(element), sentinels)
+          if (key.isNotEmpty()) keys.add(key)
+        }
+      else -> {
+        val key = restorePlaceholders(parameterStringValue(declaration), sentinels)
+        if (key.isNotEmpty()) keys.add(key)
+      }
+    }
+    return keys
+  }
+
+  private fun restorePlaceholders(value: String, sentinels: List<Pair<String, String>>): String {
+    var restored = value
+    for ((sentinel, original) in sentinels) {
+      if (restored.contains(sentinel)) restored = restored.replace(sentinel, original)
+    }
+    return restored
+  }
+
+  /**
+   * Best-effort, placeholder-tolerant line scanner for the declared secret key names. Retained as
+   * the fallback for plans that snakeyaml cannot load as a mapping (e.g. a substituted value that
+   * injects a document-truncating newline). Over-captures rather than dropping tokens, so the
+   * redactor stays fail-safe toward over-redaction. Does NOT spec-decode escapes/folding — that is
+   * the snakeyaml primary path's job (issue #6141).
+   */
+  internal fun parsePlanSecretKeysBestEffort(planContent: String): Set<String> {
     val lines = planContent.split('\n')
     val keys = LinkedHashSet<String>()
     var index = 0

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
@@ -189,12 +189,44 @@ class SecretRedactorTest {
   }
 
   @Test
-  fun `a plain multiline flow scalar captures each line's token (fail-safe over-capture)`() {
-    // A plain (unquoted) scalar spanning lines is captured token-per-line so both are redacted,
-    // rather
-    // than blended into one mis-named key (#6097 Codex — plain-scalar folding).
+  fun `a plain multiline flow scalar folds to one key per YAML spec`() {
+    // A plain (unquoted) scalar spanning lines folds its line break to a space per the YAML spec,
+    // so
+    // `[API⏎TOKEN]` is the single key `API TOKEN` — snakeyaml decodes it exactly (issue #6141).
+    // Still fail-safe: if no parameter matches `API TOKEN`, the value layer over-redacts.
     val yaml = "name: P\nsecretParameters: [\n  API\n  TOKEN\n]\nsteps:\n  - tool: observe"
-    assertEquals(setOf("API", "TOKEN"), SecretRedactor.parsePlanSecretKeys(yaml))
+    assertEquals(setOf("API TOKEN"), SecretRedactor.parsePlanSecretKeys(yaml))
+  }
+
+  @Test
+  fun `decodes double-quoted hex unicode and control escapes to the spec-correct key name`() {
+    // Issue #6141: the hand-rolled scanner left these escapes literal; snakeyaml spec-decodes them.
+    // `\x54` -> T, `A` -> A, `\U00000042` -> B, plus `\t`/`\n` control escapes.
+    val hex = "name: P\nsecretParameters: [\"API\\x54OKEN\"]\nsteps:\n  - tool: observe"
+    assertEquals(setOf("APITOKEN"), SecretRedactor.parsePlanSecretKeys(hex))
+
+    val unicode = "name: P\nsecretParameters: [\"\\u0041\\U00000042\"]\nsteps:\n  - tool: observe"
+    assertEquals(setOf("AB"), SecretRedactor.parsePlanSecretKeys(unicode))
+
+    val control = "name: P\nsecretParameters: [\"A\\tB\\nC\"]\nsteps:\n  - tool: observe"
+    assertEquals(setOf("A\tB\nC"), SecretRedactor.parsePlanSecretKeys(control))
+  }
+
+  @Test
+  fun `decodes a block-sequence double-quoted hex-escaped key`() {
+    // The block-sequence form is decoded the same way as the flow form (issue #6141).
+    val yaml = "name: P\nsecretParameters:\n  - \"API\\x54OKEN\"\nsteps:\n  - tool: observe"
+    assertEquals(setOf("APITOKEN"), SecretRedactor.parsePlanSecretKeys(yaml))
+  }
+
+  @Test
+  fun `falls back to the best-effort scanner when the substituted plan is not loadable`() {
+    // A substituted value can inject a newline that truncates the flow sequence, so snakeyaml
+    // cannot
+    // load the document. The best-effort scanner still over-captures every declared token so no
+    // secret's value is dropped (issue #6141 fail-safe).
+    val truncated = "name: P\nsecretParameters: [\n  TOKEN,\n  PASSWORD"
+    assertEquals(setOf("TOKEN", "PASSWORD"), SecretRedactor.parsePlanSecretKeys(truncated))
   }
 
   @Test

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
@@ -191,7 +191,7 @@ enum PlanMetadataParser {
                 if !rawTrimmed.hasPrefix("-") {
                     break
                 }
-                let item = unquote(rawTrimmed.dropFirst().trimmingCharacters(in: .whitespaces))
+                let item = unquoteFlowScalar(rawTrimmed.dropFirst().trimmingCharacters(in: .whitespaces))
                 if !item.isEmpty {
                     keys.insert(item)
                 }
@@ -280,6 +280,7 @@ enum PlanMetadataParser {
         var keys: [String] = []
         var current = ""
         var itemHasQuotedChar = false
+        var itemHadDoubleQuote = false
         var depth = 0
         var started = false
         var activeQuote: Character?
@@ -291,13 +292,25 @@ enum PlanMetadataParser {
         // is a valid key and is preserved rather than trimmed away (#6097).
         func flushItem() {
             let trimmed = current.trimmingCharacters(in: .whitespaces)
+            let raw: String?
             if !trimmed.isEmpty {
-                keys.append(trimmed)
+                raw = trimmed
             } else if itemHasQuotedChar {
-                keys.append(current)
+                // A quoted scalar whose content is only whitespace (e.g. `" "`) is a valid key; keep
+                // the untrimmed content so the space survives (#6097).
+                raw = current
+            } else {
+                raw = nil
+            }
+            if let raw {
+                // A double-quoted item's escapes were accumulated raw; decode the full escape set
+                // now (issue #6141). A plain/single-quoted item is kept verbatim so a literal
+                // `${...}` placeholder or `\`-containing plain scalar is not mis-decoded.
+                keys.append(itemHadDoubleQuote ? decodeDoubleQuoted(raw) : raw)
             }
             current = ""
             itemHasQuotedChar = false
+            itemHadDoubleQuote = false
         }
 
         // Drop a trailing CR so a CRLF-authored quoted multiline key does not embed `\r` (#6097).
@@ -311,16 +324,12 @@ enum PlanMetadataParser {
                 if let quote = activeQuote {
                     if quote == "\"" {
                         if escaped {
-                            // `\"` decodes cleanly to `"`; any OTHER escape (`\xNN`, `\uNNNN`, `\n`, …)
-                            // is NOT spec-decoded here — keep the backslash so the value layer sees this
-                            // key as low-confidence and over-redacts rather than trusting a coincidental
-                            // (decoy) match (#6097).
-                            if character == "\"" {
-                                current.append("\"")
-                            } else {
-                                current.append("\\")
-                                current.append(character)
-                            }
+                            // Accumulate the escape sequence RAW (`\` + the char); `decodeDoubleQuoted`
+                            // resolves the full escape set at flush (`\xNN`, `\uNNNN`, `\U........`,
+                            // `\n`, `\t`, `\0`, `\/`, …) to the spec-correct key name (issue #6141). A
+                            // `\"` here is a literal quote, not the scalar terminator (#6097).
+                            current.append("\\")
+                            current.append(character)
                             itemHasQuotedChar = true
                             escaped = false
                         } else if character == "\\" {
@@ -346,6 +355,7 @@ enum PlanMetadataParser {
                     inComment = true
                 } else if character == "\"" || character == "'" {
                     activeQuote = character
+                    if character == "\"" { itemHadDoubleQuote = true }
                 } else if character == "[" {
                     depth += 1
                     current.append(character)
@@ -427,40 +437,90 @@ enum PlanMetadataParser {
         return result
     }
 
-    /// Unquote a flow-list scalar: a single-quoted scalar is literal, a double-quoted scalar has its
-    /// backslash escapes resolved (so `"a\"]b"` yields `a"]b`), matching the escape tracking used to
-    /// find the sequence terminator and to split items (#6097).
+    /// Unquote a flow-list scalar: a single-quoted scalar is literal apart from `''` -> `'`, a
+    /// double-quoted scalar has its full escape set resolved (`\xNN`, `\uNNNN`, `\U........`, `\n`,
+    /// `\t`, `\0`, `\/`, …). Matches the escape tracking used to find the sequence terminator and to
+    /// split items (#6097), and the spec-correct decoding snakeyaml gives the Android runner (#6141).
     private static func unquoteFlowScalar(_ value: String) -> String {
         if value.count >= 2 {
             if value.hasPrefix("\"") && value.hasSuffix("\"") {
-                return unescapeDoubleQuoted(String(value.dropFirst().dropLast()))
+                return decodeDoubleQuoted(String(value.dropFirst().dropLast()))
             }
             if value.hasPrefix("'") && value.hasSuffix("'") {
-                return String(value.dropFirst().dropLast())
+                return String(value.dropFirst().dropLast()).replacingOccurrences(of: "''", with: "'")
             }
         }
         return value
     }
 
-    /// Resolve backslash escapes inside a double-quoted YAML scalar: `\` escapes the next character
-    /// literally (so `\"` -> `"`, `\\` -> `\`). Sufficient for key names (#6097).
-    private static func unescapeDoubleQuoted(_ inner: String) -> String {
+    /// Resolve the escape sequences inside a double-quoted YAML scalar to the spec-correct key name
+    /// (issue #6141). iOS has no YAML dependency, so this decodes the escape set the runner cares
+    /// about: `\xNN` / `\uNNNN` / `\U........` hex/Unicode escapes, plus `\n` `\t` `\r` `\0` `\a`
+    /// `\b` `\f` `\v` `\e` `\"` `\\` `\/` `\ ` `\N` `\_` `\L` `\P`. A trailing `\` with nothing to
+    /// escape, or a malformed `\x`/`\u`/`\U` sequence, is kept literal so a bad escape never drops
+    /// data (fail-safe over-capture). An unknown escape drops the backslash and keeps the character,
+    /// matching lenient decoders.
+    private static func decodeDoubleQuoted(_ inner: String) -> String {
         var result = ""
-        var escaped = false
-        for character in inner {
-            if escaped {
+        result.reserveCapacity(inner.count)
+        var iterator = inner.makeIterator()
+        while let character = iterator.next() {
+            guard character == "\\" else {
                 result.append(character)
-                escaped = false
-            } else if character == "\\" {
-                escaped = true
-            } else {
-                result.append(character)
+                continue
+            }
+            guard let escape = iterator.next() else {
+                result.append("\\")
+                break
+            }
+            switch escape {
+            case "0": result.append("\u{0000}")
+            case "a": result.append("\u{0007}")
+            case "b": result.append("\u{0008}")
+            case "t", "\t": result.append("\u{0009}")
+            case "n": result.append("\u{000A}")
+            case "v": result.append("\u{000B}")
+            case "f": result.append("\u{000C}")
+            case "r": result.append("\u{000D}")
+            case "e": result.append("\u{001B}")
+            case " ": result.append("\u{0020}")
+            case "\"": result.append("\"")
+            case "/": result.append("/")
+            case "\\": result.append("\\")
+            case "N": result.append("\u{0085}")
+            case "_": result.append("\u{00A0}")
+            case "L": result.append("\u{2028}")
+            case "P": result.append("\u{2029}")
+            case "x": result.append(readHexScalar(&iterator, digits: 2, fallback: escape))
+            case "u": result.append(readHexScalar(&iterator, digits: 4, fallback: escape))
+            case "U": result.append(readHexScalar(&iterator, digits: 8, fallback: escape))
+            default:
+                // Unknown escape: lenient decoders drop the backslash and keep the character.
+                result.append(escape)
             }
         }
-        if escaped {
-            result.append("\\")
-        }
         return result
+    }
+
+    /// Read exactly `digits` hex characters and return the decoded scalar. On a malformed sequence
+    /// (too few hex digits, or a value that is not a valid Unicode scalar) fall back to emitting the
+    /// escape letter followed by the consumed characters — a bad escape never crashes or drops data.
+    private static func readHexScalar(
+        _ iterator: inout String.Iterator,
+        digits: Int,
+        fallback: Character
+    ) -> String {
+        var hex = ""
+        for _ in 0..<digits {
+            guard let next = iterator.next() else { break }
+            hex.append(next)
+        }
+        if hex.count == digits,
+           let code = UInt32(hex, radix: 16),
+           let scalar = Unicode.Scalar(code) {
+            return String(scalar)
+        }
+        return String(fallback) + hex
     }
 
     private static func parsePlatform(_ value: String) throws -> AutoMobilePlanExecutor.PlanPlatform {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -584,9 +584,10 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
     }
 
     func testSecretValueRedactedWhenKeyUsesHexEscapeViaFailSafe() throws {
-        // The key `"API\x54OKEN"` is not spec-decoded by the scanner, so it can't be matched to the
-        // parameter `APITOKEN` by name; the strengthened value-layer fail-safe over-redacts so the
-        // secret still cannot leak (#6097 — the important security assertion).
+        // The key `"API\x54OKEN"` is now spec-decoded to `APITOKEN` (issue #6141), so it matches the
+        // parameter `APITOKEN` by name and its value is redacted directly. Even if decoding had
+        // failed, the value-layer fail-safe would over-redact, so the secret still cannot leak
+        // (#6097 — the important security assertion, which holds either way).
         let secret = "SECRET-hex-7b3"
         let plan =
             "name: P\nsecretParameters: [\"API\\x54OKEN\"]\nsteps:\n  - tool: observe\n  - tool: inputText\n    text: \"field\""
@@ -613,9 +614,10 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
     }
 
     func testSecretValueRedactedDespiteDecoyParameterMatchingUnDecodedHexKey() throws {
-        // Parameters contain BOTH the real `APITOKEN` (what YAML decodes `"API\x54OKEN"` to) and a
-        // decoy `APIx54OKEN` matching the scanner's un-decoded spelling. The fail-safe must not trust
-        // the decoy exact-match; it over-redacts so the REAL secret cannot leak (#6097 — decoy).
+        // Parameters contain BOTH the real `APITOKEN` (what the scanner now decodes `"API\x54OKEN"`
+        // to — issue #6141) and a decoy `APIx54OKEN` matching the OLD un-decoded spelling. Decoding
+        // resolves the key to `APITOKEN`, so the real secret is redacted by exact match and the decoy
+        // is never trusted; the secret cannot leak (#6097 — decoy).
         let real = "REAL-hex-secret-1a2"
         let plan =
             "name: P\nsecretParameters: [\"API\\x54OKEN\"]\nsteps:\n  - tool: observe\n  - tool: inputText\n    text: \"field\""
@@ -998,7 +1000,11 @@ private final class ScriptedCapturingModelResponder: ModelResponding, @unchecked
 }
 
 /// Direct tests of `PlanMetadataParser`'s `secretParameters:` parsing (#6029). Parity note: these
-/// forms must all parse the same set of keys snakeyaml gives the Android runner.
+/// forms parse the same keys snakeyaml gives the Android runner for the common and escaped forms
+/// (issue #6141 added full double-quoted escape decoding here). The one deliberate divergence is a
+/// PLAIN scalar spanning lines (`[API⏎TOKEN]`): iOS's scanner over-captures token-per-line
+/// (`["API","TOKEN"]`) while snakeyaml folds it to `"API TOKEN"` — both fail safe toward
+/// over-redaction, neither leaks.
 /// Tests of `PlanMetadataParser.parseSecretParameterKeys` — the RAW, placeholder-tolerant scanner
 /// that replaces the previous substituted-content / YAML-load parsing (#6029 convergence).
 final class PlanMetadataSecretParametersParsingTests: XCTestCase {
@@ -1189,6 +1195,44 @@ final class PlanMetadataSecretParametersParsingTests: XCTestCase {
         // key and must be kept so its parameter value is redacted (#6097 Codex — quoted whitespace).
         let yaml = "name: P\nsecretParameters: [\" \"]\nsteps:\n  - tool: observe"
         XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), [" "])
+    }
+
+    func testDoubleQuotedHexEscapeIsDecodedToSpecCorrectKey() {
+        // Issue #6141: `\x54` decodes to `T`, so `"API\x54OKEN"` yields the key `APITOKEN` — matching
+        // what snakeyaml gives the Android runner.
+        let yaml = "name: P\nsecretParameters: [\"API\\x54OKEN\"]\nsteps:\n  - tool: observe"
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["APITOKEN"])
+    }
+
+    func testDoubleQuotedUnicodeEscapesAreDecoded() {
+        // `A` -> A, `\U00000042` -> B (issue #6141).
+        let yaml = "name: P\nsecretParameters: [\"\\u0041\\U00000042\"]\nsteps:\n  - tool: observe"
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["AB"])
+    }
+
+    func testDoubleQuotedControlEscapesAreDecoded() {
+        // `\t` -> TAB, `\n` -> LF (issue #6141).
+        let yaml = "name: P\nsecretParameters: [\"A\\tB\\nC\"]\nsteps:\n  - tool: observe"
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["A\tB\nC"])
+    }
+
+    func testBlockSequenceDoubleQuotedHexEscapeIsDecoded() {
+        // The block-sequence form decodes escapes the same way as the flow form (issue #6141).
+        let yaml = "name: P\nsecretParameters:\n  - \"API\\x54OKEN\"\nsteps:\n  - tool: observe"
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["APITOKEN"])
+    }
+
+    func testMalformedHexEscapeIsKeptLiteralFailSafe() {
+        // A `\x` with too few hex digits cannot decode; keep it literal (fail-safe over-capture) so
+        // the token is still treated as a secret key rather than dropped (issue #6141).
+        let yaml = "name: P\nsecretParameters: [\"API\\xZZ\"]\nsteps:\n  - tool: observe"
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["APIxZZ"])
+    }
+
+    func testSingleQuotedBlockScalarUnescapesDoubledQuote() {
+        // A single-quoted scalar is literal except `''` -> `'` (issue #6141).
+        let yaml = "name: P\nsecretParameters:\n  - 'API''TOKEN'\nsteps:\n  - tool: observe"
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["API'TOKEN"])
     }
 
     func testFlushBlockStopsAtNextTopLevelKey() {


### PR DESCRIPTION
## Summary

Replaces the hand-rolled, best-effort `secretParameters:` key-name scanners on both runners with spec-correct YAML scalar decoding, closing the encoding gaps called out in [#6141](https://github.com/kaeawc/auto-mobile/issues/6141) (`\xNN` / `\uNNNN` / `\U........` hex/Unicode escapes, control/simple double-quote escapes, folding, line-endings).

The redaction guarantee was already fail-safe (a mis-named key over-redacts, never leaks). This makes the common path resolve keys by their true name, so the value-layer lenient/over-redact fallback becomes a rare backstop rather than the norm.

## Android — `SecretRedactor.parsePlanSecretKeys`

Follows the issue's recommended direction (snakeyaml is already a dependency):

1. Substitute every `${...}` placeholder with a YAML-safe sentinel so a real parser does not choke on unquoted placeholders in flow collections.
2. Load the plan through snakeyaml — decoding escapes, multi-line folding, and CRLF to the spec-correct key name. `SafeConstructor` is used so a redactor cannot become a YAML-deserialization gadget for untrusted plan content (escapes still decode — they are resolved by the reader).
3. Map the sentinels back to their original `${...}` text.
4. Fall back to the existing placeholder-tolerant line scanner (`parsePlanSecretKeysBestEffort`) when the substituted plan is not loadable as a mapping (e.g. a substituted value injected a document-truncating newline), so a declared key is never dropped.

## iOS — `PlanMetadataParser`

`ios/XCTestRunner` has no YAML dependency, so (per the issue's alternative) the hand-rolled scanner is extended to decode the full double-quoted escape set (`\xNN`, `\uNNNN`, `\U........`, `\n`, `\t`, `\r`, `\0`, `\a`, `\b`, `\f`, `\v`, `\e`, `\"`, `\\`, `\/`, `\ `, `\N`, `\_`, `\L`, `\P`) plus the single-quoted `''` un-escape — across the inline, block, and multi-line flow paths. A malformed `\x`/`\u`/`\U` sequence is kept literal (fail-safe over-capture).

### Deliberate platform divergence
A PLAIN scalar spanning lines (`[API⏎TOKEN]`): snakeyaml folds it to the single key `API TOKEN` (spec-correct); iOS's scanner over-captures token-per-line (`["API","TOKEN"]`). Both fail safe toward over-redaction; neither leaks. Documented in the iOS test parity note.

## Alternatives checked (per CLAUDE.md "prefer structured parser / existing dependency")
- **snakeyaml** — already a direct dependency (`libs.snakeyaml`, used by `TestPlanValidator`); reused on Android rather than hand-rolling.
- **iOS** — no YAML package in `ios/XCTestRunner`; adding one was out of scope, so the existing scanner was extended (Foundation only) as the issue suggests.

## Tests
- Android `SecretRedactorTest`: added hex/Unicode/control-escape decoding (flow + block), snakeyaml fallback-on-truncation; updated the plain-multiline test to the spec-correct folded key.
- iOS `PlanMetadataSecretParametersParsingTests`: added hex/Unicode/control-escape, malformed-escape-kept-literal, and single-quoted `''` cases; refreshed the parity note and the two hex end-to-end comments.

## Validation
- Android: `:junit-runner:test --tests SecretRedactorTest --tests AutoMobilePlanRedactionTest` — BUILD SUCCESSFUL.
- `scripts/ktfmt/validate_ktfmt.sh` — clean; `scripts/all_fast_validate_checks.sh` — green; `validate-bun-test-timings.sh` — no changed TS tests.
- iOS `swift test` could not run locally (package requires Swift tools 6.3.0; 6.2.4 installed) — CI covers it; all cases traced by hand against the existing suite.

Closes #6141
