### PR TITLE
fix(session): revalidate ownership before ANR shutdown

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -55,6 +55,8 @@ import {
 export type { DeviceAllocationCriteria, DeviceAllocationRequest } from "./DeviceCriteriaMatcher";
 export type { DeviceRecoveryPolicy } from "./poolConfig";
 
+type AutolockClient = { mcpSessionId?: string; expectedSessionId?: string };
+
 function resolveLifecycleCoordinator(
   coordinator: VirtualDeviceLifecycleCoordinator | undefined,
 ): VirtualDeviceLifecycleCoordinator {
@@ -4891,7 +4893,7 @@ export class DevicePool {
     >,
     stableRuntimeName = expectedIdentity.name,
     verifiedAndroidAvdName?: string,
-    autolockClient?: { mcpSessionId?: string },
+    autolockClient?: AutolockClient,
   ): Promise<DeviceReadinessReservation> {
     // The stable-name reservation exists to bridge an Android emulator changing
     // serials across a reboot. iOS UDIDs are stable, so a name reservation there
@@ -5012,7 +5014,7 @@ export class DevicePool {
   async reserveDeviceForShutdown(
     deviceId: string,
     abortSignal?: AbortSignal,
-    autolockClient?: { mcpSessionId?: string },
+    autolockClient?: AutolockClient,
   ): Promise<
     | {
         device: PooledDevice;
@@ -5057,7 +5059,7 @@ export class DevicePool {
     deviceId: string,
     identity: ShutdownIdentityReservation,
     abortSignal: AbortSignal | undefined,
-    autolockClient: { mcpSessionId?: string } | undefined,
+    autolockClient: AutolockClient | undefined,
   ): Promise<PooledDevice | undefined> {
     const releaseSessionOnAbort = () => identity.releaseSession?.();
     abortSignal?.addEventListener("abort", releaseSessionOnAbort, { once: true });
@@ -5110,7 +5112,7 @@ export class DevicePool {
     deviceId: string,
     identity: ShutdownIdentityReservation,
     abortSignal: AbortSignal | undefined,
-    autolockClient: { mcpSessionId?: string } | undefined,
+    autolockClient: AutolockClient | undefined,
   ): Promise<PooledDevice | undefined> {
     return await this.assignmentMutex.runExclusive(() => {
       if (abortSignal?.aborted) {
@@ -5733,20 +5735,24 @@ export class DevicePool {
 
   private getOwnedAutolockSession(
     device: PooledDevice,
-    client: { mcpSessionId?: string } | undefined,
+    client: AutolockClient | undefined,
   ): Session | undefined {
     if (!client) {
       return undefined;
     }
     const { mcpSessionId } = client;
+    if (
+      "expectedSessionId" in client &&
+      mcpSessionId &&
+      this.mcpSessionAutolockMap.get(mcpSessionId) !== client.expectedSessionId
+    ) {
+      throw new ActionableError(
+        `Device '${device.id}' is already assigned to another session. ` +
+          "Acquire a different device or wait for its owner to release it.",
+      );
+    }
     const session = device.sessionId ? this.sessionManager.getSession(device.sessionId) : null;
     if (!session) {
-      if (mcpSessionId && this.mcpSessionAutolockMap.has(mcpSessionId)) {
-        throw new ActionableError(
-          `Device '${device.id}' is already assigned to another session. ` +
-            "Acquire a different device or wait for its owner to release it.",
-        );
-      }
       return undefined;
     }
     if (
@@ -5762,6 +5768,10 @@ export class DevicePool {
       );
     }
     return session;
+  }
+
+  captureAutolockSessionForMcpSession(mcpSessionId: string | undefined): string | undefined {
+    return mcpSessionId ? this.mcpSessionAutolockMap.get(mcpSessionId) : undefined;
   }
 
   private throwIfFreshStartAlreadyBound(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5741,6 +5741,12 @@ export class DevicePool {
     const { mcpSessionId } = client;
     const session = device.sessionId ? this.sessionManager.getSession(device.sessionId) : null;
     if (!session) {
+      if (mcpSessionId && this.mcpSessionAutolockMap.has(mcpSessionId)) {
+        throw new ActionableError(
+          `Device '${device.id}' is already assigned to another session. ` +
+            "Acquire a different device or wait for its owner to release it.",
+        );
+      }
       return undefined;
     }
     if (

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -357,6 +357,7 @@ export class DevicePool {
   private lastUsedAtMarker = 0;
   private lastReleasedDeviceId: string | null = null;
   private readonly mcpSessionAutolockMap: Map<string, string> = new Map();
+  private readonly mcpSessionRecoveryDevices: Map<string, PooledDevice> = new Map();
   private readonly refreshMissingDeviceMisses: Map<string, number> = new Map();
   private readonly suppressedAutoStartDeviceImageKeys: Set<string> = new Set();
   private readonly suppressedAutoStartImageKeyByDeviceId: Map<string, string> = new Map();
@@ -5027,12 +5028,20 @@ export class DevicePool {
       throw abortSignal.reason ?? new Error("Shutdown reservation cancelled");
     }
     const identity = this.reserveShutdownSessionIdentity(deviceId);
-    const expectedDevice = await this.reserveShutdownDeviceWithAbort(
-      deviceId,
-      identity,
-      abortSignal,
-      autolockClient,
-    );
+    let expectedDevice: PooledDevice | undefined;
+    try {
+      expectedDevice = await this.reserveShutdownDeviceWithAbort(
+        deviceId,
+        identity,
+        abortSignal,
+        autolockClient,
+      );
+    } catch (error) {
+      if (autolockClient?.mcpSessionId) {
+        this.mcpSessionRecoveryDevices.delete(autolockClient.mcpSessionId);
+      }
+      throw error;
+    }
     if (!expectedDevice) {
       identity.releaseSession?.();
       return undefined;
@@ -5049,6 +5058,9 @@ export class DevicePool {
       // the pool, so it must not queue behind a refresh holding assignmentMutex.
       if (this.shutdownReservations.get(capturedDevice.id) === capturedDevice) {
         this.shutdownReservations.delete(capturedDevice.id);
+      }
+      if (autolockClient?.mcpSessionId) {
+        this.mcpSessionRecoveryDevices.delete(autolockClient.mcpSessionId);
       }
       identity.releaseSession?.();
     };
@@ -5134,6 +5146,9 @@ export class DevicePool {
       // A readiness await can outlive this client's ownership. Check it while
       // reserving shutdown so a stale request cannot reboot another session's device.
       this.getOwnedAutolockSession(currentDevice, autolockClient);
+      if (autolockClient?.mcpSessionId && "expectedSessionId" in autolockClient) {
+        this.mcpSessionRecoveryDevices.set(autolockClient.mcpSessionId, currentDevice);
+      }
       if (this.shutdownReservations.get(deviceId) === currentDevice) {
         throw new ActionableError(`Device '${deviceId}' is already shutting down.`);
       }
@@ -5595,6 +5610,11 @@ export class DevicePool {
     verifiedAndroidAvdIdentity?: DeviceInfo,
     achievedReadiness: DeviceReadinessLevel = "automationReady",
   ): Promise<string> {
+    if (mcpSessionId && this.mcpSessionRecoveryDevices.has(mcpSessionId)) {
+      throw new ActionableError(
+        `MCP session '${mcpSessionId}' is recovering a device and cannot remap until recovery finishes.`,
+      );
+    }
     const androidAvdIdentity = verifiedAndroidAvdIdentity ?? sourceImage;
 
     // Ensure device is in the pool (it may have been freshly booted)

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5584,8 +5584,13 @@ export class DevicePool {
     if (!isDevicePoolAutolockEnabled()) {
       return undefined;
     }
-    return this.assignmentMutex.runExclusive(() =>
-      this.autolockDeviceExclusive(
+    return this.assignmentMutex.runExclusive(() => {
+      if (mcpSessionId && this.mcpSessionRecoveryDevices.has(mcpSessionId)) {
+        throw new ActionableError(
+          `MCP session '${mcpSessionId}' is recovering a device and cannot remap until recovery finishes.`,
+        );
+      }
+      return this.autolockDeviceExclusive(
         deviceId,
         platform,
         mcpSessionId,
@@ -5595,8 +5600,8 @@ export class DevicePool {
         readinessReservationOwners,
         verifiedAndroidAvdIdentity,
         achievedReadiness,
-      ),
-    );
+      );
+    });
   }
 
   private async autolockDeviceExclusive(
@@ -5610,11 +5615,6 @@ export class DevicePool {
     verifiedAndroidAvdIdentity?: DeviceInfo,
     achievedReadiness: DeviceReadinessLevel = "automationReady",
   ): Promise<string> {
-    if (mcpSessionId && this.mcpSessionRecoveryDevices.has(mcpSessionId)) {
-      throw new ActionableError(
-        `MCP session '${mcpSessionId}' is recovering a device and cannot remap until recovery finishes.`,
-      );
-    }
     const androidAvdIdentity = verifiedAndroidAvdIdentity ?? sourceImage;
 
     // Ensure device is in the pool (it may have been freshly booted)

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5012,6 +5012,7 @@ export class DevicePool {
   async reserveDeviceForShutdown(
     deviceId: string,
     abortSignal?: AbortSignal,
+    autolockClient?: { mcpSessionId?: string },
   ): Promise<
     | {
         device: PooledDevice;
@@ -5028,6 +5029,7 @@ export class DevicePool {
       deviceId,
       identity,
       abortSignal,
+      autolockClient,
     );
     if (!expectedDevice) {
       identity.releaseSession?.();
@@ -5055,6 +5057,7 @@ export class DevicePool {
     deviceId: string,
     identity: ShutdownIdentityReservation,
     abortSignal: AbortSignal | undefined,
+    autolockClient: { mcpSessionId?: string } | undefined,
   ): Promise<PooledDevice | undefined> {
     const releaseSessionOnAbort = () => identity.releaseSession?.();
     abortSignal?.addEventListener("abort", releaseSessionOnAbort, { once: true });
@@ -5063,6 +5066,7 @@ export class DevicePool {
         deviceId,
         identity,
         abortSignal,
+        autolockClient,
       );
       if (abortSignal?.aborted) {
         if (expectedDevice && this.shutdownReservations.get(deviceId) === expectedDevice) {
@@ -5106,6 +5110,7 @@ export class DevicePool {
     deviceId: string,
     identity: ShutdownIdentityReservation,
     abortSignal: AbortSignal | undefined,
+    autolockClient: { mcpSessionId?: string } | undefined,
   ): Promise<PooledDevice | undefined> {
     return await this.assignmentMutex.runExclusive(() => {
       if (abortSignal?.aborted) {
@@ -5124,6 +5129,9 @@ export class DevicePool {
       if (!currentDevice) {
         return undefined;
       }
+      // A readiness await can outlive this client's ownership. Check it while
+      // reserving shutdown so a stale request cannot reboot another session's device.
+      this.getOwnedAutolockSession(currentDevice, autolockClient);
       if (this.shutdownReservations.get(deviceId) === currentDevice) {
         throw new ActionableError(`Device '${deviceId}' is already shutting down.`);
       }

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -3303,6 +3303,7 @@ async function rebootAndroidAfterSystemUiAnr(
   timer: Timer,
   signal: AbortSignal | undefined,
   progress: { report: ProgressCallback } | undefined,
+  recoveryAutolockClient: { mcpSessionId?: string; expectedSessionId?: string } | undefined,
   publishReplacementReadinessMarker?: (replacement: BootedDevice) => void,
 ): Promise<{
   boot: DeviceBootResult;
@@ -3325,7 +3326,7 @@ async function rebootAndroidAfterSystemUiAnr(
         boot.device,
         sourceImage.name,
         sourceImage.name,
-        isDevicePoolAutolockEnabled() ? { mcpSessionId: args.__mcpSessionId } : undefined,
+        recoveryAutolockClient,
       )
     : undefined;
   let shutdownReservation: Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>;
@@ -3337,7 +3338,7 @@ async function rebootAndroidAfterSystemUiAnr(
       devicePool,
       boot.device.deviceId,
       signal,
-      args.__mcpSessionId,
+      recoveryAutolockClient,
     );
     await shutdownAndroidForSystemUiAnr(boot.device, deviceManager, timer, totalDeadlineMs, signal);
     shutdownWasConfirmed = true;
@@ -3403,7 +3404,7 @@ async function reserveSystemUiAnrShutdown(
   devicePool: DevicePool | undefined,
   deviceId: string,
   signal: AbortSignal | undefined,
-  mcpSessionId: string | undefined,
+  autolockClient: { mcpSessionId?: string; expectedSessionId?: string } | undefined,
 ): Promise<Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>> {
   if (!devicePool) {
     return undefined;
@@ -3411,7 +3412,7 @@ async function reserveSystemUiAnrShutdown(
   const reservation = await devicePool.reserveDeviceForShutdown(
     deviceId,
     signal,
-    isDevicePoolAutolockEnabled() ? { mcpSessionId } : undefined,
+    autolockClient,
   );
   if (reservation) {
     devicePool.markIntentionalShutdown(deviceId);
@@ -3671,10 +3672,17 @@ async function prepareStartDeviceRunnerReadiness(
   input: StartDeviceRunnerReadinessInput,
 ): Promise<SystemUiAnrRecoveryResult & { recovered: boolean }> {
   const devicePool = getStartDevicePool(input.daemonState);
+  const recoveryAutolockClient =
+    isDevicePoolAutolockEnabled() && devicePool
+      ? {
+          mcpSessionId: input.args.__mcpSessionId,
+          expectedSessionId: devicePool.captureAutolockSessionForMcpSession(input.args.__mcpSessionId),
+        }
+      : undefined;
   const readinessResult = await ensureRunnerReadyWithSystemUiAnrRecovery(
     input.boot,
     createRunnerReadinessAttempt(input),
-    createSystemUiAnrRebooter(input, devicePool),
+    createSystemUiAnrRebooter(input, devicePool, recoveryAutolockClient),
   );
   if (readinessResult.recovered) {
     try {
@@ -3764,6 +3772,7 @@ function createRunnerReadinessAttempt(
 function createSystemUiAnrRebooter(
   input: StartDeviceRunnerReadinessInput,
   devicePool: DevicePool | undefined,
+  recoveryAutolockClient: { mcpSessionId?: string; expectedSessionId?: string } | undefined,
 ): (candidate: DeviceBootResult) => Promise<SystemUiAnrRecoveryResult> {
   return async (candidate) =>
     await rebootAndroidAfterSystemUiAnr(
@@ -3776,6 +3785,7 @@ function createSystemUiAnrRebooter(
       input.timer,
       input.signal,
       input.progress ? { report: input.progress } : undefined,
+      recoveryAutolockClient,
       (replacement) => input.publishRecoveredReadinessMarker?.(replacement),
     );
 }

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -3409,11 +3409,7 @@ async function reserveSystemUiAnrShutdown(
   if (!devicePool) {
     return undefined;
   }
-  const reservation = await devicePool.reserveDeviceForShutdown(
-    deviceId,
-    signal,
-    autolockClient,
-  );
+  const reservation = await devicePool.reserveDeviceForShutdown(deviceId, signal, autolockClient);
   if (reservation) {
     devicePool.markIntentionalShutdown(deviceId);
   }
@@ -3676,7 +3672,9 @@ async function prepareStartDeviceRunnerReadiness(
     isDevicePoolAutolockEnabled() && devicePool
       ? {
           mcpSessionId: input.args.__mcpSessionId,
-          expectedSessionId: devicePool.captureAutolockSessionForMcpSession(input.args.__mcpSessionId),
+          expectedSessionId: devicePool.captureAutolockSessionForMcpSession(
+            input.args.__mcpSessionId,
+          ),
         }
       : undefined;
   const readinessResult = await ensureRunnerReadyWithSystemUiAnrRecovery(

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -3325,6 +3325,7 @@ async function rebootAndroidAfterSystemUiAnr(
         boot.device,
         sourceImage.name,
         sourceImage.name,
+        isDevicePoolAutolockEnabled() ? { mcpSessionId: args.__mcpSessionId } : undefined,
       )
     : undefined;
   let shutdownReservation: Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>;
@@ -3336,6 +3337,7 @@ async function rebootAndroidAfterSystemUiAnr(
       devicePool,
       boot.device.deviceId,
       signal,
+      args.__mcpSessionId,
     );
     await shutdownAndroidForSystemUiAnr(boot.device, deviceManager, timer, totalDeadlineMs, signal);
     shutdownWasConfirmed = true;
@@ -3401,11 +3403,16 @@ async function reserveSystemUiAnrShutdown(
   devicePool: DevicePool | undefined,
   deviceId: string,
   signal: AbortSignal | undefined,
+  mcpSessionId: string | undefined,
 ): Promise<Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>> {
   if (!devicePool) {
     return undefined;
   }
-  const reservation = await devicePool.reserveDeviceForShutdown(deviceId, signal);
+  const reservation = await devicePool.reserveDeviceForShutdown(
+    deviceId,
+    signal,
+    isDevicePoolAutolockEnabled() ? { mcpSessionId } : undefined,
+  );
   if (reservation) {
     devicePool.markIntentionalShutdown(deviceId);
   }

--- a/test/daemon/devicePoolAutolockOwnership.test.ts
+++ b/test/daemon/devicePoolAutolockOwnership.test.ts
@@ -278,17 +278,18 @@ test.each(["agent-B", "agent-A", "agent-A-reassigned"])(
         timer: h.timer,
         notifyResourcesChanged: async () => {},
         ensureCtrlProxyReady: async (request) => {
-          if (++readinessAttempts === 1) {
-            throw new SystemUiAnrRecoveryRequiredError("System UI ANR");
-          }
-          recoveredExitListeners = recoveredProcess.listenerCount("exit");
-          recoveredOutputListeners = recoveredProcess.stdout.listenerCount("data");
-          if (client === "agent-A-reassigned") {
+          ++readinessAttempts;
+          if (client === "agent-A-reassigned" && readinessAttempts === 1) {
             const otherDevice = { ...device, deviceId: "emulator-5558", name: "Other AVD" };
             deviceUtils.setBootedDevices("android", [request.device, otherDevice]);
             await h.pool.addDevice(otherDevice);
             secondOwner = await h.pool.autolockDevice(otherDevice.deviceId, "android", "agent-A");
           }
+          if (readinessAttempts === 1) {
+            throw new SystemUiAnrRecoveryRequiredError("System UI ANR");
+          }
+          recoveredExitListeners = recoveredProcess.listenerCount("exit");
+          recoveredOutputListeners = recoveredProcess.stdout.listenerCount("data");
         },
       });
       registerDeviceTools();
@@ -310,9 +311,10 @@ test.each(["agent-B", "agent-A", "agent-A-reassigned"])(
           expect(h.manager.getDeviceReadiness(owner!)).toBe("automationReady");
         } else {
           await expect(acquiring).rejects.toThrow("another session");
-          expect(readinessAttempts).toBe(2);
+          expect(readinessAttempts).toBe(1);
           expect(secondOwner).toBeDefined();
-          expect(h.manager.getSession(owner!)?.assignedDevice).toBe(image.deviceId);
+          expect(deviceUtils.getExecutedOperations()).not.toContain(`killDevice:${device.name}`);
+          expect(h.manager.getSession(owner!)?.assignedDevice).toBe(device.deviceId);
         }
         expect(h.pool.resolveAutolockSessionForMcpSession("agent-A")).toBe(secondOwner ?? owner);
         expect(h.pool.resolveAutolockSessionForMcpSession("agent-B")).toBeUndefined();

--- a/test/daemon/devicePoolAutolockOwnership.test.ts
+++ b/test/daemon/devicePoolAutolockOwnership.test.ts
@@ -247,7 +247,7 @@ test("registered getAndroid preserves its caller's UUID and rejects a different 
   });
 });
 
-test.each(["agent-B", "agent-A", "agent-A-reassigned"])(
+test.each(["agent-B", "agent-A"])(
   "System UI recovery respects the requesting autolock owner: %s",
   async (client) => {
     await withAutolock(async () => {
@@ -270,7 +270,6 @@ test.each(["agent-B", "agent-A", "agent-A-reassigned"])(
       let readinessAttempts = 0;
       let recoveredExitListeners = 0;
       let recoveredOutputListeners = 0;
-      let secondOwner: string | undefined;
       DaemonState.getInstance().initialize(h.manager, h.pool);
       setDeviceToolsDependencies({
         deviceManagerFactory: () => deviceUtils,
@@ -279,12 +278,6 @@ test.each(["agent-B", "agent-A", "agent-A-reassigned"])(
         notifyResourcesChanged: async () => {},
         ensureCtrlProxyReady: async (request) => {
           ++readinessAttempts;
-          if (client === "agent-A-reassigned" && readinessAttempts === 1) {
-            const otherDevice = { ...device, deviceId: "emulator-5558", name: "Other AVD" };
-            deviceUtils.setBootedDevices("android", [request.device, otherDevice]);
-            await h.pool.addDevice(otherDevice);
-            secondOwner = await h.pool.autolockDevice(otherDevice.deviceId, "android", "agent-A");
-          }
           if (readinessAttempts === 1) {
             throw new SystemUiAnrRecoveryRequiredError("System UI ANR");
           }
@@ -297,7 +290,7 @@ test.each(["agent-B", "agent-A", "agent-A-reassigned"])(
         const owner = await h.pool.autolockDevice(device.deviceId, "android", "agent-A", image);
         const acquiring = ToolRegistry.getTool("getAndroid")!.handler({
           deviceId: device.deviceId,
-          __mcpSessionId: client === "agent-A-reassigned" ? "agent-A" : client,
+          __mcpSessionId: client,
         });
         if (client === "agent-B") {
           await expect(acquiring).rejects.toThrow("another session");
@@ -309,14 +302,8 @@ test.each(["agent-B", "agent-A", "agent-A-reassigned"])(
           expect(readinessAttempts).toBe(2);
           expect(h.manager.getSession(owner!)?.assignedDevice).toBe(image.deviceId);
           expect(h.manager.getDeviceReadiness(owner!)).toBe("automationReady");
-        } else {
-          await expect(acquiring).rejects.toThrow("another session");
-          expect(readinessAttempts).toBe(1);
-          expect(secondOwner).toBeDefined();
-          expect(deviceUtils.getExecutedOperations()).not.toContain(`killDevice:${device.name}`);
-          expect(h.manager.getSession(owner!)?.assignedDevice).toBe(device.deviceId);
         }
-        expect(h.pool.resolveAutolockSessionForMcpSession("agent-A")).toBe(secondOwner ?? owner);
+        expect(h.pool.resolveAutolockSessionForMcpSession("agent-A")).toBe(owner);
         expect(h.pool.resolveAutolockSessionForMcpSession("agent-B")).toBeUndefined();
         if (readinessAttempts > 1) {
           expect(recoveredExitListeners).toBeGreaterThan(0);
@@ -324,7 +311,7 @@ test.each(["agent-B", "agent-A", "agent-A-reassigned"])(
           expect(recoveredProcess.stdout.listenerCount("data")).toBe(recoveredOutputListeners);
         }
         expect(await h.db.selectFrom("device_sessions").selectAll().execute()).toHaveLength(
-          secondOwner ? 2 : 1,
+          1,
         );
       } finally {
         resetDeviceToolsDependencies();
@@ -335,3 +322,55 @@ test.each(["agent-B", "agent-A", "agent-A-reassigned"])(
     });
   },
 );
+
+test("System UI recovery rejects a remapped client while its first target is idle", async () => {
+  await withAutolock(async () => {
+    const deviceUtils = new FakeDeviceUtils();
+    const h = await harness(deviceUtils);
+    const matcher = new FakeDeviceMatcher();
+    const device = h.devices.bootedDevices[0];
+    const image = { ...device, deviceId: "emulator-5556", isRunning: false };
+    const otherDevice = { ...device, deviceId: "emulator-5558", name: "Other AVD" };
+    deviceUtils.setBootedDevices("android", [device]);
+    deviceUtils.setDeviceImages("android", [image]);
+    matcher.setBootedResult(device);
+    matcher.setImageResult(image);
+    let readinessAttempts = 0;
+    let secondOwner: string | undefined;
+    DaemonState.getInstance().initialize(h.manager, h.pool);
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => deviceUtils,
+      deviceMatcherFactory: () => matcher,
+      timer: h.timer,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async (request) => {
+        ++readinessAttempts;
+        if (readinessAttempts === 1) {
+          deviceUtils.setBootedDevices("android", [request.device, otherDevice]);
+          await h.pool.addDevice(otherDevice);
+          secondOwner = await h.pool.autolockDevice(otherDevice.deviceId, "android", "agent-A");
+          throw new SystemUiAnrRecoveryRequiredError("System UI ANR");
+        }
+      },
+    });
+    registerDeviceTools();
+    try {
+      await expect(
+        ToolRegistry.getTool("getAndroid")!.handler({
+          deviceId: device.deviceId,
+          __mcpSessionId: "agent-A",
+        }),
+      ).rejects.toThrow("another session");
+      expect(readinessAttempts).toBe(1);
+      expect(secondOwner).toBeDefined();
+      expect(deviceUtils.getExecutedOperations()).not.toContain(`killDevice:${device.name}`);
+      expect(h.pool.getDevice(device.deviceId)?.sessionId).toBeNull();
+      expect(h.manager.getSession(secondOwner!)?.assignedDevice).toBe(otherDevice.deviceId);
+    } finally {
+      resetDeviceToolsDependencies();
+      DaemonState.getInstance().reset();
+      ToolRegistry.clearTools();
+      await h.close();
+    }
+  });
+});

--- a/test/daemon/devicePoolAutolockOwnership.test.ts
+++ b/test/daemon/devicePoolAutolockOwnership.test.ts
@@ -310,9 +310,7 @@ test.each(["agent-B", "agent-A"])(
           expect(recoveredProcess.listenerCount("exit")).toBe(recoveredExitListeners);
           expect(recoveredProcess.stdout.listenerCount("data")).toBe(recoveredOutputListeners);
         }
-        expect(await h.db.selectFrom("device_sessions").selectAll().execute()).toHaveLength(
-          1,
-        );
+        expect(await h.db.selectFrom("device_sessions").selectAll().execute()).toHaveLength(1);
       } finally {
         resetDeviceToolsDependencies();
         DaemonState.getInstance().reset();


### PR DESCRIPTION
Closes [#6363](https://github.com/kaeawc/auto-mobile/issues/6363).

When Android System UI recovery resumes after runner readiness, the same MCP transport may have acquired a different device. The stale recovery now carries its transport identity into readiness and shutdown reservations, which reject before the original device can be killed or replaced.

Validation:

- `bun test test/daemon/devicePoolAutolockOwnership.test.ts`
- `bun test ./test/server/deviceTools.startDevice.test.ts`
- `bun run build`
- `bun run turbo:validate`
