### PR TITLE
test: inject Timer into FakeIOSCtrlProxy operation delays

### DIFF
--- a/test/fakes/FakeIOSCtrlProxy.test.ts
+++ b/test/fakes/FakeIOSCtrlProxy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { FakeIOSCtrlProxy } from "./FakeIOSCtrlProxy";
+import { FakeTimer } from "./FakeTimer";
+
+describe("FakeIOSCtrlProxy operation delays", () => {
+  test("pressKey waits for the injected virtual clock before recording success", async () => {
+    const timer = new FakeTimer();
+    const proxy = new FakeIOSCtrlProxy(timer);
+    proxy.setOperationDelay("pressKey", 500);
+    let settled = false;
+    const result = proxy.requestPressKey("tab", []).then((value) => {
+      settled = true;
+      return value;
+    });
+
+    expect(timer.getSleepHistory()).toEqual([500]);
+    timer.advanceTime(499);
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(proxy.getPressKeyHistory()).toEqual([]);
+    timer.advanceTime(1);
+    expect((await result).success).toBe(true);
+    expect(proxy.getPressKeyHistory()).toEqual([{ key: "tab", modifiers: [] }]);
+  });
+
+  test("other operations use the same injected clock", async () => {
+    const timer = new FakeTimer();
+    const proxy = new FakeIOSCtrlProxy(timer);
+    proxy.setOperationDelay("pressHome", 250);
+    const result = proxy.requestPressHome();
+    expect(timer.getSleepHistory()).toEqual([250]);
+    timer.advanceTime(250);
+    expect((await result).success).toBe(true);
+    expect(proxy.getPressHomeRequestCount()).toBe(1);
+  });
+
+  test("zero delays and the no-argument constructor remain compatible", async () => {
+    const timer = new FakeTimer();
+    const proxy = new FakeIOSCtrlProxy(timer);
+    expect((await proxy.requestPressKey("tab", [])).success).toBe(true);
+    expect(timer.getSleepHistory()).toEqual([]);
+    expect((await new FakeIOSCtrlProxy().requestPressHome()).success).toBe(true);
+  });
+
+  test("configured failures reject after virtual delay without recording success", async () => {
+    const timer = new FakeTimer();
+    const proxy = new FakeIOSCtrlProxy(timer);
+    const failure = new Error("configured failure");
+    proxy.setOperationDelay("pressKey", 500);
+    proxy.setFailureMode("pressKey", failure);
+    const result = proxy.requestPressKey("tab", []).catch((error: unknown) => error);
+    expect(timer.getSleepHistory()).toEqual([500]);
+    timer.advanceTime(500);
+    expect(await result).toBe(failure);
+    expect(proxy.getPressKeyHistory()).toEqual([]);
+    proxy.setFailureMode("pressKey", null);
+    proxy.setOperationDelay("pressKey", 0);
+    expect((await proxy.requestPressKey("tab", [])).success).toBe(true);
+  });
+});

--- a/test/fakes/FakeIOSCtrlProxy.ts
+++ b/test/fakes/FakeIOSCtrlProxy.ts
@@ -31,6 +31,7 @@ import { ViewHierarchyResult } from "../../src/models";
 import { ViewHierarchyQueryOptions } from "../../src/models/ViewHierarchyQueryOptions";
 import { PerformanceTracker } from "../../src/utils/PerformanceTracker";
 import { defaultTimer } from "../../src/utils/SystemTimer";
+import type { Timer } from "../../src/utils/SystemTimer";
 import type { InputKeyModifier, InputKeyName } from "../../src/features/action/InputKey";
 
 /**
@@ -39,6 +40,8 @@ import type { InputKeyModifier, InputKeyName } from "../../src/features/action/I
  * Tracks method calls for test assertions
  */
 export class FakeIOSCtrlProxy implements IOSCtrlProxy {
+  constructor(private readonly timer: Timer = defaultTimer) {}
+
   // Configurable response data
   private hierarchyData: CtrlProxyHierarchy | null = null;
   private screenshotData: string | null = null;
@@ -493,7 +496,7 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
   private async applyDelay(operation: string): Promise<void> {
     const delay = this.operationDelays.get(operation);
     if (delay && delay > 0) {
-      await defaultTimer.sleep(delay);
+      await this.timer.sleep(delay);
     }
   }
 

--- a/test/lint/fakeHygiene.test.ts
+++ b/test/lint/fakeHygiene.test.ts
@@ -25,7 +25,8 @@ const FAKES_DIR = path.join(import.meta.dir, "..", "fakes");
 const ALLOWLIST: Record<string, string[]> = {
   "FakeIOSCtrlProxy.ts": [
     'import { defaultTimer } from "../../src/utils/SystemTimer";',
-    "await defaultTimer.sleep(delay);",
+    // Preserve the existing default only at construction; delayed calls use the injected timer.
+    "constructor(private readonly timer: Timer = defaultTimer) {}",
     "timestamp: Date.now(),",
   ],
   "FakeWebSocket.ts": [


### PR DESCRIPTION
## Summary

Configured delays in `FakeIOSCtrlProxy` always used the real timer, preventing tests from advancing them with `FakeTimer`. Accept an optional existing `Timer` in the constructor and use it in the shared delay method. Existing no-argument callers keep their behavior.

Closes [issue 6362](https://github.com/kaeawc/auto-mobile/issues/6362).

## Validation

- Four regression tests cover delayed key history/results, another delayed operation, zero-delay/default construction, and failure recovery. Three failed before the change; all pass after it, each under 3 ms.
- `bun run typecheck`: no new errors.
- `scripts/all_fast_validate_checks.sh`: 35 passed.
- Changed-file formatting and Runtime Behavior review passed.
- `AUTOMOBILE_UNIT_TEST_WORKERS=4 bun run turbo:validate`: all seven tasks passed. An initial unrelated downloader timeout passed on isolated recheck and this full rerun.
- Fake-hygiene allowance moves from the direct sleep call to the compatible constructor default, preserving the exact-line allowance count. The hygiene and regression suites pass together (115 tests).
