### PR TITLE
fix(utils): BufferQueue peek(0) empty-safe and discard amortized O(1) (#6705)

### DIFF
--- a/src/utils/BufferQueue.ts
+++ b/src/utils/BufferQueue.ts
@@ -8,11 +8,36 @@
  * single chunk and copy only when they span a boundary; {@link takeDetached}
  * performs the single detached copy needed when a decoded payload must outlive
  * the chunks it was assembled from.
+ *
+ * Consumed chunks are retired by advancing a head-chunk index rather than
+ * `Array.shift()`, which would reindex the whole array on every fully-consumed
+ * chunk and reintroduce quadratic reference movement under the exact
+ * high-fragmentation shape this class exists to handle. The consumed prefix is
+ * spliced away only when it grows past half the backing array, keeping discard
+ * amortized O(1) while still releasing consumed chunk references promptly.
  */
 export class BufferQueue {
   private chunks: Buffer[] = [];
+  // Index of the first live chunk in `chunks`; entries before it are consumed.
+  private headChunk = 0;
+  // Consumed-byte offset within `chunks[headChunk]`.
   private headOffset = 0;
   length = 0;
+
+  // Total backing-array elements moved by compaction over this queue's lifetime.
+  // Exposed via {@link compactionWorkUnits} purely as a test seam so consumption
+  // can be shown to stay linear without a flaky wall-clock benchmark.
+  private compactionWork = 0;
+
+  /** Test seam: number of backing-array slots currently retained. */
+  get retainedChunkCount(): number {
+    return this.chunks.length;
+  }
+
+  /** Test seam: cumulative array elements moved by compaction (see class doc). */
+  get compactionWorkUnits(): number {
+    return this.compactionWork;
+  }
 
   append(chunk: Buffer): void {
     if (chunk.length === 0) {
@@ -26,7 +51,10 @@ export class BufferQueue {
     if (length > this.length) {
       throw new RangeError(`cannot peek ${length} bytes from ${this.length}-byte queue`);
     }
-    const first = this.chunks[0];
+    if (length === 0) {
+      return Buffer.alloc(0);
+    }
+    const first = this.chunks[this.headChunk];
     const firstAvailable = first.length - this.headOffset;
     if (firstAvailable >= length) {
       return first.subarray(this.headOffset, this.headOffset + length);
@@ -40,6 +68,9 @@ export class BufferQueue {
     if (length > this.length) {
       throw new RangeError(`cannot take ${length} bytes from ${this.length}-byte queue`);
     }
+    if (length === 0) {
+      return Buffer.alloc(0);
+    }
     const out = Buffer.allocUnsafe(length);
     this.copyTo(out, length);
     this.discard(length);
@@ -52,26 +83,28 @@ export class BufferQueue {
     }
     let remaining = length;
     while (remaining > 0) {
-      const first = this.chunks[0];
+      const first = this.chunks[this.headChunk];
       const available = first.length - this.headOffset;
       if (remaining < available) {
         this.headOffset += remaining;
         this.length -= remaining;
-        return;
+        remaining = 0;
+        break;
       }
-      this.chunks.shift();
+      this.headChunk++;
       this.headOffset = 0;
       this.length -= available;
       remaining -= available;
     }
+    this.compact();
   }
 
   toBuffer(): Buffer {
     if (this.length === 0) {
       return Buffer.alloc(0);
     }
-    const first = this.chunks[0];
-    if (this.chunks.length === 1) {
+    const first = this.chunks[this.headChunk];
+    if (this.headChunk === this.chunks.length - 1) {
       return first.subarray(this.headOffset);
     }
     const out = Buffer.allocUnsafe(this.length);
@@ -81,15 +114,33 @@ export class BufferQueue {
 
   replace(bytes: Buffer): void {
     this.chunks = bytes.length === 0 ? [] : [bytes];
+    this.headChunk = 0;
     this.headOffset = 0;
     this.length = bytes.length;
   }
 
+  private compact(): void {
+    if (this.headChunk === this.chunks.length) {
+      // Fully drained: drop all references at once and reset to a pristine state.
+      this.chunks.length = 0;
+      this.headChunk = 0;
+      return;
+    }
+    // Amortized O(1): only reindex once the consumed prefix is at least half the
+    // array, so total elements moved across a full drain stays linear in chunk
+    // count rather than the quadratic cost of an Array.shift() per chunk.
+    if (this.headChunk * 2 >= this.chunks.length) {
+      this.chunks.splice(0, this.headChunk);
+      this.compactionWork += this.chunks.length;
+      this.headChunk = 0;
+    }
+  }
+
   private copyTo(destination: Buffer, length: number): void {
     let copied = 0;
-    for (let index = 0; copied < length; index++) {
+    for (let index = this.headChunk; copied < length; index++) {
       const chunk = this.chunks[index];
-      const start = index === 0 ? this.headOffset : 0;
+      const start = index === this.headChunk ? this.headOffset : 0;
       const available = chunk.length - start;
       const count = Math.min(available, length - copied);
       chunk.copy(destination, copied, start, start + count);

--- a/test/utils/BufferQueue.property.test.ts
+++ b/test/utils/BufferQueue.property.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import { BufferQueue } from "../../src/utils/BufferQueue";
+
+// Property-based testing. See Backoff.property.test.ts for the rationale behind
+// the pinned seed.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+type Op =
+  | { kind: "append"; bytes: number[] }
+  | { kind: "peek"; length: number }
+  | { kind: "take"; length: number }
+  | { kind: "discard"; length: number };
+
+const smallByteArray = fc.array(fc.integer({ min: 0, max: 255 }), { minLength: 0, maxLength: 6 });
+const opArb: fc.Arbitrary<Op> = fc.oneof(
+  fc.record({ kind: fc.constant("append" as const), bytes: smallByteArray }),
+  fc.record({ kind: fc.constant("peek" as const), length: fc.nat({ max: 8 }) }),
+  fc.record({ kind: fc.constant("take" as const), length: fc.nat({ max: 8 }) }),
+  fc.record({ kind: fc.constant("discard" as const), length: fc.nat({ max: 8 }) }),
+);
+
+describe("BufferQueue (property-based)", () => {
+  test("append/peek/take/discard match a flat-buffer reference model", () => {
+    fc.assert(
+      fc.property(fc.array(opArb, { minLength: 0, maxLength: 60 }), (ops) => {
+        const queue = new BufferQueue();
+        let model: number[] = [];
+        for (const op of ops) {
+          switch (op.kind) {
+            case "append":
+              queue.append(Buffer.from(op.bytes));
+              model = model.concat(op.bytes);
+              break;
+            case "peek":
+              if (op.length > model.length) {
+                expect(() => queue.peek(op.length)).toThrow(RangeError);
+              } else {
+                expect([...queue.peek(op.length)]).toEqual(model.slice(0, op.length));
+              }
+              break;
+            case "take":
+              if (op.length > model.length) {
+                expect(() => queue.takeDetached(op.length)).toThrow(RangeError);
+              } else {
+                expect([...queue.takeDetached(op.length)]).toEqual(model.slice(0, op.length));
+                model = model.slice(op.length);
+              }
+              break;
+            case "discard":
+              if (op.length > model.length) {
+                expect(() => queue.discard(op.length)).toThrow(RangeError);
+              } else {
+                queue.discard(op.length);
+                model = model.slice(op.length);
+              }
+              break;
+          }
+          expect(queue.length).toBe(model.length);
+          expect([...queue.toBuffer()]).toEqual(model);
+        }
+      }),
+      RUN_OPTIONS,
+    );
+  });
+});

--- a/test/utils/BufferQueue.test.ts
+++ b/test/utils/BufferQueue.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import { BufferQueue } from "../../src/utils/BufferQueue";
+
+describe("BufferQueue", () => {
+  describe("peek", () => {
+    test("peek(0) on an empty queue returns an empty buffer instead of throwing", () => {
+      const queue = new BufferQueue();
+      const result = queue.peek(0);
+      expect(result.length).toBe(0);
+    });
+
+    test("peek(0) on a non-empty queue returns an empty buffer without consuming", () => {
+      const queue = new BufferQueue();
+      queue.append(Buffer.from([1, 2, 3]));
+      expect(queue.peek(0).length).toBe(0);
+      expect(queue.length).toBe(3);
+    });
+
+    test("peek returns a contiguous view when the read fits in the head chunk", () => {
+      const queue = new BufferQueue();
+      queue.append(Buffer.from([1, 2, 3, 4]));
+      expect([...queue.peek(2)]).toEqual([1, 2]);
+    });
+
+    test("peek copies across chunk boundaries", () => {
+      const queue = new BufferQueue();
+      queue.append(Buffer.from([1, 2]));
+      queue.append(Buffer.from([3, 4]));
+      expect([...queue.peek(3)]).toEqual([1, 2, 3]);
+    });
+
+    test("peek beyond the queue length throws RangeError", () => {
+      const queue = new BufferQueue();
+      queue.append(Buffer.from([1]));
+      expect(() => queue.peek(2)).toThrow(RangeError);
+    });
+  });
+
+  describe("takeDetached", () => {
+    test("takeDetached(0) returns an empty buffer and does not consume", () => {
+      const queue = new BufferQueue();
+      queue.append(Buffer.from([1, 2, 3]));
+      expect(queue.takeDetached(0).length).toBe(0);
+      expect(queue.length).toBe(3);
+    });
+
+    test("takeDetached copies bytes out and advances past them", () => {
+      const queue = new BufferQueue();
+      queue.append(Buffer.from([1, 2, 3, 4]));
+      expect([...queue.takeDetached(2)]).toEqual([1, 2]);
+      expect(queue.length).toBe(2);
+      expect([...queue.toBuffer()]).toEqual([3, 4]);
+    });
+  });
+
+  describe("discard", () => {
+    test("discarding all bytes one at a time leaves an empty queue", () => {
+      const queue = new BufferQueue();
+      const n = 64;
+      for (let i = 0; i < n; i++) {
+        queue.append(Buffer.from([i & 0xff]));
+      }
+      expect(queue.length).toBe(n);
+      for (let i = 0; i < n; i++) {
+        queue.discard(1);
+      }
+      expect(queue.length).toBe(0);
+      expect(queue.toBuffer().length).toBe(0);
+    });
+
+    test("partial discard within the head chunk advances the offset", () => {
+      const queue = new BufferQueue();
+      queue.append(Buffer.from([1, 2, 3, 4]));
+      queue.discard(1);
+      expect(queue.length).toBe(3);
+      expect([...queue.toBuffer()]).toEqual([2, 3, 4]);
+    });
+
+    test("discard spanning a boundary drops whole chunks and keeps a partial tail", () => {
+      const queue = new BufferQueue();
+      queue.append(Buffer.from([1, 2]));
+      queue.append(Buffer.from([3, 4]));
+      queue.append(Buffer.from([5, 6]));
+      queue.discard(3);
+      expect(queue.length).toBe(3);
+      expect([...queue.toBuffer()]).toEqual([4, 5, 6]);
+    });
+
+    test("discard beyond the queue length throws RangeError", () => {
+      const queue = new BufferQueue();
+      queue.append(Buffer.from([1]));
+      expect(() => queue.discard(2)).toThrow(RangeError);
+    });
+
+    test("appending again after a full drain reuses the queue correctly", () => {
+      const queue = new BufferQueue();
+      queue.append(Buffer.from([1, 2]));
+      queue.discard(2);
+      expect(queue.length).toBe(0);
+      queue.append(Buffer.from([9, 8, 7]));
+      expect(queue.length).toBe(3);
+      expect([...queue.toBuffer()]).toEqual([9, 8, 7]);
+    });
+  });
+
+  describe("linear consumption of highly fragmented streams", () => {
+    test("draining many one-byte chunks does bounded, linear compaction work", () => {
+      const queue = new BufferQueue();
+      const n = 4096;
+      for (let i = 0; i < n; i++) {
+        queue.append(Buffer.from([i & 0xff]));
+      }
+      // Retained slots start at n (what was appended) and must never exceed it as
+      // we drain — a shift()-per-chunk implementation would still be correct here
+      // but quadratic; the counter below is what pins linearity.
+      let maxRetained = 0;
+      for (let i = 0; i < n; i++) {
+        queue.discard(1);
+        maxRetained = Math.max(maxRetained, queue.retainedChunkCount);
+      }
+      expect(queue.length).toBe(0);
+      expect(queue.retainedChunkCount).toBe(0);
+      expect(maxRetained).toBeLessThanOrEqual(n);
+      // Total array elements moved by compaction stays within a small constant
+      // multiple of n; O(n^2) shifting would blow far past this bound.
+      expect(queue.compactionWorkUnits).toBeLessThanOrEqual(3 * n);
+    });
+  });
+
+  describe("replace", () => {
+    test("replace swaps in new bytes and resets consumption state", () => {
+      const queue = new BufferQueue();
+      queue.append(Buffer.from([1, 2, 3]));
+      queue.discard(1);
+      queue.replace(Buffer.from([7, 8]));
+      expect(queue.length).toBe(2);
+      expect([...queue.toBuffer()]).toEqual([7, 8]);
+    });
+
+    test("replace with an empty buffer empties the queue", () => {
+      const queue = new BufferQueue();
+      queue.append(Buffer.from([1, 2, 3]));
+      queue.replace(Buffer.alloc(0));
+      expect(queue.length).toBe(0);
+      expect(queue.toBuffer().length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`BufferQueue` is the chunk accumulator behind the screen-frame and WebRTC stream
parsers. Two edge cases contradicted its "keep fragmented streams linear" contract:

- **`peek(0)` crashed on an empty queue.** A zero-length read passes the
  `length > this.length` range check, then dereferenced `chunks[0]` (`undefined`)
  and threw `TypeError` instead of returning an empty buffer. Latent today only
  because every caller uses positive fixed header sizes.
- **`discard()` was quadratic in chunk count.** It retired each fully-consumed
  chunk with `Array.shift()`, reindexing the whole array per chunk — so draining
  a highly fragmented frame (many tiny socket segments) did O(n²) reference
  movement, the exact shape the class exists to keep linear.

The fix returns an empty buffer for zero-length `peek`/`takeDetached`, and retires
consumed chunks by advancing a head-chunk index, splicing the consumed prefix only
once it grows past half the backing array (amortized O(1), with consumed chunk
references still released promptly). Public API semantics are otherwise unchanged;
the parsers (`frameProtocol.ts`, `VideoServerStreamParser.ts`) touch only that API.

Part of epic #6379.

## Linked Issue

Closes #6705

## Bug / Regression Context

- **Observed symptom:** `peek(0)` on an empty queue throws `TypeError`; draining a
  many-chunk queue does avoidable O(n²) array reindexing.
- **Repro steps / conditions:** `new BufferQueue().peek(0)` (crash); append N
  one-byte chunks and discard them (quadratic `shift()` work).

## Validation

- [x] New `test/utils/BufferQueue.test.ts` (unit: zero-length reads, partial/boundary
  discards, full-drain reuse, replace) and `test/utils/BufferQueue.property.test.ts`
  (randomized op sequence vs a flat-buffer reference model). A test-visible
  `compactionWorkUnits` counter pins linearity without a wall-clock benchmark.
  16 pass; red first for the `peek(0)` crash.
- [x] `bun test test/features/screen-stream test/features/webrtc` — 544 pass (consumers).
- [x] `bun run lint` — no new violations.
- [x] `bun run typecheck` — no new errors.
- [x] `slack codex review` self-review run before opening (no blocking findings).

## Follow-ups

- None.
