### PR TITLE
fix(retry): cancel the losing backoff timer on aborted RetryExecutor sleep (#6707)

### DIFF
--- a/src/utils/retry/RetryExecutor.ts
+++ b/src/utils/retry/RetryExecutor.ts
@@ -182,23 +182,31 @@ export class DefaultRetryExecutor implements RetryExecutor {
     // either way; { once: true } alone only cleans up on abort, which leaked
     // one listener per retry on a long-lived signal (#6138).
     let onAbort: (() => void) | undefined;
+    // The scheduled timeout has no cancellation handle of its own once the
+    // race settles via abort; without clearing it here it stays scheduled for
+    // its full delay, leaking one timer per aborted retry (#6707). Mirrors the
+    // cancellable pattern in DaemonManager.sleepUnlessAborted (manager.ts).
+    let handle: NodeJS.Timeout | undefined;
     try {
       // The `await` is load-bearing: it keeps `finally` from running until the
-      // race settles, so the listener is removed after (not before) it can fire.
-      return await Promise.race([
-        this.timer.sleep(delay).then(() => false),
-        new Promise<boolean>((resolve) => {
-          // Recheck: timer.sleep() above runs first and may abort synchronously,
-          // after which the event has already fired and a listener would hang.
-          if (signal.aborted) {
-            resolve(true);
-            return;
-          }
-          onAbort = () => resolve(true);
-          signal.addEventListener("abort", onAbort, { once: true });
-        }),
-      ]);
+      // race settles, so the listener/timeout are cleaned up after (not
+      // before) the race can settle.
+      return await new Promise<boolean>((resolve) => {
+        handle = this.timer.setTimeout(() => resolve(false), delay);
+        // Recheck: timer.setTimeout() above may abort the signal
+        // synchronously as a side effect (e.g. a Timer stub), after which the
+        // event has already fired and a listener registered below would hang.
+        if (signal.aborted) {
+          resolve(true);
+          return;
+        }
+        onAbort = () => resolve(true);
+        signal.addEventListener("abort", onAbort, { once: true });
+      });
     } finally {
+      if (handle !== undefined) {
+        this.timer.clearTimeout(handle);
+      }
       if (onAbort) {
         signal.removeEventListener("abort", onAbort);
       }

--- a/test/utils/retry/RetryExecutor.test.ts
+++ b/test/utils/retry/RetryExecutor.test.ts
@@ -214,11 +214,12 @@ describe("DefaultRetryExecutor", () => {
       expect(removed).toBe(added);
     });
 
-    it("removes the abort listener when abort wins the race mid-sleep", async () => {
-      // Manual FakeTimer: the sleep never resolves, so the only way execute()
-      // settles is via the abort listener. This pins that `finally` runs after
-      // the race settles (a `return Promise.race` without `await` would remove
-      // the listener before it could fire and hang here).
+    it("removes the abort listener and clears the pending timeout when abort wins the race mid-sleep", async () => {
+      // Manual FakeTimer: the scheduled timeout never fires on its own, so the
+      // only way execute() settles is via the abort listener. This pins that
+      // `finally` runs after the race settles (a `return` without `await`
+      // would remove the listener/timeout before they could fire and hang
+      // here).
       const controller = new AbortController();
       const signal = controller.signal;
       let removed = 0;
@@ -236,7 +237,10 @@ describe("DefaultRetryExecutor", () => {
       );
 
       await Promise.resolve();
-      expect(timer.getPendingSleepCount()).toBe(1);
+      // The delay is scheduled via timer.setTimeout (not timer.sleep), so it
+      // shows up as a pending timeout, not a pending sleep.
+      expect(timer.getPendingSleepCount()).toBe(0);
+      expect(timer.getPendingTimeoutCount()).toBe(1);
 
       controller.abort();
       const result = await resultPromise;
@@ -245,21 +249,49 @@ describe("DefaultRetryExecutor", () => {
       expect(result.error?.message).toBe("Operation aborted");
       expect(result.attempts).toBe(1);
       expect(removed).toBe(1);
-      // The losing sleep stays registered on the fake timer; it is bounded
-      // (one per abort) and pre-existing behavior.
-      expect(timer.getPendingSleepCount()).toBe(1);
+      // #6707: the losing timer.setTimeout(...) must be cleared when abort
+      // wins the race, so no timer lingers past the aborted sleep. Previously
+      // this stayed at 1 (leaked) — the fix clears the handle unconditionally
+      // in `finally`.
+      expect(timer.getPendingTimeoutCount()).toBe(0);
     });
 
-    it("settles when the injected sleep aborts the signal synchronously", async () => {
-      // timer.sleep() is evaluated before the abort-promise executor runs, so a
-      // Timer that aborts synchronously must be caught by the recheck inside the
-      // executor; otherwise the listener registers after the event already fired
-      // and execute() never settles.
+    it("does not accumulate pending timers across many aborted retries", async () => {
+      // #6707: each aborted sleepUnlessAborted() call must clear its
+      // timer.setTimeout handle. Without the fix, every aborted retry leaks
+      // one pending timeout on the fake timer, so pending count grows
+      // unboundedly across executions; with the fix it stays at 0.
+      const executions = 25;
+      for (let i = 0; i < executions; i++) {
+        const controller = new AbortController();
+        const resultPromise = executor.execute(
+          async () => {
+            throw new Error("Retry");
+          },
+          { signal: controller.signal, delays: 100, maxAttempts: 3 },
+        );
+
+        await Promise.resolve();
+        controller.abort();
+        const result = await resultPromise;
+
+        expect(result.success).toBe(false);
+        expect(timer.getPendingTimeoutCount()).toBe(0);
+        expect(timer.getPendingSleepCount()).toBe(0);
+      }
+    });
+
+    it("settles when the injected setTimeout aborts the signal synchronously", async () => {
+      // timer.setTimeout() is evaluated before the abort-listener registration
+      // below it, so a Timer that aborts synchronously as a side effect of
+      // scheduling must be caught by the recheck inside the executor;
+      // otherwise the listener registers after the event already fired and
+      // execute() never settles.
       const controller = new AbortController();
       class SyncAbortingTimer extends FakeTimer {
-        override sleep(ms: number): Promise<void> {
+        override setTimeout(callback: () => void, ms: number): NodeJS.Timeout {
           controller.abort();
-          return super.sleep(ms);
+          return super.setTimeout(callback, ms);
         }
       }
       const abortingExecutor = new DefaultRetryExecutor(new SyncAbortingTimer());


### PR DESCRIPTION
## Summary

`RetryExecutor.sleepUnlessAborted()` raced `timer.sleep(delay)` against an abort
listener with `Promise.race`, but `timer.sleep()` exposes no cancellation handle —
so when abort won, the losing sleep stayed scheduled for its full delay, leaking
one timer per aborted retry and potentially delaying clean process exit.

The delay is now scheduled via the injected `timer.setTimeout(...)` and its handle
is cleared unconditionally in `finally`, mirroring the cancellable pattern already
used in `DaemonManager`. The timeout is cancelled whether it fired (no-op) or abort
won (real cancellation), so nothing lingers. The `#6138` listener cleanup and the
synchronous-abort recheck are preserved (the recheck now guards a signal aborted as
a side effect of scheduling).

Part of epic #6379.

## Linked Issue

Closes #6707

## Bug / Regression Context

- **Prior attempts:** #6138 fixed the abort-listener leak but left the losing sleep uncancellable.
- **Observed symptom:** after an aborted backoff, one timer stays pending until its full delay; the prior test pinned this at `getPendingSleepCount() === 1` as accepted pre-existing behavior.
- **Repro steps / conditions:** start an execution whose failure enters a retry backoff, abort the signal, and observe the pending timer never clears.

## Validation

- [x] `test/utils/retry/RetryExecutor.test.ts` — 18 pass. Updated the mid-sleep-abort test to assert `getPendingTimeoutCount()` drops to `0` after abort (was `1`, leaked), and added a 25-iteration test proving aborted executions never accumulate pending timers. FakeTimer tracks sleeps and timeouts in separate counters, so the assertion moved to the timeout counter to prove genuine cancellation rather than an untouched counter.
- [x] `bun run lint` — no new violations. `bun run typecheck` — no new errors.
- [x] `slack codex review` self-review before opening: no findings — verified the only production signal-bearing caller and the generic nonzero-delay path against both FakeTimer and SystemTimer, and that the tests discriminate timeout scheduling/cleanup.

## Follow-ups

- None.
