### PR TITLE
fix(record): fall back when optional Android capability lookup fails

### DIFF
--- a/src/features/record/android/DualTrackRecorder.ts
+++ b/src/features/record/android/DualTrackRecorder.ts
@@ -88,9 +88,16 @@ export class DualTrackRecorder {
       throw new Error("[DualTrackRecorder] Unable to connect to the accessibility service.");
     }
     if (this.recordWithSendKeys) {
-      const supportedCommands = await a11y.getSupportedCommands();
-      this.recordWithSupportedSendKeys =
-        supportedCommands?.includes("request_insert_text") ?? false;
+      this.recordWithSupportedSendKeys = false;
+      try {
+        const supportedCommands = await a11y.getSupportedCommands();
+        this.recordWithSupportedSendKeys =
+          supportedCommands?.includes("request_insert_text") ?? false;
+      } catch (error) {
+        logger.warn(
+          `[DualTrackRecorder] Capability lookup failed; recording text with inputText: ${error}`,
+        );
+      }
     }
 
     // Notify Kotlin service that recording is starting (enables interaction event emission)

--- a/test/features/record/android/DualTrackRecorder.test.ts
+++ b/test/features/record/android/DualTrackRecorder.test.ts
@@ -19,13 +19,17 @@ import { FakeTimer } from "../../../fakes/FakeTimer";
 type InteractionListener = (event: { type: string; [key: string]: unknown }) => void;
 
 class FakeGestureEmitter implements GestureEmitter {
+  startCount = 0;
+  stopCount = 0;
   private onGestureHandler?: (event: GestureEvent) => void;
 
   start(onGesture: (event: GestureEvent) => void, _onError?: (err: Error) => void): void {
+    this.startCount++;
     this.onGestureHandler = onGesture;
   }
 
   stop(): void {
+    this.stopCount++;
     this.onGestureHandler = undefined;
   }
 
@@ -35,21 +39,30 @@ class FakeGestureEmitter implements GestureEmitter {
 }
 
 class FakeA11ySource implements A11ySource {
+  capabilityError: Error | undefined;
+  connectionError: Error | undefined;
+  connected = true;
+  subscriptionCount = 0;
+  unsubscribeCount = 0;
   private listener?: InteractionListener;
 
   constructor(private readonly supportedCommands: string[] | null = ["request_insert_text"]) {}
 
   async ensureConnected(): Promise<boolean> {
-    return true;
+    if (this.connectionError) {throw this.connectionError;}
+    return this.connected;
   }
 
   async getSupportedCommands(): Promise<string[] | null> {
+    if (this.capabilityError) {throw this.capabilityError;}
     return this.supportedCommands;
   }
 
   onInteraction(listener: InteractionListener): () => void {
+    this.subscriptionCount++;
     this.listener = listener;
     return () => {
+      this.unsubscribeCount++;
       this.listener = undefined;
     };
   }
@@ -260,6 +273,36 @@ describe("DualTrackRecorder", () => {
 
     expect(steps).toEqual([{ tool: "inputText", params: { text: "hello@example.com" } }]);
   });
+
+  test("rejected optional capabilities still start, record inputText, and clean up", async () => {
+    fakeA11y.capabilityError = new Error("capability lookup failed");
+    await recorder.start();
+    expect(fakeGestures.startCount).toBe(1);
+    expect(fakeA11y.subscriptionCount).toBe(1);
+    fakeA11y.emit({
+      type: "inputText",
+      timestamp: fakeTimer.now(),
+      text: "hello@example.com",
+      element: { "resource-id": "com.example:id/email" },
+    });
+    const { steps } = await recorder.stop();
+    expect(steps).toEqual([{ tool: "inputText", params: { text: "hello@example.com" } }]);
+    expect(fakeGestures.stopCount).toBe(1);
+    expect(fakeA11y.unsubscribeCount).toBe(1);
+  });
+
+  test.each(["disconnected", "rejected"])(
+    "required connection %s still fails startup",
+    async (mode) => {
+      fakeA11y.connected = false;
+      if (mode === "rejected") {fakeA11y.connectionError = new Error("connection failed");}
+      await expect(recorder.start()).rejects.toThrow(
+        mode === "rejected" ? "connection failed" : "Unable to connect",
+      );
+      expect(fakeGestures.startCount).toBe(0);
+      expect(fakeA11y.subscriptionCount).toBe(0);
+    },
+  );
 
   test("consecutive inputText events on same element are coalesced", async () => {
     await recorder.start();

--- a/test/features/record/android/DualTrackRecorder.test.ts
+++ b/test/features/record/android/DualTrackRecorder.test.ts
@@ -49,12 +49,16 @@ class FakeA11ySource implements A11ySource {
   constructor(private readonly supportedCommands: string[] | null = ["request_insert_text"]) {}
 
   async ensureConnected(): Promise<boolean> {
-    if (this.connectionError) {throw this.connectionError;}
+    if (this.connectionError) {
+      throw this.connectionError;
+    }
     return this.connected;
   }
 
   async getSupportedCommands(): Promise<string[] | null> {
-    if (this.capabilityError) {throw this.capabilityError;}
+    if (this.capabilityError) {
+      throw this.capabilityError;
+    }
     return this.supportedCommands;
   }
 
@@ -295,7 +299,9 @@ describe("DualTrackRecorder", () => {
     "required connection %s still fails startup",
     async (mode) => {
       fakeA11y.connected = false;
-      if (mode === "rejected") {fakeA11y.connectionError = new Error("connection failed");}
+      if (mode === "rejected") {
+        fakeA11y.connectionError = new Error("connection failed");
+      }
       await expect(recorder.start()).rejects.toThrow(
         mode === "rejected" ? "connection failed" : "Unable to connect",
       );


### PR DESCRIPTION
## Summary

Android recording now continues when the optional sendKeys capability lookup rejects. It logs the failure and records text with the existing `inputText` fallback. Required connection failures still abort startup, and supported runners keep recording `sendKeys`.

Closes [issue 6361](https://github.com/kaeawc/auto-mobile/issues/6361).

## Validation

- Regression reproduced before the fix; all 30 recorder tests now pass, each under 1 ms. Coverage includes emitter startup, accessibility subscription, recorded text, cleanup, both connection-failure forms, and existing supported-runner behavior.
- `AUTOMOBILE_UNIT_TEST_WORKERS=4 bun run turbo:validate`: seven tasks passed.
- `bun run typecheck`: no new errors.
- `scripts/all_fast_validate_checks.sh`: 35 passed.
- Runtime Behavior review: no findings. Uses existing interfaces, fakes, timer, and logging; no new dependencies.
