### PR TITLE
perf(logging): gate log-rotation size check on a byte interval, not every write (#6651)

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -526,8 +526,42 @@ const recoverFromFailedRotation = async (
   await reportLogFailure("Log rotation failed", error);
 };
 
-// Function to check log file size and rotate if necessary
-const checkAndRotateLog = async (): Promise<void> => {
+// Bytes accumulated since the last time checkAndRotateLog actually stat'd the
+// file. Seeded at Infinity so the very first write after the stream opens
+// forces an immediate check regardless of what THIS process has written so
+// far -- the file may already be oversized left over from a previous run
+// (e.g. the daemon's single, stably-named log surviving across restarts,
+// see the `ownLogPrefix` comment above), and this process has no prior
+// writes of its own yet to compare against.
+let bytesSinceLastRotationCheck = Number.POSITIVE_INFINITY;
+
+// Only re-stat once writes could plausibly have pushed the file within
+// striking distance of MAX_LOG_SIZE, instead of on every single write
+// (issue #6651). A steady stream of small, serialized writes previously paid
+// for an `fs.existsSync` + `await statAsync` pair ahead of every line even
+// though rotation only needs to happen once every MAX_LOG_SIZE bytes of
+// output. Fixed (not a fraction of MAX_LOG_SIZE) and deliberately small so
+// overshoot past MAX_LOG_SIZE stays a small multiple of this interval (a few
+// tens of KiB): buffered writes flushed between checks can defer a stat by
+// more than one interval's worth of bytes, so the bound is roughly this
+// interval plus one flush of pending output, not exactly this value.
+const ROTATION_CHECK_INTERVAL_BYTES = 32 * 1024;
+
+// Function to check log file size and rotate if necessary. Only actually
+// stats the file once `lineByteLength` (this write's contribution) has
+// pushed the accumulated total since the last check past
+// ROTATION_CHECK_INTERVAL_BYTES -- see `bytesSinceLastRotationCheck` above.
+// `rotationInFlight`'s concurrent-caller coalescing (beginOrJoinRotationCheck)
+// is untouched: it still covers every writer that arrives while an actual
+// check/rotation cycle is running; only this too-eager triggering condition
+// changed.
+const checkAndRotateLog = async (lineByteLength: number): Promise<void> => {
+  bytesSinceLastRotationCheck += lineByteLength;
+  if (bytesSinceLastRotationCheck < ROTATION_CHECK_INTERVAL_BYTES) {
+    return;
+  }
+  bytesSinceLastRotationCheck = 0;
+
   const paths = fileLogPaths();
   if (!paths || !logStream) {
     return;
@@ -710,7 +744,7 @@ const writeToFile = async (line: string): Promise<void> => {
     logStream = openLogStream(logFilePath);
   }
   if (logStream) {
-    await checkAndRotateLog();
+    await checkAndRotateLog(Buffer.byteLength(line) + 1);
   }
   const stream = logStream;
   if (!stream) {

--- a/test/utils/logger-rotation-check-interval.test.ts
+++ b/test/utils/logger-rotation-check-interval.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test, spyOn } from "bun:test";
+import fs, { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Seeds a log file at a given size without paying for real data writes. A
+ * sparse file (grown via ftruncate rather than write) reports the same
+ * `stat().size` the rotation check reads, but the filesystem never allocates
+ * the backing pages -- keeping these real-fs rotation tests fast. Mirrors the
+ * helper in logger-sink-degradation.test.ts (#6149).
+ */
+const seedLogFileSize = (targetPath: string, size: number): void => {
+  const fd = fs.openSync(targetPath, "w");
+  try {
+    fs.ftruncateSync(fd, size);
+  } finally {
+    fs.closeSync(fd);
+  }
+};
+
+let importCounter = 0;
+
+/**
+ * Loads a fresh instance of the logger module against an isolated log dir.
+ * Each test needs its own module instance because rotation state
+ * (`bytesSinceLastRotationCheck`, `logStream`, `rotationInFlight`) is
+ * process/module-level; a fresh dynamic import resets it, matching the
+ * pattern used throughout logger-sink-degradation.test.ts.
+ */
+async function loggerWithEnv(logDir: string): Promise<typeof import("../../src/utils/logger")> {
+  const previousFormat = process.env.AUTOMOBILE_LOG_FORMAT;
+  const previousSink = process.env.AUTOMOBILE_LOG_SINK;
+  const previousLogDir = process.env.AUTOMOBILE_LOG_DIR;
+  process.env.AUTOMOBILE_LOG_FORMAT = "text";
+  process.env.AUTOMOBILE_LOG_SINK = "file";
+  process.env.AUTOMOBILE_LOG_DIR = logDir;
+  try {
+    return await import(`../../src/utils/logger.ts?rotation-check-interval-${importCounter++}`);
+  } finally {
+    if (previousFormat === undefined) {
+      delete process.env.AUTOMOBILE_LOG_FORMAT;
+    } else {
+      process.env.AUTOMOBILE_LOG_FORMAT = previousFormat;
+    }
+    if (previousSink === undefined) {
+      delete process.env.AUTOMOBILE_LOG_SINK;
+    } else {
+      process.env.AUTOMOBILE_LOG_SINK = previousSink;
+    }
+    if (previousLogDir === undefined) {
+      delete process.env.AUTOMOBILE_LOG_DIR;
+    } else {
+      process.env.AUTOMOBILE_LOG_DIR = previousLogDir;
+    }
+  }
+}
+
+describe("checkAndRotateLog is gated on an interval, not run on every write (#6651)", () => {
+  test("N sequential small writes trigger far fewer size checks than N", async () => {
+    const logDir = mkdtempSync(join(tmpdir(), "am-logger-rotate-interval-"));
+    const targetLogFile = join(logDir, `stdio-${process.pid}.log`);
+    // `fs.existsSync` is called through the `fs` namespace object (unlike
+    // io.ts's statAsync, which is destructured at import time and so can't be
+    // spied on), making it a reliable probe for how many independent
+    // check-and-maybe-rotate cycles actually ran their own stat -- same
+    // technique as the #6149 round-3 test in logger-sink-degradation.test.ts.
+    const existsSyncSpy = spyOn(fs, "existsSync");
+
+    let mod: typeof import("../../src/utils/logger") | undefined;
+    try {
+      mod = await loggerWithEnv(logDir);
+      const callsForTarget = (): number =>
+        existsSyncSpy.mock.calls.filter((call: unknown[]) => call[0] === targetLogFile).length;
+
+      // Each call is awaited via flush() before the next is issued -- the
+      // exact "steady, serialized stream of writes" repro from the issue,
+      // where every write's promise settles before the next line is logged.
+      const N = 25;
+      for (let i = 0; i < N; i++) {
+        mod.logger.info(`small line ${i}`);
+        await mod.logger.flush();
+      }
+
+      // Before the fix, checkAndRotateLog ran unconditionally on every write,
+      // so this would be N (one existsSync call per line). Gating on
+      // accumulated bytes must keep it far below N: only the mandatory
+      // first-write check should have run, since these lines are tiny
+      // relative to the check-interval threshold.
+      const calls = callsForTarget();
+      expect(calls).toBeGreaterThanOrEqual(1);
+      expect(calls).toBeLessThan(N / 5);
+    } finally {
+      existsSyncSpy.mockRestore();
+      await mod?.logger.closeAfterFlush();
+      rmSync(logDir, { recursive: true, force: true });
+    }
+  });
+
+  test("rotation still triggers once accumulated writes cross the size threshold", async () => {
+    const logDir = mkdtempSync(join(tmpdir(), "am-logger-rotate-interval-trigger-"));
+    const targetLogFile = join(logDir, `stdio-${process.pid}.log`);
+    // Leave a 20KB margin below the 10MiB rotation threshold -- comfortably
+    // less than the (32KB) check-interval worth of writes below, so the
+    // first check that fires after the margin is crossed is guaranteed to
+    // also see the file at or above MAX_LOG_SIZE.
+    const MAX_LOG_SIZE = 10 * 1024 * 1024;
+    seedLogFileSize(targetLogFile, MAX_LOG_SIZE - 20_000);
+
+    let mod: typeof import("../../src/utils/logger") | undefined;
+    try {
+      mod = await loggerWithEnv(logDir);
+
+      // First write forces the mandatory initial check (the file may already
+      // be oversized from a previous process run) -- it must NOT rotate yet,
+      // since the seeded size is comfortably under the threshold.
+      mod.logger.info("kickoff");
+      await mod.logger.flush();
+      expect(fs.readdirSync(logDir).length).toBe(1);
+
+      // formatLogRecord caps any single message at 1000 characters, so
+      // crossing the byte-accumulation threshold (and, past that, the 20KB
+      // real-size margin) takes repeated writes rather than one giant one.
+      // Each ~1000-char message line is roughly 1032 bytes once the
+      // timestamp/level prefix is added, so ~50 lines (~51KB) comfortably
+      // crosses both the 32KB check-interval gate and the 20KB on-disk
+      // margin, forcing a real stat that observes the file at/above
+      // MAX_LOG_SIZE and rotates.
+      for (let i = 0; i < 50; i++) {
+        mod.logger.info("x".repeat(1000));
+        await mod.logger.flush();
+      }
+
+      const files = fs.readdirSync(logDir);
+      const backups = files.filter((f) => f !== `stdio-${process.pid}.log`);
+      expect(backups.length).toBeGreaterThan(0);
+    } finally {
+      await mod?.logger.closeAfterFlush();
+      rmSync(logDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`checkAndRotateLog` ran an `fs.existsSync` + `await statAsync` pair ahead of
**every** serialized log line, even though rotation is only needed once every
`MAX_LOG_SIZE` (10 MiB) of output — a syscall pair per write under sustained logging.

It now accumulates bytes written since the last real check and only stats once the
total crosses `ROTATION_CHECK_INTERVAL_BYTES` (32 KiB, fixed and far below
`MAX_LOG_SIZE`), then resets. The counter is seeded at `Infinity` so the first write
after the stream opens still forces an immediate check (the file may already be
oversized from a prior daemon run). The `rotationInFlight` concurrent-caller
coalescing is untouched — only the too-eager trigger condition changed. Stat calls
drop from N to ~1 for a steady stream of N small lines.

Overshoot past `MAX_LOG_SIZE` stays a small multiple of the interval (a few tens of
KiB — buffered writes flushed between checks can defer a stat by a bit more than one
interval; the codex-review repro measured ~38 KB worst case, ~0.4% of the 10 MiB cap).

Part of epic #6379. Note: PR for the low-severity #6700 also touches `logger.ts`
(`closeLogStream`); this change is confined to the rotation size-check path and does
not touch close-stream logic, so the two are independent.

## Linked Issue

Closes #6651

## Bug / Regression Context

- **Observed symptom:** one `existsSync` + `statAsync` syscall pair per log line.
- **Repro steps / conditions:** a steady, serialized stream of small log lines pays a size-check syscall ahead of each one, though rotation is a per-10-MiB event.

## Validation

- [x] New `test/utils/logger-rotation-check-interval.test.ts` — proves 25 serialized small writes trigger ~1 size-check (was 25) via a filtered `fs.existsSync` spy, AND that rotation still fires once accumulated writes cross the threshold. Red first.
- [x] Logger regression set (`logger-close`, `logger-sink-degradation`, `logger-structured`, `logger-redaction`, `loggerPrune`, `logger-init-pidfile-crash`, etc.) — 75 pass; whole `test/utils/` — 3003 pass.
- [x] `bun run lint` — no new violations. `bun run typecheck` — no new errors.
- [x] `slack codex review` self-review: no blocking findings; its reproductions confirmed rotation fires with bounded overshoot.

## Follow-ups

- None. (32 KiB interval is a fixed constant; making it env-tunable was out of scope.)
