### PR TITLE
fix: propagate plan request deadlines to internal steps

### DIFF
--- a/src/features/toolSelection/toolSelectionContext.ts
+++ b/src/features/toolSelection/toolSelectionContext.ts
@@ -1,7 +1,16 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { SessionToolSelectionService } from "./SessionToolSelectionService";
+import type { ProgressCallback } from "../../server/toolRegistry";
 
 export type ToolSelectionContext = {
+  /** Trusted enclosing plan metadata, reattached after each step's schema parse. */
+  planRequest?: {
+    deadlineMs?: unknown;
+    timeoutMs?: unknown;
+    startTime?: unknown;
+    liveDeadlineKey?: unknown;
+    progress?: ProgressCallback;
+  };
   routingSessionUuid?: string;
   execution?: {
     executionId: string;
@@ -22,6 +31,7 @@ export const runWithToolSelectionContext = async <T>(
   const parent = toolSelectionContext.getStore();
   return toolSelectionContext.run(
     {
+      planRequest: context.planRequest ?? parent?.planRequest,
       routingSessionUuid: context.routingSessionUuid ?? parent?.routingSessionUuid,
       execution: context.execution ?? parent?.execution,
       toolSelectionProfileUuid:

--- a/src/server/planTools.ts
+++ b/src/server/planTools.ts
@@ -14,6 +14,13 @@ import {
 import { startMcpRecording, stopMcpRecording, getMcpRecordingStatus } from "./mcpRecordingManager";
 import { serverConfig } from "../utils/ServerConfig";
 import { PlanExecutionOrchestrator, PlanExecutionRequest } from "./planExecutionOrchestrator";
+import { runWithToolSelectionContext } from "../features/toolSelection/toolSelectionContext";
+import {
+  INTERNAL_MCP_REQUEST_DEADLINE_PARAM,
+  INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
+  INTERNAL_EXECUTION_START_TIME_PARAM,
+  INTERNAL_LIVE_DEADLINE_KEY_PARAM,
+} from "../daemon/constants";
 
 const testMetadataSchema = z.object({
   testClass: z.string(),
@@ -115,7 +122,21 @@ const executePlanTool = async (
     progress,
     signal,
   });
-  const result = await orchestrator.execute();
+  // These fields come from the enclosing MCP call, never from step params.
+  // Preserve the live registry key rather than freezing its current deadline.
+  const internalParams = params as Record<string, unknown>;
+  const result = await runWithToolSelectionContext(
+    {
+      planRequest: {
+        deadlineMs: internalParams[INTERNAL_MCP_REQUEST_DEADLINE_PARAM],
+        timeoutMs: internalParams[INTERNAL_MCP_REQUEST_TIMEOUT_PARAM],
+        startTime: internalParams[INTERNAL_EXECUTION_START_TIME_PARAM],
+        liveDeadlineKey: internalParams[INTERNAL_LIVE_DEADLINE_KEY_PARAM],
+        progress,
+      },
+    },
+    () => orchestrator.execute(),
+  );
   return createStructuredToolResponse(result);
 };
 

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -61,6 +61,12 @@ import {
 } from "../features/toolSelection/toolSelectionContext";
 import { isDeviceLostError, throwDeviceLostFromAbortSignal } from "./deviceLossOutcome";
 import { executionTracker } from "./executionTracker";
+import {
+  INTERNAL_MCP_REQUEST_DEADLINE_PARAM,
+  INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
+  INTERNAL_EXECUTION_START_TIME_PARAM,
+  INTERNAL_LIVE_DEADLINE_KEY_PARAM,
+} from "../daemon/constants";
 
 // Re-exported for backward compatibility; the implementation now lives in
 // ./TopLevelUnionFlattener so the schema-flattening concern is independently testable.
@@ -1400,7 +1406,13 @@ export class ToolRegistryClass {
     const invocation = this.createInternalToolInvocationContext(args, options);
 
     return runWithToolSelectionContext(invocation, () =>
-      this.invokeInternalTool(resolved, invocation.args, progress, signal, options.targetDevice),
+      this.invokeInternalTool(
+        resolved,
+        invocation.args,
+        progress ?? getToolSelectionContext()?.planRequest?.progress,
+        signal,
+        options.targetDevice,
+      ),
     );
   }
 
@@ -1409,6 +1421,18 @@ export class ToolRegistryClass {
     options: InternalToolCallOptions,
   ): InternalToolInvocationContext {
     const context = getToolSelectionContext();
+    const request = context?.planRequest;
+    if (request) {
+      // Parent metadata wins even when absent: a passthrough step schema must
+      // not let plan content choose another request's live deadline.
+      args = {
+        ...args,
+        [INTERNAL_MCP_REQUEST_DEADLINE_PARAM]: request.deadlineMs,
+        [INTERNAL_MCP_REQUEST_TIMEOUT_PARAM]: request.timeoutMs,
+        [INTERNAL_EXECUTION_START_TIME_PARAM]: request.startTime,
+        [INTERNAL_LIVE_DEADLINE_KEY_PARAM]: request.liveDeadlineKey,
+      };
+    }
     // An internal call inherits the ambient ROUTING session (issue #4611 Gap C)
     // so a plan step or navigation replay routes to the same derived/label
     // session the outer call resolved to, not the base session.

--- a/test/plan/planExecutorDeadline.test.ts
+++ b/test/plan/planExecutorDeadline.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { z } from "zod/v4";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { DefaultPlanExecutor } from "../../src/utils/plan/PlanExecutor";
+import { runWithToolSelectionContext } from "../../src/features/toolSelection/toolSelectionContext";
+import { FakeTimer } from "../fakes/FakeTimer";
+import {
+  resetSetUIStateFactory,
+  setSetUIStateFactory,
+  setUIStateHandler,
+} from "../../src/server/formTools";
+import { ProgressExtendableDeadline } from "../../src/daemon/mcpRequestTimeout";
+import {
+  getLiveDeadlineMs,
+  registerLiveDeadline,
+  unregisterLiveDeadline,
+} from "../../src/daemon/liveDeadlineRegistry";
+import {
+  INTERNAL_LIVE_DEADLINE_KEY_PARAM,
+  INTERNAL_MCP_REQUEST_DEADLINE_PARAM,
+  INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
+  INTERNAL_EXECUTION_START_TIME_PARAM,
+} from "../../src/daemon/constants";
+
+describe("plan internal request inheritance", () => {
+  afterEach(() => {
+    ToolRegistry.clearTools();
+    resetSetUIStateFactory();
+    unregisterLiveDeadline("plan-deadline");
+  });
+
+  test("step progress extends the enclosing live deadline after schema parsing", async () => {
+    const timer = new FakeTimer();
+    const deadline = new ProgressExtendableDeadline(timer.now(), 10_000);
+    registerLiveDeadline("plan-deadline", deadline);
+    const observed: unknown[] = [];
+    ToolRegistry.register(
+      "deadlineStep",
+      "deadline aware step",
+      z.object({}),
+      async (args, progress) => {
+        observed.push(args[INTERNAL_MCP_REQUEST_DEADLINE_PARAM]);
+        observed.push(args[INTERNAL_MCP_REQUEST_TIMEOUT_PARAM]);
+        observed.push(args[INTERNAL_EXECUTION_START_TIME_PARAM]);
+        observed.push(getLiveDeadlineMs(args[INTERNAL_LIVE_DEADLINE_KEY_PARAM]));
+        timer.advanceTime(5_000);
+        await progress?.(1, 2, "field completed");
+        observed.push(getLiveDeadlineMs(args[INTERNAL_LIVE_DEADLINE_KEY_PARAM]));
+        return { success: true };
+      },
+    );
+    const result = await runWithToolSelectionContext(
+      {
+        planRequest: {
+          deadlineMs: 10_000,
+          timeoutMs: 10_000,
+          startTime: 0,
+          liveDeadlineKey: "plan-deadline",
+          progress: async () => {
+            deadline.extendOnProgress(timer.now(), 10_000);
+          },
+        },
+      },
+      () =>
+        new DefaultPlanExecutor(timer).executePlan(
+          {
+            name: "deadline",
+            mcpVersion: "1.0",
+            steps: [{ tool: "deadlineStep", params: {} }],
+          },
+          0,
+        ),
+    );
+    expect(result.success).toBe(true);
+    expect(observed).toEqual([10_000, 10_000, 0, 10_000, 15_000]);
+  });
+
+  test("setUIState inside a plan sees the enclosing deadline through its existing handler", async () => {
+    const snapshots: unknown[] = [];
+    const progress = async () => {};
+    setSetUIStateFactory(() => ({
+      execute: async (_options, inheritedProgress, _signal, deadlineMs, liveDeadline) => {
+        snapshots.push(deadlineMs, liveDeadline?.(), inheritedProgress);
+        return { success: true, fields: [], totalAttempts: 0 };
+      },
+    }));
+    registerLiveDeadline("plan-deadline", new ProgressExtendableDeadline(0, 80_000));
+    ToolRegistry.register(
+      "deadlineForm",
+      "form step",
+      z.object({}),
+      (args, inheritedProgress, signal) =>
+        setUIStateHandler(
+          { deviceId: "fake", name: "fake", platform: "android" },
+          { ...args, fields: [{ selector: { elementId: "name" }, value: "Grace" }] },
+          inheritedProgress,
+          signal,
+        ),
+    );
+    await runWithToolSelectionContext(
+      { planRequest: { deadlineMs: 80_000, liveDeadlineKey: "plan-deadline", progress } },
+      () =>
+        new DefaultPlanExecutor(new FakeTimer()).executePlan(
+          { name: "form", mcpVersion: "1.0", steps: [{ tool: "deadlineForm", params: {} }] },
+          0,
+        ),
+    );
+    expect(snapshots).toEqual([80_000, 80_000, progress]);
+  });
+
+  test("step-supplied metadata cannot replace the enclosing request", async () => {
+    const calls: unknown[] = [];
+    ToolRegistry.register("deadlineStep", "step", z.object({}).passthrough(), async (args) => {
+      calls.push(args[INTERNAL_MCP_REQUEST_DEADLINE_PARAM], args[INTERNAL_LIVE_DEADLINE_KEY_PARAM]);
+      return { success: true };
+    });
+    await runWithToolSelectionContext({ planRequest: { deadlineMs: 42 } }, () =>
+      new DefaultPlanExecutor(new FakeTimer()).executePlan(
+        {
+          name: "spoof",
+          mcpVersion: "1.0",
+          steps: [
+            {
+              tool: "deadlineStep",
+              params: {
+                [INTERNAL_MCP_REQUEST_DEADLINE_PARAM]: 999_999,
+                [INTERNAL_LIVE_DEADLINE_KEY_PARAM]: "other-request",
+              },
+            },
+          ],
+        },
+        0,
+      ),
+    );
+    expect(calls).toEqual([42, undefined]);
+  });
+
+  test("concurrent internal calls keep request context isolated and leave plain calls unchanged", async () => {
+    ToolRegistry.register("deadlineStep", "step", z.object({}), async (args) => {
+      await Promise.resolve();
+      return args[INTERNAL_MCP_REQUEST_DEADLINE_PARAM];
+    });
+    const results = await Promise.all(
+      [1, 2].map((deadlineMs) =>
+        runWithToolSelectionContext({ planRequest: { deadlineMs } }, () =>
+          ToolRegistry.callInternal("deadlineStep", {}),
+        ),
+      ),
+    );
+    expect(results).toEqual([1, 2]);
+    expect(await ToolRegistry.callInternal("deadlineStep", {})).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

When `setUIState` runs inside `executePlan`, its step previously lost the enclosing request deadline and progress callback after schema parsing. Bind the plan's transport metadata in the existing request context and inherit it at `ToolRegistry.callInternal`, so deadline-aware steps see the same live, progress-extended deadline as the enclosing call.

The parent request overrides step-supplied internal metadata, concurrent calls retain separate contexts, and calls outside a plan retain their current behavior. This reuses the existing AsyncLocalStorage seam and adds no dependency or public schema change.

## Linked Issue

Closes [#6277](https://github.com/kaeawc/auto-mobile/issues/6277).

## Validation

- Three regression tests failed before implementation; all 18 focused tests now pass, including the existing `setUIState` handler.
- `bun run turbo:validate`: all seven tasks pass, including the full unit suite, lint, build, and execution-boundary checks.
- `bun run typecheck`: no new errors.
- `bash scripts/validate-bun-test-timings.sh`: passes the 100ms timing gate, including isolated reruns.
- `bun run format:check` and `git diff --check`: pass.
- FakeTimer tests verify live progress extension, metadata spoof resistance, request isolation, and plain-call fallback.
