### PR TITLE
fix(android): supplement incomplete action hierarchies with UIAutomator

### DIFF
--- a/src/features/action/AndroidHierarchyFallback.ts
+++ b/src/features/action/AndroidHierarchyFallback.ts
@@ -1,0 +1,196 @@
+import { defaultIdGenerator, type IdGenerator } from "../../utils/IdGenerator";
+import { parseStringPromise } from "xml2js";
+import type { ViewHierarchyNode, ViewHierarchyResult, HierarchySource } from "../../models";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { Timer } from "../../utils/SystemTimer";
+import { parseBounds } from "../../utils/bounds";
+import { throwIfAborted } from "../../utils/toolUtils";
+import { logger } from "../../utils/logger";
+import { DefaultElementParser } from "../utility/ElementParser";
+
+export interface AndroidHierarchyFallbackDeps {
+  adb: Pick<AdbExecutor, "execute" | "getForegroundApp">;
+  timer: Timer;
+  idGenerator?: IdGenerator;
+}
+
+interface XmlNode {
+  $?: Record<string, string>;
+  node?: XmlNode[];
+}
+
+// Resource IDs repeat in lists and across windows. Only identical visible
+// descriptors at identical coordinates can be discarded in favor of CtrlProxy.
+function nodeKey(attributes: Record<string, unknown>, bounds: unknown): string {
+  const rect = parseBounds(bounds ?? attributes.bounds);
+  return JSON.stringify([
+    attributes.package,
+    attributes.class,
+    attributes["resource-id"] ?? "",
+    attributes.text ?? "",
+    attributes["content-desc"] ?? "",
+    rect ? [rect.left, rect.top, rect.right, rect.bottom] : null,
+  ]);
+}
+
+function missingXmlNodes(
+  nodes: XmlNode[],
+  nativeKeys: Set<string>,
+  packageName: string,
+): ViewHierarchyNode[] {
+  return nodes.flatMap((node) => {
+    const children = missingXmlNodes(node.node ?? [], nativeKeys, packageName);
+    const attributes = node.$;
+    const bounds = parseBounds(attributes?.bounds);
+    if (
+      !attributes ||
+      attributes.package !== packageName ||
+      !bounds ||
+      bounds.right <= bounds.left ||
+      bounds.bottom <= bounds.top
+    ) {
+      return children;
+    }
+    const candidate: ViewHierarchyNode = {
+      $: { ...attributes, "hierarchy-source": "uiautomator" },
+      bounds,
+      ...(children.length ? { node: children } : {}),
+    };
+    // The XML format has no native action identity. Never manufacture or accept
+    // one from a dump: these nodes are coordinate-only candidates.
+    delete candidate.$["view-id"];
+    delete candidate.$["unique-id"];
+    delete candidate.$.actions;
+    if (nativeKeys.has(nodeKey(candidate.$, candidate.bounds))) {
+      return children;
+    }
+    return [candidate];
+  });
+}
+
+function mergeMissingNodes(
+  original: ViewHierarchyResult,
+  nodes: XmlNode[],
+  packageName: string,
+): ViewHierarchyResult {
+  const parser = new DefaultElementParser();
+  const nativeKeys = new Set(
+    parser
+      .flattenViewHierarchy(original, { includeWindows: true })
+      .map((entry) => nodeKey(entry.element, entry.element.bounds)),
+  );
+  const missing = missingXmlNodes(nodes, nativeKeys, packageName);
+  if (!missing.length) {
+    return original;
+  }
+  // Keep native roots/IDs untouched. The XML additions cannot inherit a
+  // device-authored frame token, receipt timestamp, or verified freshness.
+  const merged: ViewHierarchyResult = {
+    ...original,
+    packageName: packageName,
+    hierarchy: { node: { $: {}, node: [...parser.extractRootNodes(original), ...missing] } },
+    sources: [
+      ...new Set<HierarchySource>([...(original.sources ?? ["control-proxy"]), "uiautomator"]),
+    ],
+    fresh: false,
+  };
+  delete merged.frameContext;
+  delete merged.receivedAt;
+  delete merged.updatedAt;
+  return merged;
+}
+
+/** Add missing same-app XML content without certifying a mixed capture as complete. */
+export async function supplementAndroidHierarchy(
+  original: ViewHierarchyResult,
+  deps: AndroidHierarchyFallbackDeps,
+  deadline: number,
+  signal?: AbortSignal,
+): Promise<ViewHierarchyResult> {
+  throwIfAborted(signal);
+  if (deps.timer.now() >= deadline) {
+    return original;
+  }
+  const path = dumpPath(deps.idGenerator);
+  const execute = async (args: string[]) => {
+    throwIfAborted(signal);
+    const remaining = deadline - deps.timer.now();
+    if (remaining <= 0) {
+      throw new Error("Hierarchy fallback deadline exhausted");
+    }
+    return deps.adb.execute(args, {
+      timeoutMs: remaining,
+      signal,
+      noRetry: true,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+  };
+  try {
+    const foreground = await deps.adb.getForegroundApp(signal, deadline - deps.timer.now());
+    if (!foreground) {
+      return original;
+    }
+    if (original.packageName !== undefined && original.packageName !== foreground.packageName) {
+      return original;
+    }
+    await execute(["shell", "uiautomator", "dump", path]);
+    const result = await execute(["shell", "cat", path]);
+    throwIfAborted(signal);
+    return await verifyAndMergeDump(original, result.stdout, foreground, deps, deadline, signal);
+  } catch (error) {
+    throwIfAborted(signal);
+    logger.debug("[HierarchyFallback] Could not supplement incomplete CtrlProxy hierarchy", error);
+    return original;
+  } finally {
+    await removeDump(deps, path, deadline);
+  }
+}
+
+async function removeDump(
+  deps: AndroidHierarchyFallbackDeps,
+  path: string,
+  deadline: number,
+): Promise<void> {
+  const remaining = deadline - deps.timer.now();
+  if (remaining > 0) {
+    try {
+      await deps.adb.execute(["shell", "rm", "-f", path], {
+        timeoutMs: Math.min(remaining, 100),
+        noRetry: true,
+      });
+    } catch (error) {
+      logger.debug("[HierarchyFallback] Could not remove temporary dump", error);
+    }
+  }
+}
+
+function dumpPath(idGenerator: IdGenerator = defaultIdGenerator): string {
+  return `/data/local/tmp/automobile-hierarchy-${idGenerator.next()}.xml`;
+}
+
+async function verifyAndMergeDump(
+  original: ViewHierarchyResult,
+  contents: string,
+  foreground: { packageName: string; userId: number },
+  deps: AndroidHierarchyFallbackDeps,
+  deadline: number,
+  signal?: AbortSignal,
+): Promise<ViewHierarchyResult> {
+  const parsed: { hierarchy?: XmlNode } = await parseStringPromise(contents, {
+    explicitArray: true,
+  });
+  const nodes = parsed.hierarchy?.node;
+  if (!Array.isArray(nodes) || deps.timer.now() >= deadline) {
+    return original;
+  }
+  const currentApp = await deps.adb.getForegroundApp(signal, deadline - deps.timer.now());
+  throwIfAborted(signal);
+  if (
+    currentApp?.packageName !== foreground.packageName ||
+    currentApp?.userId !== foreground.userId ||
+    deps.timer.now() >= deadline
+  ) {
+    return original;
+  }
+  return mergeMissingNodes(original, nodes, foreground.packageName);
+}

--- a/src/features/action/DragAndDrop.ts
+++ b/src/features/action/DragAndDrop.ts
@@ -346,6 +346,7 @@ export class DragAndDrop extends BaseVisualChange {
       this.accessibilityService,
       HIERARCHY_REFRESH_TIMEOUT_MS,
       signal,
+      { adb: this.adb, timer: this.timer },
     );
 
     if (!rawHierarchy) {

--- a/src/features/action/TapAnyElement.ts
+++ b/src/features/action/TapAnyElement.ts
@@ -498,6 +498,7 @@ export class TapAnyElement extends BaseVisualChange {
           this.accessibilityService,
           effectiveTimeoutMs,
           signal,
+          { adb: this.adb, timer: this.timer },
         );
         return rawHierarchy ? this.prepareViewHierarchyForResponse(rawHierarchy, screenSize) : null;
       }

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -1147,6 +1147,7 @@ export class TapOnElement extends BaseVisualChange {
           this.accessibilityService,
           effectiveTimeoutMs,
           signal,
+          { adb: this.adb, timer: this.timer },
         );
 
         return rawHierarchy ? this.prepareViewHierarchyForResponse(rawHierarchy, screenSize) : null;
@@ -2161,6 +2162,13 @@ export class TapOnElement extends BaseVisualChange {
     options?: TapOnElementOptions,
     isTalkBackEnabled?: boolean,
   ): Promise<ScreenReaderNavigationResult | undefined> {
+    // XML-only candidates have no CtrlProxy node identity, even if their resource
+    // ID also exists in the incomplete native tree. Never retarget semantic actions.
+    if (element["hierarchy-source"] === "uiautomator") {
+      await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal, true);
+      return undefined;
+    }
+
     // Check if TalkBack is enabled (not just any accessibility service)
     const talkBackEnabled =
       typeof isTalkBackEnabled === "boolean"

--- a/src/features/action/refreshAndroidViewHierarchy.ts
+++ b/src/features/action/refreshAndroidViewHierarchy.ts
@@ -2,29 +2,21 @@ import type { ViewHierarchyResult } from "../../models";
 import type { AndroidCtrlProxyClient } from "../observe/android";
 import { NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { serverConfig } from "../../utils/ServerConfig";
-import { logger } from "../../utils/logger";
+import { defaultTimer } from "../../utils/SystemTimer";
+import {
+  supplementAndroidHierarchy,
+  type AndroidHierarchyFallbackDeps,
+} from "./AndroidHierarchyFallback";
 
-/**
- * Shared Android view hierarchy refresh: sync from the accessibility service
- * and surface whether CtrlProxy reported the capture as incomplete.
- *
- * A uiautomator-dump fallback for the incomplete case was attempted here via
- * `ViewHierarchy.getUiAutomatorHierarchy`/`mergeHierarchies`, but neither method
- * was ever implemented (issue #6252) — the call always threw and was silently
- * swallowed, so the "fallback" was dead code that never ran. Removed rather
- * than reimplemented: building a real uiautomator-dump-and-merge pipeline is a
- * separate feature, not a typecheck-baseline sweep fix. Callers already treat
- * `ctrlProxyIncomplete` as a signal (see `ObserveScreen.ts`), so the incomplete
- * hierarchy is still returned as-is for them to act on.
- *
- * Returns the raw (unfiltered) hierarchy — callers are responsible for
- * any post-processing (filtering, attachRawViewHierarchy, etc.).
- */
+/** Refresh CtrlProxy, supplement incomplete captures within the same caller budget. */
 export async function refreshAndroidViewHierarchy(
   accessibilityService: AndroidCtrlProxyClient,
   timeoutMs: number,
   signal?: AbortSignal,
+  fallback?: AndroidHierarchyFallbackDeps,
 ): Promise<ViewHierarchyResult | null> {
+  const timer = fallback?.timer ?? defaultTimer;
+  const deadline = timer.now() + timeoutMs;
   const syncResult = await accessibilityService.requestHierarchySync(
     new NoOpPerformanceTracker(),
     serverConfig.isRawElementSearchEnabled(),
@@ -40,10 +32,8 @@ export async function refreshAndroidViewHierarchy(
     return null;
   }
 
-  if (rawHierarchy.ctrlProxyIncomplete) {
-    logger.debug(
-      "[refreshAndroidViewHierarchy] Accessibility service returned incomplete hierarchy; no uiautomator fallback is implemented, returning as-is",
-    );
+  if (rawHierarchy.ctrlProxyIncomplete && fallback) {
+    return supplementAndroidHierarchy(rawHierarchy, fallback, deadline, signal);
   }
 
   return rawHierarchy;

--- a/test/features/action/AndroidHierarchyFallback.test.ts
+++ b/test/features/action/AndroidHierarchyFallback.test.ts
@@ -1,0 +1,231 @@
+import { FakeIdGenerator } from "../../fakes/FakeIdGenerator";
+import { describe, expect, test } from "bun:test";
+import { supplementAndroidHierarchy } from "../../../src/features/action/AndroidHierarchyFallback";
+import type { ViewHierarchyResult } from "../../../src/models";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { DefaultElementParser } from "../../../src/features/utility/ElementParser";
+
+const path = "/data/local/tmp/automobile-hierarchy-test.xml";
+const xml = (body: string) => `<?xml version="1.0"?><hierarchy rotation="0">${body}</hierarchy>`;
+const node = (text: string, bounds = "[0,0][100,100]", id = "com.test:id/row") =>
+  `<node package="com.test" class="android.widget.Button" resource-id="${id}" text="${text}" bounds="${bounds}" clickable="true"/>`;
+function fixture(contents = xml(node("Missing"))) {
+  const adb = new FakeAdbClient();
+  adb.setForegroundApp({ packageName: "com.test", userId: 0 });
+  adb.setCommandResult(`shell cat ${path}`, contents);
+  const timer = new FakeTimer();
+  const original: ViewHierarchyResult = {
+    hierarchy: {
+      node: {
+        $: { package: "com.android.systemui", class: "Bar", "view-id": "native" },
+        bounds: { left: 0, top: 0, right: 100, bottom: 10 },
+      },
+    },
+    packageName: "com.test",
+    ctrlProxyIncomplete: true,
+    fresh: true,
+    frameContext: "native-frame",
+    receivedAt: 10,
+  };
+  const run = (signal?: AbortSignal) =>
+    supplementAndroidHierarchy(
+      original,
+      { adb, timer, idGenerator: new FakeIdGenerator(["test"]) },
+      1000,
+      signal,
+    );
+  return { adb, timer, original, run };
+}
+describe("Android hierarchy fallback", () => {
+  test("adds missing app content without native IDs or false frame verification", async () => {
+    const { run, original, adb } = fixture();
+    const result = await run();
+    const elements = new DefaultElementParser().flattenViewHierarchy(result).map((x) => x.element);
+    expect(elements.find((x) => x.text === "Missing")).toMatchObject({
+      "resource-id": "com.test:id/row",
+      "hierarchy-source": "uiautomator",
+    });
+    expect(elements.find((x) => x.text === "Missing")?.["view-id"]).toBeUndefined();
+    expect(elements.find((x) => x.class === "Bar")?.["view-id"]).toBe("native");
+    expect(result.frameContext).toBeUndefined();
+    expect(result.fresh).toBe(false);
+    expect(result.ctrlProxyIncomplete).toBe(true);
+    expect(result.sources).toEqual(["control-proxy", "uiautomator"]);
+    expect(original.frameContext).toBe("native-frame");
+    expect(adb.wasCommandExecuted(`shell rm -f ${path}`)).toBe(true);
+  });
+  test("deduplicates matching native nodes but retains repeated IDs at other bounds", async () => {
+    const { original, run } = fixture(xml(node("Same") + node("Other", "[0,100][100,200]")));
+    original.hierarchy = {
+      node: {
+        $: {
+          package: "com.test",
+          class: "android.widget.Button",
+          "resource-id": "com.test:id/row",
+          text: "Same",
+          "view-id": "native-row",
+        },
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      },
+    };
+    const result = await run();
+    const elements = new DefaultElementParser().flattenViewHierarchy(result).map((x) => x.element);
+    expect(elements).toHaveLength(2);
+    expect(elements.find((x) => x.text === "Same")?.["view-id"]).toBe("native-row");
+    expect(elements.find((x) => x.text === "Other")?.bounds.top).toBe(100);
+  });
+  test.each(["", "not xml", xml(node("Other").replaceAll("com.test", "com.other"))])(
+    "keeps incomplete data for unusable or different-app dumps: %s",
+    async (contents) => {
+      const { run, original } = fixture(contents);
+      expect(await run()).toBe(original);
+    },
+  );
+  test("does not read stale XML after a failed dump", async () => {
+    const { run, original, adb } = fixture();
+    adb.setCommandError(`shell uiautomator dump ${path}`, new Error("dump failed"));
+    expect(await run()).toBe(original);
+    expect(adb.wasCommandExecuted(`shell cat ${path}`)).toBe(false);
+  });
+  test("propagates caller cancellation", async () => {
+    const { run } = fixture();
+    const controller = new AbortController();
+    controller.abort();
+    await expect(run(controller.signal)).rejects.toThrow();
+  });
+  test("skips fallback after the shared deadline", async () => {
+    const { adb, timer, original } = fixture();
+    expect(
+      await supplementAndroidHierarchy(
+        original,
+        { adb, timer, idGenerator: new FakeIdGenerator(["test"]) },
+        0,
+      ),
+    ).toBe(original);
+    expect(adb.wasCommandExecuted(`shell uiautomator dump ${path}`)).toBe(false);
+  });
+});
+
+describe("fallback foreground ownership", () => {
+  test("resolves a withheld app root from the foreground probe", async () => {
+    const { original, run } = fixture();
+    delete original.packageName;
+    const result = await run();
+    expect(result.packageName).toBe("com.test");
+    expect(result.sources).toContain("uiautomator");
+  });
+  test("rejects a known different foreground app", async () => {
+    const { original, run, adb } = fixture();
+    adb.setForegroundApp({ packageName: "com.other", userId: 0 });
+    expect(await run()).toBe(original);
+    expect(adb.wasCommandExecuted(`shell uiautomator dump ${path}`)).toBe(false);
+  });
+  test("rejects an app switch during the dump", async () => {
+    class SwitchingAdb extends FakeAdbClient {
+      private calls = 0;
+      override async getForegroundApp() {
+        return { packageName: ++this.calls === 1 ? "com.test" : "com.other", userId: 0 };
+      }
+    }
+    const { original, timer } = fixture();
+    const adb = new SwitchingAdb();
+    adb.setCommandResult(`shell cat ${path}`, xml(node("Missing")));
+    expect(
+      await supplementAndroidHierarchy(
+        original,
+        { adb, timer, idGenerator: new FakeIdGenerator(["test"]) },
+        1000,
+      ),
+    ).toBe(original);
+  });
+  test("promotes missing descendants of a duplicate wrapper", async () => {
+    const { original, run } = fixture(
+      xml(
+        '<node package="com.test" class="Frame" resource-id="root" bounds="[0,0][100,100]">' +
+          node("Missing") +
+          "</node>",
+      ),
+    );
+    original.hierarchy = {
+      node: {
+        $: { package: "com.test", class: "Frame", "resource-id": "root", "view-id": "native-root" },
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      },
+    };
+    const elements = new DefaultElementParser()
+      .flattenViewHierarchy(await run())
+      .map((x) => x.element);
+    expect(elements).toHaveLength(2);
+    expect(elements.find((x) => x.text === "Missing")).toBeDefined();
+    expect(elements.find((x) => x.class === "Frame")?.["view-id"]).toBe("native-root");
+  });
+});
+
+describe("fallback native identity inventory", () => {
+  test("retains a native window-only node instead of an XML duplicate", async () => {
+    const { original, run } = fixture(xml(node("Same")));
+    original.windows = [
+      {
+        id: 1,
+        type: 1,
+        hierarchy: {
+          $: {},
+          node: [
+            {
+              $: {
+                package: "com.test",
+                class: "android.widget.Button",
+                "resource-id": "com.test:id/row",
+                text: "Same",
+                "view-id": "native-window",
+              },
+              bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+            },
+          ],
+        },
+      },
+    ];
+    expect(await run()).toBe(original);
+    const elements = new DefaultElementParser()
+      .flattenViewHierarchy(original, { includeWindows: true })
+      .map((x) => x.element);
+    expect(elements.find((x) => x.text === "Same")?.["view-id"]).toBe("native-window");
+  });
+});
+
+describe("fallback capture identity boundaries", () => {
+  test("deduplicates id-less nodes with omitted native attributes and reordered bounds", async () => {
+    const { original, run } = fixture(xml(node("Same", "[0,0][100,100]", "")));
+    original.hierarchy = {
+      node: {
+        $: {
+          package: "com.test",
+          class: "android.widget.Button",
+          text: "Same",
+          "view-id": "native-idless",
+        },
+        bounds: { bottom: 100, right: 100, top: 0, left: 0 },
+      },
+    };
+    expect(await run()).toBe(original);
+  });
+  test("rejects a same-package user switch", async () => {
+    class SwitchingUserAdb extends FakeAdbClient {
+      private calls = 0;
+      override async getForegroundApp() {
+        return { packageName: "com.test", userId: this.calls++ };
+      }
+    }
+    const { original, timer } = fixture();
+    const adb = new SwitchingUserAdb();
+    adb.setCommandResult(`shell cat ${path}`, xml(node("Missing")));
+    expect(
+      await supplementAndroidHierarchy(
+        original,
+        { adb, timer, idGenerator: new FakeIdGenerator(["test"]) },
+        1000,
+      ),
+    ).toBe(original);
+  });
+});

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -48,6 +48,29 @@ describe("TapOnElement TalkBack mode detection", () => {
     ).mockResolvedValue(undefined);
   });
 
+  test.each(["tap", "doubleTap", "longPress"])(
+    "XML-only %s never invokes native semantic targeting",
+    async (action) => {
+      fakeAccessibilityDetector.setTalkBackEnabled(true);
+      const element = {
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+        "resource-id": "repeated:id/row",
+        "hierarchy-source": "uiautomator",
+      };
+      await (tapOnElement as any).executeAndroidTap(action, 50, 50, 500, element);
+      expect(executeAndroidTapWithAccessibility).not.toHaveBeenCalled();
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith(
+        action,
+        50,
+        50,
+        500,
+        element,
+        undefined,
+        true,
+      );
+    },
+  );
+
   describe("when TalkBack is disabled", () => {
     beforeEach(() => {
       fakeAccessibilityDetector.setTalkBackEnabled(false);

--- a/test/features/action/refreshAndroidViewHierarchy.test.ts
+++ b/test/features/action/refreshAndroidViewHierarchy.test.ts
@@ -1,16 +1,18 @@
+import { FakeIdGenerator } from "../../fakes/FakeIdGenerator";
 import { describe, expect, test } from "bun:test";
 import type { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import type { ViewHierarchyResult } from "../../../src/models";
 import { refreshAndroidViewHierarchy } from "../../../src/features/action/refreshAndroidViewHierarchy";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeCtrlProxy } from "../../fakes/FakeCtrlProxy";
 
 /**
  * Issue #6252: `refreshAndroidViewHierarchy`'s incomplete-hierarchy fallback
  * called `viewHierarchy.getUiAutomatorHierarchy` / `viewHierarchy.mergeHierarchies`,
  * neither of which was ever implemented on `ViewHierarchy` — every fallback
- * attempt threw and was silently swallowed. The function no longer attempts
- * the nonexistent fallback; it must return the (possibly incomplete) hierarchy
- * as-is without throwing.
+ * attempt threw and was silently swallowed. Without injected ADB it still returns the capture unchanged. With ADB,
+ * issue #6323 supplements incomplete captures within the original deadline.
  */
 describe("refreshAndroidViewHierarchy", () => {
   const asClient = (fake: FakeCtrlProxy): AndroidCtrlProxyClient =>
@@ -45,7 +47,7 @@ describe("refreshAndroidViewHierarchy", () => {
     expect(result).toEqual(completeResult);
   });
 
-  test("returns an incomplete hierarchy as-is without throwing (no uiautomator fallback exists)", async () => {
+  test("returns an incomplete hierarchy as-is without throwing (no fallback executor supplied)", async () => {
     const fakeCtrlProxy = new FakeCtrlProxy();
     fakeCtrlProxy.setHierarchyData({
       updatedAt: Date.now(),
@@ -93,5 +95,48 @@ describe("refreshAndroidViewHierarchy", () => {
     await refreshAndroidViewHierarchy(asClient(fakeCtrlProxy), 1000);
 
     expect(fakeCtrlProxy.getLastRequestHierarchySyncArgs()?.timeoutMs).toBe(1000);
+  });
+});
+
+describe("refresh fallback budget", () => {
+  test.each([true, false])("supplements only incomplete captures: %s", async (incomplete) => {
+    const timer = new FakeTimer();
+    class SyncClient extends FakeCtrlProxy {
+      override async requestHierarchySync(
+        ...args: Parameters<FakeCtrlProxy["requestHierarchySync"]>
+      ) {
+        timer.advanceTime(200);
+        return super.requestHierarchySync(...args);
+      }
+    }
+    const client = new SyncClient();
+    client.setHierarchyData({ packageName: "com.test", hierarchy: { $: {} } });
+    client.setViewHierarchyResult({
+      hierarchy: { node: { $: {} } },
+      packageName: "com.test",
+      ctrlProxyIncomplete: incomplete,
+    });
+    const adb = new FakeAdbClient();
+    adb.setForegroundApp({ packageName: "com.test", userId: 0 });
+    adb.setCommandResult(
+      "shell cat /data/local/tmp/automobile-hierarchy-test.xml",
+      '<hierarchy><node package="com.test" class="Button" text="Missing" bounds="[0,0][10,10]"/></hierarchy>',
+    );
+    const controller = new AbortController();
+    const result = await refreshAndroidViewHierarchy(
+      client as unknown as AndroidCtrlProxyClient,
+      1000,
+      controller.signal,
+      { adb, timer, idGenerator: new FakeIdGenerator(["test"]) },
+    );
+    expect(result).not.toBeNull();
+    const calls = adb.getCommandCalls();
+    expect(calls.length).toBe(incomplete ? 3 : 0);
+    if (incomplete) {
+      expect(calls[0].timeoutMs).toBe(800);
+      expect(calls[1].timeoutMs).toBe(800);
+      expect(calls[0].signal).toBe(controller.signal);
+      expect(result?.sources).toContain("uiautomator");
+    }
   });
 });


### PR DESCRIPTION
## Summary

When CtrlProxy returns an incomplete Android hierarchy during tapOn, tapAny, or dragAndDrop refresh, supplement it with a bounded UIAutomator XML dump. Previously these callers returned the partial tree unchanged, leaving otherwise visible app controls unavailable to selection.

The fallback verifies foreground package/user ownership before and after capture, preserves native nodes and IDs, and deduplicates equivalent XML nodes across the main hierarchy and native window hierarchies. XML-only tapOn candidates use coordinates rather than attempting native semantic actions with a repeated resource ID. Mixed captures retain the incomplete flag, report both sources, and carry no native frame/freshness claim.

Closes [#6323](https://github.com/kaeawc/auto-mobile/issues/6323).

## Implementation and prior work

The dead fallback calls removed by [PR #6274](https://github.com/kaeawc/auto-mobile/pull/6274) are replaced with a focused module, preserving the separation that motivated the earlier removal in [PR #1139](https://github.com/kaeawc/auto-mobile/pull/1139). The merge tests also cover the duplicate-node regression previously addressed in [PR #1004](https://github.com/kaeawc/auto-mobile/pull/1004).

Reuses AdbExecutor, Timer/FakeTimer, IdGenerator/FakeIdGenerator, bounds parsing, and ElementParser. Uses the already-installed xml2js parser because the runtime standard library has no XML parser; no new dependency or shared baseline changes. Dump/read/probes share the caller's remaining deadline, cancellation propagates, and failure preserves the original partial result. Temporary dump cleanup is bounded by remaining time.

## Validation

- Full Turbo lint/build/unit-test gate.
- Typecheck: no new errors; existing 147-error baseline unchanged.
- Full formatting check and changed-unit timing gate.
- 53 focused fallback, deadline, identity, and TalkBack dispatch tests pass; newly added units stay below 100 ms.
- Independent runtime and delivery reviews, plus a generated mixed-capture identity/temporal review, completed before publication.

No live Android device was exercised. Sequential capture cannot prove that all inaccessible windows became visible or that the app stayed on one screen; the existing tapOn pre-tap stability check remains in place, and the merged capture is explicitly unverified.
