### PR TITLE
fix(snapshot): serialize archive-budget eviction to stop concurrent over-eviction (#6491)

### DIFF
--- a/src/server/deviceSnapshotManager.ts
+++ b/src/server/deviceSnapshotManager.ts
@@ -91,24 +91,55 @@ const LEGACY_MANIFEST_FILENAME = "manifest.json";
 // sufficient — cross-process coordination is out of scope.
 const captureLocks = new Map<string, Promise<unknown>>();
 
-function withCaptureLock<T>(snapshotName: string, task: () => Promise<T>): Promise<T> {
-  const prior = captureLocks.get(snapshotName) ?? Promise.resolve();
+// Serializes the archive byte-budget eviction pass across ALL names and devices.
+// Captures on different names/devices take different (per-name) capture locks, so
+// their eviction passes would otherwise interleave against the same table and the
+// same budget: each reads the same up-front list and running total, then both
+// delete least-recently-accessed rows, and a pass that gets `deleted === false`
+// for rows another pass already removed credits itself nothing and keeps walking
+// — over-evicting well past the budget and emptying the archive (issue #6491).
+// Running the whole pass under one lock keyed on a CONSTANT makes passes QUEUE,
+// so each pass's up-front list/total read is accurate for its own duration. This
+// narrows rather than widens what is held: capture work stays parallel; only the
+// budget arithmetic is one-at-a-time. A separate map (not captureLocks) is used so
+// a snapshot whose name happens to equal the key can't serialize against it.
+const archiveBudgetLocks = new Map<string, Promise<unknown>>();
+const ARCHIVE_BUDGET_LOCK_KEY = "archive-budget";
+
+// Shared serialization primitive: run `task` after any prior holder of `key`
+// settles, keeping a promise-chain tail in `locks` and dropping the entry once
+// this is the last holder so the map doesn't grow unbounded.
+function withSerializedLock<T>(
+  locks: Map<string, Promise<unknown>>,
+  key: string,
+  task: () => Promise<T>,
+): Promise<T> {
+  const prior = locks.get(key) ?? Promise.resolve();
   // Run after the prior holder settles, regardless of whether it resolved or
-  // rejected, so one failed capture doesn't wedge every later same-name capture.
+  // rejected, so one failed holder doesn't wedge every later one for this key.
   const run = prior.then(task, task);
   const tail = run.then(
     () => undefined,
     () => undefined,
   );
-  captureLocks.set(snapshotName, tail);
+  locks.set(key, tail);
   void tail.finally(() => {
-    // Drop the entry once this is the last holder, so the map doesn't grow
-    // unbounded across distinct snapshot names.
-    if (captureLocks.get(snapshotName) === tail) {
-      captureLocks.delete(snapshotName);
+    if (locks.get(key) === tail) {
+      locks.delete(key);
     }
   });
   return run;
+}
+
+function withCaptureLock<T>(snapshotName: string, task: () => Promise<T>): Promise<T> {
+  return withSerializedLock(captureLocks, snapshotName, task);
+}
+
+// A capture holds its per-NAME capture lock while awaiting this DISTINCT
+// constant-keyed lock; the budget lock is a leaf (nothing acquired here awaits a
+// capture lock), so there is no re-entrancy and no deadlock.
+function withArchiveBudgetLock<T>(task: () => Promise<T>): Promise<T> {
+  return withSerializedLock(archiveBudgetLocks, ARCHIVE_BUDGET_LOCK_KEY, task);
 }
 
 function getSnapshotPathOptions(context: {
@@ -170,6 +201,7 @@ export async function setDeviceSnapshotManagerDependencies(
 export function resetDeviceSnapshotManagerDependencies(): void {
   moduleDependencies = null;
   captureLocks.clear();
+  archiveBudgetLocks.clear();
 }
 
 function configToInput(config: DeviceSnapshotConfig): DeviceSnapshotConfigInput {
@@ -469,55 +501,62 @@ function isReservedScopeSegment(snapshotName: string): boolean {
 async function enforceDeviceSnapshotArchiveLimit(
   maxArchiveSizeMb: number,
 ): Promise<SnapshotArchiveEvictionResult> {
-  const maxSizeBytes = Math.max(0, Math.floor(maxArchiveSizeMb * 1024 * 1024));
-  const { snapshotRepository } = await getDeviceSnapshotDependencies();
-  const snapshots = await snapshotRepository.listSnapshots({
-    orderByLastAccessed: "asc",
-  });
+  // The entire pass — list read, running total, and delete loop — runs under one
+  // constant-keyed lock so concurrent passes queue instead of interleaving. A
+  // later pass therefore re-reads a fresh, accurate list AFTER the prior pass
+  // finished deleting, and only ever credits/reports rows it actually removed
+  // (issue #6491).
+  return withArchiveBudgetLock(async () => {
+    const maxSizeBytes = Math.max(0, Math.floor(maxArchiveSizeMb * 1024 * 1024));
+    const { snapshotRepository } = await getDeviceSnapshotDependencies();
+    const snapshots = await snapshotRepository.listSnapshots({
+      orderByLastAccessed: "asc",
+    });
 
-  let currentSizeBytes = snapshots.reduce((sum, snapshot) => sum + snapshot.sizeBytes, 0);
+    let currentSizeBytes = snapshots.reduce((sum, snapshot) => sum + snapshot.sizeBytes, 0);
 
-  if (maxSizeBytes === 0 || currentSizeBytes <= maxSizeBytes) {
+    if (maxSizeBytes === 0 || currentSizeBytes <= maxSizeBytes) {
+      return {
+        evictedSnapshotNames: [],
+        currentSizeBytes,
+        maxSizeBytes,
+      };
+    }
+
+    const evictedSnapshotNames: string[] = [];
+
+    for (const snapshot of snapshots) {
+      if (currentSizeBytes <= maxSizeBytes) {
+        break;
+      }
+
+      try {
+        const deleted = await deleteDeviceSnapshotRecord(snapshot);
+        if (deleted) {
+          evictedSnapshotNames.push(snapshot.snapshotName);
+          currentSizeBytes -= snapshot.sizeBytes;
+        }
+      } catch (error) {
+        logger.warn(`[DeviceSnapshot] Failed to evict snapshot ${snapshot.snapshotName}: ${error}`);
+      }
+    }
+
+    if (currentSizeBytes > maxSizeBytes) {
+      logger.warn(
+        `[DeviceSnapshot] Archive size ${currentSizeBytes} bytes still exceeds limit ${maxSizeBytes} bytes after eviction`,
+      );
+    }
+
+    if (evictedSnapshotNames.length > 0) {
+      await notifySnapshotResources();
+    }
+
     return {
-      evictedSnapshotNames: [],
+      evictedSnapshotNames,
       currentSizeBytes,
       maxSizeBytes,
     };
-  }
-
-  const evictedSnapshotNames: string[] = [];
-
-  for (const snapshot of snapshots) {
-    if (currentSizeBytes <= maxSizeBytes) {
-      break;
-    }
-
-    try {
-      const deleted = await deleteDeviceSnapshotRecord(snapshot);
-      if (deleted) {
-        evictedSnapshotNames.push(snapshot.snapshotName);
-        currentSizeBytes -= snapshot.sizeBytes;
-      }
-    } catch (error) {
-      logger.warn(`[DeviceSnapshot] Failed to evict snapshot ${snapshot.snapshotName}: ${error}`);
-    }
-  }
-
-  if (currentSizeBytes > maxSizeBytes) {
-    logger.warn(
-      `[DeviceSnapshot] Archive size ${currentSizeBytes} bytes still exceeds limit ${maxSizeBytes} bytes after eviction`,
-    );
-  }
-
-  if (evictedSnapshotNames.length > 0) {
-    await notifySnapshotResources();
-  }
-
-  return {
-    evictedSnapshotNames,
-    currentSizeBytes,
-    maxSizeBytes,
-  };
+  });
 }
 
 export async function getDeviceSnapshotConfig(): Promise<DeviceSnapshotConfig> {

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -247,6 +247,144 @@ describe("deviceSnapshotManager", () => {
     expect(listed[0]?.snapshotName).toBe("race");
   });
 
+  test("concurrent captures on two devices run one budget eviction, never over-evicting (#6491)", async () => {
+    // Two sessions capture DIFFERENT names on DIFFERENT devices. They take
+    // different per-NAME capture locks, so both reach the archive-budget
+    // eviction phase concurrently. Under the pre-fix code both eviction passes
+    // read the same list and the same running total up front, then delete
+    // least-recently-accessed first: pass A evicts the over-budget tail while
+    // pass B — getting `deleted === false` for every row A already removed —
+    // credits itself nothing and keeps walking, deleting snapshots that were
+    // never over budget (including a snapshot the other session just captured),
+    // emptying the archive. The fix serializes the budget arithmetic on one
+    // constant-keyed lock, so the second pass re-reads a fresh, accurate list.
+    const MB = 1024 * 1024;
+    const maxArchiveSizeMb = 3;
+    const maxSizeBytes = maxArchiveSizeMb * MB;
+
+    const config: DeviceSnapshotConfig = {
+      includeAppData: true,
+      includeSettings: true,
+      useVmSnapshot: false,
+      strictBackupMode: false,
+      vmSnapshotTimeoutMs: 12000,
+      maxArchiveSizeMb,
+    };
+    await configRepository.setConfig(config);
+
+    // Physical-style device ids (not "emulator-...") keep the eviction delete on
+    // the simple unscoped path — no AVD-scoped second delete to reason about.
+    const deviceA: BootedDevice = { deviceId: "device-a", name: "Device A", platform: "android" };
+    const deviceB: BootedDevice = { deviceId: "device-b", name: "Device B", platform: "android" };
+
+    // Three pre-seeded 1 MB snapshots, oldest-accessed first.
+    for (const [name, accessedMs] of [
+      ["s1", 1000],
+      ["s2", 2000],
+      ["s3", 3000],
+    ] as const) {
+      const timestamp = new Date(accessedMs).toISOString();
+      const manifest: DeviceSnapshotManifest = {
+        snapshotName: name,
+        timestamp,
+        deviceId: "seed-device",
+        deviceName: "Seed Device",
+        platform: "android",
+        snapshotType: "adb",
+        includeAppData: true,
+        includeSettings: true,
+      };
+      await repository.insertSnapshot({
+        snapshotName: name,
+        deviceId: "seed-device",
+        deviceName: "Seed Device",
+        platform: "android",
+        snapshotType: "adb",
+        includeAppData: true,
+        includeSettings: true,
+        createdAt: timestamp,
+        lastAccessedAt: timestamp,
+        sizeBytes: 1 * MB,
+        manifest,
+      });
+    }
+
+    // The two new captures are the newest-accessed and 1 MB each. After both
+    // insert, the archive holds 5 MB against a 3 MB budget, so a correct single
+    // pass evicts exactly the two oldest (s1, s2) and stops.
+    fakeTimer.advanceTime(1_000_000);
+    store.setSnapshotSize("cap-a", 1 * MB);
+    store.setSnapshotSize("cap-b", 1 * MB);
+
+    // A deferred gate per capture: both captures block inside the provider until
+    // released, so both are in flight and both reach eviction together.
+    const started: string[] = [];
+    const releases: Array<() => void> = [];
+    await setDeviceSnapshotManagerDependencies({
+      createCaptureProvider: () => ({
+        capture: async (args) => {
+          started.push(args.snapshotName);
+          await new Promise<void>((resolve) => releases.push(resolve));
+          const timestamp = new Date(fakeTimer.now()).toISOString();
+          const manifest: DeviceSnapshotManifest = {
+            snapshotName: args.snapshotName,
+            timestamp,
+            deviceId: TEST_DEVICE.deviceId,
+            deviceName: TEST_DEVICE.name,
+            platform: TEST_DEVICE.platform,
+            snapshotType: "adb",
+            includeAppData: args.includeAppData ?? true,
+            includeSettings: args.includeSettings ?? true,
+          };
+          return { snapshotName: args.snapshotName, timestamp, snapshotType: "adb", manifest };
+        },
+      }),
+    });
+
+    // Deterministic microtask-only polling — no real timers.
+    const waitUntil = async (cond: () => boolean): Promise<void> => {
+      for (let i = 0; i < 1000 && !cond(); i++) {
+        await Promise.resolve();
+      }
+      if (!cond()) {
+        throw new Error(`waitUntil timed out; started=${JSON.stringify(started)}`);
+      }
+    };
+
+    const p1 = captureDeviceSnapshot(deviceA, { snapshotName: "cap-a", includeAppData: true });
+    const p2 = captureDeviceSnapshot(deviceB, { snapshotName: "cap-b", includeAppData: true });
+
+    // Both captures are simultaneously in flight (different names => different locks).
+    await waitUntil(() => started.length >= 2);
+    expect(started.slice().sort()).toEqual(["cap-a", "cap-b"]);
+
+    // Release both; both proceed to insert their record and then evict.
+    releases.forEach((release) => release());
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    const survivors = (await repository.listSnapshots()).map((record) => record.snapshotName);
+    const survivorNames = new Set(survivors);
+    const totalSize = (await repository.listSnapshots()).reduce(
+      (sum, record) => sum + record.sizeBytes,
+      0,
+    );
+    const allInitial = ["s1", "s2", "s3", "cap-a", "cap-b"];
+    const rowsRemoved = allInitial.filter((name) => !survivorNames.has(name)).sort();
+    const evictedUnion = [...r1.evictedSnapshotNames, ...r2.evictedSnapshotNames].sort();
+
+    // Only the over-budget tail (the two oldest) is evicted; nothing beyond it.
+    expect(survivorNames).toEqual(new Set(["s3", "cap-a", "cap-b"]));
+    // Neither session's freshly-captured snapshot was destroyed by the other pass.
+    expect(await repository.getSnapshot("cap-a")).not.toBeNull();
+    expect(await repository.getSnapshot("cap-b")).not.toBeNull();
+    // The archive ends trimmed to (not below) the budget.
+    expect(totalSize).toBe(maxSizeBytes);
+    expect(totalSize).toBeLessThanOrEqual(maxSizeBytes);
+    // Reported evicted names equal the rows actually removed — no phantoms, no omissions.
+    expect(rowsRemoved).toEqual(["s1", "s2"]);
+    expect(evictedUnion).toEqual(["s1", "s2"]);
+  });
+
   test("restoreDeviceSnapshot touches lastAccessedAt and forwards manifest", async () => {
     const createdAt = new Date(0).toISOString();
     const manifest: DeviceSnapshotManifest = {


### PR DESCRIPTION
## Summary

Captures serialize per snapshot **name** (`withCaptureLock`), and each capture ends
by enforcing the archive byte budget. Two sessions capturing different names on
different devices hold different capture locks, so their eviction passes interleaved
against the same table and the same budget: both read the same up-front list and
running total, both deleted least-recently-accessed rows, and a pass that got
`deleted === false` for rows another pass had already removed credited itself
nothing and kept walking its stale list — over-evicting well past the budget and, in
the worst case, **emptying the archive** (deleting a snapshot another session had
just captured). `evictedSnapshotNames` was wrong on both sides.

The entire `enforceDeviceSnapshotArchiveLimit` pass — list read, running total, and
delete loop — now runs under one lock keyed on a **constant**, so passes queue
instead of interleaving. A later pass re-reads a fresh, accurate list only after the
prior pass finished deleting, so it never acts on stale credit and reports only rows
it actually removed. This **narrows** what is held: capture work stays parallel, only
the budget arithmetic is one-at-a-time.

The per-name `withCaptureLock` is generalized into a shared
`withSerializedLock(map, key, task)` primitive (same idiom as existing lock queues in
`sessionManager`/`socketServer`); `withArchiveBudgetLock` uses a **separate** map so a
snapshot named like the key can't collide, and is a leaf lock (nothing under it awaits
a capture lock) so the capture→budget nesting cannot deadlock.

Part of epic #6379. This is the HIGH-severity item of the snapshot cluster; it does
not touch `DeviceSnapshotStore`/repositories, so it is independent of the planned
#6492/#6493 PRs.

## Linked Issue

Closes #6491

## Bug / Regression Context

- **Observed symptom:** on a host driving two devices, a single eviction overlap can empty the archive instead of trimming to budget; the next restore fails with `Snapshot '<name>' not found` even though the capture reported success, with no indication it was evicted.
- **Repro:** two `captureDeviceSnapshot` calls for different names on two devices reaching the eviction phase concurrently over a small `maxArchiveSizeMb`.

## Validation

- [x] New deterministic two-device test in `test/server/deviceSnapshotManager.test.ts`: a deferred fake-provider promise forces both captures into eviction together. **Red** (old code): survivors `{cap-b}` only — pass B over-evicted `s3` + `cap-a` (4 rows removed vs 2). **Green** (fixed): survivors `{s3, cap-a, cap-b}` at exactly budget; union of both `evictedSnapshotNames` = `[s1, s2]`. 18 pass.
- [x] Related suites green: `snapshotTools`, `deviceSnapshotResources`, `configManagerDefaultRepositories` (existing lower-`maxArchiveSizeMb` eviction cases stay green).
- [x] `bun run lint` — no new violations. `bun run typecheck` — no new errors.
- [x] `slack codex review` self-review: no blocking findings; it confirmed the lock idiom matches existing serialization patterns and the no-deadlock reasoning.

## Follow-ups

- Budget lock is in-process only (matches the existing capture lock's documented single-process assumption; cross-process coordination remains out of scope).
