### PR TITLE
fix(snapshot): read back on-disk settings.json/metadata.json, not just flat manifest.json (#6492)

### DIFF
--- a/src/server/deviceSnapshotManager.ts
+++ b/src/server/deviceSnapshotManager.ts
@@ -284,7 +284,9 @@ function isLegacyManifest(value: unknown): value is DeviceSnapshotManifest {
 // Structural check for the settings.json payload CaptureSnapshot.saveSettings
 // writes (src/features/action/CaptureSnapshot.ts:360-371): the raw
 // `{global?, secure?, system?}` triplet, not a full manifest.
-function isSettingsPayload(value: unknown): value is NonNullable<DeviceSnapshotManifest["settings"]> {
+function isSettingsPayload(
+  value: unknown,
+): value is NonNullable<DeviceSnapshotManifest["settings"]> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return false;
   }
@@ -292,7 +294,9 @@ function isSettingsPayload(value: unknown): value is NonNullable<DeviceSnapshotM
   const settings = value as Record<string, unknown>;
   return (["global", "secure", "system"] as const).every((key) => {
     const entry = settings[key];
-    return entry === undefined || (typeof entry === "object" && entry !== null && !Array.isArray(entry));
+    return (
+      entry === undefined || (typeof entry === "object" && entry !== null && !Array.isArray(entry))
+    );
   });
 }
 
@@ -679,7 +683,12 @@ async function importScopedLegacySnapshots(
         continue;
       }
 
-      const manifest = await discoverSnapshotManifest(snapshotName, snapshotStore, pathOptions, now);
+      const manifest = await discoverSnapshotManifest(
+        snapshotName,
+        snapshotStore,
+        pathOptions,
+        now,
+      );
       if (!manifest) {
         continue;
       }

--- a/src/server/deviceSnapshotManager.ts
+++ b/src/server/deviceSnapshotManager.ts
@@ -256,6 +256,10 @@ function buildArchiveEntry(record: DeviceSnapshotRecord): Record<string, unknown
   };
 }
 
+// Validates the shape of a manifest read back from disk. Shared by every
+// on-disk manifest source this module reads: the modern per-platform
+// metadata.json (issue #6492) and the legacy flat manifest.json it falls back
+// to for pre-#5707 snapshots.
 function isLegacyManifest(value: unknown): value is DeviceSnapshotManifest {
   if (!value || typeof value !== "object") {
     return false;
@@ -277,6 +281,21 @@ function isLegacyManifest(value: unknown): value is DeviceSnapshotManifest {
   );
 }
 
+// Structural check for the settings.json payload CaptureSnapshot.saveSettings
+// writes (src/features/action/CaptureSnapshot.ts:360-371): the raw
+// `{global?, secure?, system?}` triplet, not a full manifest.
+function isSettingsPayload(value: unknown): value is NonNullable<DeviceSnapshotManifest["settings"]> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const settings = value as Record<string, unknown>;
+  return (["global", "secure", "system"] as const).every((key) => {
+    const entry = settings[key];
+    return entry === undefined || (typeof entry === "object" && entry !== null && !Array.isArray(entry));
+  });
+}
+
 function normalizeLegacyManifest(
   snapshotName: string,
   manifest: DeviceSnapshotManifest,
@@ -295,33 +314,137 @@ function resolveLegacyTimestamp(timestamp: string, fallback: string): string {
   return Number.isNaN(Date.parse(timestamp)) ? fallback : timestamp;
 }
 
-async function readLegacyManifest(
-  snapshotName: string,
-  snapshotStore: DeviceSnapshotStore,
-): Promise<DeviceSnapshotManifest | null> {
-  const manifestPath = path.join(
-    snapshotStore.getSnapshotPath(snapshotName),
-    LEGACY_MANIFEST_FILENAME,
-  );
-
+async function readManifestFile(manifestPath: string): Promise<DeviceSnapshotManifest | null> {
   try {
     const manifestJson = await fs.readFile(manifestPath, "utf-8");
     const parsed = JSON.parse(manifestJson) as unknown;
     if (!isLegacyManifest(parsed)) {
-      logger.warn(`[DeviceSnapshot] Legacy manifest for '${snapshotName}' is invalid`);
+      logger.warn(`[DeviceSnapshot] Manifest at '${manifestPath}' has an unexpected shape`);
       return null;
     }
-
-    return normalizeLegacyManifest(snapshotName, parsed);
+    return parsed;
   } catch (error) {
+    // ENOENT (this manifest filename doesn't exist here) is an expected miss —
+    // the caller tries the next filename/source. Anything else (malformed
+    // JSON, permission error) is unexpected and worth a trace, but still just
+    // degrades to "no manifest found here" rather than throwing (best-effort
+    // recovery path).
     const code = (error as NodeJS.ErrnoException).code;
     if (code !== "ENOENT") {
-      logger.warn(
-        `[DeviceSnapshot] Failed to read legacy manifest for '${snapshotName}': ${error}`,
-      );
+      logger.warn(`[DeviceSnapshot] Failed to read manifest at '${manifestPath}': ${error}`);
     }
     return null;
   }
+}
+
+/**
+ * Read the full manifest for `snapshotName`, preferring the modern
+ * `metadata.json` that every current capture path writes at the (possibly
+ * scoped) snapshot directory — this is the same artifact iOS capture writes
+ * via `CaptureSnapshot.saveIosMetadata` (`getMetadataPath`) — and falling back
+ * to the legacy flat `manifest.json` for pre-#5707 snapshots that predate both
+ * `metadata.json` and directory scoping (issue #6492).
+ */
+async function readSnapshotManifest(
+  snapshotName: string,
+  snapshotStore: DeviceSnapshotStore,
+  pathOptions: SnapshotPathOptions | undefined,
+): Promise<DeviceSnapshotManifest | null> {
+  const modern = await readManifestFile(snapshotStore.getMetadataPath(snapshotName, pathOptions));
+  if (modern) {
+    return normalizeLegacyManifest(snapshotName, modern);
+  }
+
+  const legacyPath = path.join(
+    snapshotStore.getSnapshotPathWithOptions(snapshotName, pathOptions),
+    LEGACY_MANIFEST_FILENAME,
+  );
+  const legacy = await readManifestFile(legacyPath);
+  if (legacy) {
+    return normalizeLegacyManifest(snapshotName, legacy);
+  }
+
+  return null;
+}
+
+/**
+ * Reconstruct a manifest from settings.json alone for a settings-only Android
+ * capture (`CaptureSnapshot.saveSettings`, `getSettingsPath`) that has no
+ * metadata.json/manifest.json anywhere — the case where settings were
+ * "write-only" (issue #6492). settings.json carries none of the manifest's
+ * other fields, so anything not derivable from the scan context (the
+ * AVD-scoped directory name, if any) is left at a safe, honestly-unknown
+ * default rather than guessed — deviceId in particular cannot be recovered.
+ */
+async function readSettingsOnlyManifest(
+  snapshotName: string,
+  snapshotStore: DeviceSnapshotStore,
+  pathOptions: SnapshotPathOptions | undefined,
+  now: () => Date,
+): Promise<DeviceSnapshotManifest | null> {
+  const settingsPath = snapshotStore.getSettingsPath(snapshotName, pathOptions);
+
+  let settingsJson: string;
+  try {
+    settingsJson = await fs.readFile(settingsPath, "utf-8");
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      logger.warn(`[DeviceSnapshot] Failed to read settings for '${snapshotName}': ${error}`);
+    }
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(settingsJson);
+  } catch (error) {
+    logger.warn(`[DeviceSnapshot] Settings file for '${snapshotName}' is not valid JSON: ${error}`);
+    return null;
+  }
+
+  if (!isSettingsPayload(parsed)) {
+    logger.warn(`[DeviceSnapshot] Settings file for '${snapshotName}' has an unexpected shape`);
+    return null;
+  }
+
+  return {
+    snapshotName,
+    timestamp: now().toISOString(),
+    deviceId: "",
+    deviceName: pathOptions?.avdName ?? "",
+    platform: "android",
+    snapshotType: "adb",
+    includeAppData: false,
+    includeSettings: true,
+    settings: parsed,
+  };
+}
+
+/**
+ * Discover a snapshot's manifest from whatever it actually wrote to disk:
+ * the full manifest first (metadata.json, then legacy manifest.json), and —
+ * only for a non-iOS path, since settings.json is never written for iOS —
+ * the settings-only fallback second. Returns null if neither source exists
+ * or parses, so the caller treats the directory as not a recoverable
+ * snapshot rather than throwing (issue #6492).
+ */
+async function discoverSnapshotManifest(
+  snapshotName: string,
+  snapshotStore: DeviceSnapshotStore,
+  pathOptions: SnapshotPathOptions | undefined,
+  now: () => Date,
+): Promise<DeviceSnapshotManifest | null> {
+  const manifest = await readSnapshotManifest(snapshotName, snapshotStore, pathOptions);
+  if (manifest) {
+    return manifest;
+  }
+
+  if (pathOptions?.platform === "ios") {
+    return null;
+  }
+
+  return readSettingsOnlyManifest(snapshotName, snapshotStore, pathOptions, now);
 }
 
 async function importLegacySnapshot(
@@ -330,8 +453,9 @@ async function importLegacySnapshot(
   snapshotStore: DeviceSnapshotStore,
   snapshotRepository: DeviceSnapshotRepository,
   now: () => Date,
+  pathOptions?: SnapshotPathOptions,
 ): Promise<DeviceSnapshotRecord | null> {
-  const sizeBytes = await snapshotStore.getSnapshotSizeBytes(snapshotName);
+  const sizeBytes = await snapshotStore.getSnapshotSizeBytes(snapshotName, pathOptions);
   const fallbackTimestamp = now().toISOString();
   const createdAt = resolveLegacyTimestamp(manifest.timestamp, fallbackTimestamp);
 
@@ -364,15 +488,93 @@ async function hydrateLegacySnapshot(
   snapshotRepository: DeviceSnapshotRepository,
   now: () => Date,
 ): Promise<DeviceSnapshotRecord | null> {
-  const manifest = await readLegacyManifest(snapshotName, snapshotStore);
-  if (!manifest) {
+  const flatManifest = await discoverSnapshotManifest(snapshotName, snapshotStore, undefined, now);
+  if (flatManifest) {
+    return importLegacySnapshot(snapshotName, flatManifest, snapshotStore, snapshotRepository, now);
+  }
+
+  // Not at the flat/unscoped path — a restore-by-name doesn't know which
+  // AVD/device scope (if any) holds this snapshot, so probe every scoped
+  // directory the same way importScopedLegacySnapshots does (#5707, #6492).
+  const scoped = await findScopedSnapshotManifest(snapshotName, snapshotStore, now);
+  if (!scoped) {
     return null;
   }
 
-  return importLegacySnapshot(snapshotName, manifest, snapshotStore, snapshotRepository, now);
+  return importLegacySnapshot(
+    snapshotName,
+    scoped.manifest,
+    snapshotStore,
+    snapshotRepository,
+    now,
+    scoped.pathOptions,
+  );
 }
 
-async function importLegacySnapshotArchive(
+/**
+ * Enumerate the AVD/device-scoped directories under `android/` and `ios/`
+ * (the layout every current capture path writes to since #5707), yielding
+ * one `SnapshotPathOptions` per scope directory found. Isolated so both the
+ * single-name lookup (`findScopedSnapshotManifest`) and the full-archive scan
+ * (`importScopedLegacySnapshots`) derive the same path shape the writers use
+ * rather than re-deriving path structure at each call site (issue #6492).
+ */
+async function* iterateScopedSnapshotDirs(
+  snapshotStore: DeviceSnapshotStore,
+): AsyncGenerator<{ pathOptions: SnapshotPathOptions; scopedDirPath: string }> {
+  for (const platform of ["android", "ios"] as const) {
+    const scopeRootPath = path.join(snapshotStore.getBasePath(), platform);
+    let deviceDirs: Dirent[];
+    try {
+      deviceDirs = await fs.readdir(scopeRootPath, { withFileTypes: true });
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        logger.warn(`[DeviceSnapshot] Failed to scan ${platform} snapshot scope: ${error}`);
+      }
+      continue;
+    }
+
+    for (const deviceDir of deviceDirs) {
+      if (!deviceDir.isDirectory()) {
+        continue;
+      }
+
+      const pathOptions: SnapshotPathOptions =
+        platform === "ios"
+          ? { platform: "ios", deviceId: deviceDir.name }
+          : { platform: "android", avdName: deviceDir.name };
+
+      yield { pathOptions, scopedDirPath: path.join(scopeRootPath, deviceDir.name) };
+    }
+  }
+}
+
+async function findScopedSnapshotManifest(
+  snapshotName: string,
+  snapshotStore: DeviceSnapshotStore,
+  now: () => Date,
+): Promise<{ manifest: DeviceSnapshotManifest; pathOptions: SnapshotPathOptions } | null> {
+  for await (const { pathOptions } of iterateScopedSnapshotDirs(snapshotStore)) {
+    const exists = await snapshotStore.snapshotDirectoryExists(snapshotName, pathOptions);
+    if (!exists) {
+      continue;
+    }
+
+    const manifest = await discoverSnapshotManifest(snapshotName, snapshotStore, pathOptions, now);
+    if (manifest) {
+      return { manifest, pathOptions };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Import every legacy-recoverable snapshot at the flat/unscoped base path
+ * (pre-#5707 layout, and physical-device captures that never scope by AVD).
+ */
+async function importFlatLegacySnapshots(
   snapshotRepository: DeviceSnapshotRepository,
   snapshotStore: DeviceSnapshotStore,
   now: () => Date,
@@ -398,18 +600,23 @@ async function importLegacySnapshotArchive(
 
     const snapshotName = entry.name;
     // A `<name>${SNAPSHOT_REPLACING_SUFFIX}` directory is an interrupted-overwrite
-    // set-aside copy (holding the prior snapshot's manifest.json), never a real
+    // set-aside copy (holding the prior snapshot's manifest), never a real
     // snapshot — importing it would resurrect stale data as a phantom snapshot
     // that consumes archive budget and is "restorable" against dead contents
     // (#5713). Skip it; the next overwrite of the base name clears it.
     if (snapshotName.endsWith(SNAPSHOT_REPLACING_SUFFIX)) {
       continue;
     }
+    // "android"/"ios" are scope roots (#5707), not snapshot directories
+    // themselves — importScopedLegacySnapshots walks their contents.
+    if (isReservedScopeSegment(snapshotName)) {
+      continue;
+    }
     if (existingSnapshots.has(snapshotName)) {
       continue;
     }
 
-    const manifest = await readLegacyManifest(snapshotName, snapshotStore);
+    const manifest = await discoverSnapshotManifest(snapshotName, snapshotStore, undefined, now);
     if (!manifest) {
       continue;
     }
@@ -428,6 +635,97 @@ async function importLegacySnapshotArchive(
   }
 
   return imported;
+}
+
+/**
+ * Import every legacy-recoverable snapshot nested under the `android/<avd>/`
+ * and `ios/<udid>/` scope directories (#5707 layout) that has no DB row yet.
+ * Orphaned scoped directories were previously invisible to this scan — the
+ * top-level `readdir` in importFlatLegacySnapshots never descends into them
+ * (issue #6492).
+ */
+async function importScopedLegacySnapshots(
+  snapshotRepository: DeviceSnapshotRepository,
+  snapshotStore: DeviceSnapshotStore,
+  now: () => Date,
+  existingSnapshots: Set<string>,
+): Promise<boolean> {
+  let imported = false;
+
+  for await (const { pathOptions, scopedDirPath } of iterateScopedSnapshotDirs(snapshotStore)) {
+    let snapshotDirs: Dirent[];
+    try {
+      snapshotDirs = await fs.readdir(scopedDirPath, { withFileTypes: true });
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        logger.warn(`[DeviceSnapshot] Failed to scan snapshots under ${scopedDirPath}: ${error}`);
+      }
+      continue;
+    }
+
+    for (const snapshotDir of snapshotDirs) {
+      if (!snapshotDir.isDirectory()) {
+        continue;
+      }
+
+      const snapshotName = snapshotDir.name;
+      // Same interrupted-overwrite set-aside case as the flat scan, but
+      // nested one level deeper under the AVD/device scope (#5713, #6492).
+      if (snapshotName.endsWith(SNAPSHOT_REPLACING_SUFFIX)) {
+        continue;
+      }
+      if (existingSnapshots.has(snapshotName)) {
+        continue;
+      }
+
+      const manifest = await discoverSnapshotManifest(snapshotName, snapshotStore, pathOptions, now);
+      if (!manifest) {
+        continue;
+      }
+
+      const record = await importLegacySnapshot(
+        snapshotName,
+        manifest,
+        snapshotStore,
+        snapshotRepository,
+        now,
+        pathOptions,
+      );
+      if (record) {
+        existingSnapshots.add(snapshotName);
+        imported = true;
+      }
+    }
+  }
+
+  return imported;
+}
+
+async function importLegacySnapshotArchive(
+  snapshotRepository: DeviceSnapshotRepository,
+  snapshotStore: DeviceSnapshotStore,
+  now: () => Date,
+  existingSnapshots: Set<string>,
+): Promise<boolean> {
+  // Order matters only for existingSnapshots de-duplication: a flat-path
+  // snapshot is checked first, so a scoped orphan sharing its name is skipped
+  // rather than double-imported (the name-keyed record table cannot tell
+  // them apart — a pre-existing limitation, see #5741 item 4).
+  const importedFlat = await importFlatLegacySnapshots(
+    snapshotRepository,
+    snapshotStore,
+    now,
+    existingSnapshots,
+  );
+  const importedScoped = await importScopedLegacySnapshots(
+    snapshotRepository,
+    snapshotStore,
+    now,
+    existingSnapshots,
+  );
+
+  return importedFlat || importedScoped;
 }
 
 async function notifySnapshotResources(): Promise<void> {

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -811,4 +811,198 @@ describe("deviceSnapshotManager", () => {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }
   });
+
+  describe("scoped on-disk settings/metadata read-back (#6492)", () => {
+    test("listDeviceSnapshots discovers an AVD-scoped Android metadata.json with no DB row", async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-manager-scoped-meta-"));
+      try {
+        const realStore = new DeviceSnapshotStore(tempRoot);
+        await realStore.ensureSnapshotsDirectory();
+        await setDeviceSnapshotManagerDependencies({ snapshotStore: realStore as any });
+
+        const snapshotName = "baseline";
+        const androidOptions = { platform: "android" as const, avdName: "Pixel_7" };
+        const scopedDir = realStore.getSnapshotPathWithOptions(snapshotName, androidOptions);
+        await fs.mkdir(scopedDir, { recursive: true });
+
+        const timestamp = new Date(fakeTimer.now()).toISOString();
+        const manifest: DeviceSnapshotManifest = {
+          snapshotName,
+          timestamp,
+          deviceId: "emulator-5554",
+          deviceName: "Pixel_7",
+          platform: "android",
+          snapshotType: "adb",
+          includeAppData: false,
+          includeSettings: true,
+          settings: { global: { foo: "bar" } },
+        };
+        await fs.writeFile(
+          realStore.getMetadataPath(snapshotName, androidOptions),
+          JSON.stringify(manifest, null, 2),
+        );
+
+        // No DB row exists for this snapshot yet — it lives only on disk.
+        expect(await repository.getSnapshot(snapshotName)).toBeNull();
+
+        const { snapshots, count, totalSizeBytes } = await listDeviceSnapshots();
+
+        expect(count).toBe(1);
+        expect(snapshots[0]?.snapshotName).toBe(snapshotName);
+        expect(totalSizeBytes).toBeGreaterThan(0);
+
+        const record = await repository.getSnapshot(snapshotName);
+        expect(record).not.toBeNull();
+        expect(record?.manifest.settings).toEqual(manifest.settings);
+      } finally {
+        await fs.rm(tempRoot, { recursive: true, force: true });
+      }
+    });
+
+    test("restoreDeviceSnapshot hydrates an AVD-scoped metadata.json snapshot directly, with no prior listDeviceSnapshots call", async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-manager-scoped-restore-"));
+      try {
+        const realStore = new DeviceSnapshotStore(tempRoot);
+        await realStore.ensureSnapshotsDirectory();
+        await setDeviceSnapshotManagerDependencies({ snapshotStore: realStore as any });
+
+        const snapshotName = "baseline";
+        const androidOptions = { platform: "android" as const, avdName: "Pixel_7" };
+        const scopedDir = realStore.getSnapshotPathWithOptions(snapshotName, androidOptions);
+        await fs.mkdir(scopedDir, { recursive: true });
+
+        const timestamp = new Date(fakeTimer.now()).toISOString();
+        const manifest: DeviceSnapshotManifest = {
+          snapshotName,
+          timestamp,
+          deviceId: "emulator-5554",
+          deviceName: "Pixel_7",
+          platform: "android",
+          snapshotType: "adb",
+          includeAppData: false,
+          includeSettings: true,
+          settings: { global: { foo: "bar" } },
+        };
+        await fs.writeFile(
+          realStore.getMetadataPath(snapshotName, androidOptions),
+          JSON.stringify(manifest, null, 2),
+        );
+
+        expect(await repository.getSnapshot(snapshotName)).toBeNull();
+
+        // No listDeviceSnapshots() call first — restore must find it on its own.
+        const { result, manifest: returnedManifest } = await restoreDeviceSnapshot(TEST_DEVICE, {
+          snapshotName,
+        });
+
+        expect(result.snapshotType).toBe("adb");
+        expect(returnedManifest.settings).toEqual(manifest.settings);
+        expect(restoreCalls[0]?.manifest.settings).toEqual(manifest.settings);
+      } finally {
+        await fs.rm(tempRoot, { recursive: true, force: true });
+      }
+    });
+
+    test("restoreDeviceSnapshot round-trips a settings-only Android capture's settings.json when the DB row is absent", async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-manager-settings-only-"));
+      try {
+        const realStore = new DeviceSnapshotStore(tempRoot);
+        await realStore.ensureSnapshotsDirectory();
+        await setDeviceSnapshotManagerDependencies({ snapshotStore: realStore as any });
+
+        const snapshotName = "settings-baseline";
+        const androidOptions = { platform: "android" as const, avdName: "Pixel_7" };
+        const scopedDir = realStore.getSnapshotPathWithOptions(snapshotName, androidOptions);
+        await fs.mkdir(scopedDir, { recursive: true });
+
+        // This is exactly what CaptureSnapshot.saveSettings writes: the raw
+        // settings triplet, NOT a full manifest — no metadata.json/manifest.json
+        // exists anywhere for this snapshot (mirrors the real non-VM Android
+        // settings-only capture path).
+        const settings = {
+          global: { some_global_setting: "1" },
+          secure: { some_secure_setting: "on" },
+          system: { some_system_setting: "off" },
+        };
+        await fs.writeFile(
+          realStore.getSettingsPath(snapshotName, androidOptions),
+          JSON.stringify(settings, null, 2),
+        );
+
+        expect(await repository.getSnapshot(snapshotName)).toBeNull();
+
+        const { result, manifest } = await restoreDeviceSnapshot(TEST_DEVICE, {
+          snapshotName,
+        });
+
+        expect(result.snapshotType).toBe("adb");
+        expect(manifest.platform).toBe("android");
+        expect(manifest.includeSettings).toBe(true);
+        expect(manifest.settings).toEqual(settings);
+        expect(restoreCalls[0]?.manifest.settings).toEqual(settings);
+      } finally {
+        await fs.rm(tempRoot, { recursive: true, force: true });
+      }
+    });
+
+    test("listDeviceSnapshots skips a '.replacing' set-aside directory nested under android/<avd>/", async () => {
+      const tempRoot = await fs.mkdtemp(
+        path.join(os.tmpdir(), "snapshot-manager-scoped-replacing-"),
+      );
+      try {
+        const realStore = new DeviceSnapshotStore(tempRoot);
+        await realStore.ensureSnapshotsDirectory();
+        await setDeviceSnapshotManagerDependencies({ snapshotStore: realStore as any });
+
+        const androidOptions = { platform: "android" as const, avdName: "Pixel_5" };
+        const asideDir = realStore.getSnapshotPathWithOptions("ghost.replacing", androidOptions);
+        await fs.mkdir(asideDir, { recursive: true });
+
+        const manifest: DeviceSnapshotManifest = {
+          snapshotName: "ghost",
+          timestamp: new Date(0).toISOString(),
+          deviceId: "emulator-5554",
+          deviceName: "Pixel_5",
+          platform: "android",
+          snapshotType: "adb",
+          includeAppData: false,
+          includeSettings: true,
+        };
+        await fs.writeFile(path.join(asideDir, "metadata.json"), JSON.stringify(manifest));
+
+        const { snapshots } = await listDeviceSnapshots();
+
+        expect(snapshots.some((entry) => entry.snapshotName === "ghost.replacing")).toBe(false);
+        expect(await repository.getSnapshot("ghost.replacing")).toBeNull();
+      } finally {
+        await fs.rm(tempRoot, { recursive: true, force: true });
+      }
+    });
+
+    test("listDeviceSnapshots degrades a malformed scoped metadata.json to a skip, without throwing", async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-manager-scoped-bad-"));
+      try {
+        const realStore = new DeviceSnapshotStore(tempRoot);
+        await realStore.ensureSnapshotsDirectory();
+        await setDeviceSnapshotManagerDependencies({ snapshotStore: realStore as any });
+
+        const snapshotName = "corrupt";
+        const androidOptions = { platform: "android" as const, avdName: "Pixel_5" };
+        const scopedDir = realStore.getSnapshotPathWithOptions(snapshotName, androidOptions);
+        await fs.mkdir(scopedDir, { recursive: true });
+        await fs.writeFile(
+          realStore.getMetadataPath(snapshotName, androidOptions),
+          "{ not valid json",
+        );
+
+        const { snapshots, count } = await listDeviceSnapshots();
+
+        expect(count).toBe(0);
+        expect(snapshots).toEqual([]);
+        expect(await repository.getSnapshot(snapshotName)).toBeNull();
+      } finally {
+        await fs.rm(tempRoot, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/test/utils/deviceSnapshotStore.property.test.ts
+++ b/test/utils/deviceSnapshotStore.property.test.ts
@@ -154,7 +154,8 @@ describe("DeviceSnapshotStore.getSnapshotPathWithOptions (property-based, #6493)
         fc.constantFrom<"android" | "ios">("android", "ios"),
         fc.oneof(safeSegment, hostileSegment, escapingSegment),
         (snapshotName, platform, scopeSegment) => {
-          const options = platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
+          const options =
+            platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
           const result = attempt(() => store.getSnapshotPathWithOptions(snapshotName, options));
 
           if (!result.ok) {
@@ -175,7 +176,8 @@ describe("DeviceSnapshotStore.getSnapshotPathWithOptions (property-based, #6493)
         fc.constantFrom<"android" | "ios">("android", "ios"),
         escapingSegment,
         (snapshotName, platform, scopeSegment) => {
-          const options = platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
+          const options =
+            platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
           const result = attempt(() => store.getSnapshotPathWithOptions(snapshotName, options));
           return result.ok === false && result.error instanceof ActionableError;
         },
@@ -191,7 +193,8 @@ describe("DeviceSnapshotStore.getSnapshotPathWithOptions (property-based, #6493)
         fc.constantFrom<"android" | "ios">("android", "ios"),
         safeSegment,
         (snapshotName, platform, scopeSegment) => {
-          const options = platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
+          const options =
+            platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
           const result = attempt(() => store.getSnapshotPathWithOptions(snapshotName, options));
           return result.ok === true && isStrictlyInside(basePath, result.value);
         },
@@ -207,7 +210,8 @@ describe("DeviceSnapshotStore.getSnapshotPathWithOptions (property-based, #6493)
         fc.constantFrom<"android" | "ios">("android", "ios"),
         safeSegment,
         (snapshotName, platform, scopeSegment) => {
-          const options = platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
+          const options =
+            platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
           const snapshotPath = store.getSnapshotPathWithOptions(snapshotName, options);
           const settingsPath = store.getSettingsPath(snapshotName, options);
           const metadataPath = store.getMetadataPath(snapshotName, options);


### PR DESCRIPTION
## Summary

`listDeviceSnapshots` and restore recognized only a legacy flat `manifest.json`, so
snapshots whose on-disk state is a **scoped** `metadata.json` (`ios/<udid>/`,
`android/<avd>/`) or a **settings-only** `settings.json` (a non-VM Android capture
writes no manifest at all) were invisible to listing, contributed nothing to the
archive-size total, and failed to restore with `Snapshot '<name>' not found` even
though capture reported success.

Adds read-back/discovery on the **read side only** (write paths untouched):
- `readSnapshotManifest` prefers `metadata.json`, falls back to the legacy flat
  `manifest.json` (byte-for-byte legacy behavior preserved).
- `readSettingsOnlyManifest` reconstructs a manifest from `settings.json` alone for
  non-VM Android captures (`deviceId` is genuinely unrecoverable from disk → `""`).
- `iterateScopedSnapshotDirs` / `importScopedLegacySnapshots` walk `android/<avd>/`
  and `ios/<udid>/`, skipping `.replacing` set-aside dirs at both the flat and nested
  level.

All path derivation reuses `DeviceSnapshotStore`'s `getMetadataPath`/`getSettingsPath`/
`getSnapshotPathWithOptions`; malformed/missing files degrade to a skip, never throw.

Part of epic #6379 (snapshot cluster). Independent of #6491 (touches the
eviction-lock functions) and #6493 (touches `DeviceSnapshotStore`/validation).

## Linked Issue

Closes #6492

## Bug / Regression Context

- **Observed symptom:** a scoped-`metadata.json` or settings-only Android snapshot with no DB row is not listed, not counted toward the archive total, and restore reports `Snapshot '<name>' not found`.
- **Repro:** capture (non-VM Android → `settings.json`; scoped → `metadata.json`) then drop/miss the DB row; the on-disk artifact is never read back.

## Validation

- [x] 5 new tests in `test/server/deviceSnapshotManager.test.ts` (AVD-scoped `metadata.json` discovery, settings-only round-trip, `.replacing` skip nested under `android/<avd>/`, malformed-scoped degrade-to-skip, restore hydration). Red first: 3 of 5 failed pre-fix (`count: 0`, `Snapshot not found`).
- [x] `bun test deviceSnapshotManager + deviceSnapshotStore` → 37 pass; `CaptureSnapshot`/`RestoreSnapshot` → 70 pass; full repo → 6920 pass.
- [x] `bun run lint` — no new violations. `bun run typecheck` — no new errors.
- [x] `slack codex review` self-review: no blocking findings.

## Follow-ups

- Settings-only recovery sets `deviceId=""` (unrecoverable from disk); affects only the listed `deviceId` field, not restore. VM-type Android snapshots write no on-disk artifact and remain unrecoverable from disk if the DB row is lost — out of this issue's scope (`settings.json`/`metadata.json` only).
