### PR TITLE
fix(snapshot): validate scope path segments so resolved paths can't escape the base dir (#6493)

### DIFF
--- a/src/utils/DeviceSnapshotStore.ts
+++ b/src/utils/DeviceSnapshotStore.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "fs";
 import * as path from "path";
 import * as os from "os";
 import { logger } from "./logger";
+import { assertSafePathSegment } from "./snapshotNameValidation";
 import type { Platform } from "../models";
 
 /**
@@ -51,12 +52,22 @@ export class DeviceSnapshotStore {
 
   getSnapshotPathWithOptions(snapshotName: string, options?: SnapshotPathOptions): string {
     if (options?.platform === "ios" && options.deviceId) {
+      // deviceId is the simulator UDID, sourced from simctl rather than a
+      // validated caller-supplied name. Reject it before it is joined onto
+      // basePath — an unvalidated scope segment containing '..' or a
+      // separator can otherwise resolve the scoped path outside the
+      // snapshots directory entirely (issue #6493).
+      assertSafePathSegment("iOS device id", options.deviceId);
       return path.join(this.basePath, "ios", options.deviceId, snapshotName);
     }
 
     // Android emulators scope by AVD name so the same snapshot name can be
     // reused across AVDs without a filesystem collision (#5707).
     if (options?.platform === "android" && options.avdName) {
+      // avdName comes from `adb emu avd name` output (trimmed to its first
+      // line), not from a validated caller-supplied name. Same containment
+      // rule as above (issue #6493).
+      assertSafePathSegment("Android AVD name", options.avdName);
       return path.join(this.basePath, "android", options.avdName, snapshotName);
     }
 

--- a/src/utils/snapshotNameValidation.ts
+++ b/src/utils/snapshotNameValidation.ts
@@ -2,6 +2,68 @@ import * as path from "path";
 import { ActionableError } from "../models";
 
 /**
+ * Reject a path segment that could escape its intended parent directory once
+ * joined onto it with `path.join`. Shared by {@link assertSafeSnapshotName}
+ * (the snapshot name itself) and any other single path segment that is joined
+ * onto `DeviceSnapshotStore`'s base directory without going through name
+ * validation — e.g. the Android AVD name / iOS device UDID segments
+ * `getSnapshotPathWithOptions` scopes snapshots by, which come from external
+ * tool output (`adb emu avd name`, simctl) rather than a validated
+ * caller-supplied name (issue #6493).
+ *
+ * `kind` is a human-readable label (e.g. "snapshot name", "Android AVD name")
+ * used only in the thrown message, so one canonical check backs every path
+ * segment this codebase joins onto a base directory rather than a second copy
+ * per call site.
+ *
+ * The segment must be a single, non-empty path segment made of ordinary
+ * characters — no separators, no `.`/`..`, no NUL, no absolute path.
+ */
+export function assertSafePathSegment(kind: string, value: string): void {
+  const reject = (reason: string): never => {
+    throw new ActionableError(
+      `Invalid ${kind} '${value}': ${reason}. Use a single path segment ` +
+        "without path separators, '.'/'..', or an absolute path.",
+    );
+  };
+
+  if (typeof value !== "string" || value.trim().length === 0) {
+    reject(`${kind} must be a non-empty string`);
+    return;
+  }
+
+  // NUL can truncate a path in native syscalls, hiding the real target.
+  if (value.includes("\0")) {
+    reject(`${kind} contains a NUL byte`);
+    return;
+  }
+
+  // Any separator (POSIX '/' or Windows '\\') makes the value more than one
+  // path segment — this catches 'a/b' and the leading separator of most
+  // absolute paths — so joining it can descend into or escape the base
+  // directory.
+  if (value.includes("/") || value.includes("\\")) {
+    reject(`${kind} contains a path separator`);
+    return;
+  }
+
+  // '.' and '..' as the whole value are the traversal primitives that have no
+  // separator of their own; '..' escapes the base directory outright.
+  if (value === "." || value === "..") {
+    reject(`${kind} is a path traversal segment`);
+    return;
+  }
+
+  // Absolute paths (including Windows drive-letter forms like 'C:\\x' that
+  // survive the separator check on POSIX) must never be joined onto a base
+  // directory.
+  if (path.isAbsolute(value) || path.win32.isAbsolute(value)) {
+    reject(`${kind} is an absolute path`);
+    return;
+  }
+}
+
+/**
  * Reject a `snapshotName` that could escape the snapshots directory before it
  * reaches any filesystem path or emulator/simulator command.
  *
@@ -17,43 +79,5 @@ import { ActionableError } from "../models";
  * characters — no separators, no `.`/`..`, no NUL, no absolute path.
  */
 export function assertSafeSnapshotName(snapshotName: string): void {
-  const reject = (reason: string): never => {
-    throw new ActionableError(
-      `Invalid snapshot name '${snapshotName}': ${reason}. Use a single name segment ` +
-        "without path separators, '.'/'..', or an absolute path.",
-    );
-  };
-
-  if (typeof snapshotName !== "string" || snapshotName.trim().length === 0) {
-    reject("name must be a non-empty string");
-    return;
-  }
-
-  // NUL can truncate a path in native syscalls, hiding the real target.
-  if (snapshotName.includes("\0")) {
-    reject("name contains a NUL byte");
-    return;
-  }
-
-  // Any separator (POSIX '/' or Windows '\\') makes the name more than one path
-  // segment — this catches 'a/b' and the leading separator of most absolute
-  // paths — so joining it can descend into or escape the snapshots directory.
-  if (snapshotName.includes("/") || snapshotName.includes("\\")) {
-    reject("name contains a path separator");
-    return;
-  }
-
-  // '.' and '..' as the whole name are the traversal primitives that have no
-  // separator of their own; '..' escapes the snapshots directory outright.
-  if (snapshotName === "." || snapshotName === "..") {
-    reject("name is a path traversal segment");
-    return;
-  }
-
-  // Absolute paths (including Windows drive-letter forms like 'C:\\x' that
-  // survive the separator check on POSIX) must never be joined onto basePath.
-  if (path.isAbsolute(snapshotName) || path.win32.isAbsolute(snapshotName)) {
-    reject("name is an absolute path");
-    return;
-  }
+  assertSafePathSegment("snapshot name", snapshotName);
 }

--- a/test/utils/deviceSnapshotStore.property.test.ts
+++ b/test/utils/deviceSnapshotStore.property.test.ts
@@ -1,0 +1,252 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import * as path from "path";
+import * as os from "os";
+import {
+  DeviceSnapshotStore,
+  SNAPSHOT_REPLACING_SUFFIX,
+  type SnapshotPathOptions,
+} from "../../src/utils/DeviceSnapshotStore";
+import { assertSafeSnapshotName } from "../../src/utils/snapshotNameValidation";
+import { ActionableError } from "../../src/models";
+
+// Property-based tests for the RESOLVED snapshot path (issue #6493).
+//
+// `assertSafeSnapshotName` only validates the snapshot name itself
+// (property-tested in test/utils/snapshotNameValidation.property.test.ts).
+// `DeviceSnapshotStore.getSnapshotPathWithOptions` composes the final on-disk
+// path from TWO more segments that were never validated: the Android AVD name
+// (sourced from `adb emu avd name` output) and the iOS device UDID (sourced
+// from simctl) — see SnapshotPathOptions. Both are external-tool output, not a
+// validated caller-supplied name, so a hostile or malformed value can carry a
+// '..' or path-separator component straight into `path.join(basePath, scope,
+// name)`.
+//
+// The one promise every caller relies on — captures, deletes, eviction,
+// settings/metadata/app-data writes all funnel through this one function — is
+// CONTAINMENT: the resolved path must stay strictly inside `basePath`. This
+// suite pins that invariant across a large, adversarial input space, exercising
+// the REAL `DeviceSnapshotStore` (not a reimplementation of path.join).
+//
+// A pinned seed keeps CI deterministic (see test/utils/Backoff.property.test.ts
+// for the rationale). On failure fast-check prints the seed and the shrunk
+// counterexample; bump `numRuns` locally to widen the search.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const basePath = path.join(os.tmpdir(), "am-device-snapshot-store-property-test");
+const store = new DeviceSnapshotStore(basePath);
+
+// Snapshot names accepted by the real name validator. `DeviceSnapshotStore`
+// itself does not re-validate the name (that is the caller's job), so this
+// generator exercises the store the way a validated caller does, without
+// reimplementing `assertSafeSnapshotName`'s acceptance logic.
+function isAcceptedName(name: string): boolean {
+  try {
+    assertSafeSnapshotName(name);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const nameUnit = fc.oneof(
+  fc.constantFrom("a", "b", "1", "-", "_", ".", " ", "/", "\\", "\0"),
+  fc.integer({ min: 0x20, max: 0x7e }).map((code) => String.fromCharCode(code)),
+);
+const acceptedName = fc
+  .string({ unit: nameUnit, minLength: 0, maxLength: 16 })
+  .filter(isAcceptedName);
+
+// Units biased toward the characters that make a scope segment escape
+// basePath: separators, dot segments, NUL, drive-letter/home prefixes — mixed
+// with ordinary characters so a meaningful fraction of samples are plain.
+const hostileUnit = fc.oneof(
+  fc.constantFrom(
+    "/",
+    "\\",
+    ".",
+    "..",
+    "\0",
+    ":",
+    "~",
+    "C:",
+    " ",
+    "\t",
+    "a",
+    "b",
+    "1",
+    "-",
+    "_",
+    "é",
+  ),
+  fc.integer({ min: 0x20, max: 0x7e }).map((code) => String.fromCharCode(code)),
+);
+const hostileSegment = fc.string({ unit: hostileUnit, maxLength: 24 });
+
+// Segments deliberately constructed to escape `basePath` once joined the way
+// `getSnapshotPathWithOptions` does — a leading `..` component, an embedded
+// separator, or an absolute-path prefix — the exact shapes `avdName`/
+// `deviceId` could take if the underlying tool ever emits unexpected output.
+//
+// A SINGLE leading '..' only cancels the fixed "android"/"ios" prefix segment
+// and lands back inside basePath at the current nesting depth (a scoping
+// bypass, not an outright escape today) — but TWO OR MORE leading '..'
+// components climb past basePath itself onto the real filesystem, and even a
+// single '..' would escape the moment a future change adds another scope
+// level (exactly the fragility issue #6493 flags). Both shapes belong here:
+// the validator must reject the segment on its own shape, not on whether it
+// happens to still resolve inside basePath at today's fixed nesting depth.
+const dotDotDepth = fc.integer({ min: 1, max: 4 });
+const escapingSegment = fc.oneof(
+  fc.constant(".."),
+  fc.constant("."),
+  fc
+    .tuple(dotDotDepth, fc.string({ unit: hostileUnit, maxLength: 8 }))
+    .map(([depth, s]) => `${Array(depth).fill("..").join("/")}/${s || "x"}`),
+  fc
+    .tuple(dotDotDepth, fc.string({ unit: hostileUnit, maxLength: 8 }))
+    .map(([depth, s]) => `${Array(depth).fill("..").join("\\")}\\${s || "x"}`),
+  fc.string({ unit: hostileUnit, maxLength: 8 }).map((s) => `/${s}`),
+  fc.string({ unit: hostileUnit, maxLength: 8 }).map((s) => `C:\\${s}`),
+  fc.string({ unit: hostileUnit, maxLength: 8 }).map((s) => `${s || "a"}/${s || "b"}`),
+);
+
+// Ordinary AVD-name / UDID-shaped segments — the accepted domain real device
+// identifiers take. AVD names are typically snake/kebab-ish; simulator UDIDs
+// are upper-hex-with-dashes. Neither ever needs a separator, dot segment, or
+// absolute-path prefix.
+const safeSegmentChars = Array.from(
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_",
+);
+const safeSegment = fc
+  .string({ unit: fc.constantFrom(...safeSegmentChars), minLength: 1, maxLength: 24 })
+  .filter((s) => s !== "." && s !== "..");
+
+function isStrictlyInside(base: string, candidate: string): boolean {
+  const resolvedBase = path.resolve(base);
+  const resolvedCandidate = path.resolve(candidate);
+  return resolvedCandidate.startsWith(resolvedBase + path.sep);
+}
+
+type Attempt = { ok: true; value: string } | { ok: false; error: unknown };
+
+function attempt(fn: () => string): Attempt {
+  try {
+    return { ok: true, value: fn() };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+function androidOptions(avdName: string): SnapshotPathOptions {
+  return { platform: "android", avdName };
+}
+
+function iosOptions(deviceId: string): SnapshotPathOptions {
+  return { platform: "ios", deviceId };
+}
+
+describe("DeviceSnapshotStore.getSnapshotPathWithOptions (property-based, #6493)", () => {
+  test("containment: every resolved scoped path stays strictly inside basePath, or is rejected", () => {
+    fc.assert(
+      fc.property(
+        acceptedName,
+        fc.constantFrom<"android" | "ios">("android", "ios"),
+        fc.oneof(safeSegment, hostileSegment, escapingSegment),
+        (snapshotName, platform, scopeSegment) => {
+          const options = platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
+          const result = attempt(() => store.getSnapshotPathWithOptions(snapshotName, options));
+
+          if (!result.ok) {
+            // Validation rejected the scope segment — nothing escaped.
+            return result.error instanceof ActionableError;
+          }
+          return isStrictlyInside(basePath, result.value);
+        },
+      ),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("hardening: a scope segment built to escape basePath is always rejected", () => {
+    fc.assert(
+      fc.property(
+        acceptedName,
+        fc.constantFrom<"android" | "ios">("android", "ios"),
+        escapingSegment,
+        (snapshotName, platform, scopeSegment) => {
+          const options = platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
+          const result = attempt(() => store.getSnapshotPathWithOptions(snapshotName, options));
+          return result.ok === false && result.error instanceof ActionableError;
+        },
+      ),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("acceptance: ordinary AVD-name / UDID-shaped scope segments are never rejected", () => {
+    fc.assert(
+      fc.property(
+        acceptedName,
+        fc.constantFrom<"android" | "ios">("android", "ios"),
+        safeSegment,
+        (snapshotName, platform, scopeSegment) => {
+          const options = platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
+          const result = attempt(() => store.getSnapshotPathWithOptions(snapshotName, options));
+          return result.ok === true && isStrictlyInside(basePath, result.value);
+        },
+      ),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("derived-path agreement: settings/metadata/app-data paths sit strictly under the resolved snapshot path", () => {
+    fc.assert(
+      fc.property(
+        acceptedName,
+        fc.constantFrom<"android" | "ios">("android", "ios"),
+        safeSegment,
+        (snapshotName, platform, scopeSegment) => {
+          const options = platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
+          const snapshotPath = store.getSnapshotPathWithOptions(snapshotName, options);
+          const settingsPath = store.getSettingsPath(snapshotName, options);
+          const metadataPath = store.getMetadataPath(snapshotName, options);
+          const appDataPath = store.getAppDataPath(snapshotName, options);
+          const replacingPath = `${snapshotPath}${SNAPSHOT_REPLACING_SUFFIX}`;
+
+          return (
+            isStrictlyInside(snapshotPath, settingsPath) &&
+            isStrictlyInside(snapshotPath, metadataPath) &&
+            isStrictlyInside(snapshotPath, appDataPath) &&
+            // The set-aside directory is a SIBLING of the snapshot path, not a
+            // descendant — but it must still resolve inside basePath, and it
+            // must never collide with the snapshot path itself.
+            isStrictlyInside(basePath, replacingPath) &&
+            path.resolve(replacingPath) !== path.resolve(snapshotPath)
+          );
+        },
+      ),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("non-collision: two distinct safe scope segments on the same platform never resolve to the same path", () => {
+    fc.assert(
+      fc.property(
+        acceptedName,
+        fc.constantFrom<"android" | "ios">("android", "ios"),
+        safeSegment,
+        safeSegment,
+        (snapshotName, platform, segmentA, segmentB) => {
+          fc.pre(segmentA !== segmentB);
+          const optionsA = platform === "android" ? androidOptions(segmentA) : iosOptions(segmentA);
+          const optionsB = platform === "android" ? androidOptions(segmentB) : iosOptions(segmentB);
+          const pathA = store.getSnapshotPathWithOptions(snapshotName, optionsA);
+          const pathB = store.getSnapshotPathWithOptions(snapshotName, optionsB);
+          return path.resolve(pathA) !== path.resolve(pathB);
+        },
+      ),
+      RUN_OPTIONS,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`DeviceSnapshotStore.getSnapshotPathWithOptions` scopes snapshots by an Android AVD
name or iOS device UDID and joined that segment straight onto `basePath` **without
validation**. Those segments come from external tool output (`adb emu avd name`,
`simctl`), not a validated caller-supplied name, so a segment containing `..`, a path
separator, or an absolute path could resolve the scoped snapshot path **outside** the
snapshots base directory — a containment that held only by luck of the current fixed
nesting depth (a fast-check property found the escape: `avdName = "../../x"`).

Extracts `assertSafePathSegment(kind, value)` from `assertSafeSnapshotName` (which now
delegates to it, behavior unchanged) and validates the AVD/UDID scope segment in
`getSnapshotPathWithOptions` — the single funnel every scoped path (settings, metadata,
app-data, `.replacing`, delete/size) flows through — so one check closes the escape for
every call site.

Adds a pinned-seed fast-check property suite over the real `DeviceSnapshotStore`:
containment (resolved path strictly under base), hardening (escape-shaped segments
always rejected), acceptance (ordinary AVD/UDID shapes never rejected), derived-path
agreement, and pairwise non-collision.

Part of epic #6379 (snapshot cluster). Additive; independent of #6491/#6492 (touches
`DeviceSnapshotStore`/validation, not the eviction-lock or read-back paths).

## Linked Issue

Closes #6493

## Bug / Regression Context

- **Observed symptom:** no property test pinned that resolved snapshot paths stay inside the base dir; an unvalidated AVD/UDID scope segment (`../../x`) resolves the scoped path outside the snapshots directory.
- **Repro:** `getSnapshotPathWithOptions("name", { platform: "android", avdName: "../../x" })` → path outside `basePath`.

## Validation

- [x] New `test/utils/deviceSnapshotStore.property.test.ts` (5 property tests, seed 1_234_567 × 300 runs). **Red** first: containment + hardening failed on the `../../x` counterexample. **Green** after: all pass; combined snapshot/validation suites 34–141 pass.
- [x] `bun run lint` — no new violations. `bun run typecheck` — no new errors.
- [x] `slack codex review` self-review: ran the property tests (34 + 5 pass), reviewed against the prior traversal fix (#5705/#5732); no blocking findings.

## Follow-ups

- None. (The `isReservedScopeSegment` flat-path reclaim reserving only literal `"android"`/`"ios"` is #5707/#6492 territory, untouched here.)
