### PR TITLE
fix(db): DatabaseHealthProbe single authoritative timeout, no racing pair (#6655)

### DIFF
--- a/src/db/DatabaseHealthProbe.ts
+++ b/src/db/DatabaseHealthProbe.ts
@@ -70,7 +70,6 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
   private pendingRequest: {
     resolve: () => void;
     reject: (error: Error) => void;
-    timeoutHandle: NodeJS.Timeout;
   } | null = null;
 
   constructor(dependencies: DatabaseHealthProbeDependencies = {}) {
@@ -93,12 +92,21 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
       throw migrationsError;
     }
 
+    // check() owns the SINGLE authoritative timeout for the whole probe.
+    // executeSelectOneInWorker() no longer arms an independent timer of its
+    // own (issue #6655): racing two equal-duration timeouts made the
+    // observed outcome depend on which one a given Timer/runtime happened to
+    // fire first, rather than on explicit code. If this timeout wins the
+    // race, abandon any in-flight worker round-trip so pendingRequest never
+    // outlives check() and a subsequent check() always attempts a fresh
+    // probe instead of short-circuiting on "already running".
     let timeoutHandle: NodeJS.Timeout | null = null;
     try {
       await Promise.race([
         this.executeSelectOne(),
         new Promise<never>((_, reject) => {
           timeoutHandle = this.timer.setTimeout(() => {
+            this.abandonPendingWorkerRequest();
             reject(new Error(`Database health probe timed out after ${this.timeoutMs}ms`));
           }, this.timeoutMs);
           if (typeof (timeoutHandle as { unref?: () => void }).unref === "function") {
@@ -119,11 +127,26 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
     if (this.pendingRequest) {
       const pending = this.pendingRequest;
       this.pendingRequest = null;
-      this.timer.clearTimeout(pending.timeoutHandle);
       pending.reject(new Error("Database health probe disposed"));
     }
     if (worker) {
       await worker.terminate();
+    }
+  }
+
+  /**
+   * Clear any in-flight worker request and null out the worker so a fresh
+   * one is created on the next check(). Used when check()'s own timeout
+   * fires while a worker round-trip is still pending — the worker is
+   * abandoned (terminated fire-and-forget) rather than left to eventually
+   * settle a request nobody is awaiting anymore.
+   */
+  private abandonPendingWorkerRequest(): void {
+    const worker = this.worker;
+    this.worker = null;
+    this.pendingRequest = null;
+    if (worker) {
+      void worker.terminate();
     }
   }
 
@@ -134,16 +157,7 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
     const worker = this.getWorker();
     const requestId = ++this.workerRequestId;
     return new Promise<void>((resolve, reject) => {
-      const timeoutHandle = this.timer.setTimeout(() => {
-        this.pendingRequest = null;
-        this.worker = null;
-        void worker.terminate();
-        reject(new Error(`Database health probe timed out after ${this.timeoutMs}ms`));
-      }, this.timeoutMs);
-      if (typeof (timeoutHandle as { unref?: () => void }).unref === "function") {
-        (timeoutHandle as { unref: () => void }).unref();
-      }
-      this.pendingRequest = { resolve, reject, timeoutHandle };
+      this.pendingRequest = { resolve, reject };
       worker.postMessage({ id: requestId });
     });
   }
@@ -162,7 +176,6 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
       }
       const pending = this.pendingRequest;
       this.pendingRequest = null;
-      this.timer.clearTimeout(pending.timeoutHandle);
       if (message.ok) {
         pending.resolve();
         return;
@@ -183,7 +196,6 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
       }
       const pending = this.pendingRequest;
       this.pendingRequest = null;
-      this.timer.clearTimeout(pending.timeoutHandle);
       pending.reject(error);
     });
     worker.on("exit", (code) => {
@@ -196,7 +208,6 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
       }
       const pending = this.pendingRequest;
       this.pendingRequest = null;
-      this.timer.clearTimeout(pending.timeoutHandle);
       pending.reject(new Error(`Database health probe worker exited with code ${code}`));
     });
     this.worker = worker;

--- a/test/db/DatabaseHealthProbe.integration.test.ts
+++ b/test/db/DatabaseHealthProbe.integration.test.ts
@@ -60,6 +60,28 @@ class FakeProbeWorker {
   }
 }
 
+/**
+ * A worker that never responds to `postMessage` — simulates a probe
+ * round-trip that wedges mid-flight so only `check()`'s own timeout can
+ * bound the wait (issue #6655).
+ */
+class WedgedProbeWorker {
+  terminateCalls = 0;
+
+  postMessage(_message: { id: number }): void {
+    // Intentionally never posts a response.
+  }
+
+  on(): this {
+    return this;
+  }
+
+  async terminate(): Promise<number> {
+    this.terminateCalls++;
+    return 0;
+  }
+}
+
 describe("DefaultDatabaseHealthProbe", () => {
   let tempDirs: string[] = [];
 
@@ -173,5 +195,49 @@ describe("DefaultDatabaseHealthProbe", () => {
     await probe.check();
 
     expect(workers).toHaveLength(2);
+  });
+
+  test("clears pendingRequest and leaks no timer when check()'s timeout wins over a wedged worker", async () => {
+    const timer = new FakeTimer();
+    const wedgedWorker = new WedgedProbeWorker();
+    const healthyWorkers: FakeProbeWorker[] = [];
+    let workerFactoryCalls = 0;
+    const probe = new DefaultDatabaseHealthProbe({
+      timer,
+      getMigrationsError: () => null,
+      getDatabasePath: () => "/tmp/auto-mobile-test.db",
+      timeoutMs: 100,
+      workerFactory: () => {
+        workerFactoryCalls += 1;
+        if (workerFactoryCalls === 1) {
+          return wedgedWorker;
+        }
+        const worker = new FakeProbeWorker();
+        healthyWorkers.push(worker);
+        return worker;
+      },
+    });
+
+    const firstCheck = probe.check();
+    // Force whichever timer was registered LAST to fire first, simulating a
+    // Timer/runtime that does not guarantee FIFO-among-equal-delay firing
+    // (the fragility #6655 calls out: two independently-armed same-duration
+    // timeouts with no enforced ordering).
+    timer.fireNewestPendingTimeout();
+
+    await expect(firstCheck).rejects.toThrow("Database health probe timed out after 100ms");
+
+    // The losing timer (if the implementation still races two of them) must
+    // not be left pending once check() has settled.
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+
+    // A subsequent check() must attempt a fresh probe rather than
+    // short-circuiting on "Database health probe is already running" because
+    // the abandoned worker's pendingRequest was never cleared.
+    await expect(probe.check()).resolves.toBeUndefined();
+    expect(healthyWorkers).toHaveLength(1);
+
+    await probe.dispose();
+    expect(timer.getPendingTimeoutCount()).toBe(0);
   });
 });

--- a/test/fakes/FakeTimer.ts
+++ b/test/fakes/FakeTimer.ts
@@ -447,6 +447,30 @@ export class FakeTimer implements Timer {
   }
 
   /**
+   * Fire the most-recently-registered pending timeout immediately, ignoring
+   * the normal due-time/FIFO-registration-order tie-break that `advanceTime`
+   * uses. Simulates a Timer implementation (or runtime) that does not
+   * guarantee FIFO-among-equal-delay firing, so a test can assert behavior
+   * holds regardless of which of two same-duration timers actually fires
+   * first (see the `DatabaseHealthProbe` two-timeout ordering fragility,
+   * issue #6655). No-op if there are no pending timeouts.
+   */
+  fireNewestPendingTimeout(): void {
+    let newest: PendingTimeout | undefined;
+    for (const timeout of this.pendingTimeouts) {
+      if (!newest || timeout.seq > newest.seq) {
+        newest = timeout;
+      }
+    }
+    if (!newest) {
+      return;
+    }
+    this.pendingTimeouts = this.pendingTimeouts.filter((candidate) => candidate !== newest);
+    this.currentTime = Math.max(this.currentTime, newest.timestamp + newest.ms);
+    newest.callback();
+  }
+
+  /**
    * Get count of pending intervals.
    */
   getPendingIntervalCount(): number {


### PR DESCRIPTION
## Summary

`DatabaseHealthProbe.check()` armed an outer `Promise.race` timeout while
`executeSelectOneInWorker()` armed a second, independent timer of the **same
duration**. Nothing enforced which fired first — it relied on the runtime's implicit
FIFO tie-break among equal-delay timers. If that assumption ever broke, `check()`
could settle via the outer timer while `pendingRequest` stayed set (cleared only by
the orphaned inner timer up to `timeoutMs` later), causing spurious "already running"
rejections on the next `check()`.

Collapse to a **single authoritative timeout**: `executeSelectOneInWorker()` no longer
arms any timer; `check()`'s timer is the sole owner and, on fire, calls the new
`abandonPendingWorkerRequest()` to synchronously null `pendingRequest`/`worker` and
fire-and-forget `terminate()` the abandoned worker. Cleanup is guaranteed by the one
timeout callback rather than by two timers racing, and there is no second timer to leak.
`daemon.ts` is unchanged — `check()`'s public `Promise<void>` contract is preserved.

Part of epic #6379.

## Linked Issue

Closes #6655

## Bug / Regression Context

- **Observed symptom:** two equal-duration timeouts race with no enforced ordering; if the non-FIFO order occurs, `pendingRequest` is left set and the next `check()` spuriously reports "already running", plus a leaked pending timer.
- **Repro:** a wedged probe worker + a Timer that fires the outer timeout before the inner one.

## Validation

- [x] `test/db/DatabaseHealthProbe.integration.test.ts` — added a `WedgedProbeWorker` and a `FakeTimer.fireNewestPendingTimeout()` seam to force the adversarial (non-FIFO) order; asserts `pendingRequest` cleared, zero leaked pending timers, and a follow-up `check()` succeeds. Red first: `getPendingTimeoutCount()` was 1 (leaked). 7 pass targeted; full `test/db` 1050 pass.
- [x] `bun run lint` — no new violations. `bun run typecheck` — no new errors.
- [x] `slack codex review` self-review: ran the targeted tests; verdict "timeout cleanup correctly resets the wedged worker state… no actionable regressions."

## Follow-ups

- None. `deviceTeardownOperationRepository` already behaves correctly and is unchanged.
