### PR TITLE
fix(db): report in-progress provisioning instead of restarting, and expire the operations table (#6652)

### DIFF
--- a/src/db/migrations/2026_09_08_000_provision_device_operations_expiry.ts
+++ b/src/db/migrations/2026_09_08_000_provision_device_operations_expiry.ts
@@ -21,8 +21,5 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
-  await db.schema
-    .alterTable("provision_device_operations")
-    .dropColumn("expires_at_ms")
-    .execute();
+  await db.schema.alterTable("provision_device_operations").dropColumn("expires_at_ms").execute();
 }

--- a/src/db/migrations/2026_09_08_000_provision_device_operations_expiry.ts
+++ b/src/db/migrations/2026_09_08_000_provision_device_operations_expiry.ts
@@ -1,0 +1,28 @@
+import { type Kysely, sql } from "kysely";
+
+// #6652: without an expiry, `provision_device_operations` never sheds rows, so
+// it grows one row per distinct operationId for the life of the database.
+// Existing rows predate this column and get `expires_at_ms` defaulted to 0 --
+// already-expired -- so the very next `begin()` call's prune sweep
+// (`ProvisionDeviceOperationRepository.begin()`) reclaims the pre-existing
+// backlog too, not just newly inserted rows.
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const existingColumn = await sql<{ name: string }>`
+    SELECT name FROM pragma_table_info('provision_device_operations')
+    WHERE name = 'expires_at_ms'
+  `.execute(db);
+
+  if (existingColumn.rows.length === 0) {
+    await db.schema
+      .alterTable("provision_device_operations")
+      .addColumn("expires_at_ms", "integer", (column) => column.notNull().defaultTo(0))
+      .execute();
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("provision_device_operations")
+    .dropColumn("expires_at_ms")
+    .execute();
+}

--- a/src/db/provisionDeviceOperationRepository.ts
+++ b/src/db/provisionDeviceOperationRepository.ts
@@ -4,18 +4,22 @@ import { getDatabase } from "./database";
 import type { Database } from "./types";
 import { logger } from "../utils/logger";
 
+export type ProvisionDeviceOperationBeginResult =
+  | { started: true; reconcileExistingConfiguration: boolean }
+  | {
+      started: false;
+      result: Record<string, unknown>;
+      reconcileExistingConfiguration: boolean;
+    }
+  | { started: false; inProgress: true };
+
 export interface ProvisionDeviceOperationStore {
   begin(
     operationId: string,
     requestFingerprint: string,
-  ): Promise<
-    | { started: true; reconcileExistingConfiguration: boolean }
-    | {
-        started: false;
-        result: Record<string, unknown>;
-        reconcileExistingConfiguration: boolean;
-      }
-  >;
+    nowMs: number,
+    expiresAtMs: number,
+  ): Promise<ProvisionDeviceOperationBeginResult>;
   markDeviceCreationStarted(operationId: string): Promise<void>;
   complete(operationId: string, result: Record<string, unknown>): Promise<void>;
   fail(
@@ -30,6 +34,16 @@ export class ProvisionDeviceOperationConflictError extends Error {
   constructor(operationId: string) {
     super(`operationId '${operationId}' was already used for a different provisionDevice request`);
     this.name = "ProvisionDeviceOperationConflictError";
+  }
+}
+
+export class ProvisionDeviceOperationInProgressError extends Error {
+  constructor(operationId: string) {
+    super(
+      `operationId '${operationId}' is still being provisioned by an earlier attempt with no ` +
+        "terminal result yet; wait for it to finish or retry with a new operationId",
+    );
+    this.name = "ProvisionDeviceOperationInProgressError";
   }
 }
 
@@ -62,15 +76,19 @@ export class ProvisionDeviceOperationRepository implements ProvisionDeviceOperat
   async begin(
     operationId: string,
     requestFingerprint: string,
-  ): Promise<
-    | { started: true; reconcileExistingConfiguration: boolean }
-    | {
-        started: false;
-        result: Record<string, unknown>;
-        reconcileExistingConfiguration: boolean;
-      }
-  > {
+    nowMs: number,
+    expiresAtMs: number,
+  ): Promise<ProvisionDeviceOperationBeginResult> {
     const db = this.getDb();
+    // Prune expired rows before the lookup (mirrors
+    // DeviceTeardownOperationRepository.begin(), deviceTeardownOperationRepository.ts:59):
+    // this both bounds table growth (#6652) and is how a genuinely abandoned
+    // "running" row (its owning process crashed before complete()/fail() ran)
+    // ages out into a fresh start, distinct from a still-live running row.
+    await db
+      .deleteFrom("provision_device_operations")
+      .where("expires_at_ms", "<=", nowMs)
+      .execute();
     const existing = await db
       .selectFrom("provision_device_operations")
       .selectAll()
@@ -92,6 +110,7 @@ export class ProvisionDeviceOperationRepository implements ProvisionDeviceOperat
           error_code: null,
           error_message: null,
           creation_started: 0,
+          expires_at_ms: expiresAtMs,
         })
         .execute();
       return { started: true, reconcileExistingConfiguration: false };
@@ -170,13 +189,7 @@ export class ProvisionDeviceOperationRepository implements ProvisionDeviceOperat
       error_message: string | null;
       creation_started: number;
     },
-  ):
-    | { started: true; reconcileExistingConfiguration: boolean }
-    | {
-        started: false;
-        result: Record<string, unknown>;
-        reconcileExistingConfiguration: boolean;
-      } {
+  ): ProvisionDeviceOperationBeginResult {
     if (existing.request_fingerprint !== requestFingerprint) {
       throw new ProvisionDeviceOperationConflictError(operationId);
     }
@@ -189,6 +202,14 @@ export class ProvisionDeviceOperationRepository implements ProvisionDeviceOperat
           reconcileExistingConfiguration: existing.creation_started === 1,
         };
       }
+    }
+    // A "running" row that survived the expiry sweep above is still within its
+    // TTL, so a prior attempt (this process or another) may genuinely be
+    // executing it right now. Report in-progress rather than silently
+    // re-entering the provisioning lifecycle (#6652 defect 1) -- unlike
+    // "failed", which stays retryable immediately.
+    if (existing.status === "running") {
+      return { started: false, inProgress: true };
     }
     return {
       started: true,

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -548,6 +548,7 @@ export interface ProvisionDeviceOperationsTable {
   error_code: string | null;
   error_message: string | null;
   creation_started: number;
+  expires_at_ms: number;
   created_at: Generated<string>;
   updated_at: Generated<string>;
 }

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -107,6 +107,7 @@ import { MIN_AVD_RAM_MB } from "../utils/android-cmdline-tools/AvdConfigReader";
 import {
   ProvisionDeviceOperationRepository,
   ProvisionDeviceOperationConflictError,
+  ProvisionDeviceOperationInProgressError,
   type ProvisionDeviceOperationStore,
 } from "../db/provisionDeviceOperationRepository";
 import {
@@ -461,6 +462,13 @@ const DEVICE_SHUTDOWN_POLL_INTERVAL_MS = 1_000;
 const DEVICE_SHUTDOWN_POST_RELEASE_RECHECK_TIMEOUT_MS = 1_000;
 const DEVICE_SHUTDOWN_TERMINAL_RELEASE_RETRIES = 2;
 const TEARDOWN_OPERATION_RESULT_TTL_MS = 5 * 60 * 1_000;
+// A live provisionDevice attempt can legitimately hold its operation row for as
+// long as its own timeoutMs budget allows, capped at MAX_DEVICE_READY_TIMEOUT_MS
+// (~14m50s). Give the stored row headroom beyond that ceiling so a still-live
+// attempt is never mistaken for abandoned while genuinely within its own
+// deadline, plus room afterward for idempotent replay before the row is pruned
+// (#6652).
+const PROVISION_DEVICE_OPERATION_TTL_MS = MAX_DEVICE_READY_TIMEOUT_MS + 15 * 60 * 1_000;
 
 function getShutdownInitiatingExecutionId(): string | undefined {
   return getToolSelectionContext()?.execution?.executionId;
@@ -4127,7 +4135,21 @@ export function registerDeviceTools() {
   ): Promise<Record<string, unknown>> {
     const deps = getDeviceToolsDependencies();
     const store = deps.provisionDeviceOperationStoreFactory();
-    const operation = await store.begin(args.operationId, fingerprint);
+    const nowMs = deps.timer.now();
+    const operation = await store.begin(
+      args.operationId,
+      fingerprint,
+      nowMs,
+      nowMs + PROVISION_DEVICE_OPERATION_TTL_MS,
+    );
+    if ("inProgress" in operation) {
+      // A live (non-expired) "running" row for this operationId/fingerprint --
+      // report in-progress instead of silently re-running the provisioning
+      // lifecycle (#6652 defect 1). Thrown before the try/catch below so this
+      // never reaches store.fail(), which would incorrectly overwrite the
+      // still-running attempt's row.
+      throw new ProvisionDeviceOperationInProgressError(args.operationId);
+    }
     try {
       if (
         !operation.started &&
@@ -5093,6 +5115,9 @@ export function registerDeviceTools() {
     }
     if (error instanceof ProvisionDeviceOperationConflictError) {
       return createToolErrorResponse("operation_conflict", error.message);
+    }
+    if (error instanceof ProvisionDeviceOperationInProgressError) {
+      return createToolErrorResponse("operation_in_progress", error.message);
     }
     return createToolErrorResponse("platform_command_failed", errorMessage(error));
   }

--- a/test/db/provisionDeviceOperationRepository.integration.test.ts
+++ b/test/db/provisionDeviceOperationRepository.integration.test.ts
@@ -15,10 +15,14 @@ describe("ProvisionDeviceOperationRepository", () => {
     await db.destroy();
   });
 
+  // A far-future expiry keeps these behavior-only assertions independent of
+  // the pruning/staleness tests below.
+  const FAR_FUTURE_EXPIRY_MS = 1_000_000;
+
   test("replays a completed operation and rejects reuse with a different request", async () => {
     const repository = new ProvisionDeviceOperationRepository(db);
 
-    expect(await repository.begin("operation-1", "request-a")).toEqual({
+    expect(await repository.begin("operation-1", "request-a", 0, FAR_FUTURE_EXPIRY_MS)).toEqual({
       started: true,
       reconcileExistingConfiguration: false,
     });
@@ -27,7 +31,7 @@ describe("ProvisionDeviceOperationRepository", () => {
       name: "phone-api-36-a",
     });
 
-    expect(await repository.begin("operation-1", "request-a")).toEqual({
+    expect(await repository.begin("operation-1", "request-a", 0, FAR_FUTURE_EXPIRY_MS)).toEqual({
       started: false,
       result: {
         deviceId: "emulator-5554",
@@ -35,7 +39,9 @@ describe("ProvisionDeviceOperationRepository", () => {
       },
       reconcileExistingConfiguration: false,
     });
-    await expect(repository.begin("operation-1", "request-b")).rejects.toThrow(
+    await expect(
+      repository.begin("operation-1", "request-b", 0, FAR_FUTURE_EXPIRY_MS),
+    ).rejects.toThrow(
       "operationId 'operation-1' was already used for a different provisionDevice request",
     );
   });
@@ -43,34 +49,58 @@ describe("ProvisionDeviceOperationRepository", () => {
   test("permits configuration reconciliation only after creation began", async () => {
     const repository = new ProvisionDeviceOperationRepository(db);
 
-    await repository.begin("operation-retry", "request-a");
+    await repository.begin("operation-retry", "request-a", 0, FAR_FUTURE_EXPIRY_MS);
     await repository.fail("operation-retry", "platform_command_failed", "config write failed");
 
-    expect(await repository.begin("operation-retry", "request-a")).toEqual({
-      started: true,
-      reconcileExistingConfiguration: false,
-    });
+    expect(await repository.begin("operation-retry", "request-a", 0, FAR_FUTURE_EXPIRY_MS)).toEqual(
+      {
+        started: true,
+        reconcileExistingConfiguration: false,
+      },
+    );
 
     await repository.markDeviceCreationStarted("operation-retry");
     await repository.fail("operation-retry", "platform_command_failed", "config write failed");
 
-    expect(await repository.begin("operation-retry", "request-a")).toEqual({
-      started: true,
-      reconcileExistingConfiguration: true,
-    });
+    expect(await repository.begin("operation-retry", "request-a", 0, FAR_FUTURE_EXPIRY_MS)).toEqual(
+      {
+        started: true,
+        reconcileExistingConfiguration: true,
+      },
+    );
   });
 
   test("retains creation provenance when replaying a completed operation", async () => {
     const repository = new ProvisionDeviceOperationRepository(db);
 
-    await repository.begin("operation-created", "request-a");
+    await repository.begin("operation-created", "request-a", 0, FAR_FUTURE_EXPIRY_MS);
     await repository.markDeviceCreationStarted("operation-created");
     await repository.complete("operation-created", { created: true });
 
-    expect(await repository.begin("operation-created", "request-a")).toEqual({
+    expect(await repository.begin("operation-created", "request-a", 0, FAR_FUTURE_EXPIRY_MS)).toEqual(
+      {
+        started: false,
+        result: { created: true },
+        reconcileExistingConfiguration: true,
+      },
+    );
+  });
+
+  test("reports in-progress instead of restarting a still-running operation (#6652 defect 1)", async () => {
+    const repository = new ProvisionDeviceOperationRepository(db);
+
+    expect(await repository.begin("operation-running", "request-a", 0, 10_000)).toEqual({
+      started: true,
+      reconcileExistingConfiguration: false,
+    });
+
+    // No complete()/fail() ever runs on this row -- simulates a daemon crash
+    // or restart mid-provisioning. A retry with the same idempotency key while
+    // the row is still within its TTL must be told the operation is already
+    // in progress, not silently re-run from scratch.
+    expect(await repository.begin("operation-running", "request-a", 5_000, 10_000)).toEqual({
       started: false,
-      result: { created: true },
-      reconcileExistingConfiguration: true,
+      inProgress: true,
     });
   });
 
@@ -94,5 +124,43 @@ describe("ProvisionDeviceOperationRepository", () => {
       started: true,
       reconcileExistingConfiguration: false,
     });
+  });
+
+  test("treats an expired running row as abandoned and starts a fresh attempt", async () => {
+    const repository = new ProvisionDeviceOperationRepository(db);
+
+    await repository.begin("operation-crashed", "request-a", 0, 1_000);
+
+    // Past its TTL with no complete()/fail(): the owning process is gone, so
+    // this must be distinguishable from a genuinely live "running" row above
+    // rather than reporting in-progress forever.
+    expect(await repository.begin("operation-crashed", "request-a", 1_000, 11_000)).toEqual({
+      started: true,
+      reconcileExistingConfiguration: false,
+    });
+  });
+
+  test("prunes expired rows on a later begin() call instead of growing without bound (#6652 defect 2)", async () => {
+    const repository = new ProvisionDeviceOperationRepository(db);
+
+    await repository.begin("stale-1", "request-a", 0, 1_000);
+    await repository.begin("stale-2", "request-b", 0, 1_000);
+
+    expect(
+      await db.selectFrom("provision_device_operations").select("operation_id").execute(),
+    ).toHaveLength(2);
+
+    // A begin() call for an unrelated operationId, well past the stale rows'
+    // expiry, must sweep them out rather than leaving them to accumulate
+    // forever.
+    await repository.begin("fresh", "request-c", 5_000, 15_000);
+
+    expect(
+      await db
+        .selectFrom("provision_device_operations")
+        .select("operation_id")
+        .orderBy("operation_id")
+        .execute(),
+    ).toEqual([{ operation_id: "fresh" }]);
   });
 });

--- a/test/db/provisionDeviceOperationRepository.integration.test.ts
+++ b/test/db/provisionDeviceOperationRepository.integration.test.ts
@@ -77,13 +77,13 @@ describe("ProvisionDeviceOperationRepository", () => {
     await repository.markDeviceCreationStarted("operation-created");
     await repository.complete("operation-created", { created: true });
 
-    expect(await repository.begin("operation-created", "request-a", 0, FAR_FUTURE_EXPIRY_MS)).toEqual(
-      {
-        started: false,
-        result: { created: true },
-        reconcileExistingConfiguration: true,
-      },
-    );
+    expect(
+      await repository.begin("operation-created", "request-a", 0, FAR_FUTURE_EXPIRY_MS),
+    ).toEqual({
+      started: false,
+      result: { created: true },
+      reconcileExistingConfiguration: true,
+    });
   });
 
   test("reports in-progress instead of restarting a still-running operation (#6652 defect 1)", async () => {

--- a/test/server/deviceTools.provisionDevice.test.ts
+++ b/test/server/deviceTools.provisionDevice.test.ts
@@ -52,10 +52,19 @@ class FakeProvisionDeviceOperationStore implements ProvisionDeviceOperationStore
     string,
     { fingerprint: string; result?: Record<string, unknown>; creationStarted: boolean }
   >();
+  private readonly forcedInProgress = new Set<string>();
   completeError: Error | undefined;
   failCalls = 0;
 
+  /** Simulate a "running" row left behind by a crashed/earlier attempt. */
+  markInProgress(operationId: string): void {
+    this.forcedInProgress.add(operationId);
+  }
+
   async begin(operationId: string, requestFingerprint: string) {
+    if (this.forcedInProgress.has(operationId)) {
+      return { started: false as const, inProgress: true as const };
+    }
     const existing = this.results.get(operationId);
     if (!existing) {
       this.results.set(operationId, {
@@ -1917,6 +1926,44 @@ describe("provisionDevice handler", () => {
         code: "operation_conflict",
       },
     });
+  });
+
+  test("reports in-progress instead of re-running provisioning for an already-running operation", async () => {
+    operationStore.markInProgress("operation-already-running");
+
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+
+    const response = JSON.parse(
+      (
+        (await tool.handler({
+          operationId: "operation-already-running",
+          device: {
+            platform: "android",
+            name: "phone-api-36-a",
+            spec: {
+              runtime: "system-images;android-36;google_apis;x86_64",
+              deviceType: "pixel_9",
+            },
+          },
+          boot: false,
+          readiness: "none",
+        })) as any
+      ).content[0].text,
+    );
+
+    expect(response).toMatchObject({
+      success: false,
+      error: {
+        code: "operation_in_progress",
+      },
+    });
+    // The lifecycle must never run for an in-progress row -- otherwise this is
+    // just the #6652 defect-1 restart bug wearing a different response shape.
+    expect(exactProvisioner.requests).toHaveLength(0);
+    expect(operationStore.failCalls).toBe(0);
   });
 
   test("enforces timeoutMs across exact provisioning before boot begins", async () => {

--- a/test/utils/deviceSnapshotStore.property.test.ts
+++ b/test/utils/deviceSnapshotStore.property.test.ts
@@ -154,7 +154,8 @@ describe("DeviceSnapshotStore.getSnapshotPathWithOptions (property-based, #6493)
         fc.constantFrom<"android" | "ios">("android", "ios"),
         fc.oneof(safeSegment, hostileSegment, escapingSegment),
         (snapshotName, platform, scopeSegment) => {
-          const options = platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
+          const options =
+            platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
           const result = attempt(() => store.getSnapshotPathWithOptions(snapshotName, options));
 
           if (!result.ok) {
@@ -175,7 +176,8 @@ describe("DeviceSnapshotStore.getSnapshotPathWithOptions (property-based, #6493)
         fc.constantFrom<"android" | "ios">("android", "ios"),
         escapingSegment,
         (snapshotName, platform, scopeSegment) => {
-          const options = platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
+          const options =
+            platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
           const result = attempt(() => store.getSnapshotPathWithOptions(snapshotName, options));
           return result.ok === false && result.error instanceof ActionableError;
         },
@@ -191,7 +193,8 @@ describe("DeviceSnapshotStore.getSnapshotPathWithOptions (property-based, #6493)
         fc.constantFrom<"android" | "ios">("android", "ios"),
         safeSegment,
         (snapshotName, platform, scopeSegment) => {
-          const options = platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
+          const options =
+            platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
           const result = attempt(() => store.getSnapshotPathWithOptions(snapshotName, options));
           return result.ok === true && isStrictlyInside(basePath, result.value);
         },
@@ -207,7 +210,8 @@ describe("DeviceSnapshotStore.getSnapshotPathWithOptions (property-based, #6493)
         fc.constantFrom<"android" | "ios">("android", "ios"),
         safeSegment,
         (snapshotName, platform, scopeSegment) => {
-          const options = platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
+          const options =
+            platform === "android" ? androidOptions(scopeSegment) : iosOptions(scopeSegment);
           const snapshotPath = store.getSnapshotPathWithOptions(snapshotName, options);
           const settingsPath = store.getSettingsPath(snapshotName, options);
           const metadataPath = store.getMetadataPath(snapshotName, options);


### PR DESCRIPTION
## Summary

Two defects in the `provisionDevice` operation store:

1. `resolveExisting()` only special-cased a `"succeeded"` row; a `"running"` row (a
   crash/restart before `complete()`/`fail()` ran) fell through to `{started: true}`,
   silently **re-running** the whole provisioning lifecycle for a device another
   attempt was still provisioning.
2. `provision_device_operations` had **no expiry/pruning** (unlike its sibling
   `device_teardown_operations`), so it grew one row per `operationId` forever.

Fix mirrors the teardown repo's expiry pattern: add an `expires_at_ms` column
(additive, idempotent migration), delete expired rows before the lookup in `begin()`,
and return `{started: false, inProgress: true}` for a live `"running"` row within its
TTL. **Staleness detection is the expiry itself** — a row past its TTL is swept before
`resolveExisting` runs (treated as fresh), a live one survives and reports in-progress.
TTL = `MAX_DEVICE_READY_TIMEOUT_MS + 15min` via the injected clock (generous headroom
over provisionDevice's own hard timeout). `deviceTools` maps the in-progress signal to a
new `operation_in_progress` tool error and short-circuits before the `fail()` path so it
never overwrites the other attempt's row. `deviceTeardownOperationRepository` already
behaves correctly and is unchanged.

Part of epic #6379.

## Linked Issue

Closes #6652

## Bug / Regression Context

- **Observed symptom:** a second provision request for a device already provisioning restarts the lifecycle; the operations table grows unbounded.
- **Repro:** request provisioning, leave a `"running"` row (crash before completion), request again → old code returns `{started: true}` and relaunches.

## Validation

- [x] `provisionDeviceOperationRepository.integration.test.ts` + `deviceTools.provisionDevice.test.ts` — 32 pass. New tests: in-progress reporting, expired-row-treated-as-fresh boundary, cross-`operationId` pruning, and an end-to-end tool test asserting `operation_in_progress` without touching the provisioner/`fail()`. Red first: 2 of 6 repo tests failed (`started:true`, no prune). Full `test/db` + all `deviceTools.*` = 1269 pass.
- [x] New idempotent migration `2026_09_08_000_provision_device_operations_expiry.ts` (defaults existing rows to `0` so the backlog is reclaimed on the next `begin()`).
- [x] `bun run lint` — no new violations. `bun run typecheck` — no new errors.
- [x] `slack codex review` self-review: ran the tests (26 pass), no findings.

## Follow-ups

- The ~30-min TTL is a deliberate bounded idempotent-replay window (vs the prior unbounded-forever replay). `deviceTeardownOperationRepository` needed no change.
