### PR TITLE
fix(db): make linkUIElementsToEdge idempotent against the edge_ui_elements unique index (#6463)

### DIFF
--- a/src/db/navigationRepository.ts
+++ b/src/db/navigationRepository.ts
@@ -527,6 +527,14 @@ export class NavigationRepository {
 
   /**
    * Link UI elements to an edge.
+   *
+   * Idempotent under UNIQUE(edge_id, ui_element_id) (idx_edge_ui_elements_pk, #6463):
+   * two `SelectedElement`s in the same interaction can resolve to the same
+   * `ui_elements` row (matched on text/resourceId/contentDescription with no bounds),
+   * and re-observing the same edge later re-links element ids already linked from a
+   * prior call. Neither case may throw `SQLITE_CONSTRAINT_UNIQUE` — that would abort
+   * the enclosing `recordNavigationEvent` transaction and silently drop the whole
+   * navigation-graph write, not just the offending link.
    */
   async linkUIElementsToEdge(edgeId: number, uiElementIds: number[]): Promise<void> {
     if (uiElementIds.length === 0) {
@@ -534,13 +542,66 @@ export class NavigationRepository {
     }
 
     const db = this.getDb();
-    const values: NewEdgeUIElement[] = uiElementIds.map((uiElementId, index) => ({
-      edge_id: edgeId,
-      ui_element_id: uiElementId,
-      selection_order: index,
-    }));
+    // storeUIElements calls this on a repository already bound to the enclosing
+    // recordNavigationEvent transaction (via withExecutor), so opening a nested
+    // `db.transaction()` would throw "Nested transactions are not supported" —
+    // mirrors the db.isTransaction guard in getOrCreateUIElement/promoteSuggestion.
+    if (db.isTransaction) {
+      return this.linkUIElementsToEdgeWithin(db, edgeId, uiElementIds);
+    }
+    return db
+      .transaction()
+      .execute((trx) => this.linkUIElementsToEdgeWithin(trx, edgeId, uiElementIds));
+  }
 
-    await db.insertInto("edge_ui_elements").values(values).execute();
+  private async linkUIElementsToEdgeWithin(
+    trx: Kysely<Database>,
+    edgeId: number,
+    uiElementIds: number[],
+  ): Promise<void> {
+    // Read what this edge already links, inside the transaction, so new elements
+    // are appended AFTER the current maximum selection_order rather than restarting
+    // at zero. Restarting collided on order across calls: linking [A,B] then [B,C]
+    // gave both B and C order 1, so getUIElementsForEdge()'s `ORDER BY
+    // selection_order` could not preserve a stable observation order.
+    const existing = await trx
+      .selectFrom("edge_ui_elements")
+      .select(["ui_element_id", "selection_order"])
+      .where("edge_id", "=", edgeId)
+      .execute();
+    const existingIds = new Set<number>(existing.map((row) => row.ui_element_id));
+    let nextOrder = existing.reduce((max, row) => Math.max(max, row.selection_order), -1) + 1;
+
+    // De-dupe within this call, and skip pairs already linked (they keep their
+    // recorded order). Two ids resolving to the same ui_elements row must not
+    // produce two rows for one (edge_id, ui_element_id) pair.
+    const seen = new Set<number>();
+    const values: NewEdgeUIElement[] = [];
+    for (const uiElementId of uiElementIds) {
+      if (seen.has(uiElementId) || existingIds.has(uiElementId)) {
+        continue;
+      }
+      seen.add(uiElementId);
+      values.push({
+        edge_id: edgeId,
+        ui_element_id: uiElementId,
+        selection_order: nextOrder++,
+      });
+    }
+
+    if (values.length === 0) {
+      return;
+    }
+
+    // onConflict is retained as a safety net against a concurrent inserter racing
+    // the same pair between the read above and this insert; it keeps the
+    // first-recorded row, matching the "leave existing identity alone on conflict"
+    // convention used elsewhere in this file's onConflict upserts (e.g. getOrCreateApp).
+    await trx
+      .insertInto("edge_ui_elements")
+      .values(values)
+      .onConflict((oc) => oc.columns(["edge_id", "ui_element_id"]).doNothing())
+      .execute();
   }
 
   /**

--- a/test/db/navigationRepository.integration.test.ts
+++ b/test/db/navigationRepository.integration.test.ts
@@ -257,6 +257,92 @@ describe("NavigationRepository", () => {
     });
   });
 
+  describe("linkUIElementsToEdge / getUIElementsForEdge", () => {
+    test("links UI elements to an edge in selection order", async () => {
+      await repo.getOrCreateApp("com.example.app");
+      const edge = await repo.createEdge("com.example.app", "A", "B", "tapOn", null, 1000);
+      const first = await repo.getOrCreateUIElement(
+        "com.example.app",
+        { text: "First", resourceId: "btn_first" },
+        1000,
+      );
+      const second = await repo.getOrCreateUIElement(
+        "com.example.app",
+        { text: "Second", resourceId: "btn_second" },
+        1000,
+      );
+
+      await repo.linkUIElementsToEdge(edge.id, [first.id, second.id]);
+
+      const linked = await repo.getUIElementsForEdge(edge.id);
+      expect(linked.map((e) => e.id)).toEqual([first.id, second.id]);
+    });
+
+    test("a duplicate ui_element_id within a single call does not throw and links once (issue #6463)", async () => {
+      await repo.getOrCreateApp("com.example.app");
+      const edge = await repo.createEdge("com.example.app", "A", "B", "tapOn", null, 1000);
+      // Two SelectedElements that resolve to the same ui_elements row (matched on
+      // text/resourceId/contentDescription with no bounds — #6463's root cause).
+      const element = await repo.getOrCreateUIElement(
+        "com.example.app",
+        { text: "Row", resourceId: "list_row" },
+        1000,
+      );
+
+      await repo.linkUIElementsToEdge(edge.id, [element.id, element.id]);
+
+      const linked = await repo.getUIElementsForEdge(edge.id);
+      expect(linked.map((e) => e.id)).toEqual([element.id]);
+    });
+
+    test("re-linking overlapping/identical UI elements to the same edge is idempotent (issue #6463)", async () => {
+      await repo.getOrCreateApp("com.example.app");
+      const edge = await repo.createEdge("com.example.app", "A", "B", "tapOn", null, 1000);
+      const first = await repo.getOrCreateUIElement(
+        "com.example.app",
+        { text: "First", resourceId: "btn_first" },
+        1000,
+      );
+      const second = await repo.getOrCreateUIElement(
+        "com.example.app",
+        { text: "Second", resourceId: "btn_second" },
+        1000,
+      );
+      const third = await repo.getOrCreateUIElement(
+        "com.example.app",
+        { text: "Third", resourceId: "btn_third" },
+        1000,
+      );
+
+      await repo.linkUIElementsToEdge(edge.id, [first.id, second.id]);
+
+      // Re-observing the same edge: second.id repeats, third.id is newly selected.
+      // Must not throw SQLITE_CONSTRAINT_UNIQUE on (edge_id, ui_element_id).
+      await repo.linkUIElementsToEdge(edge.id, [second.id, third.id]);
+
+      const linked = await repo.getUIElementsForEdge(edge.id);
+      const ids = linked.map((e) => e.id);
+      // At most one row per (edge_id, ui_element_id) pair — the acceptance criterion
+      // from #6463 — and every element ever linked to this edge remains discoverable.
+      expect(new Set(ids).size).toBe(ids.length);
+      // Selection order must be STABLE across calls: new elements append after the
+      // existing maximum selection_order rather than restarting at zero. Restarting
+      // gave both `second` and `third` order 1, so this ordered assertion pins that
+      // getUIElementsForEdge() returns first-observed, then newly-observed (#6463).
+      expect(ids).toEqual([first.id, second.id, third.id]);
+    });
+
+    test("linking zero elements is a no-op", async () => {
+      await repo.getOrCreateApp("com.example.app");
+      const edge = await repo.createEdge("com.example.app", "A", "B", "tapOn", null, 1000);
+
+      await repo.linkUIElementsToEdge(edge.id, []);
+
+      const linked = await repo.getUIElementsForEdge(edge.id);
+      expect(linked).toHaveLength(0);
+    });
+  });
+
   describe("setNodeModals / getNodeModals", () => {
     test("sets and retrieves modal stack for a node", async () => {
       await repo.getOrCreateApp("com.example.app");


### PR DESCRIPTION
## Summary

`linkUIElementsToEdge` inserted into `edge_ui_elements` with no `onConflict` handling,
so re-linking an edge from a later observation (or a single call with a duplicate
`ui_element_id`) violated the UNIQUE index on `(edge_id, ui_element_id)` and threw
`SQLITE_CONSTRAINT_UNIQUE`.

De-dupe the incoming ids, skip pairs already linked, and insert new ones with
`onConflict(["edge_id","ui_element_id"]).doNothing()` as a race safety net — the
accumulate semantics the issue offers as an alternative to the sibling
delete-before-insert (an edge can legitimately have several distinct UI elements that
all trigger the same transition, unlike single-state modals/scroll). New elements get
`selection_order` **appended after the edge's current maximum** (read inside the
transaction), not restarting at zero — restarting collided on order across calls
(linking `[A,B]` then `[B,C]` gave both B and C order 1), corrupting
`getUIElementsForEdge()`'s `ORDER BY selection_order`.

Runs inside a transaction via a new private `linkUIElementsToEdgeWithin`, guarding
`db.isTransaction` the same way `getOrCreateUIElement`/`promoteSuggestion` do — because
`NavigationGraphManager` calls this while already bound to `recordNavigationEvent`'s
transaction, so an unconditional `db.transaction()` would throw "Nested transactions
are not supported".

Part of epic #6379 (navigation cluster; #6656 stacks on the same file's modal methods,
which are untouched here).

## Linked Issue

Closes #6463

## Bug / Regression Context

- **Observed symptom:** re-observing/re-recording an edge with overlapping UI elements throws `SQLITE_CONSTRAINT_UNIQUE` on `edge_ui_elements`.
- **Repro:** `linkUIElementsToEdge(e, [a,b])` then `linkUIElementsToEdge(e, [b,c])`.

## Validation

- [x] `test/db/navigationRepository.integration.test.ts` — 46 pass. Tests: single-call duplicate id, cross-call overlapping re-link (now asserts **stable append order** `[a,b,c]`), zero-elements no-op. Red first: UNIQUE violation, and the ordered assertion caught the order-collision.
- [x] `bun run lint` — no new violations. `bun run typecheck` — no new errors.
- [x] `slack codex review` self-review flagged a P2 (selection_order restarting at zero) on the first pass; fixed by appending after the current max, and the **re-review confirmed** "correctly deduplicates … while preserving stable selection order and transaction behavior."

## Follow-ups

- None. `setNodeModals`/`setEdgeModals`/`setScrollPosition` (transactional, #6656) untouched.
