### PR TITLE
fix(daemon): preserve explicit restart handoff

### DIFF
--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -226,6 +226,16 @@ export const DAEMON_SHUTDOWN_TIMEOUT_MS = 10000;
 /** Stable control-socket error used to signal a retryable shutdown transition. */
 export const DAEMON_SHUTTING_DOWN_ERROR_MESSAGE = "Daemon is shutting down";
 
+/** Deliberate no-process/no-lock pause between explicit restart stop and start. */
+export const DAEMON_RESTART_HANDOFF_DELAY_MS = 1_000;
+
+/**
+ * How long a recovering proxy preserves an explicit restart's empty handoff
+ * before it may auto-start a replacement itself. Keep headroom beyond the
+ * manager's deliberate delay for scheduling and readiness polling.
+ */
+export const DAEMON_RESTART_HANDOFF_TIMEOUT_MS = DAEMON_RESTART_HANDOFF_DELAY_MS + 500;
+
 /**
  * Minimum age (ms since startedAt) before the proxy will restart a daemon on
  * version mismatch. Prevents thrash when concurrent agents on different versions

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -226,15 +226,34 @@ export const DAEMON_SHUTDOWN_TIMEOUT_MS = 10000;
 /** Stable control-socket error used to signal a retryable shutdown transition. */
 export const DAEMON_SHUTTING_DOWN_ERROR_MESSAGE = "Daemon is shutting down";
 
+/** Bound on the post-SIGKILL process-exit confirmation. */
+export const DAEMON_FORCED_STOP_TIMEOUT_MS = 1_000;
+
+/**
+ * Bound on one synchronous `ps`/PowerShell/CIM process-table scan. `execSync`
+ * otherwise has no timeout, so this also makes the restart handoff calculable.
+ */
+export const DAEMON_PROCESS_TABLE_SCAN_TIMEOUT_MS = 5_000;
+
+/** Bound on the explicit-restart canonical-port availability probe. */
+export const DAEMON_PORT_AVAILABILITY_PROBE_TIMEOUT_MS = 1_000;
+
 /** Deliberate no-process/no-lock pause between explicit restart stop and start. */
 export const DAEMON_RESTART_HANDOFF_DELAY_MS = 1_000;
 
 /**
  * How long a recovering proxy preserves an explicit restart's empty handoff
- * before it may auto-start a replacement itself. Keep headroom beyond the
- * manager's deliberate delay for scheduling and readiness polling.
+ * before it may auto-start a replacement itself. This covers the complete
+ * bounded lock-free interval after peer EOF: concurrent graceful/forced
+ * cleanup, the final process-table and port preflight, and the deliberate
+ * stop/start delay.
  */
-export const DAEMON_RESTART_HANDOFF_TIMEOUT_MS = DAEMON_RESTART_HANDOFF_DELAY_MS + 500;
+export const DAEMON_RESTART_HANDOFF_TIMEOUT_MS =
+  DAEMON_SHUTDOWN_TIMEOUT_MS +
+  DAEMON_FORCED_STOP_TIMEOUT_MS +
+  DAEMON_PROCESS_TABLE_SCAN_TIMEOUT_MS +
+  DAEMON_PORT_AVAILABILITY_PROBE_TIMEOUT_MS +
+  DAEMON_RESTART_HANDOFF_DELAY_MS;
 
 /**
  * Minimum age (ms since startedAt) before the proxy will restart a daemon on

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1151,7 +1151,8 @@ export class DaemonMcpProxy {
 
   private async waitForDaemonShutdownRestartWindow(): Promise<void> {
     const socketPath = this.config.socketPath ?? SOCKET_PATH;
-    const deadline = this.timer.now() + DAEMON_STARTUP_TIMEOUT_MS;
+    let deadline =
+      this.timer.now() + Math.max(DAEMON_STARTUP_TIMEOUT_MS, DAEMON_RESTART_HANDOFF_TIMEOUT_MS);
     let emptyHandoffDeadline: number | undefined;
     while (!this.closing && this.timer.now() < deadline) {
       if (await DaemonClient.isAvailable(socketPath)) {
@@ -1174,6 +1175,9 @@ export class DaemonMcpProxy {
         // racing to start a daemon with this proxy's potentially different
         // options.
         emptyHandoffDeadline ??= this.timer.now() + DAEMON_RESTART_HANDOFF_TIMEOUT_MS;
+        // A short startup-timeout override must not truncate the complete
+        // bounded restart preflight after the empty handoff is first observed.
+        deadline = Math.max(deadline, emptyHandoffDeadline);
         if (this.timer.now() >= emptyHandoffDeadline) {
           return;
         }
@@ -1644,8 +1648,12 @@ export class DaemonMcpProxy {
     this.connectionClosedUnsubscribe?.();
     this.connectionClosedUnsubscribe = client.onConnectionClosed(() => {
       if (this.client === client) {
-        void this.resetConnection();
+        // EOF is the only connection-wide shutdown signal an idle proxy receives,
+        // and a subscribed release notification can be lost while the old socket
+        // drains. Arm the same successor barrier before reset detaches this client.
+        this.waitForDaemonShutdownDisconnect();
         this.completeDaemonShutdownDisconnect();
+        void this.resetConnection();
       }
     });
   }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -20,6 +20,7 @@ import {
   DAEMON_BOUND_SESSION_PARAM,
   DAEMON_RELEASED_SESSION_PARAM,
   DAEMON_SHUTDOWN_TIMEOUT_MS,
+  DAEMON_RESTART_HANDOFF_TIMEOUT_MS,
 } from "./constants";
 import { PROGRESS_NOTIFICATION_METHOD, type DaemonNotification, type DaemonOptions } from "./types";
 import { listChangedKindForMethod, type ListChangedKind } from "../server/listChangedBroadcast";
@@ -1151,15 +1152,34 @@ export class DaemonMcpProxy {
   private async waitForDaemonShutdownRestartWindow(): Promise<void> {
     const socketPath = this.config.socketPath ?? SOCKET_PATH;
     const deadline = this.timer.now() + DAEMON_STARTUP_TIMEOUT_MS;
+    let emptyHandoffDeadline: number | undefined;
     while (!this.closing && this.timer.now() < deadline) {
       if (await DaemonClient.isAvailable(socketPath)) {
         return;
       }
       const status = await this.daemonManager.status();
-      if (!status.running || this.daemonManager.isStartupLockHeldByLiveProcess()) {
+      const startupLockHeld = this.daemonManager.isStartupLockHeldByLiveProcess();
+      if (startupLockHeld && this.config.autoStartDaemon) {
+        // doConnect() may now join the lock holder through DaemonManager.start().
         return;
       }
-      await this.timer.sleep(Math.min(100, deadline - this.timer.now()));
+      if (startupLockHeld || status.running) {
+        // A successor has begun publishing ownership. Clients with auto-start
+        // disabled cannot join its lock, so keep their barrier active until its
+        // socket becomes reachable under the overall startup deadline.
+        emptyHandoffDeadline = undefined;
+      } else {
+        // Explicit restart deliberately leaves no PID and no startup lock while
+        // it pauses between stop and start. Preserve that handoff instead of
+        // racing to start a daemon with this proxy's potentially different
+        // options.
+        emptyHandoffDeadline ??= this.timer.now() + DAEMON_RESTART_HANDOFF_TIMEOUT_MS;
+        if (this.timer.now() >= emptyHandoffDeadline) {
+          return;
+        }
+      }
+      const waitDeadline = emptyHandoffDeadline ?? deadline;
+      await this.timer.sleep(Math.min(100, waitDeadline - this.timer.now()));
     }
   }
 

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -30,6 +30,7 @@ import {
   DAEMON_STARTUP_TIMEOUT_MS,
   DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS,
   DAEMON_SHUTDOWN_TIMEOUT_MS,
+  DAEMON_RESTART_HANDOFF_DELAY_MS,
   READINESS_PROBE_MAX_ATTEMPTS,
   READINESS_PROBE_BACKOFF_MS,
   DEFAULT_DAEMON_PORT,
@@ -1795,7 +1796,7 @@ export class DaemonManager implements DaemonManagerLike {
     // Failing loudly here, naming the orphan, is strictly better than that.
     await this.assertNoSurvivingDaemonBeforeRestart(restartOptions);
     // Wait a bit before starting
-    await this.timer.sleep(1000);
+    await this.timer.sleep(DAEMON_RESTART_HANDOFF_DELAY_MS);
     await this.start(restartOptions);
   }
 

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -30,6 +30,9 @@ import {
   DAEMON_STARTUP_TIMEOUT_MS,
   DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS,
   DAEMON_SHUTDOWN_TIMEOUT_MS,
+  DAEMON_FORCED_STOP_TIMEOUT_MS,
+  DAEMON_PROCESS_TABLE_SCAN_TIMEOUT_MS,
+  DAEMON_PORT_AVAILABILITY_PROBE_TIMEOUT_MS,
   DAEMON_RESTART_HANDOFF_DELAY_MS,
   READINESS_PROBE_MAX_ATTEMPTS,
   READINESS_PROBE_BACKOFF_MS,
@@ -138,15 +141,6 @@ export interface DaemonProcessFinder {
 }
 
 export const DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
-
-/**
- * Bound on the synchronous `ps`/PowerShell/CIM process-table scan (issue #6140,
- * folded from PR #6109 review). `execSync` has no timeout by default, so a slow
- * `ps` or Windows CIM query on a loaded machine can block the event loop for far
- * longer than the caller's remaining rejoin budget — this caps that single call so
- * it can never itself consume the whole budget.
- */
-export const DAEMON_PROCESS_TABLE_SCAN_TIMEOUT_MS = 5000;
 
 /**
  * Floor the process-table scan timeout is clamped to (issue #6140 review). Node's
@@ -384,8 +378,6 @@ export interface DaemonPortAvailabilityChecker {
   isPortFree(port: number, host: string): Promise<boolean>;
 }
 
-const PORT_AVAILABILITY_PROBE_TIMEOUT_MS = 1000;
-
 class NetDaemonPortAvailabilityChecker implements DaemonPortAvailabilityChecker {
   isPortFree(port: number, host: string): Promise<boolean> {
     return new Promise((resolvePromise) => {
@@ -401,7 +393,7 @@ class NetDaemonPortAvailabilityChecker implements DaemonPortAvailabilityChecker 
       };
       const timeoutHandle = defaultTimer.setTimeout(
         () => finish(false),
-        PORT_AVAILABILITY_PROBE_TIMEOUT_MS,
+        DAEMON_PORT_AVAILABILITY_PROBE_TIMEOUT_MS,
       );
       probeServer.once("error", () => finish(false));
       probeServer.listen(port, host, () => finish(true));
@@ -1563,7 +1555,7 @@ export class DaemonManager implements DaemonManagerLike {
         stderrLog(`Daemon did not stop gracefully, sending SIGKILL...`);
         process.kill(pid, "SIGKILL");
 
-        if (!(await this.waitForStop(pid, 1000))) {
+        if (!(await this.waitForStop(pid, DAEMON_FORCED_STOP_TIMEOUT_MS))) {
           throw new Error(`Daemon process ${pid} did not exit after SIGKILL`);
         }
       }
@@ -1915,7 +1907,7 @@ export class DaemonManager implements DaemonManagerLike {
       );
     }
 
-    if (!(await this.waitForStop(pid, 1000))) {
+    if (!(await this.waitForStop(pid, DAEMON_FORCED_STOP_TIMEOUT_MS))) {
       throw new ActionableError(`Verified daemon process ${pid} did not exit after SIGKILL`);
     }
   }

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -18,6 +18,7 @@ import {
   DAEMON_BOUND_SESSION_REPLAY_TTL_MS,
   DAEMON_TOOL_SELECTION_PROFILE_PARAM,
   DAEMON_STARTUP_TIMEOUT_MS,
+  DAEMON_RESTART_HANDOFF_TIMEOUT_MS,
 } from "../../src/daemon/constants";
 import { logger } from "../../src/utils/logger";
 import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
@@ -1933,9 +1934,10 @@ describe("DaemonMcpProxy", () => {
       const manager = matchingDaemonManager();
       const timer = new FakeTimer();
       let availabilityChecks = 0;
+      let successorAvailable = false;
       const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockImplementation(async () => {
         availabilityChecks += 1;
-        return availabilityChecks === 1;
+        return availabilityChecks === 1 || successorAvailable;
       });
 
       const proxy = new DaemonMcpProxy({
@@ -1957,9 +1959,116 @@ describe("DaemonMcpProxy", () => {
         manager.statusResult = { running: false };
         await timer.advanceTimeAsync(100);
 
+        expect(timer.getPendingSleeps()).toEqual([100]);
+        expect(manager.startCalled).toBe(false);
+        expect(freshClient.connectCallCount).toBe(0);
+
+        successorAvailable = true;
+        await timer.advanceTimeAsync(100);
+
         await expect(recovery).resolves.toEqual(recoveredResult);
         expect(quiescedClient.closeCallCount).toBe(1);
-        expect(manager.startCalled).toBe(true);
+        expect(manager.startCalled).toBe(false);
+        expect(freshClient.callToolCalls).toEqual([
+          { toolName: "tapOn", params: { text: "Button" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("waits through a successor startup lock when auto-start is disabled (#6336)", async () => {
+      const recoveredResult = { content: [{ type: "text", text: "joined successor" }] };
+      const quiescedClient = new ScriptedDaemonClient({
+        toolError: new DaemonShuttingDownError(),
+      });
+      const freshClient = new ScriptedDaemonClient({
+        toolResult: recoveredResult,
+      });
+      const clients = [quiescedClient, freshClient];
+      const manager = matchingDaemonManager();
+      const timer = new FakeTimer();
+      let availabilityChecks = 0;
+      let successorAvailable = false;
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockImplementation(async () => {
+        availabilityChecks += 1;
+        return availabilityChecks === 1 || successorAvailable;
+      });
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        daemonManager: manager,
+        autoStartDaemon: false,
+        timer,
+      });
+
+      try {
+        const recovery = proxy.callTool("tapOn", { text: "Button" });
+        for (let i = 0; i < 20 && timer.getPendingSleepCount() === 0; i++) {
+          await Promise.resolve();
+        }
+
+        manager.statusResult = { running: false };
+        await timer.advanceTimeAsync(100);
+        manager.startupLockHeldByLiveProcess = true;
+        await timer.advanceTimeAsync(100);
+
+        expect(timer.getPendingSleeps()).toEqual([100]);
+        expect(freshClient.connectCallCount).toBe(0);
+
+        successorAvailable = true;
+        await timer.advanceTimeAsync(100);
+
+        await expect(recovery).resolves.toEqual(recoveredResult);
+        expect(manager.startCalled).toBe(false);
+        expect(freshClient.callToolCalls).toEqual([
+          { toolName: "tapOn", params: { text: "Button" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("bounds an empty restart handoff before auto-starting a replacement (#6336)", async () => {
+      const recoveredResult = { content: [{ type: "text", text: "self-started replacement" }] };
+      const quiescedClient = new ScriptedDaemonClient({
+        toolError: new DaemonShuttingDownError(),
+      });
+      const freshClient = new ScriptedDaemonClient({
+        toolResult: recoveredResult,
+      });
+      const clients = [quiescedClient, freshClient];
+      const manager = matchingDaemonManager();
+      const timer = new FakeTimer();
+      let availabilityChecks = 0;
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockImplementation(async () => {
+        availabilityChecks += 1;
+        return availabilityChecks === 1;
+      });
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        daemonManager: manager,
+        autoStartDaemon: true,
+        timer,
+      });
+
+      try {
+        const recovery = proxy.callTool("tapOn", { text: "Button" });
+        for (let i = 0; i < 20 && timer.getPendingSleepCount() === 0; i++) {
+          await Promise.resolve();
+        }
+
+        manager.statusResult = { running: false };
+        await timer.advanceTimeAsync(100);
+        expect(manager.startCalled).toBe(false);
+
+        await timer.advanceTimeAsync(DAEMON_RESTART_HANDOFF_TIMEOUT_MS);
+
+        await expect(recovery).resolves.toEqual(recoveredResult);
+        expect(manager.startCallCount).toBe(1);
         expect(freshClient.callToolCalls).toEqual([
           { toolName: "tapOn", params: { text: "Button" } },
         ]);

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -18,6 +18,7 @@ import {
   DAEMON_BOUND_SESSION_REPLAY_TTL_MS,
   DAEMON_TOOL_SELECTION_PROFILE_PARAM,
   DAEMON_STARTUP_TIMEOUT_MS,
+  DAEMON_RESTART_HANDOFF_DELAY_MS,
   DAEMON_RESTART_HANDOFF_TIMEOUT_MS,
 } from "../../src/daemon/constants";
 import { logger } from "../../src/utils/logger";
@@ -2031,6 +2032,59 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("arms the restart handoff when an idle peer closes without a shutdown notification (#6336)", async () => {
+      const recoveredResult = { content: [{ type: "text", text: "joined EOF successor" }] };
+      const idleClient = new FakeDaemonClient({
+        daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+      });
+      const freshClient = new FakeDaemonClient({
+        toolResult: recoveredResult,
+      });
+      const clients: DaemonClientLike[] = [idleClient, freshClient];
+      const manager = matchingDaemonManager();
+      const timer = new FakeTimer();
+      let availabilityChecks = 0;
+      let successorAvailable = false;
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockImplementation(async () => {
+        availabilityChecks += 1;
+        return availabilityChecks === 1 || successorAvailable;
+      });
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        daemonManager: manager,
+        autoStartDaemon: true,
+        timer,
+      });
+
+      try {
+        await proxy.listTools();
+        manager.statusResult = { running: false };
+        idleClient.emitConnectionClosed();
+
+        const recovery = proxy.callTool("tapOn", { text: "Button" });
+        for (let i = 0; i < 20 && timer.getPendingSleepCount() === 0; i++) {
+          await Promise.resolve();
+        }
+
+        expect(timer.getPendingSleeps()).toEqual([100]);
+        expect(manager.startCalled).toBe(false);
+        expect(freshClient.isConnected()).toBe(false);
+
+        successorAvailable = true;
+        await timer.advanceTimeAsync(100);
+
+        await expect(recovery).resolves.toEqual(recoveredResult);
+        expect(manager.startCalled).toBe(false);
+        expect(freshClient.callToolCalls).toEqual([
+          { toolName: "tapOn", params: { text: "Button" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("bounds an empty restart handoff before auto-starting a replacement (#6336)", async () => {
       const recoveredResult = { content: [{ type: "text", text: "self-started replacement" }] };
       const quiescedClient = new ScriptedDaemonClient({
@@ -2065,7 +2119,11 @@ describe("DaemonMcpProxy", () => {
         await timer.advanceTimeAsync(100);
         expect(manager.startCalled).toBe(false);
 
-        await timer.advanceTimeAsync(DAEMON_RESTART_HANDOFF_TIMEOUT_MS);
+        const oldDelayOnlyBudget = DAEMON_RESTART_HANDOFF_DELAY_MS + 500;
+        await timer.advanceTimeAsync(oldDelayOnlyBudget);
+        expect(manager.startCalled).toBe(false);
+
+        await timer.advanceTimeAsync(DAEMON_RESTART_HANDOFF_TIMEOUT_MS - oldDelayOnlyBudget);
 
         await expect(recovery).resolves.toEqual(recoveredResult);
         expect(manager.startCallCount).toBe(1);

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -6,7 +6,6 @@ import { tmpdir } from "node:os";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import {
   DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES,
-  DAEMON_PROCESS_TABLE_SCAN_TIMEOUT_MS,
   createDefaultDaemonProcessFinder,
   daemonBuildIdentityStatusLines,
   DaemonManager,
@@ -34,6 +33,7 @@ import { FakeTimer } from "../fakes/FakeTimer";
 import { formatLockContent } from "../../src/utils/fileLock";
 import {
   DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS,
+  DAEMON_PROCESS_TABLE_SCAN_TIMEOUT_MS,
   DAEMON_STARTUP_TIMEOUT_MS,
 } from "../../src/daemon/constants";
 

--- a/test/daemon/proxyResultMintedSession.test.ts
+++ b/test/daemon/proxyResultMintedSession.test.ts
@@ -4,7 +4,11 @@ import { DaemonClient, DaemonUnavailableError } from "../../src/daemon/client";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { SessionHeartbeatMonitor } from "../../src/daemon/SessionHeartbeatMonitor";
 import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../../src/server/sessionReleaseBroadcast";
-import { DAEMON_SHUTDOWN_TIMEOUT_MS, DAEMON_VERSION } from "../../src/daemon/constants";
+import {
+  DAEMON_RESTART_HANDOFF_TIMEOUT_MS,
+  DAEMON_SHUTDOWN_TIMEOUT_MS,
+  DAEMON_VERSION,
+} from "../../src/daemon/constants";
 import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
 import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -301,8 +305,14 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
       manager.statusResult = { running: false };
       await timer.advanceTimeAsync(100);
 
+      expect(manager.startCalled).toBe(false);
+      expect(replacementDaemon.nextIndex()).toBe(0);
+
+      daemonAvailable = true;
+      await timer.advanceTimeAsync(100);
+
       await expect(reacquired).resolves.toEqual(deviceStartResult(M2));
-      expect(manager.startCalled).toBe(true);
+      expect(manager.startCalled).toBe(false);
       expect(replacementDaemon.nextIndex()).toBe(1);
       expect(sessionManager.getSession(M2)?.hasReceivedHeartbeat).toBe(true);
     } finally {
@@ -346,6 +356,7 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
 
       manager.statusResult = { running: false };
       await timer.advanceTimeAsync(DAEMON_SHUTDOWN_TIMEOUT_MS);
+      await timer.advanceTimeAsync(DAEMON_RESTART_HANDOFF_TIMEOUT_MS);
 
       await expect(reacquired).resolves.toEqual(deviceStartResult(M2));
       expect(manager.startCalled).toBe(true);


### PR DESCRIPTION
## Summary

- preserve the recovery barrier during an explicit restart's no-PID/no-lock handoff
- arm the barrier when an idle proxy receives EOF without a shutdown notification
- derive the handoff budget from bounded cleanup, preflight, and restart-delay phases
- keep auto-start-disabled clients behind a live successor startup lock until its socket is reachable
- retain bounded fallback self-start when no successor appears

## Root cause

The recovery barrier added in [#6337](https://github.com/kaeawc/auto-mobile/pull/6337) treated a missing daemon PID as completion and was armed only by a session-release notification or shutdown error. An idle proxy can receive only EOF, and `DaemonManager.restart()` remains lock-free through bounded cleanup, preflight, and its one-second stop/start delay. Another proxy could therefore race into that interval and either start a daemon with different options or fail recovery when auto-start was disabled.

This follows up on the [P1 review finding](https://github.com/kaeawc/auto-mobile/pull/6337#discussion_r3962281165) for [#6336](https://github.com/kaeawc/auto-mobile/issues/6336).

## Impact

Recovering clients now preserve the intended restart owner and options through the complete explicit handoff, including EOF-only shutdowns. If no successor appears, the barrier expires after the full 18-second worst-case handoff budget and normal auto-start behavior resumes.

## Validation

- `bun test test/daemon/daemonMcpProxy.test.ts test/daemon/proxyResultMintedSession.test.ts test/daemon/manager.test.ts --bail`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `scripts/all_fast_validate_checks.sh` (35/35)
- `bun run turbo:test`
