### PR TITLE
fix(ios): expose typed bound-session loss across restart

### DIFF
--- a/docs/using/dynamic-tools.md
+++ b/docs/using/dynamic-tools.md
@@ -35,3 +35,9 @@ or `--mcp-recording`. Plan-only tools are never shown in public discovery.
 
 If a tool is missing, check its exact name and required process options, then
 refresh discovery after the `notifications/tools/list_changed` notification.
+
+## Device-session recovery after a daemon restart
+
+A shared-daemon restart ends every device session bound to its prior daemon
+instance. Do not retry or retarget the former session UUID: acquire a fresh
+session with `getAndroid`, `getApple`, or `startDevice` before continuing.

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -10,7 +10,9 @@ import {
   DaemonNotification,
   isDaemonNotification,
   PROGRESS_NOTIFICATION_METHOD,
+  sanitizeBoundSessionLoss,
 } from "./types";
+import type { BoundSessionLoss } from "./types";
 import {
   SOCKET_PATH,
   PID_FILE_PATH,
@@ -46,6 +48,17 @@ export class DaemonShuttingDownError extends DaemonUnavailableError {
   constructor() {
     super(DAEMON_SHUTTING_DOWN_ERROR_MESSAGE);
     this.name = "DaemonShuttingDownError";
+  }
+}
+
+/** A terminal loss of a session explicitly bound to the forwarded request. */
+export class DaemonBoundSessionLostError extends ActionableError {
+  constructor(readonly failure: BoundSessionLoss) {
+    super(
+      `Device session ${failure.sessionUuid} is no longer active (${failure.reason}). ` +
+        "Acquire a new device session before continuing.",
+    );
+    this.name = "DaemonBoundSessionLostError";
   }
 }
 
@@ -609,8 +622,11 @@ export class DaemonClient {
       pending.resolve(response);
     } else {
       const transportFailure = sanitizeDeviceControlTransportFailure(response.transportFailure);
+      const boundSessionLoss = sanitizeBoundSessionLoss(response.boundSessionLoss);
       pending.reject(
-        transportFailure
+        boundSessionLoss
+          ? new DaemonBoundSessionLostError(boundSessionLoss)
+          : transportFailure
           ? new DeviceControlTransportError(
               response.error || "Device-control transport failure",
               transportFailure,

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -627,13 +627,13 @@ export class DaemonClient {
         boundSessionLoss
           ? new DaemonBoundSessionLostError(boundSessionLoss)
           : transportFailure
-          ? new DeviceControlTransportError(
-              response.error || "Device-control transport failure",
-              transportFailure,
-            )
-          : response.error === DAEMON_SHUTTING_DOWN_ERROR_MESSAGE
-            ? new DaemonShuttingDownError()
-            : new ActionableError(response.error || "Unknown error from daemon"),
+            ? new DeviceControlTransportError(
+                response.error || "Device-control transport failure",
+                transportFailure,
+              )
+            : response.error === DAEMON_SHUTTING_DOWN_ERROR_MESSAGE
+              ? new DaemonShuttingDownError()
+              : new ActionableError(response.error || "Unknown error from daemon"),
       );
     }
   }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1,6 +1,7 @@
 import { errorMessage } from "../utils/describeUnknownError";
 import { shellQuote } from "../utils/shellQuote";
 import {
+  DaemonBoundSessionLostError,
   DaemonClient,
   DaemonShuttingDownError,
   DaemonUnavailableError,
@@ -1550,6 +1551,14 @@ export class DaemonMcpProxy {
         throw error;
       }
       this.throwIfBoundSessionFenced(allowReleasedSession);
+      if (error instanceof DaemonBoundSessionLostError) {
+        this.fenceBoundSessionUuid(
+          error.failure.sessionUuid,
+          error.failure.reason,
+          error.failure.release,
+        );
+        throw this.boundSessionExpiredError();
+      }
       if (!this.isRecoverableDaemonSessionError(error)) {
         throw error;
       }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1552,6 +1552,13 @@ export class DaemonMcpProxy {
       }
       this.throwIfBoundSessionFenced(allowReleasedSession);
       if (error instanceof DaemonBoundSessionLostError) {
+        if (error.failure.sessionUuid !== this.boundSessionUuid) {
+          throw new DaemonBoundSessionExpiredError(
+            error.failure.sessionUuid,
+            error.failure.reason,
+            error.failure.release,
+          );
+        }
         this.fenceBoundSessionUuid(
           error.failure.sessionUuid,
           error.failure.reason,
@@ -1831,6 +1838,12 @@ export class DaemonMcpProxy {
     progressToken?: string | number,
     onProgress?: DaemonProxyProgressCallback,
   ): Promise<any> {
+    // These are daemon-internal routing markers. Never accept caller-controlled
+    // values: only this proxy may add them after selecting its active binding.
+    const callerArgs = { ...args };
+    delete callerArgs[DAEMON_BOUND_SESSION_PARAM];
+    delete callerArgs[DAEMON_RELEASED_SESSION_PARAM];
+    delete callerArgs[DAEMON_TOOL_SELECTION_PROFILE_PARAM];
     // Device-session acquisition (getAndroid/getApple/startDevice) mints a NEW
     // session in its RESULT and is never routed to — or fenced by — the connection's
     // bound session: it must be admitted even on a terminally fenced connection so
@@ -1842,8 +1855,8 @@ export class DaemonMcpProxy {
     // after a device has been bound.
     const routingArgs =
       name === SET_TOOL_ENABLED_TOOL_NAME || isSessionAcquisition
-        ? args
-        : this.withBoundSessionUuid(args);
+        ? callerArgs
+        : this.withBoundSessionUuid(callerArgs);
     const forwardedArgs = this.withToolSelectionProfile(routingArgs);
     const forwardedSessionUuid = this.sessionUuidFromArgs(forwardedArgs);
     this.retainReleaseEpochReference(forwardedSessionUuid);
@@ -1873,7 +1886,7 @@ export class DaemonMcpProxy {
         this.refreshReplayLeaseForBoundSessionResult(forwardedArgs, callReleaseEpoch);
         return result;
       }
-      this.rememberToolSelectionProfile(name, args, result);
+      this.rememberToolSelectionProfile(name, callerArgs, result);
       if (isSessionAcquisition) {
         await this.bindResultMintedDeviceSession(name, result, callReleaseEpoch);
         return result;
@@ -2520,6 +2533,8 @@ export class DaemonMcpProxy {
       name === "executePlan" ||
       name === "setActiveDevice" ||
       name === SET_TOOL_ENABLED_TOOL_NAME ||
+      error instanceof DaemonBoundSessionExpiredError ||
+      error instanceof DaemonBoundSessionLostError ||
       this.isRecoverableDaemonSessionError(error) ||
       this.isUnadmittedDaemonSessionError(error) ||
       this.shouldSkipLeaseRefreshForDeviceControlTransportError(error)

--- a/src/daemon/daemonRequestHandlers.ts
+++ b/src/daemon/daemonRequestHandlers.ts
@@ -1,5 +1,5 @@
 import { DaemonRequest } from "./types";
-import { DeviceLabelMap, Session } from "./sessionManager";
+import { DeviceLabelMap, Session, type SessionReleaseSnapshot } from "./sessionManager";
 import type { DeviceRecoveryEligibility, DeviceRecoveryPolicy, PooledDevice } from "./devicePool";
 import type { DeviceSessionRecord } from "./deviceSessionRegistry";
 import { DAEMON_HEARTBEAT_METHOD, DAEMON_LIST_DEVICE_SESSIONS_METHOD } from "./constants";
@@ -21,6 +21,7 @@ export interface DaemonStateAccess {
   isInitialized(): boolean;
   getSessionManager(): {
     getSession(sessionId: string): Session | null;
+    getTerminalReleaseSnapshot?(sessionId: string): SessionReleaseSnapshot | undefined;
     recordHeartbeat?(sessionId: string): void;
     getSessionForDevice?(deviceId: string): string | null;
     getDeviceLabels(sessionId: string): DeviceLabelMap | undefined;

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -14,11 +14,13 @@ import { McpTimeoutError } from "./McpTimeoutError";
 import { DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS } from "../utils/deviceTimeouts";
 import { errorMessage } from "../utils/describeUnknownError";
 import {
+  BOUND_SESSION_LOSS_CODE,
   DaemonNotification,
   DaemonRequest,
   DaemonResponse,
   PROGRESS_NOTIFICATION_METHOD,
   SessionContext,
+  type BoundSessionLoss,
 } from "./types";
 import {
   SOCKET_PATH,
@@ -135,6 +137,16 @@ const MCP_CLIENT_IDLE_CLOSE_MS = 5 * 60 * 1000;
 const DAEMON_REQUEST_HANDLER_DRAIN_TIMEOUT_MS = 1_000;
 /** Keep shutdown bounded if a client cannot flush a release notification. */
 const DAEMON_NOTIFICATION_WRITE_DRAIN_TIMEOUT_MS = 1_000;
+
+class ReleasedBoundSessionError extends Error {
+  constructor(readonly failure: BoundSessionLoss) {
+    super(
+      `Device session ${failure.sessionUuid} is no longer active (${failure.reason}). ` +
+        "Acquire a new device session before continuing.",
+    );
+    this.name = "ReleasedBoundSessionError";
+  }
+}
 
 /**
  * Bound on the observation-only liveness probe a LOCK-LESS bind runs against an
@@ -1104,6 +1116,9 @@ export class UnixSocketServer {
           ...(error instanceof DeviceControlTransportError
             ? { transportFailure: error.failure }
             : {}),
+          ...(error instanceof ReleasedBoundSessionError
+            ? { boundSessionLoss: error.failure }
+            : {}),
           ...(error instanceof InputTypeTextAppendError ? { charsSent: error.charsSent } : {}),
         };
       }
@@ -1708,6 +1723,9 @@ export class UnixSocketServer {
         context.totalTimeoutMs,
       );
     } catch (error) {
+      if (error instanceof ReleasedBoundSessionError) {
+        throw error;
+      }
       const message = errorMessage(error);
       if (message.includes("Session not found")) {
         return this.retryExpiredMcpSession(context, identity, mcpClient);
@@ -2490,7 +2508,17 @@ export class UnixSocketServer {
     if (!this.isReleasedBoundSession(args)) {
       return;
     }
-    throw new Error(`Session not found: ${this.getSessionUuid(args)}`);
+    const sessionUuid = this.getSessionUuid(args);
+    if (!sessionUuid) {
+      throw new Error("Released bound session is missing its session UUID.");
+    }
+    const release = this.daemonState.getSessionManager().getTerminalReleaseSnapshot?.(sessionUuid);
+    throw new ReleasedBoundSessionError({
+      code: BOUND_SESSION_LOSS_CODE,
+      sessionUuid,
+      reason: release?.releaseReason ?? "session-not-found",
+      ...(release ? { release } : {}),
+    });
   }
 
   private getRequestArgumentScopeKey(args: unknown): string | undefined {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -96,9 +96,7 @@ function hasSessionReleaseSnapshotFields(
   ].every(Boolean);
 }
 
-function isSessionReleaseHeartbeat(
-  value: unknown,
-): value is SessionReleaseSnapshot["heartbeat"] {
+function isSessionReleaseHeartbeat(value: unknown): value is SessionReleaseSnapshot["heartbeat"] {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return false;
   }

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -59,11 +59,103 @@ export interface DaemonResponse {
    */
   transportFailure?: DeviceControlTransportFailure;
   /**
+   * Machine-readable terminal loss of the device session explicitly bound to
+   * this request. This must never be mistaken for an expired loopback MCP
+   * transport session and retried against a replacement daemon.
+   */
+  boundSessionLoss?: BoundSessionLoss;
+  /**
    * Number of leading characters delivered by a failed Android
    * `input/typeText` append request. Present only when the append operation
    * reached the device before failing, or explicitly reports zero progress.
    */
   charsSent?: number;
+}
+
+export const BOUND_SESSION_LOSS_CODE = "bound_session_lost";
+
+export interface BoundSessionLoss {
+  code: typeof BOUND_SESSION_LOSS_CODE;
+  sessionUuid: string;
+  reason: string;
+  /** Captured before the terminal session was removed, when still available. */
+  release?: SessionReleaseSnapshot;
+}
+
+function hasSessionReleaseSnapshotFields(
+  record: Record<string, unknown>,
+  expectedSessionUuid: string,
+): record is Record<string, unknown> &
+  Pick<SessionReleaseSnapshot, "deviceId" | "releaseReason" | "releasedAtMs" | "terminal"> {
+  return [
+    record.sessionId === expectedSessionUuid,
+    typeof record.deviceId === "string",
+    typeof record.releaseReason === "string",
+    typeof record.releasedAtMs === "number" && Number.isFinite(record.releasedAtMs),
+    typeof record.terminal === "boolean",
+  ].every(Boolean);
+}
+
+function isSessionReleaseHeartbeat(
+  value: unknown,
+): value is SessionReleaseSnapshot["heartbeat"] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return [
+    typeof record.lastHeartbeatMs === "number" && Number.isFinite(record.lastHeartbeatMs),
+    typeof record.hasReceivedHeartbeat === "boolean",
+    typeof record.timeoutMs === "number" && Number.isFinite(record.timeoutMs),
+    typeof record.ageMs === "number" && Number.isFinite(record.ageMs),
+  ].every(Boolean);
+}
+
+function sanitizeSessionReleaseSnapshot(
+  value: unknown,
+  expectedSessionUuid: string,
+): SessionReleaseSnapshot | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    !hasSessionReleaseSnapshotFields(record, expectedSessionUuid) ||
+    !isSessionReleaseHeartbeat(record.heartbeat)
+  ) {
+    return undefined;
+  }
+  return {
+    sessionId: expectedSessionUuid,
+    deviceId: record.deviceId,
+    releaseReason: record.releaseReason,
+    releasedAtMs: record.releasedAtMs,
+    terminal: record.terminal,
+    heartbeat: record.heartbeat,
+  };
+}
+
+export function sanitizeBoundSessionLoss(value: unknown): BoundSessionLoss | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record.code !== BOUND_SESSION_LOSS_CODE ||
+    typeof record.sessionUuid !== "string" ||
+    record.sessionUuid.trim().length === 0 ||
+    typeof record.reason !== "string" ||
+    record.reason.trim().length === 0
+  ) {
+    return undefined;
+  }
+  const release = sanitizeSessionReleaseSnapshot(record.release, record.sessionUuid);
+  return {
+    code: BOUND_SESSION_LOSS_CODE,
+    sessionUuid: record.sessionUuid,
+    reason: record.reason,
+    ...(release ? { release } : {}),
+  };
 }
 
 /**

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -2362,6 +2362,59 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("does not let an unrelated typed loss clear the current binding", async () => {
+      const client = new ScriptedDaemonClient({});
+      const originalCallTool = client.callTool.bind(client);
+      let failedRequestParams: Record<string, any> | undefined;
+      client.callTool = async (toolName, params) => {
+        if (params.sessionUuid === "ios-session-b") {
+          failedRequestParams = { ...params };
+          throw new DaemonBoundSessionLostError({
+            code: "bound_session_lost",
+            sessionUuid: "ios-session-b",
+            reason: "session-not-found",
+          });
+        }
+        return await originalCallTool(toolName, params);
+      };
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", {
+          deviceId: "ios-simulator-a",
+          sessionUuid: "ios-session-a",
+        });
+        await expect(
+          proxy.callTool("observe", {
+            deviceId: "ios-simulator-b",
+            sessionUuid: "ios-session-b",
+            __autoMobileBoundSessionUuid: "ios-session-b",
+          }),
+        ).rejects.toMatchObject({
+          sessionUuid: "ios-session-b",
+          reason: "session-not-found",
+        });
+        expect(failedRequestParams).toEqual({
+          deviceId: "ios-simulator-b",
+          sessionUuid: "ios-session-b",
+        });
+
+        await proxy.callTool("observe", { deviceId: "ios-simulator-a" });
+        expect(client.callToolCalls.at(-1)).toEqual({
+          toolName: "observe",
+          params: { deviceId: "ios-simulator-a", sessionUuid: "ios-session-a" },
+        });
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("callTool recovers when a sibling's socket dropped (DaemonUnavailableError)", async () => {
       const recoveredResult = { content: [{ type: "text", text: "sibling recovered" }] };
       const staleClient = new ScriptedDaemonClient({

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -6,6 +6,7 @@ import {
   DaemonToolUnavailableError,
 } from "../../src/daemon/daemonMcpProxy";
 import {
+  DaemonBoundSessionLostError,
   DaemonClient,
   DaemonShuttingDownError,
   DaemonUnavailableError,
@@ -2318,6 +2319,48 @@ describe("DaemonMcpProxy", () => {
     // Critically, a *daemon-returned application error* that merely mentions a
     // transport code (e.g. a tool reporting a downstream `connect ECONNREFUSED`)
     // stays an ActionableError and must NOT be retried.
+
+    test("fences typed bound-session loss without reconnecting or replaying", async () => {
+      const staleClient = new ScriptedDaemonClient({
+        toolError: new DaemonBoundSessionLostError({
+          code: "bound_session_lost",
+          sessionUuid: "ios-session-a",
+          reason: "daemon-shutdown",
+        }),
+      });
+      const freshClient = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "must not replay" }] },
+      });
+      const clients = [staleClient, freshClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        initialSessionUuid: "ios-session-a",
+        clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await expect(
+          proxy.callTool("observe", { deviceId: "ios-simulator-a" }),
+        ).rejects.toMatchObject({
+          sessionUuid: "ios-session-a",
+          reason: "daemon-shutdown",
+        });
+        expect(staleClient.closeCallCount).toBe(0);
+        expect(staleClient.callToolCalls).toEqual([
+          {
+            toolName: "observe",
+            params: { deviceId: "ios-simulator-a", sessionUuid: "ios-session-a" },
+          },
+        ]);
+        expect(freshClient.connectCallCount).toBe(0);
+        expect(freshClient.callToolCalls).toEqual([]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
 
     test("callTool recovers when a sibling's socket dropped (DaemonUnavailableError)", async () => {
       const recoveredResult = { content: [{ type: "text", text: "sibling recovered" }] };

--- a/test/daemon/daemonTransportError.integration.test.ts
+++ b/test/daemon/daemonTransportError.integration.test.ts
@@ -3,7 +3,11 @@ import { createServer, type Server, type Socket } from "node:net";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir, platform } from "node:os";
-import { DaemonClient, DaemonUnavailableError } from "../../src/daemon/client";
+import {
+  DaemonBoundSessionLostError,
+  DaemonClient,
+  DaemonUnavailableError,
+} from "../../src/daemon/client";
 import { DeviceControlTransportError } from "../../src/daemon/deviceControlTransportFailure";
 
 const isWindows = platform() === "win32";
@@ -129,6 +133,66 @@ describe("DaemonClient device-control transport response", () => {
         expect(JSON.stringify((error as DeviceControlTransportError).failure)).not.toContain(
           "secret.invalid",
         );
+      } finally {
+        await client.close();
+      }
+    },
+  );
+});
+
+describe("DaemonClient bound-session loss response", () => {
+  const tempDirs: string[] = [];
+  let server: Server | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = null;
+    }
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  (isWindows ? test.skip : test)(
+    "rehydrates a bound-session loss without treating it as transport failure",
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), "daemon-bound-session-loss-test-"));
+      tempDirs.push(dir);
+      const socketPath = join(dir, "daemon.sock");
+      const failure = {
+        code: "bound_session_lost" as const,
+        sessionUuid: "ios-session-a",
+        reason: "daemon-shutdown",
+      };
+
+      server = createServer((connection: Socket) => {
+        connection.once("data", (data) => {
+          const request = JSON.parse(data.toString().trim()) as { id: string };
+          connection.write(
+            `${JSON.stringify({
+              id: request.id,
+              type: "mcp_response",
+              success: false,
+              error: "Device session ios-session-a is no longer active (daemon-shutdown).",
+              boundSessionLoss: failure,
+            })}\n`,
+          );
+        });
+      });
+      await new Promise<void>((resolve) => server!.listen(socketPath, resolve));
+
+      const client = new DaemonClient(socketPath, 2000);
+      await client.connect();
+
+      try {
+        await client.callTool("observe", { sessionUuid: "ios-session-a" });
+        throw new Error("Expected observe to reject");
+      } catch (error) {
+        expect(error).toBeInstanceOf(DaemonBoundSessionLostError);
+        expect((error as DaemonBoundSessionLostError).failure).toEqual(failure);
+        expect(error).not.toBeInstanceOf(DeviceControlTransportError);
       } finally {
         await client.close();
       }

--- a/test/daemon/proxyResultMintedSession.test.ts
+++ b/test/daemon/proxyResultMintedSession.test.ts
@@ -51,24 +51,36 @@ function deviceStartResult(sessionUuid: string): {
   return { content: [{ type: "text", text: JSON.stringify({ sessionUuid }) }] };
 }
 
+interface AcquiringClientOptions {
+  acquisitionTool?: "getAndroid" | "getApple";
+  deviceId?: string;
+  platform?: "android" | "ios";
+}
+
 // A FakeDaemonClient standing in for a daemon that mints a fresh device session
-// on each getAndroid call (recorded in a real SessionManager), returns its id in
-// the RESULT, and forwards daemon/heartbeat to the same SessionManager.
+// on each device-acquisition call (recorded in a real SessionManager), returns
+// its id in the RESULT, and forwards daemon/heartbeat to the same SessionManager.
 function acquiringClient(
   sessionManager: SessionManager,
   mintedIds: string[],
+  options: AcquiringClientOptions = {},
 ): { client: FakeDaemonClient; nextIndex: () => number } {
+  const {
+    acquisitionTool = "getAndroid",
+    deviceId = "emulator-5554",
+    platform = "android",
+  } = options;
   let acquired = 0;
   const client = new FakeDaemonClient({
     onCallTool: async (toolName) => {
-      if (toolName === "getAndroid") {
+      if (toolName === acquisitionTool) {
         const sessionId = mintedIds[acquired];
         acquired += 1;
-        await sessionManager.createSession(sessionId, "emulator-5554", "android", 60_000);
+        await sessionManager.createSession(sessionId, deviceId, platform, 60_000);
       }
     },
     toolResultFor: (toolName) =>
-      toolName === "getAndroid" ? deviceStartResult(mintedIds[acquired - 1]) : undefined,
+      toolName === acquisitionTool ? deviceStartResult(mintedIds[acquired - 1]) : undefined,
     onCallDaemonMethod: (method, params) => {
       if (method === "daemon/heartbeat" && typeof params.sessionId === "string") {
         sessionManager.recordHeartbeat(params.sessionId);
@@ -317,6 +329,96 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
       expect(sessionManager.getSession(M2)?.hasReceivedHeartbeat).toBe(true);
     } finally {
       await proxy.close();
+    }
+  });
+
+  test("fences independent iOS clients across a shared-daemon restart (#6724)", async () => {
+    const firstApple = acquiringClient(sessionManager, ["ios-session-a"], {
+      acquisitionTool: "getApple",
+      deviceId: "ios-simulator-a",
+      platform: "ios",
+    });
+    const secondApple = acquiringClient(sessionManager, ["ios-session-b"], {
+      acquisitionTool: "getApple",
+      deviceId: "ios-simulator-b",
+      platform: "ios",
+    });
+    const replacementApple = acquiringClient(sessionManager, ["ios-replacement-a"], {
+      acquisitionTool: "getApple",
+      deviceId: "ios-simulator-a",
+      platform: "ios",
+    });
+    const replacementSecondApple = acquiringClient(sessionManager, ["ios-replacement-b"], {
+      acquisitionTool: "getApple",
+      deviceId: "ios-simulator-b",
+      platform: "ios",
+    });
+    const firstClients = [firstApple.client, replacementApple.client];
+    const secondClients = [secondApple.client, replacementSecondApple.client];
+    const firstProxy = new DaemonMcpProxy({
+      clientFactory: () => firstClients.shift()!,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+    const secondProxy = new DaemonMcpProxy({
+      clientFactory: () => secondClients.shift()!,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      await Promise.all([
+        firstProxy.callTool("getApple", {}),
+        secondProxy.callTool("getApple", {}),
+      ]);
+      firstApple.client.emitNotification(
+        SESSION_RELEASED_NOTIFICATION_METHOD,
+        "ios-session-a",
+        "daemon-shutdown",
+      );
+      secondApple.client.emitNotification(
+        SESSION_RELEASED_NOTIFICATION_METHOD,
+        "ios-session-b",
+        "daemon-shutdown",
+      );
+
+      await Promise.all([
+        expect(
+          firstProxy.callTool("observe", { deviceId: "ios-simulator-a" }),
+        ).rejects.toMatchObject({ reason: "daemon-shutdown" }),
+        expect(
+          secondProxy.callTool("observe", { deviceId: "ios-simulator-b" }),
+        ).rejects.toMatchObject({ reason: "daemon-shutdown" }),
+      ]);
+      expect(firstApple.client.callToolCalls).toEqual([{ toolName: "getApple", params: {} }]);
+      expect(secondApple.client.callToolCalls).toEqual([{ toolName: "getApple", params: {} }]);
+
+      firstApple.client.emitConnectionClosed();
+      secondApple.client.emitConnectionClosed();
+      await Promise.all([firstProxy.callTool("getApple", {}), secondProxy.callTool("getApple", {})]);
+      await Promise.all([
+        firstProxy.callTool("observe", { deviceId: "ios-simulator-a" }),
+        secondProxy.callTool("observe", { deviceId: "ios-simulator-b" }),
+      ]);
+
+      expect(replacementApple.client.callToolCalls).toEqual([
+        { toolName: "getApple", params: {} },
+        {
+          toolName: "observe",
+          params: { deviceId: "ios-simulator-a", sessionUuid: "ios-replacement-a" },
+        },
+      ]);
+      expect(replacementSecondApple.client.callToolCalls).toEqual([
+        { toolName: "getApple", params: {} },
+        {
+          toolName: "observe",
+          params: { deviceId: "ios-simulator-b", sessionUuid: "ios-replacement-b" },
+        },
+      ]);
+    } finally {
+      await Promise.all([firstProxy.close(), secondProxy.close()]);
     }
   });
 

--- a/test/daemon/proxyResultMintedSession.test.ts
+++ b/test/daemon/proxyResultMintedSession.test.ts
@@ -397,7 +397,10 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
 
       firstApple.client.emitConnectionClosed();
       secondApple.client.emitConnectionClosed();
-      await Promise.all([firstProxy.callTool("getApple", {}), secondProxy.callTool("getApple", {})]);
+      await Promise.all([
+        firstProxy.callTool("getApple", {}),
+        secondProxy.callTool("getApple", {}),
+      ]);
       await Promise.all([
         firstProxy.callTool("observe", { deviceId: "ios-simulator-a" }),
         secondProxy.callTool("observe", { deviceId: "ios-simulator-b" }),

--- a/test/daemon/socketServerMcpForwardSerialization.integration.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.integration.test.ts
@@ -1044,7 +1044,11 @@ describe("UnixSocketServer MCP forward serialization", () => {
     });
 
     expect(response.success).toBe(false);
-    expect(response.error).toContain("Session not found: released-session");
+    expect(response.boundSessionLoss).toEqual({
+      code: "bound_session_lost",
+      sessionUuid: "released-session",
+      reason: "session-not-found",
+    });
     expect(clientBindings).toEqual([]);
     expect(forwardedArguments).toEqual([]);
   });
@@ -1075,7 +1079,11 @@ describe("UnixSocketServer MCP forward serialization", () => {
     });
 
     expect(response.success).toBe(false);
-    expect(response.error).toContain("Session not found: released-session");
+    expect(response.boundSessionLoss).toEqual({
+      code: "bound_session_lost",
+      sessionUuid: "released-session",
+      reason: "session-not-found",
+    });
     expect(clientBindings).toEqual([]);
   });
 
@@ -1105,7 +1113,11 @@ describe("UnixSocketServer MCP forward serialization", () => {
       });
 
       expect(response.success).toBe(false);
-      expect(response.error).toContain("Session not found: released-session");
+      expect(response.boundSessionLoss).toEqual({
+        code: "bound_session_lost",
+        sessionUuid: "released-session",
+        reason: "session-not-found",
+      });
     }
     expect(clientBindings).toEqual([]);
   });

--- a/test/daemon/socketServerMcpReconnect.integration.test.ts
+++ b/test/daemon/socketServerMcpReconnect.integration.test.ts
@@ -11,7 +11,9 @@ import { SOCKET_REQUEST_DEADLINE_MS, sendSocketRequest } from "./helpers/socketR
 import { defaultTimer } from "../../src/utils/SystemTimer";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { SessionToolBinding } from "../../src/server/SessionToolBinding";
+import { DAEMON_BOUND_SESSION_PARAM } from "../../src/daemon/constants";
 import type { DaemonResponse } from "../../src/daemon/types";
+import type { SessionReleaseSnapshot } from "../../src/daemon/sessionManager";
 
 /**
  * Minimal fake MCP client interface for testing.
@@ -53,6 +55,7 @@ function createFakeDaemonState(
   resolveDeviceLabelSession: () => string | undefined,
   resolvePrimaryDeviceOwnerSession: () => string | undefined,
   resolvePrimarySessionGeneration: () => number,
+  resolveTerminalReleaseSnapshot: () => SessionReleaseSnapshot | undefined,
 ) {
   const session = {
     sessionId: "session-a",
@@ -111,6 +114,7 @@ function createFakeDaemonState(
           ? { B: labeledSession }
           : undefined;
       },
+      getTerminalReleaseSnapshot: resolveTerminalReleaseSnapshot,
       releaseSession: async () => null,
     }),
     getDevicePool: () => ({
@@ -223,6 +227,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
   let deviceLabelSessionUuid: string | undefined;
   let primaryDeviceOwnerSessionUuid: string | undefined;
   let primarySessionGeneration: number;
+  let terminalReleaseSnapshot: SessionReleaseSnapshot | undefined;
 
   beforeEach(async () => {
     socketPath = join(tmpdir(), `mcp-rc-${randomUUID()}.sock`);
@@ -235,6 +240,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
     deviceLabelSessionUuid = "session-b";
     primaryDeviceOwnerSessionUuid = "session-a";
     primarySessionGeneration = 0;
+    terminalReleaseSnapshot = undefined;
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
@@ -247,6 +253,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
         () => deviceLabelSessionUuid,
         () => primaryDeviceOwnerSessionUuid,
         () => primarySessionGeneration,
+        () => terminalReleaseSnapshot,
       ),
       fakeTimer,
     );
@@ -304,6 +311,59 @@ describe("UnixSocketServer MCP session reconnect", () => {
     // After reconnect, the per-key client cache should hold the fresh client.
     expect((server as any).mcpClients.size).toBe(1);
     expect(clientsCreated).toBe(2);
+  });
+
+  test("returns typed bound-session loss without replaying through a fresh loopback client", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+    terminalReleaseSnapshot = {
+      sessionId: "session-a",
+      deviceId: "ios-simulator-a",
+      releaseReason: "daemon-shutdown",
+      releasedAtMs: 20_000,
+      terminal: true,
+      heartbeat: {
+        lastHeartbeatMs: 19_000,
+        hasReceivedHeartbeat: true,
+        timeoutMs: 10_000,
+        ageMs: 1_000,
+      },
+    };
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      // The route was admitted while session-a existed, then the shared daemon
+      // released it before this loopback request could execute.
+      sessionIsValid = false;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          return { content: [] };
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: {
+        sessionUuid: "session-a",
+        [DAEMON_BOUND_SESSION_PARAM]: "session-a",
+      },
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toBe(
+      "Device session session-a is no longer active (daemon-shutdown). " +
+        "Acquire a new device session before continuing.",
+    );
+    expect(response.boundSessionLoss).toEqual({
+      code: "bound_session_lost",
+      sessionUuid: "session-a",
+      reason: "daemon-shutdown",
+      release: terminalReleaseSnapshot,
+    });
+    expect(clientsCreated).toBe(1);
+    expect(callsDispatched).toBe(0);
   });
 
   test("does not retry on non-session errors and returns failure", async () => {

--- a/test/server/proxyServerSessionOwnership.test.ts
+++ b/test/server/proxyServerSessionOwnership.test.ts
@@ -156,12 +156,12 @@ describe("proxy server session ownership errors", () => {
     }
   });
 
-  test("marks daemon-shutdown loss retryable and binds an in-band replacement session (#6336)", async () => {
+  test("returns iOS daemon-shutdown loss and requires an in-band replacement session (#6724)", async () => {
     isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
     const originalClient = new FakeDaemonClient({
       daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
       toolResultFor: (toolName) =>
-        toolName === "getAndroid"
+        toolName === "getApple"
           ? {
               content: [{ type: "text", text: JSON.stringify({ sessionId: "shutdown-session" }) }],
             }
@@ -170,7 +170,7 @@ describe("proxy server session ownership errors", () => {
     const replacementClient = new FakeDaemonClient({
       daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
       toolResultFor: (toolName) =>
-        toolName === "getAndroid"
+        toolName === "getApple"
           ? {
               content: [
                 { type: "text", text: JSON.stringify({ sessionId: "replacement-session" }) },
@@ -201,7 +201,7 @@ describe("proxy server session ownership errors", () => {
       await server.connect(serverTransport);
       await client.connect(clientTransport);
       await proxy.listTools();
-      await client.callTool({ name: "getAndroid", arguments: {} });
+      await client.callTool({ name: "getApple", arguments: {} });
       originalClient.emitNotification(
         SESSION_RELEASED_NOTIFICATION_METHOD,
         "shutdown-session",
@@ -210,7 +210,7 @@ describe("proxy server session ownership errors", () => {
 
       const loss = await client.callTool({
         name: "observe",
-        arguments: { deviceId: "emulator-5554" },
+        arguments: { deviceId: "ios-simulator-1" },
       });
       expect(loss).toMatchObject({
         isError: true,
@@ -237,18 +237,18 @@ describe("proxy server session ownership errors", () => {
       });
 
       originalClient.emitConnectionClosed();
-      await client.callTool({ name: "getAndroid", arguments: {} });
+      await client.callTool({ name: "getApple", arguments: {} });
       await client.callTool({
         name: "observe",
-        arguments: { deviceId: "emulator-5554" },
+        arguments: { deviceId: "ios-simulator-1" },
       });
 
-      expect(originalClient.callToolCalls).toEqual([{ toolName: "getAndroid", params: {} }]);
+      expect(originalClient.callToolCalls).toEqual([{ toolName: "getApple", params: {} }]);
       expect(replacementClient.callToolCalls).toEqual([
-        { toolName: "getAndroid", params: {} },
+        { toolName: "getApple", params: {} },
         {
           toolName: "observe",
-          params: { deviceId: "emulator-5554", sessionUuid: "replacement-session" },
+          params: { deviceId: "ios-simulator-1", sessionUuid: "replacement-session" },
         },
       ]);
     } finally {


### PR DESCRIPTION
## Summary

Expose released bound sessions as a typed daemon-socket failure instead of
matching the ambiguous `Session not found` text. The proxy fences the former
session and returns the existing terminal ownership-loss recovery result, so
clients must deliberately acquire a fresh session.

Added deterministic coverage for two independently bound iOS simulator clients
through a shared-daemon restart, including the explicit `getApple` recovery
path and no-replay/no-retarget guarantees.

## Linked Issue

Closes [#6724](https://github.com/kaeawc/auto-mobile/issues/6724)

## Bug / Regression Context

- **Observed symptom:** a released bound session could enter loopback-session
  retry logic because both used a raw `Session not found` error string.
- **Repro steps / conditions:** restart the shared daemon while iOS clients
  hold bound sessions, then issue a session-bound operation.

## Validation

- [x] Focused daemon, socket, proxy, and iOS session-recovery tests
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `scripts/all_fast_validate_checks.sh` (35/35)
- [x] Rebased onto current `main`

## Risk

Low. The new optional wire field preserves compatibility for existing clients;
generic loopback-session expiry behavior remains unchanged.
