### PR TITLE
fix(android): cancel pending DocumentsUI activation waits

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -2241,11 +2241,18 @@ export class TapOnElement extends BaseVisualChange {
       return false;
     }
     try {
-      if (!(await this.accessibilityService.supportsNodeActionSelectors())) {
+      if (!(await this.accessibilityService.supportsNodeActionSelectors(undefined, signal))) {
         return false;
       }
       throwIfAborted(signal);
-      const result = await this.accessibilityService.requestNodeAction("click", selector);
+      const result = await this.accessibilityService.requestNodeAction(
+        "click",
+        selector,
+        undefined,
+        undefined,
+        signal,
+      );
+      throwIfAborted(signal);
       return result.success;
     } catch (error) {
       throwIfAborted(signal);

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -952,9 +952,10 @@ export interface AndroidCtrlProxy extends CtrlProxyClient {
     selector: AccessibilityNodeSelector,
     timeoutMs?: number,
     perf?: PerformanceTracker,
+    signal?: AbortSignal,
   ): Promise<A11yActionResult>;
 
-  supportsNodeActionSelectors(perf?: PerformanceTracker): Promise<boolean>;
+  supportsNodeActionSelectors(perf?: PerformanceTracker, signal?: AbortSignal): Promise<boolean>;
 
   requestActivateAccessibilityLink(
     text: string,
@@ -2435,13 +2436,20 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     timeoutMs: number = 5000,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     selector?: AccessibilityNodeSelector,
+    signal?: AbortSignal,
   ): Promise<A11yActionResult> {
     const startTime = this.timer.now();
+    const combinedSignal = combineWithAmbientAbort(signal);
+    let pendingRequestId: string | undefined;
 
     this.cancelScreenshotBackoff();
 
     try {
-      const connected = await perf.track("ensureConnection", () => this.connectWebSocket(perf));
+      const connected = await this.awaitActionWork(
+        () => perf.track("ensureConnection", () => this.connectWebSocket(perf)),
+        combinedSignal,
+      );
+      combinedSignal?.throwIfAborted();
       if (!connected) {
         logger.warn("[CTRL_PROXY] Failed to establish WebSocket connection for action");
         return {
@@ -2453,6 +2461,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       }
 
       const requestId = this.requestManager.generateId("action");
+      pendingRequestId = requestId;
       logger.debug(
         `[CTRL_PROXY] Creating action request (requestId: ${requestId}, action: ${action}, ` +
           `resourceId: ${resourceId}, selector: ${JSON.stringify(selector)})`,
@@ -2468,9 +2477,17 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
           totalTimeMs: this.timer.now() - startTime,
           error: `Action timeout after ${timeout}ms`,
         }),
+        (error, totalTimeMs) => ({ success: false, action, totalTimeMs, error }),
       );
 
+      const cancellableAction = this.awaitCancellableRequest(
+        requestId,
+        actionPromise,
+        combinedSignal,
+        startTime,
+      );
       await perf.track("sendRequest", async () => {
+        combinedSignal?.throwIfAborted();
         if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
           throw new Error("WebSocket not connected");
         }
@@ -2484,7 +2501,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         );
       });
 
-      const result = await perf.track("waitForAction", () => actionPromise);
+      const result = await perf.track("waitForAction", () => cancellableAction);
+      combinedSignal?.throwIfAborted();
       const clientDuration = this.timer.now() - startTime;
 
       if (result.success) {
@@ -2497,6 +2515,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
       return result;
     } catch (error) {
+      if (pendingRequestId) {
+        this.requestManager.resolveError(
+          pendingRequestId,
+          String(error),
+          this.timer.now() - startTime,
+        );
+      }
       const duration = this.timer.now() - startTime;
       logger.warn(`[CTRL_PROXY] Action request failed after ${duration}ms: ${error}`);
       return { success: false, action, totalTimeMs: duration, error: `${error}` };
@@ -2508,17 +2533,25 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     selector: AccessibilityNodeSelector,
     timeoutMs: number = 5000,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    signal?: AbortSignal,
   ): Promise<A11yActionResult> {
-    return this.requestAction(action, selector.resourceId, timeoutMs, perf, selector);
+    return this.requestAction(action, selector.resourceId, timeoutMs, perf, selector, signal);
   }
 
   async supportsNodeActionSelectors(
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    signal?: AbortSignal,
   ): Promise<boolean> {
-    const connected = await perf.track("ensureConnection", () => this.connectWebSocket(perf));
+    const combinedSignal = combineWithAmbientAbort(signal);
+    const connected = await this.awaitActionWork(
+      () => perf.track("ensureConnection", () => this.connectWebSocket(perf)),
+      combinedSignal,
+    );
+    combinedSignal?.throwIfAborted();
     if (connected && this.supportedCommands === null) {
-      await this.waitForHandshake();
+      await this.waitForHandshake(undefined, combinedSignal);
     }
+    combinedSignal?.throwIfAborted();
     return connected && this.isCommandSupported("node_selector_actions");
   }
 
@@ -2979,6 +3012,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       );
     };
     signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+    }
     try {
       return await promise;
     } finally {
@@ -4847,12 +4883,51 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     return this.supportedCommands?.has(messageType) === true;
   }
 
+  // Cancel only this caller's wait; connection establishment is shared with other operations.
+  private async awaitActionWork<T>(work: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    signal?.throwIfAborted();
+    if (!signal) {
+      return work();
+    }
+    let onAbort!: () => void;
+    const aborted = new Promise<never>((_resolve, reject) => {
+      onAbort = () => reject(signal.reason ?? new Error(OPERATION_CANCELLED_MESSAGE));
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+    try {
+      return await Promise.race([aborted, work()]);
+    } finally {
+      signal.removeEventListener("abort", onAbort);
+    }
+  }
+
   private async waitForHandshake(
     timeoutMs: number = AndroidCtrlProxyClient.HANDSHAKE_WAIT_TIMEOUT_MS,
+    signal?: AbortSignal,
   ): Promise<void> {
     const deadline = this.timer.now() + timeoutMs;
     while (this.supportedCommands === null && this.timer.now() < deadline) {
-      await this.timer.sleep(AndroidCtrlProxyClient.HANDSHAKE_POLL_INTERVAL_MS);
+      if (!signal) {
+        await this.timer.sleep(AndroidCtrlProxyClient.HANDSHAKE_POLL_INTERVAL_MS);
+        continue;
+      }
+      let timeout: ReturnType<Timer["setTimeout"]> | undefined;
+      try {
+        await this.awaitActionWork(
+          () =>
+            new Promise<void>((resolve) => {
+              timeout = this.timer.setTimeout(
+                resolve,
+                AndroidCtrlProxyClient.HANDSHAKE_POLL_INTERVAL_MS,
+              );
+            }),
+          signal,
+        );
+      } finally {
+        if (timeout !== undefined) {
+          this.timer.clearTimeout(timeout);
+        }
+      }
     }
   }
 

--- a/test/features/action/TapOnElement.documentsUiTap.test.ts
+++ b/test/features/action/TapOnElement.documentsUiTap.test.ts
@@ -160,3 +160,56 @@ test("does not activate or fall back after cancellation during runner capability
   expect(actions).toHaveLength(0);
   expect(adb.getAllCommands()).toHaveLength(0);
 });
+
+test.each(["capability", "action"])(
+  "propagates abort during pending %s without input fallback",
+  async (stage) => {
+    const { tap, adb, gestures } = createTap();
+    const controller = new AbortController();
+    let received: AbortSignal | undefined;
+    let finish!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    if (stage === "capability") {
+      (tap as any).accessibilityService.supportsNodeActionSelectors = async (
+        _perf: unknown,
+        signal: AbortSignal,
+      ) => {
+        received = signal;
+        signal.addEventListener("abort", finish, { once: true });
+        await pending;
+        return true;
+      };
+    } else {
+      (tap as any).accessibilityService.requestNodeAction = async (
+        _action: string,
+        _selector: unknown,
+        _timeout: unknown,
+        _perf: unknown,
+        signal: AbortSignal,
+      ) => {
+        received = signal;
+        signal.addEventListener("abort", finish, { once: true });
+        await pending;
+        return { success: true };
+      };
+    }
+    const result = (tap as any).executeAndroidTapWithCoordinates(
+      "tap",
+      540,
+      380,
+      0,
+      row,
+      controller.signal,
+    );
+    for (let i = 0; i < 12; i++) {
+      await Promise.resolve();
+    }
+    expect(received).toBe(controller.signal);
+    controller.abort();
+    await expect(result).rejects.toThrow("Operation cancelled");
+    expect(adb.getAllCommands()).toHaveLength(0);
+    expect(gestures).toHaveLength(0);
+  },
+);

--- a/test/features/observe/android/AndroidCtrlProxyClientCapabilities.test.ts
+++ b/test/features/observe/android/AndroidCtrlProxyClientCapabilities.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, spyOn } from "bun:test";
 import { AndroidCtrlProxyClient } from "../../../../src/features/observe/android";
 import { BootedDevice } from "../../../../src/models";
 import { AndroidCtrlProxyManager } from "../../../../src/utils/CtrlProxyManager";
 import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
 import { FakeAdbClientFactory } from "../../../fakes/FakeAdbClientFactory";
+import { PortManager } from "../../../../src/utils/PortManager";
 import { FakeTimer } from "../../../fakes/FakeTimer";
 import { FakeWebSocket } from "../../../fakes/FakeWebSocket";
 
@@ -13,6 +14,7 @@ describe("AndroidCtrlProxyClient node action selector capabilities", function ()
   let testDevice: BootedDevice;
 
   beforeEach(function () {
+    PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
     fakeTimer = new FakeTimer();
     fakeAdb = new FakeAdbExecutor();
     fakeAdb.setCommandResponse("forward", { stdout: "8765", stderr: "" });
@@ -33,6 +35,7 @@ describe("AndroidCtrlProxyClient node action selector capabilities", function ()
 
   afterEach(async function () {
     AndroidCtrlProxyClient.resetInstances();
+    PortManager.setPortAvailabilityCheckerForTesting(null);
   });
 
   test("waits for the connected handshake before reading node selector support", async function () {
@@ -99,6 +102,233 @@ describe("AndroidCtrlProxyClient node action selector capabilities", function ()
     } finally {
       await client.close();
     }
+  });
+  test("cancels a pending connection without closing the shared client", async () => {
+    const client = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      undefined,
+      fakeTimer,
+    );
+    let finish!: (connected: boolean) => void;
+    const connection = new Promise<boolean>((resolve) => {
+      finish = resolve;
+    });
+    const connect = spyOn(client as any, "connectWebSocket").mockReturnValue(connection);
+    const close = spyOn(client, "close");
+    const controller = new AbortController();
+    let settled = false;
+    const result = client.supportsNodeActionSelectors(undefined, controller.signal).catch(() => {
+      settled = true;
+    });
+    controller.abort();
+    for (let i = 0; i < 12; i++) {
+      await Promise.resolve();
+    }
+    expect(settled).toBe(true);
+    expect(close).not.toHaveBeenCalled();
+    finish(true);
+    await result;
+    connect.mockRestore();
+    close.mockRestore();
+    await client.close();
+  });
+
+  test("cancels handshake polling and removes its timer", async () => {
+    const client = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      undefined,
+      fakeTimer,
+    );
+    const connect = spyOn(client as any, "connectWebSocket").mockResolvedValue(true);
+    const controller = new AbortController();
+    let settled = false;
+    const result = client.supportsNodeActionSelectors(undefined, controller.signal).catch(() => {
+      settled = true;
+    });
+    for (let i = 0; i < 12; i++) {
+      await Promise.resolve();
+    }
+    controller.abort();
+    for (let i = 0; i < 12; i++) {
+      await Promise.resolve();
+    }
+    expect(settled).toBe(true);
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+    expect(fakeTimer.getPendingSleepCount()).toBe(0);
+    await result;
+    connect.mockRestore();
+    await client.close();
+  });
+
+  test("does not dispatch an action when cancellation wins the connection wait", async () => {
+    let socket!: FakeWebSocket;
+    const client = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      (url) => {
+        socket = new FakeWebSocket(url, "none", 0, fakeTimer);
+        return socket as unknown as WebSocket;
+      },
+      fakeTimer,
+    );
+    await client.ensureConnected();
+    const send = spyOn(socket, "send");
+    let finish!: (connected: boolean) => void;
+    const connect = spyOn(client as any, "connectWebSocket").mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        finish = resolve;
+      }),
+    );
+    const controller = new AbortController();
+    let settled = false;
+    const result = client
+      .requestNodeAction("click", { uniqueId: "row" }, 5000, undefined, controller.signal)
+      .then((value) => {
+        settled = true;
+        return value;
+      });
+    controller.abort();
+    for (let i = 0; i < 12; i++) {
+      await Promise.resolve();
+    }
+    expect(settled).toBe(true);
+    finish(true);
+    expect((await result).success).toBe(false);
+    expect((client as any).requestManager.getPendingCount()).toBe(0);
+    for (let i = 0; i < 12; i++) {
+      await Promise.resolve();
+    }
+    expect(send).not.toHaveBeenCalled();
+    send.mockRestore();
+    connect.mockRestore();
+    await client.close();
+  });
+
+  test.each([true, false])(
+    "cancels a sent action, cleans correlation, and ignores late success=%s",
+    async (success) => {
+      let socket!: FakeWebSocket;
+      const client = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        (url) => {
+          socket = new FakeWebSocket(url, "none", 0, fakeTimer);
+          return socket as unknown as WebSocket;
+        },
+        fakeTimer,
+      );
+      await client.ensureConnected();
+      const controller = new AbortController();
+      const add = spyOn(controller.signal, "addEventListener");
+      const remove = spyOn(controller.signal, "removeEventListener");
+      const result = client.requestNodeAction(
+        "click",
+        { uniqueId: "row" },
+        5000,
+        undefined,
+        controller.signal,
+      );
+      for (let i = 0; i < 20; i++) {
+        await Promise.resolve();
+      }
+      const manager = (client as any).requestManager;
+      const [requestId] = manager.getPendingIds();
+      expect(requestId).toBeDefined();
+      controller.abort();
+      for (let i = 0; i < 12; i++) {
+        await Promise.resolve();
+      }
+      expect(manager.getPendingCount()).toBe(0);
+      socket.simulateMessage(
+        JSON.stringify({
+          type: "action_result",
+          requestId,
+          success,
+          action: "click",
+          totalTimeMs: 1,
+        }),
+      );
+      expect((await result).success).toBe(false);
+      expect(client.isConnected()).toBe(true);
+      expect(remove.mock.calls.length).toBe(add.mock.calls.length);
+      add.mockRestore();
+      remove.mockRestore();
+      await client.close();
+    },
+  );
+  test("already-aborted requests never start connection work", async () => {
+    const client = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      undefined,
+      fakeTimer,
+    );
+    const connect = spyOn(client as any, "connectWebSocket").mockResolvedValue(true);
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      client.supportsNodeActionSelectors(undefined, controller.signal),
+    ).rejects.toThrow();
+    expect(
+      (
+        await client.requestNodeAction(
+          "click",
+          { uniqueId: "row" },
+          5000,
+          undefined,
+          controller.signal,
+        )
+      ).success,
+    ).toBe(false);
+    expect(connect).not.toHaveBeenCalled();
+    connect.mockRestore();
+    await client.close();
+  });
+
+  test.each(["response", "send failure"])("cleans up when cancellation races %s", async (mode) => {
+    let socket!: FakeWebSocket;
+    const client = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      (url) => {
+        socket = new FakeWebSocket(url, "none", 0, fakeTimer);
+        return socket as unknown as WebSocket;
+      },
+      fakeTimer,
+    );
+    await client.ensureConnected();
+    const controller = new AbortController();
+    const send = spyOn(socket, "send").mockImplementation((data) => {
+      const message = JSON.parse(String(data));
+      if (mode === "send failure") {
+        throw new Error("send failed");
+      }
+      socket.simulateMessage(
+        JSON.stringify({
+          type: "action_result",
+          requestId: message.requestId,
+          success: true,
+          action: "click",
+          totalTimeMs: 1,
+        }),
+      );
+      controller.abort();
+    });
+    const result = await client.requestNodeAction(
+      "click",
+      { uniqueId: "row" },
+      5000,
+      undefined,
+      controller.signal,
+    );
+    expect(result.success).toBe(false);
+    expect(result.action).toBe("click");
+    expect((client as any).requestManager.getPendingCount()).toBe(0);
+    expect(client.isConnected()).toBe(true);
+    send.mockRestore();
+    await client.close();
   });
 });
 


### PR DESCRIPTION
## Summary

Cancelling a DocumentsUI tap now promptly stops its pending capability or node-action wait. The tap forwards its signal to CtrlProxy, checks cancellation after activation, and never enters coordinate/ADB fallback after abort. Queued actions check cancellation before sending; pending requests remove their correlation entries, timeout, and abort listener.

Connection establishment remains shared: cancelling one caller releases that caller's wait without closing a connection other operations use. A tap already delivered to Android cannot be undone.

Closes [issue 6360](https://github.com/kaeawc/auto-mobile/issues/6360).

## Implementation

Uses the existing ambient-signal and request-management seams, plus standard `Promise.race` in one private client helper shared by connection and handshake waits. Handshake polling uses the injected timer and clears it on cancellation. Optional trailing signal arguments preserve existing callers. No new dependency, wire change, or runner release is required.

## Validation

- Five new client regressions failed before the fix. All 26 focused tests now pass, covering pending connection/handshake/action cancellation, open-socket no-dispatch, pre-aborted entry, late response races, send-failure cleanup, shared connection preservation, signal forwarding, and no input fallback. Uses fakes and virtual time, including fake port availability.
- `AUTOMOBILE_UNIT_TEST_WORKERS=4 bun run turbo:validate`: 7/7 tasks passed.
- `bun run typecheck`: no new errors.
- Formatting and patch checks passed.
- Runtime Behavior, Delivery & Enforcement, and cancellation-race review passes: no blockers.
