### PR TITLE
fix(session): retain recovery route ownership through final binding

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -57,6 +57,19 @@ export type { DeviceRecoveryPolicy } from "./poolConfig";
 
 type AutolockClient = { mcpSessionId?: string; expectedSessionId?: string };
 
+interface McpSessionRecoveryLease {
+  readonly device: PooledDevice;
+  readonly token: symbol;
+}
+
+export class McpSessionRecoveryInProgressError extends ActionableError {
+  constructor(mcpSessionId: string) {
+    super(
+      `MCP session '${mcpSessionId}' is recovering a device and cannot remap until recovery finishes.`,
+    );
+  }
+}
+
 function resolveLifecycleCoordinator(
   coordinator: VirtualDeviceLifecycleCoordinator | undefined,
 ): VirtualDeviceLifecycleCoordinator {
@@ -357,7 +370,7 @@ export class DevicePool {
   private lastUsedAtMarker = 0;
   private lastReleasedDeviceId: string | null = null;
   private readonly mcpSessionAutolockMap: Map<string, string> = new Map();
-  private readonly mcpSessionRecoveryDevices: Map<string, PooledDevice> = new Map();
+  private readonly mcpSessionRecoveryDevices: Map<string, McpSessionRecoveryLease> = new Map();
   private readonly refreshMissingDeviceMisses: Map<string, number> = new Map();
   private readonly suppressedAutoStartDeviceImageKeys: Set<string> = new Set();
   private readonly suppressedAutoStartImageKeyByDeviceId: Map<string, string> = new Map();
@@ -4649,6 +4662,7 @@ export class DevicePool {
           `Replacement device '${replacement.deviceId}' was not retained by the device pool.`,
         );
       }
+      this.transferMcpSessionRecoveryLeases(expectedDevice, replacementDevice);
       this.intentionalShutdowns.delete(expectedDevice.id);
       return {
         preservedSessionId,
@@ -5021,6 +5035,7 @@ export class DevicePool {
         device: PooledDevice;
         session?: Session;
         release: () => Promise<void>;
+        releaseRecoveryRouteLease: () => void;
       }
     | undefined
   > {
@@ -5028,20 +5043,15 @@ export class DevicePool {
       throw abortSignal.reason ?? new Error("Shutdown reservation cancelled");
     }
     const identity = this.reserveShutdownSessionIdentity(deviceId);
-    let expectedDevice: PooledDevice | undefined;
-    try {
-      expectedDevice = await this.reserveShutdownDeviceWithAbort(
-        deviceId,
-        identity,
-        abortSignal,
-        autolockClient,
-      );
-    } catch (error) {
-      if (autolockClient?.mcpSessionId) {
-        this.mcpSessionRecoveryDevices.delete(autolockClient.mcpSessionId);
-      }
-      throw error;
-    }
+    const recoveryRouteLease =
+      autolockClient?.mcpSessionId && "expectedSessionId" in autolockClient ? Symbol() : undefined;
+    const expectedDevice = await this.reserveShutdownDeviceWithAbort(
+      deviceId,
+      identity,
+      abortSignal,
+      autolockClient,
+      recoveryRouteLease,
+    );
     if (!expectedDevice) {
       identity.releaseSession?.();
       return undefined;
@@ -5059,12 +5069,16 @@ export class DevicePool {
       if (this.shutdownReservations.get(capturedDevice.id) === capturedDevice) {
         this.shutdownReservations.delete(capturedDevice.id);
       }
-      if (autolockClient?.mcpSessionId) {
-        this.mcpSessionRecoveryDevices.delete(autolockClient.mcpSessionId);
-      }
       identity.releaseSession?.();
     };
-    return { device: capturedDevice, session: identity.session, release };
+    const releaseRecoveryRouteLease = () =>
+      this.releaseMcpSessionRecoveryLease(autolockClient?.mcpSessionId, recoveryRouteLease);
+    return {
+      device: capturedDevice,
+      session: identity.session,
+      release,
+      releaseRecoveryRouteLease,
+    };
   }
 
   private async reserveShutdownDeviceWithAbort(
@@ -5072,6 +5086,7 @@ export class DevicePool {
     identity: ShutdownIdentityReservation,
     abortSignal: AbortSignal | undefined,
     autolockClient: AutolockClient | undefined,
+    recoveryRouteLease: symbol | undefined,
   ): Promise<PooledDevice | undefined> {
     const releaseSessionOnAbort = () => identity.releaseSession?.();
     abortSignal?.addEventListener("abort", releaseSessionOnAbort, { once: true });
@@ -5081,6 +5096,7 @@ export class DevicePool {
         identity,
         abortSignal,
         autolockClient,
+        recoveryRouteLease,
       );
       if (abortSignal?.aborted) {
         if (expectedDevice && this.shutdownReservations.get(deviceId) === expectedDevice) {
@@ -5090,6 +5106,7 @@ export class DevicePool {
       }
       return expectedDevice;
     } catch (error) {
+      this.releaseMcpSessionRecoveryLease(autolockClient?.mcpSessionId, recoveryRouteLease);
       identity.releaseSession?.();
       throw error;
     } finally {
@@ -5125,6 +5142,7 @@ export class DevicePool {
     identity: ShutdownIdentityReservation,
     abortSignal: AbortSignal | undefined,
     autolockClient: AutolockClient | undefined,
+    recoveryRouteLease: symbol | undefined,
   ): Promise<PooledDevice | undefined> {
     return await this.assignmentMutex.runExclusive(() => {
       if (abortSignal?.aborted) {
@@ -5146,16 +5164,56 @@ export class DevicePool {
       // A readiness await can outlive this client's ownership. Check it while
       // reserving shutdown so a stale request cannot reboot another session's device.
       this.getOwnedAutolockSession(currentDevice, autolockClient);
-      if (autolockClient?.mcpSessionId && "expectedSessionId" in autolockClient) {
-        this.mcpSessionRecoveryDevices.set(autolockClient.mcpSessionId, currentDevice);
-      }
       if (this.shutdownReservations.get(deviceId) === currentDevice) {
         throw new ActionableError(`Device '${deviceId}' is already shutting down.`);
       }
       this.completeShutdownSessionIdentity(deviceId, currentDevice, identity);
+      this.reserveMcpSessionRecoveryLease(
+        autolockClient?.mcpSessionId,
+        currentDevice,
+        recoveryRouteLease,
+      );
       this.shutdownReservations.set(deviceId, currentDevice);
       return currentDevice;
     });
+  }
+
+  private reserveMcpSessionRecoveryLease(
+    mcpSessionId: string | undefined,
+    device: PooledDevice,
+    token: symbol | undefined,
+  ): void {
+    if (!mcpSessionId || token === undefined) {
+      return;
+    }
+    if (this.mcpSessionRecoveryDevices.has(mcpSessionId)) {
+      throw new ActionableError(`MCP session '${mcpSessionId}' is already recovering a device.`);
+    }
+    this.mcpSessionRecoveryDevices.set(mcpSessionId, { device, token });
+  }
+
+  private releaseMcpSessionRecoveryLease(
+    mcpSessionId: string | undefined,
+    token: symbol | undefined,
+  ): void {
+    if (
+      mcpSessionId &&
+      token !== undefined &&
+      this.mcpSessionRecoveryDevices.get(mcpSessionId)?.token === token
+    ) {
+      this.mcpSessionRecoveryDevices.delete(mcpSessionId);
+    }
+  }
+
+  private transferMcpSessionRecoveryLeases(
+    previous: PooledDevice,
+    replacement: PooledDevice,
+  ): void {
+    for (const [mcpSessionId, lease] of this.mcpSessionRecoveryDevices) {
+      if (lease.device === previous) {
+        this.mcpSessionRecoveryDevices.set(mcpSessionId, { ...lease, device: replacement });
+      }
+    }
   }
 
   private completeShutdownSessionIdentity(
@@ -5584,13 +5642,8 @@ export class DevicePool {
     if (!isDevicePoolAutolockEnabled()) {
       return undefined;
     }
-    return this.assignmentMutex.runExclusive(() => {
-      if (mcpSessionId && this.mcpSessionRecoveryDevices.has(mcpSessionId)) {
-        throw new ActionableError(
-          `MCP session '${mcpSessionId}' is recovering a device and cannot remap until recovery finishes.`,
-        );
-      }
-      return this.autolockDeviceExclusive(
+    return this.assignmentMutex.runExclusive(() =>
+      this.autolockDeviceExclusive(
         deviceId,
         platform,
         mcpSessionId,
@@ -5600,8 +5653,8 @@ export class DevicePool {
         readinessReservationOwners,
         verifiedAndroidAvdIdentity,
         achievedReadiness,
-      );
-    });
+      ),
+    );
   }
 
   private async autolockDeviceExclusive(
@@ -5639,6 +5692,7 @@ export class DevicePool {
           `  - Use 'listDevices' to see currently available devices`,
       );
     }
+    this.assertMcpSessionCanAutolockDevice(mcpSessionId, device);
     this.assertRuntimeIdentity(device, expectedIdentity);
     this.assertNotReservedForShutdown(
       device,
@@ -5727,6 +5781,19 @@ export class DevicePool {
       `Autolocked device ${deviceId} with session ${sessionId} (timeout: ${timeoutMs}ms)`,
     );
     return sessionId;
+  }
+
+  private assertMcpSessionCanAutolockDevice(
+    mcpSessionId: string | undefined,
+    device: PooledDevice,
+  ): void {
+    if (
+      mcpSessionId &&
+      this.mcpSessionRecoveryDevices.get(mcpSessionId)?.device !== undefined &&
+      this.mcpSessionRecoveryDevices.get(mcpSessionId)?.device !== device
+    ) {
+      throw new McpSessionRecoveryInProgressError(mcpSessionId);
+    }
   }
 
   /** Warm acquisition must prove ownership before reusing a live autolock. */
@@ -5878,6 +5945,7 @@ export class DevicePool {
       ) {
         return;
       }
+      this.assertMcpSessionCanAutolockDevice(mcpSessionId, device);
       await this.deviceSessionRepository.markAutolockSession(sessionId, {
         mcpSessionId,
         daemonSessionId: this.daemonSessionId,

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -57,6 +57,7 @@ import {
 import { DaemonState } from "../daemon/daemonState";
 import type { DeviceReadinessLevel } from "../utils/DeviceSessionManager";
 import type { DevicePool, DeviceReadinessReservation, PooledDevice } from "../daemon/devicePool";
+import { McpSessionRecoveryInProgressError } from "../daemon/devicePool";
 import type { Session, SessionManager } from "../daemon/sessionManager";
 import { DeviceBootService, type DeviceBootResult } from "../utils/deviceBootService";
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
@@ -3375,6 +3376,7 @@ async function rebootAndroidAfterSystemUiAnr(
   releaseReadinessReservation?: DeviceReadinessReservation;
   retireReplacement?: () => Promise<void>;
   validatePreservedSession?: () => Promise<void>;
+  releaseRecoveryRouteLease?: () => void;
 }> {
   const sourceImage = await resolveSystemUiRecoveryImage(
     boot,
@@ -3435,6 +3437,7 @@ async function rebootAndroidAfterSystemUiAnr(
           adoptedReplacementBoot,
         ),
       validatePreservedSession: handoff?.validatePreservedSession,
+      releaseRecoveryRouteLease: shutdownReservation?.releaseRecoveryRouteLease,
     };
   } catch (error) {
     // The pool rolls an adopted replacement back before rejecting its handoff,
@@ -3458,6 +3461,9 @@ async function rebootAndroidAfterSystemUiAnr(
     throw error;
   } finally {
     await shutdownReservation?.release();
+    if (!keepReadinessReservation) {
+      shutdownReservation?.releaseRecoveryRouteLease();
+    }
     if (!keepReadinessReservation) {
       await releaseReadinessReservation?.();
     }
@@ -3649,6 +3655,7 @@ async function ensureRunnerReadyWithSystemUiAnrRecovery(
           releaseError,
         );
       }
+      recovery.releaseRecoveryRouteLease?.();
       throw readinessError;
     }
     return { ...recovery, recovered: true };
@@ -3750,6 +3757,7 @@ async function prepareStartDeviceRunnerReadiness(
     try {
       await prepareRecoveredDeviceForRunnerReadiness(input, devicePool, readinessResult);
     } catch (error) {
+      readinessResult.releaseRecoveryRouteLease?.();
       try {
         await readinessResult.retireReplacement?.();
       } catch (cleanupError) {
@@ -4159,6 +4167,9 @@ export function registerDeviceTools() {
       await completeProvisionDeviceOperation(store, args.operationId, result);
       return result;
     } catch (error) {
+      if (error instanceof McpSessionRecoveryInProgressError) {
+        throw error;
+      }
       const provisionError = toProvisionDeviceError(args, error);
       await store.fail(args.operationId, provisionError.code, provisionError.message, {
         clearCreationStarted:
@@ -4337,6 +4348,10 @@ export function registerDeviceTools() {
     try {
       return await revalidateLiveProvisionDeviceSession(args, deps, result, signal);
     } catch (error) {
+      // A transport routing conflict does not invalidate the healthy device session.
+      if (error instanceof McpSessionRecoveryInProgressError) {
+        throw error;
+      }
       await releaseProvisionDeviceSession(result, "provision-device-replay-validation-failed");
       throw error;
     }
@@ -5359,65 +5374,69 @@ export function registerDeviceTools() {
             deviceReadinessLockKey(replacement.platform, replacement.deviceId),
           ),
       });
-      state.boot = readinessResult.boot;
-      moveDeviceAcquisitionReadiness(
-        acquisitionReadinessKey,
-        deviceReadinessLockKey(state.boot.device.platform, state.boot.device.deviceId),
-      );
-      sourceImage = state.boot.sourceImage ?? sourceImage;
-      // Re-check under the later binding lock because pool identity can change
-      // while runner setup is in flight.
-      validatePooledDeviceMapping(state.boot.device, requestedIdentity);
-
-      // Publish only after runner health passes. Readiness remains per-device,
-      // so 20-40 concurrent emulators do not serialize on a host-wide gate.
-      publishWarmDeviceReady(state.boot.source, state.boot.device.deviceId);
-      await validatePreservedSystemUiAnrRecoverySession(
-        readinessResult.preservedSessionId,
-        readinessResult.validatePreservedSession,
-        readinessResult.retireReplacement,
-      );
-      const verifiedWarmAndroidAvdIdentity = getVerifiedWarmAndroidAvdIdentity(
-        state.boot,
-        sourceImage,
-      );
-      // Recovery must revalidate the caller through the same autolock path;
-      // a preserved UUID alone is not proof that this client owns the session.
-      const boundSessionId =
-        readinessResult.preservedSessionId && !isDevicePoolAutolockEnabled()
-          ? readinessResult.preservedSessionId
-          : await bindBootedDeviceSession(
-              state.boot.device,
-              args,
-              state.boot.source === "cold-boot" && !readinessResult.preservedSessionId
-                ? sourceImage
-                : undefined,
-              // Recovery already registered this process and its output tail.
-              readinessResult.preservedSessionId ? undefined : state.boot.processHandle,
-              new Set(releaseReadinessReservations.map((reservation) => reservation.owner)),
-              verifiedWarmAndroidAvdIdentity,
-            );
-      if (readinessResult.preservedSessionId) {
-        // #6227 round 7: without autolock, System UI ANR recovery bypasses
-        // `bindBootedDeviceSession` (and therefore its own
-        // `recordAcquiredSessionReadiness` call) entirely when a preserved
-        // session is being reused. But by this point
-        // `prepareStartDeviceRunnerReadiness` has already run the *same*
-        // `ensureCtrlProxyReady` setup this function always awaits for a
-        // freshly-bound session — recovery re-verified runner readiness on the
-        // replacement device before handing back `preservedSessionId` (see
-        // `ensureRunnerReadyWithSystemUiAnrRecovery`) — so the achieved level
-        // here is unconditionally `automationReady`, exactly like the
-        // freshly-bound branch. Recording it here closes the gap where a
-        // recovered session's readiness cache stayed `undefined` and the first
-        // `automationReady` tool after recovery redundantly re-ran setup.
-        recordAcquiredSessionReadiness(
-          daemonState,
-          readinessResult.preservedSessionId,
-          "automationReady",
+      try {
+        state.boot = readinessResult.boot;
+        moveDeviceAcquisitionReadiness(
+          acquisitionReadinessKey,
+          deviceReadinessLockKey(state.boot.device.platform, state.boot.device.deviceId),
         );
+        sourceImage = state.boot.sourceImage ?? sourceImage;
+        // Re-check under the later binding lock because pool identity can change
+        // while runner setup is in flight.
+        validatePooledDeviceMapping(state.boot.device, requestedIdentity);
+
+        // Publish only after runner health passes. Readiness remains per-device,
+        // so 20-40 concurrent emulators do not serialize on a host-wide gate.
+        publishWarmDeviceReady(state.boot.source, state.boot.device.deviceId);
+        await validatePreservedSystemUiAnrRecoverySession(
+          readinessResult.preservedSessionId,
+          readinessResult.validatePreservedSession,
+          readinessResult.retireReplacement,
+        );
+        const verifiedWarmAndroidAvdIdentity = getVerifiedWarmAndroidAvdIdentity(
+          state.boot,
+          sourceImage,
+        );
+        // Recovery must revalidate the caller through the same autolock path;
+        // a preserved UUID alone is not proof that this client owns the session.
+        const boundSessionId =
+          readinessResult.preservedSessionId && !isDevicePoolAutolockEnabled()
+            ? readinessResult.preservedSessionId
+            : await bindBootedDeviceSession(
+                state.boot.device,
+                args,
+                state.boot.source === "cold-boot" && !readinessResult.preservedSessionId
+                  ? sourceImage
+                  : undefined,
+                // Recovery already registered this process and its output tail.
+                readinessResult.preservedSessionId ? undefined : state.boot.processHandle,
+                new Set(releaseReadinessReservations.map((reservation) => reservation.owner)),
+                verifiedWarmAndroidAvdIdentity,
+              );
+        if (readinessResult.preservedSessionId) {
+          // #6227 round 7: without autolock, System UI ANR recovery bypasses
+          // `bindBootedDeviceSession` (and therefore its own
+          // `recordAcquiredSessionReadiness` call) entirely when a preserved
+          // session is being reused. But by this point
+          // `prepareStartDeviceRunnerReadiness` has already run the *same*
+          // `ensureCtrlProxyReady` setup this function always awaits for a
+          // freshly-bound session — recovery re-verified runner readiness on the
+          // replacement device before handing back `preservedSessionId` (see
+          // `ensureRunnerReadyWithSystemUiAnrRecovery`) — so the achieved level
+          // here is unconditionally `automationReady`, exactly like the
+          // freshly-bound branch. Recording it here closes the gap where a
+          // recovered session's readiness cache stayed `undefined` and the first
+          // `automationReady` tool after recovery redundantly re-ran setup.
+          recordAcquiredSessionReadiness(
+            daemonState,
+            readinessResult.preservedSessionId,
+            "automationReady",
+          );
+        }
+        return boundSessionId;
+      } finally {
+        readinessResult.releaseRecoveryRouteLease?.();
       }
-      return boundSessionId;
     });
     state.ownershipTransferred = true;
 

--- a/test/daemon/devicePoolAutolockOwnership.test.ts
+++ b/test/daemon/devicePoolAutolockOwnership.test.ts
@@ -372,3 +372,154 @@ test("System UI recovery rejects a remapped client while its first target is idl
     }
   });
 });
+
+test.each([false, true])(
+  "recovery route lease survives readiness and releases after failure=%s",
+  async (failReadiness) => {
+    await withAutolock(async () => {
+      const deviceUtils = new FakeDeviceUtils();
+      const h = await harness(deviceUtils);
+      const matcher = new FakeDeviceMatcher();
+      const device = h.devices.bootedDevices[0];
+      const image = { ...device, deviceId: "emulator-5556", isRunning: false };
+      const otherDevice = { ...device, deviceId: "emulator-5558", name: "Other AVD" };
+      const recoveredProcess = new FakeChildProcess(h.timer);
+      deviceUtils.setMockChildProcess(image.name, recoveredProcess as unknown as ChildProcess);
+      deviceUtils.setBootedDevices("android", [device]);
+      deviceUtils.setDeviceImages("android", [image]);
+      matcher.setBootedResult(device);
+      matcher.setImageResult(image);
+      const kill = deviceUtils.killDevice.bind(deviceUtils);
+      deviceUtils.killDevice = async (target, options) => {
+        await kill(target, options);
+        deviceUtils.setBootedDevices("android", []);
+      };
+      let readinessAttempts = 0;
+      let remapError: unknown;
+      DaemonState.getInstance().initialize(h.manager, h.pool);
+      setDeviceToolsDependencies({
+        deviceManagerFactory: () => deviceUtils,
+        deviceMatcherFactory: () => matcher,
+        timer: h.timer,
+        notifyResourcesChanged: async () => {},
+        ensureCtrlProxyReady: async (request) => {
+          ++readinessAttempts;
+          if (readinessAttempts === 1) {
+            throw new SystemUiAnrRecoveryRequiredError("System UI ANR");
+          }
+          deviceUtils.setBootedDevices("android", [request.device, otherDevice]);
+          await h.pool.addDevice(otherDevice);
+          remapError = await h.pool
+            .autolockDevice(otherDevice.deviceId, "android", "agent-A")
+            .catch((error: unknown) => error);
+          if (failReadiness) {
+            throw new Error("replacement readiness failed");
+          }
+        },
+      });
+      registerDeviceTools();
+      try {
+        const acquiring = ToolRegistry.getTool("getAndroid")!.handler({
+          deviceId: device.deviceId,
+          __mcpSessionId: "agent-A",
+        });
+        if (failReadiness) {
+          await expect(acquiring).rejects.toThrow("replacement readiness failed");
+        } else {
+          const sessionId = getDeviceSessionIdFromResult(await acquiring);
+          expect(h.manager.getSession(sessionId!)?.assignedDevice).toBe(image.deviceId);
+          expect(h.pool.resolveAutolockSessionForMcpSession("agent-A")).toBe(sessionId);
+        }
+        expect(readinessAttempts).toBe(2);
+        expect(remapError).toMatchObject({
+          message: expect.stringContaining("recovering a device"),
+        });
+        expect(h.pool.getDevice(otherDevice.deviceId)?.sessionId).toBeNull();
+        expect(
+          await h.pool.autolockDevice(otherDevice.deviceId, "android", "agent-A"),
+        ).toBeDefined();
+      } finally {
+        resetDeviceToolsDependencies();
+        DaemonState.getInstance().reset();
+        ToolRegistry.clearTools();
+        await h.close();
+      }
+    });
+  },
+);
+
+test("cancelling a shutdown reservation releases only its recovery route lease", async () => {
+  await withAutolock(async () => {
+    const h = await harness();
+    const controller = new AbortController();
+    try {
+      const pending = h.pool.reserveDeviceForShutdown("emulator-5554", controller.signal, {
+        mcpSessionId: "agent-A",
+        expectedSessionId: undefined,
+      });
+      queueMicrotask(() => controller.abort(new Error("cancelled recovery")));
+      await expect(pending).rejects.toThrow("cancelled recovery");
+      const retry = await h.pool.reserveDeviceForShutdown("emulator-5554", undefined, {
+        mcpSessionId: "agent-A",
+        expectedSessionId: undefined,
+      });
+      expect(retry).toBeDefined();
+      retry!.releaseRecoveryRouteLease();
+      await retry!.release();
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+test("a competing recovery cannot release the first recovery route lease", async () => {
+  await withAutolock(async () => {
+    const deviceUtils = new FakeDeviceUtils();
+    const h = await harness(deviceUtils);
+    const otherDevice = {
+      ...h.devices.bootedDevices[0],
+      deviceId: "emulator-5558",
+      name: "Other AVD",
+    };
+    try {
+      deviceUtils.setBootedDevices("android", [...h.devices.bootedDevices, otherDevice]);
+      await h.pool.addDevice(otherDevice);
+      const firstPending = h.pool.reserveDeviceForShutdown("emulator-5554", undefined, {
+        mcpSessionId: "agent-A",
+        expectedSessionId: undefined,
+      });
+      const competing = h.pool.reserveDeviceForShutdown("emulator-5554", undefined, {
+        mcpSessionId: "agent-A",
+        expectedSessionId: undefined,
+      });
+      const first = await firstPending;
+      expect(first).toBeDefined();
+      await expect(competing).rejects.toThrow("already shutting down");
+      await expect(
+        h.pool.autolockDevice(otherDevice.deviceId, "android", "agent-A"),
+      ).rejects.toThrow("recovering a device");
+      first!.releaseRecoveryRouteLease();
+      await first!.release();
+      const newer = await h.pool.reserveDeviceForShutdown("emulator-5554", undefined, {
+        mcpSessionId: "agent-A",
+        expectedSessionId: undefined,
+      });
+      first!.releaseRecoveryRouteLease();
+      await expect(
+        h.pool.autolockDevice(otherDevice.deviceId, "android", "agent-A"),
+      ).rejects.toThrow("recovering a device");
+      const otherSession = await h.pool.autolockDevice(otherDevice.deviceId, "android", "agent-B");
+      await expect(
+        h.pool.attachAutolockSessionToMcpSession(otherSession!, "agent-A"),
+      ).rejects.toThrow("recovering a device");
+      expect(h.pool.resolveAutolockSessionForMcpSession("agent-A")).toBeUndefined();
+      expect((await h.repository.getSession(otherSession!))?.mcp_session_id).toBe("agent-B");
+      newer!.releaseRecoveryRouteLease();
+      await newer!.release();
+      await h.pool.attachAutolockSessionToMcpSession(otherSession!, "agent-A");
+      expect(h.pool.resolveAutolockSessionForMcpSession("agent-A")).toBe(otherSession);
+    } finally {
+      await h.close();
+    }
+  });
+});

--- a/test/server/deviceTools.provisionDevice.test.ts
+++ b/test/server/deviceTools.provisionDevice.test.ts
@@ -1430,7 +1430,7 @@ describe("provisionDevice handler", () => {
     }
   });
 
-  test("associates a live autolock session with a reconnected MCP client", async () => {
+  test("reconnecting during recovery preserves the live session and completed operation", async () => {
     const originalAutolock = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
     process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
     const timer = new FakeTimer();
@@ -1477,6 +1477,27 @@ describe("provisionDevice handler", () => {
           })) as any
         ).content[0].text,
       );
+      const recoveringDevice = {
+        ...bootedDevice,
+        deviceId: "recovering-device",
+        name: "Recovery AVD",
+      };
+      await pool.addDevice(recoveringDevice);
+      const recovery = await pool.reserveDeviceForShutdown(recoveringDevice.deviceId, undefined, {
+        mcpSessionId: "mcp-session-reconnected",
+        expectedSessionId: undefined,
+      });
+      const rejected = await tool.handler({ ...args, __mcpSessionId: "mcp-session-reconnected" });
+      expect(JSON.stringify(rejected)).toContain("recovering a device");
+      expect(sessionManager.getSession(first.sessionId)).not.toBeNull();
+      expect(pool.getDevice(bootedDevice.deviceId)?.sessionId).toBe(first.sessionId);
+      expect(pool.resolveAutolockSessionForMcpSession("mcp-session-original")).toBe(
+        first.sessionId,
+      );
+      expect(pool.resolveAutolockSessionForMcpSession("mcp-session-reconnected")).toBeUndefined();
+      expect(operationStore.failCalls).toBe(0);
+      recovery!.releaseRecoveryRouteLease();
+      await recovery!.release();
       const second = JSON.parse(
         (
           (await tool.handler({


### PR DESCRIPTION
System UI ANR recovery released its transport route guard before replacement readiness and final binding. A second acquisition could replace that route, while a losing concurrent recovery could remove the first recovery's guard.

Keep an identity-scoped lease through replacement binding or cancellation, transfer its target to the replacement, and reject other route writers while recovery is active. Reconnect conflicts preserve the healthy provisioned session and completed operation so callers can retry once recovery finishes.

Closes [issue #6726](https://github.com/kaeawc/auto-mobile/issues/6726). Follow-up to [PR #6690](https://github.com/kaeawc/auto-mobile/pull/6690), addressing the remaining [lease lifetime](https://github.com/kaeawc/auto-mobile/pull/6690#discussion_r3962676095) and [competing recovery](https://github.com/kaeawc/auto-mobile/pull/6690#discussion_r3962676103) feedback.

Validation: deterministic tests cover remapping during replacement readiness, failed readiness, cancellation, competing recovery reservations, stale release callbacks, and provisioning replay conflicts. Local review also checked alternate transport-route writers and cleanup paths. Full `bun run turbo:validate` and `bun run typecheck` pass (the latter uses the repository's existing error baseline).
