### PR TITLE
fix(observe): report empty Android captures as incomplete

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -782,6 +782,14 @@ export class RealObserveScreen implements ObserveScreen {
           signal,
         ),
         activityAttributionMismatch: postCaptureForeground.activityAttributionMismatch,
+        // A matching package and recent timestamp do not verify an empty first-run
+        // capture (#6352). Use all content collections, not just clickable controls:
+        // text-only and media-only screens remain valid. This runs before caching.
+        emptyFocusedWindow:
+          this.device.platform === "android" &&
+          Boolean(result.activeWindow?.appId) &&
+          result.elements !== undefined &&
+          Object.values(result.elements).every((elements) => elements.length === 0),
         // The SETTLED/confirmed foreground, not the initial parallel sample: during an
         // A→B transition the initial sample can still read A while the hierarchy and the
         // confirming read are already on B, and comparing against stale A would retract a

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -49,7 +49,7 @@ import {
 } from "./screenshot/ObserveScreenshotRecorder";
 import { HierarchyCollector } from "./collectors/HierarchyCollector";
 import { DeviceStateCollector } from "./collectors/DeviceStateCollector";
-import { PerformanceAuditor } from "./audits/PerformanceAuditor";
+import { findAppWindowBounds, PerformanceAuditor } from "./audits/PerformanceAuditor";
 import { AccessibilityAuditor, resolveLatestScreenshotPath } from "./audits/AccessibilityAuditor";
 import { AccessibilityStateDetector } from "./audits/AccessibilityStateDetector";
 import { appendObserveError } from "./ObserveError";
@@ -227,7 +227,11 @@ function isEmptyFocusedWindow(result: ObserveResult): boolean {
   if (!result.activeWindow?.appId || !result.elements) {
     return false;
   }
-  const focused = result.viewHierarchy?.windows?.find((window) => window.isFocused)?.bounds ?? {
+  if (SYSTEM_UI_WINDOW_PACKAGES.has(result.activeWindow.appId)) {
+    return false;
+  }
+  const appBounds = findAppWindowBounds(result, result.activeWindow.appId);
+  const focused = appBounds ?? {
     top: 0,
     bottom: Infinity,
     left: -Infinity,
@@ -236,20 +240,24 @@ function isEmptyFocusedWindow(result: ObserveResult): boolean {
   // Native snapshots aggregate all windows and do not label individual nodes with
   // their package. Restrict content to the focused window and exclude system bars,
   // so a clock/icon sibling cannot certify an empty application window (#6352).
-  const systemSurface = SYSTEM_UI_WINDOW_PACKAGES.has(result.activeWindow.appId);
-  const insets = systemSurface ? { top: 0, bottom: 0 } : result.systemInsets;
+  const insets = result.systemInsets;
   const top = Math.max(focused.top, insets.top);
   const bottom = Math.min(
     focused.bottom,
     (result.viewHierarchy?.screenHeight ?? Infinity) - insets.bottom,
+  );
+  const left = Math.max(focused.left, insets.left);
+  const right = Math.min(
+    focused.right,
+    (result.viewHierarchy?.screenWidth ?? Infinity) - insets.right,
   );
   return Object.values(result.elements).every((elements) =>
     elements.every(
       ({ bounds }) =>
         bounds.bottom <= top ||
         bounds.top >= bottom ||
-        bounds.right <= focused.left ||
-        bounds.left >= focused.right,
+        bounds.right <= left ||
+        bounds.left >= right,
     ),
   );
 }

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -223,6 +223,37 @@ function isStatusBarOnlyHierarchy(result: ObserveResult): boolean {
   return hasBounds;
 }
 
+function isEmptyFocusedWindow(result: ObserveResult): boolean {
+  if (!result.activeWindow?.appId || !result.elements) {
+    return false;
+  }
+  const focused = result.viewHierarchy?.windows?.find((window) => window.isFocused)?.bounds ?? {
+    top: 0,
+    bottom: Infinity,
+    left: -Infinity,
+    right: Infinity,
+  };
+  // Native snapshots aggregate all windows and do not label individual nodes with
+  // their package. Restrict content to the focused window and exclude system bars,
+  // so a clock/icon sibling cannot certify an empty application window (#6352).
+  const systemSurface = SYSTEM_UI_WINDOW_PACKAGES.has(result.activeWindow.appId);
+  const insets = systemSurface ? { top: 0, bottom: 0 } : result.systemInsets;
+  const top = Math.max(focused.top, insets.top);
+  const bottom = Math.min(
+    focused.bottom,
+    (result.viewHierarchy?.screenHeight ?? Infinity) - insets.bottom,
+  );
+  return Object.values(result.elements).every((elements) =>
+    elements.every(
+      ({ bounds }) =>
+        bounds.bottom <= top ||
+        bounds.top >= bottom ||
+        bounds.right <= focused.left ||
+        bounds.left >= focused.right,
+    ),
+  );
+}
+
 /**
  * Synchronous counterpart to the async, device-confirmed status-bar-only gate
  * below (issue #6220): `activeWindow.appId` is empty even after every
@@ -785,11 +816,7 @@ export class RealObserveScreen implements ObserveScreen {
         // A matching package and recent timestamp do not verify an empty first-run
         // capture (#6352). Use all content collections, not just clickable controls:
         // text-only and media-only screens remain valid. This runs before caching.
-        emptyFocusedWindow:
-          this.device.platform === "android" &&
-          Boolean(result.activeWindow?.appId) &&
-          result.elements !== undefined &&
-          Object.values(result.elements).every((elements) => elements.length === 0),
+        emptyFocusedWindow: this.device.platform === "android" && isEmptyFocusedWindow(result),
         // The SETTLED/confirmed foreground, not the initial parallel sample: during an
         // A→B transition the initial sample can still read A while the hierarchy and the
         // confirming read are already on B, and comparing against stale A would retract a

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -106,6 +106,8 @@ export interface FreshnessInputs {
    * pre-#6172 runners — treated as the historical `null_root` default.
    */
   incompleteCapture?: { sdkInt?: number; reason?: CtrlProxyIncompleteReason };
+  /** Android has a foreground window but captured no accessible content (#6352). */
+  emptyFocusedWindow?: boolean;
   /**
    * ADB and CtrlProxy disagree about the current activity within the same
    * application, and a forced recapture could not safely reconcile them.
@@ -359,6 +361,18 @@ function resolveIdentityMismatch(
       verified: false,
       isFresh: false,
       warning: `The accessibility service reported the capture as incomplete: ${lead}. ${incompleteCaptureGuidance(sdkInt, reason)}`,
+      category: "window_identity",
+    };
+  }
+  if (inputs.emptyFocusedWindow) {
+    return {
+      requestedAfter,
+      actualTimestamp,
+      ageMs,
+      verified: false,
+      isFresh: false,
+      warning:
+        "The focused Android window has no captured accessible content, so this capture is incomplete. Observe again once the window has finished loading; a recent timestamp alone does not verify its content.",
       category: "window_identity",
     };
   }

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -364,7 +364,7 @@ function resolveIdentityMismatch(
       category: "window_identity",
     };
   }
-  if (inputs.emptyFocusedWindow) {
+  if (inputs.emptyFocusedWindow && !inputs.missingForegroundWindow) {
     return {
       requestedAfter,
       actualTimestamp,

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -96,6 +96,52 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(recovered.freshness?.isFresh).toBe(true);
   });
 
+  test("a status-bar sibling cannot verify an empty focused app (#6352)", async () => {
+    const timer = new FakeTimer();
+    timer.setCurrentTime(1_700_000_000_000);
+    const viewHierarchy = new FakeViewHierarchy();
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.google.android.calendar", userId: 0 });
+    const bounds = { left: 0, top: 0, right: 1080, bottom: 2400 };
+    viewHierarchy.configureHierarchy({
+      ...calendarHierarchy(timer.now()),
+      systemInsets: { top: 63, right: 0, bottom: 0, left: 0 },
+      windows: [{ id: 1, type: 1, isFocused: true, bounds }],
+      hierarchy: {
+        node: [{ bounds }, { text: "12:34", bounds: { left: 0, top: 0, right: 200, bottom: 60 } }],
+      },
+    } as any);
+    const result = await makeScreen(viewHierarchy, fakeAdb, timer).execute({
+      skipScreenshot: true,
+      skipBackStack: true,
+    });
+    expect(result.elements?.text).toHaveLength(1);
+    expect(result.freshness?.verified).toBe(false);
+    expect(result.freshness?.warning).toContain("capture is incomplete");
+    for (const content of [
+      { text: "Welcome" },
+      { clickable: true },
+      { className: "android.widget.ImageView" },
+    ]) {
+      viewHierarchy.configureHierarchy({
+        ...calendarHierarchy(timer.now()),
+        systemInsets: { top: 63, right: 0, bottom: 0, left: 0 },
+        windows: [{ id: 1, type: 1, isFocused: true, bounds }],
+        hierarchy: {
+          node: [
+            { ...content, bounds: { left: 0, top: 100, right: 100, bottom: 200 } },
+            { text: "12:34", bounds: { left: 0, top: 0, right: 200, bottom: 60 } },
+          ],
+        },
+      } as any);
+      const recovered = await makeScreen(viewHierarchy, fakeAdb, timer).execute({
+        skipScreenshot: true,
+        skipBackStack: true,
+      });
+      expect(recovered.freshness?.verified).toBe(true);
+    }
+  });
+
   afterEach(() => {
     resetObserveCacheStore();
   });

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -142,6 +142,43 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     }
   });
 
+  test("keyboard and side-system-bar siblings cannot verify an empty app (#6352)", async () => {
+    const timer = new FakeTimer();
+    timer.setCurrentTime(1_700_000_000_000);
+    const viewHierarchy = new FakeViewHierarchy();
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.google.android.calendar", userId: 0 });
+    const appBounds = { left: 0, top: 0, right: 1080, bottom: 1200 };
+    viewHierarchy.configureHierarchy({
+      ...calendarHierarchy(timer.now()),
+      systemInsets: { top: 63, right: 100, bottom: 0, left: 0 },
+      windows: [
+        { id: 1, type: 1, isActive: true, isFocused: false, bounds: appBounds },
+        {
+          id: 2,
+          type: 2,
+          isActive: true,
+          isFocused: true,
+          bounds: { left: 0, top: 1200, right: 1080, bottom: 2400 },
+        },
+      ],
+      hierarchy: {
+        node: [
+          { bounds: appBounds },
+          { text: "Keyboard", bounds: { left: 0, top: 1600, right: 300, bottom: 1700 } },
+          { text: "Back", bounds: { left: 1000, top: 100, right: 1080, bottom: 200 } },
+        ],
+      },
+    } as any);
+    const result = await makeScreen(viewHierarchy, fakeAdb, timer).execute({
+      skipScreenshot: true,
+      skipBackStack: true,
+    });
+    expect(result.elements?.text).toHaveLength(2);
+    expect(result.freshness?.verified).toBe(false);
+    expect(result.freshness?.warning).toContain("capture is incomplete");
+  });
+
   afterEach(() => {
     resetObserveCacheStore();
   });

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -26,14 +26,23 @@ const androidDevice: BootedDevice = {
   platform: "android",
 };
 
-function makeScreen(viewHierarchy: FakeViewHierarchy, fakeAdb: FakeAdbExecutor): RealObserveScreen {
-  return new RealObserveScreen(androidDevice, new FakeAdbClientFactory(fakeAdb), {
-    viewHierarchy,
-    cacheStore: new FakeObserveCacheStore(new FakeTimer()),
-    performanceAuditor: { run: async () => undefined } as any,
-    accessibilityAuditor: { run: async () => undefined } as any,
-    accessibilityStateDetector: { run: async () => undefined } as any,
-  });
+function makeScreen(
+  viewHierarchy: FakeViewHierarchy,
+  fakeAdb: FakeAdbExecutor,
+  timer?: FakeTimer,
+): RealObserveScreen {
+  return new RealObserveScreen(
+    androidDevice,
+    new FakeAdbClientFactory(fakeAdb),
+    {
+      viewHierarchy,
+      cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+      performanceAuditor: { run: async () => undefined } as any,
+      accessibilityAuditor: { run: async () => undefined } as any,
+      accessibilityStateDetector: { run: async () => undefined } as any,
+    },
+    timer,
+  );
 }
 
 function calendarHierarchy(now: number): any {
@@ -55,6 +64,38 @@ function calendarHierarchy(now: number): any {
 }
 
 describe("ObserveScreen window-identity freshness (issue #5867)", () => {
+  test("empty first-run content is incomplete even when the focused package matches (#6352)", async () => {
+    const timer = new FakeTimer();
+    timer.setCurrentTime(1_700_000_000_000);
+    const viewHierarchy = new FakeViewHierarchy();
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.google.android.calendar", userId: 0 });
+    const screen = makeScreen(viewHierarchy, fakeAdb, timer);
+
+    for (const node of [
+      undefined,
+      [],
+      { bounds: { left: 0, top: 0, right: 1080, bottom: 2400 } },
+    ]) {
+      viewHierarchy.configureHierarchy({
+        ...calendarHierarchy(timer.now()),
+        hierarchy: { node },
+      } as any);
+      const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+      expect(result.freshness?.verified).toBe(false);
+      expect(result.freshness?.isFresh).toBe(false);
+      expect(result.freshness?.warning).toContain("capture is incomplete");
+      expect(result.freshness?.warning).not.toContain("no root");
+      expect(result.freshness?.warning).not.toContain("isAccessibilityTool");
+    }
+
+    // Readable text is sufficient: no clickable control is required for recovery.
+    viewHierarchy.configureHierarchy(calendarHierarchy(timer.now()));
+    const recovered = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+    expect(recovered.freshness?.verified).toBe(true);
+    expect(recovered.freshness?.isFresh).toBe(true);
+  });
+
   afterEach(() => {
     resetObserveCacheStore();
   });


### PR DESCRIPTION
## Summary

Android observations with a known foreground window but no captured text, controls, scrolling content, or media in its content area now report `freshness.verified: false` and `isFresh: false`, with an incomplete-capture warning recommending another observation. A recent timestamp and matching package previously certified these empty first-run captures as fresh. The check uses focused-window bounds when supplied and excludes system-bar strips for app windows, so status-bar clock/icon siblings cannot mask an empty app capture.

The verdict is attached before caching and reaches the existing launchApp and observation-poll freshness guards. Text-only and media-only screens remain eligible for freshness. This implements the issue's diagnostic alternative without adding a wait or changing the native runner.

## Linked Issue

Closes [#6352](https://github.com/kaeawc/auto-mobile/issues/6352)

## Bug / Regression Context

- Chrome first-run launches could return an empty skeleton while the foreground activity was correct and UIAutomator could read the rendered screen.
- The existing incomplete-capture path depended on a runner flag. This guard also covers captures without that flag and does not diagnose an unproven null-root or accessibility-tool configuration problem.

## Validation

- Regressions failed before the fix and passed afterward: missing nodes, an empty node list, a contentless full-screen container, and an empty app with a status-bar sibling retract freshness; text/control/image content restores it. Existing specific status-bar diagnostics retain priority.
- `bun run turbo:validate`: all 7 tasks passed, including full unit tests, lint, build, and boundary checks.
- `bun run typecheck`: no new errors.
- Targeted freshness/window-identity tests and formatting check passed.
- Runtime Behavior, Delivery & Enforcement, and Window Geometry review completed. Uses existing element collections, typed window bounds, and FakeTimer; the local guard is private to its consumer, with no new dependency.

## Device Verification

The original first-run Chrome scenario has not been rerun on a device. Validation uses the real observation path with injected hierarchy and device fakes.
