### PR TITLE
fix: bound tapOn hierarchy search polling

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -151,6 +151,7 @@ export class TapOnElement extends BaseVisualChange {
   private strategy: TapStrategy;
   private longPressMetadataDetector: LongPressMetadataDetector;
   private readonly waitForCondition: WaitForCondition;
+  private static readonly SEARCH_POLL_INTERVAL_MS = 50;
   private static readonly SEARCH_UNTIL_DEFAULT_MS = 1500;
   private static readonly SEARCH_UNTIL_MIN_MS = 100;
   private static readonly SEARCH_UNTIL_MAX_MS = 12000;
@@ -1400,8 +1401,21 @@ export class TapOnElement extends BaseVisualChange {
         offScreenRejections += 1;
       }
       const deadline = startTime + searchDurationMs;
-      while (this.timer.now() < deadline) {
+      // Fast cached iOS responses must yield just like device round-trips.
+      // Keep an independent request ceiling even if the wall clock moves backward.
+      const maxRequests = Math.ceil(searchDurationMs / TapOnElement.SEARCH_POLL_INTERVAL_MS);
+      let nextPollAt = startTime;
+      while (this.timer.now() < deadline && requestCount < maxRequests) {
         throwIfAborted(signal);
+        const delayMs = Math.min(nextPollAt, deadline) - this.timer.now();
+        if (delayMs > 0) {
+          await this.timer.sleep(delayMs);
+          throwIfAborted(signal);
+        }
+        if (this.timer.now() >= deadline) {
+          break;
+        }
+        nextPollAt = this.timer.now() + TapOnElement.SEARCH_POLL_INTERVAL_MS;
         const remainingTimeMs = Math.max(0, deadline - this.timer.now());
         const refreshedHierarchy = await this.refreshViewHierarchy(
           remainingTimeMs,

--- a/test/features/action/TapOnElement.searchPolling.test.ts
+++ b/test/features/action/TapOnElement.searchPolling.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { TapOnElement } from "../../../src/features/action/TapOnElement";
+import { PortManager } from "../../../src/utils/PortManager";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeElementSelector } from "../../fakes/FakeElementSelector";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { ResultFaker } from "../../fakes/ResultFaker";
+
+function setup(platform: "android" | "ios") {
+  const timer = new FakeTimer();
+  timer.enableAutoAdvance();
+  const selector = new FakeElementSelector();
+  const command = new TapOnElement(
+    { name: "test", platform, deviceId: "test" } as any,
+    new FakeAdbClient() as any,
+    { timer, elementSelector: selector },
+  );
+  const hierarchy = { hierarchy: { node: [] } };
+  const requests: number[] = [];
+  const refresh = spyOn(command as any, "refreshViewHierarchy").mockImplementation(async () => {
+    requests.push(timer.now());
+    // Bound the broken implementation too, so the red test cannot spin forever.
+    timer.advanceTime(1);
+    return hierarchy;
+  });
+  const search = (duration = 1500, signal?: AbortSignal) =>
+    (command as any).searchForElement(
+      { action: "tap", text: "missing", searchUntil: { duration } },
+      { viewHierarchy: hierarchy, screenSize: { width: 400, height: 800 } },
+      signal,
+    );
+  return { timer, selector, refresh, requests, search };
+}
+
+describe("TapOnElement search polling", () => {
+  beforeEach(() => {
+    PortManager.reset();
+    PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
+  });
+  afterEach(() => {
+    PortManager.reset();
+    PortManager.setPortAvailabilityCheckerForTesting(null);
+  });
+  for (const platform of ["ios", "android"] as const) {
+    test(`${platform} bounds fast misses and yields between hierarchy requests`, async () => {
+      const { search, requests } = setup(platform);
+      const result = await search();
+      expect(result.selection.element).toBeNull();
+      expect(result.stats.requestCount).toBeGreaterThan(1);
+      expect(result.stats.requestCount).toBeLessThanOrEqual(30);
+      expect(result.stats.requestCount).toBe(requests.length);
+      expect(result.stats.durationMs).toBeLessThanOrEqual(1500);
+      for (let i = 1; i < requests.length; i++) {
+        expect(requests[i] - requests[i - 1]).toBeGreaterThanOrEqual(50);
+      }
+    });
+  }
+
+  test("null refreshes cannot bypass pacing", async () => {
+    const { search, refresh, timer } = setup("ios");
+    refresh.mockImplementation(async () => {
+      timer.advanceTime(1);
+      return null;
+    });
+    expect((await search()).stats.requestCount).toBeLessThanOrEqual(30);
+  });
+
+  test("finds a target on a later poll without waiting out the window", async () => {
+    const { search, refresh, selector, timer } = setup("ios");
+    const target = ResultFaker.element({ bounds: { left: 0, top: 0, right: 100, bottom: 50 } });
+    let calls = 0;
+    refresh.mockImplementation(async () => {
+      timer.advanceTime(1);
+      if (++calls === 2) {
+        selector.setNextElement(target);
+      }
+      return { hierarchy: { node: [] } };
+    });
+    const result = await search();
+    expect(result.selection.element).toBe(target);
+    expect(result.stats.requestCount).toBe(2);
+    expect(result.stats.durationMs).toBeLessThan(1500);
+  });
+
+  test("off-screen matches cannot bypass pacing", async () => {
+    const { search, selector } = setup("ios");
+    selector.setNextElement(
+      ResultFaker.element({
+        bounds: { left: 500, top: 900, right: 600, bottom: 950 },
+      }),
+    );
+    const result = await search();
+    expect(result.selection.element).toBeNull();
+    expect(result.stats.requestCount).toBeLessThanOrEqual(30);
+  });
+
+  test("request ceiling terminates even when the clock stops advancing", async () => {
+    const { search, timer } = setup("ios");
+    spyOn(timer, "now").mockReturnValue(0);
+    expect((await search()).stats.requestCount).toBe(30);
+  });
+
+  test("an initial match needs no poll or delay", async () => {
+    const { search, selector, refresh, timer } = setup("ios");
+    selector.setNextElement(
+      ResultFaker.element({
+        bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+      }),
+    );
+    expect((await search()).stats.requestCount).toBe(0);
+    expect(refresh).not.toHaveBeenCalled();
+    expect(timer.now()).toBe(0);
+  });
+
+  test("aborting during the poll delay prevents another request", async () => {
+    const { search, refresh, timer } = setup("ios");
+    const controller = new AbortController();
+    timer.setTimeout(() => controller.abort(), 25);
+    await expect(search(1500, controller.signal)).rejects.toThrow();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

A missing `tapOn` selector could repeatedly reprocess fast iOS hierarchy responses without yielding, starving the shared daemon. Pace hierarchy search requests at least 50 ms apart and cap each search at `ceil(duration / 50)` requests (30 for the default window), including null refreshes and off-screen matches. Initial matches still return immediately; cancellation is checked after each delay.

## Linked Issue

Closes [#6510](https://github.com/kaeawc/auto-mobile/issues/6510).

## Validation

- Eight FakeTimer regression tests cover Android/iOS misses, null responses, off-screen matches, a stalled clock, initial/later matches, and cancellation.
- The original implementation failed four regression checks before the fix.
- `bun run typecheck`: no new errors.
- `AUTOMOBILE_UNIT_TEST_WORKERS=4 bun run turbo:validate`: all seven tasks passed. Initial full-load run timed out in two unrelated tests; both passed focused rerun and the full suite passed at reduced parallelism.

The change reuses the injected Timer and existing port-checking fake, with no new dependency. Searches sample at 50 ms granularity. A general daemon watchdog is outside this polling fix; live Safari reproduction has not been rerun.
