### PR TITLE
fix(tap): report missing testTag selector accurately

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -1553,6 +1553,10 @@ export class TapOnElement extends BaseVisualChange {
       baseError = `Element not found with provided text '${options.text}'${containerHint}`;
     } else if (options.textAny) {
       baseError = `Element not found with any provided text '${options.textAny.join("', '")}'${containerHint}`;
+    } else if (options.testTag) {
+      baseError = `Element not found with provided testTag '${options.testTag}'${containerHint}`;
+    } else if (options.accessibilityLink) {
+      baseError = `Element not found with provided accessibilityLink '${options.accessibilityLink}'${containerHint}`;
     } else {
       baseError = `Element not found with provided elementId '${options.elementId}'${containerHint}`;
     }

--- a/test/features/action/TapOnElement.visionFallback.test.ts
+++ b/test/features/action/TapOnElement.visionFallback.test.ts
@@ -57,6 +57,46 @@ describe("TapOnElement vision fallback (handleElementNotFound)", () => {
     });
   };
 
+  const missingSelectorCases: { selector: Partial<TapOnElementOptions>; message: string }[] = [
+    {
+      selector: { elementId: "missing-id" },
+      message: "Element not found with provided elementId 'missing-id'",
+    },
+    {
+      selector: { testTag: "nonexistent-tag-xyz" },
+      message: "Element not found with provided testTag 'nonexistent-tag-xyz'",
+    },
+    { selector: { text: "Missing" }, message: "Element not found with provided text 'Missing'" },
+    {
+      selector: { textAny: ["Missing", "Absent"] },
+      message: "Element not found with any provided text 'Missing', 'Absent'",
+    },
+    {
+      selector: { accessibilityLink: "Missing link" },
+      message: "Element not found with provided accessibilityLink 'Missing link'",
+    },
+  ];
+
+  for (const { selector, message } of missingSelectorCases) {
+    for (const container of [undefined, { text: "Settings" }, { elementId: "settings-id" }]) {
+      test(`missing ${Object.keys(selector)[0]} preserves selector and container context ${JSON.stringify(container)}`, async () => {
+        const tapOn = createTapOnElement(new FakeScreenshotCapturer(), new FakeVisionAnalyzer(), {
+          ...enabledVisionConfig,
+          enabled: false,
+        });
+        const containerHint = container
+          ? container.elementId
+            ? " within container elementId 'settings-id'"
+            : " within container text 'Settings'"
+          : "";
+
+        await expect(
+          tapOn["handleElementNotFound"]({ action: "tap", ...selector, container }),
+        ).rejects.toThrow(message + containerHint);
+      });
+    }
+  }
+
   test("throws enriched error with navigation steps (high confidence)", async () => {
     const capturer = new FakeScreenshotCapturer();
     capturer.setPaths(["/screenshot.png"]);


### PR DESCRIPTION
## Summary

A missing `testTag` in `tapOn` now reports the selector name and searched value instead of `elementId 'undefined'`. Add explicit diagnostic branches for `testTag` and `accessibilityLink`, preserving existing text, textAny, elementId, and container messages. The accessibilityLink case provides defensive formatter coverage; native semantic-link activation retains its existing error path.

## Linked Issue

Closes [#6356](https://github.com/kaeawc/auto-mobile/issues/6356)

## Bug / Regression Context

Calling `tapOn` with `selector: { testTag: "nonexistent-tag-xyz" }` searched correctly but fell through to the elementId diagnostic. Fifteen regression cases cover all five selector shapes without a container and with text/elementId containers. Six new cases failed before the fix and pass afterward.

## Validation

- [x] `AUTOMOBILE_UNIT_TEST_WORKERS=2 bun run turbo:validate` passed all seven tasks. Initial default-concurrency run hit two unrelated timeout failures; both passed individually and the full reduced-concurrency rerun passed.
- [x] `bun run typecheck` reports no new errors.
- [x] `bash scripts/all_fast_validate_checks.sh`: 35 passed, zero failed.
- [x] Targeted diagnostic and tool-message tests: 45 passed.
- [x] New tests reuse existing fakes and FakeTimer, with no new helper or dependency.
- [x] Current with main at validation; Runtime Behavior review found no actionable issues.

Device verification was not performed; this change is limited to failure-message construction.
