### PR TITLE
fix(android): report unchecked state in raw hierarchy

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -1062,7 +1062,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           scrollable = if (node.isScrollable) "true" else null,
           password = if (node.isPassword) "true" else null,
           checkable = if (node.isCheckable) "true" else null,
-          checked = if (node.isChecked) "true" else null,
+          checked = if (node.isCheckable) node.isChecked.toString() else null,
           selected = if (node.isSelected) "true" else null,
           longClickable = if (node.isLongClickable) "true" else null,
           children = children,

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -29,6 +29,36 @@ class ViewHierarchyExtractorTest {
   private val json = Json { ignoreUnknownKeys = true }
 
   @Test
+  fun `raw hierarchy reports both checkable states and omits checked for other nodes`() {
+    for ((checkable, checked) in listOf(true to false, true to true, false to false)) {
+      val node = android.view.accessibility.AccessibilityNodeInfo.obtain()
+      node.className = "android.widget.Switch"
+      node.text = "Hotspot"
+      node.isVisibleToUser = true
+      node.isCheckable = checkable
+      node.isChecked = checked
+      node.setBoundsInScreen(Rect(0, 0, 100, 100))
+      android.view.accessibility.AccessibilityNodeInfo::class
+        .java
+        .getMethod("setSealed", Boolean::class.javaPrimitiveType)
+        .invoke(node, true)
+
+      val result = extractor.extractFromActiveWindow(node, disableAllFiltering = true)
+      assertNull(result!!.error)
+      val rawNode = result.hierarchy!!.node as kotlinx.serialization.json.JsonObject
+      assertEquals(
+        if (checkable) kotlinx.serialization.json.JsonPrimitive(checked.toString()) else null,
+        rawNode["checked"],
+      )
+      assertEquals(
+        if (checkable) kotlinx.serialization.json.JsonPrimitive("true") else null,
+        rawNode["checkable"],
+      )
+      node.recycle()
+    }
+  }
+
+  @Test
   fun `snapshot options reject unsafe bounds`() {
     assertThrows(IllegalArgumentException::class.java) {
       HierarchySnapshotOptions(maxDepth = -1)


### PR DESCRIPTION
## Summary

Raw Android hierarchy nodes now emit `checked: "false"` for unchecked checkable controls and `checked: "true"` for checked controls. Non-checkable nodes continue to omit the attribute. This removes the ambiguity between an unchecked switch and an unreported state.

Closes [#6349](https://github.com/kaeawc/auto-mobile/issues/6349).

## Bug / Regression Context

The extractor previously emitted `checked` only when true. The skeleton fix in [#6270](https://github.com/kaeawc/auto-mobile/pull/6270) already reports false correctly; this fixes the raw runner projection. The regression test exercises raw extraction and wire serialization for both checkable states and a non-checkable node.

## Validation

- Regression reproduced before the fix: expected `"false"`, received null.
- Android `ViewHierarchyExtractorTest` and `WireNodeCodecTest`: 91 tests passed; new regression test completed in 7 ms.
- `AUTOMOBILE_UNIT_TEST_WORKERS=2 bun run turbo:validate`: passed all seven tasks. Initial default-parallel run hit timing limits in two unrelated TypeScript tests; the reduced-concurrency run passed without changing those tests.
- `bun run typecheck`: no new errors.
- `bash scripts/ktfmt/validate_ktfmt.sh`: passed.
- Independent runtime review: no actionable findings.

## Kotlin Reuse Check

Uses existing Android `isCheckable`/`isChecked` properties, Kotlin `Boolean.toString()`, and the existing wire serializer. No helper or dependency added.

## Device Verification and Release Sequence

Validated with Robolectric through the production extractor and serializer; no live-device verification in this change. Merge this source fix first, then the next Prepare Release run rebuilds CtrlProxy and regenerates the pinned APK checksum before publication. Existing released APKs retain the old behavior until that release is installed.
