### PR TITLE
ci: move portable macOS test legs off the PR critical path

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,168 @@ permissions:
   checks: write
 
 jobs:
+  macos-bats-tests:
+    name: "macOS BATS Shell Tests"
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - name: "Install BATS"
+        shell: bash
+        run: |
+          if command -v bats &>/dev/null; then
+            echo "bats already installed: $(bats --version)"
+          elif command -v brew &>/dev/null; then
+            brew install bats-core
+          else
+            git clone --depth 1 --branch v1.14.0 https://github.com/bats-core/bats-core.git /tmp/bats-core
+            sudo /tmp/bats-core/install.sh /usr/local
+          fi
+          if command -v shellcheck &>/dev/null; then
+            echo "shellcheck already installed: $(shellcheck --version | awk '/^version:/{print $2}')"
+          elif command -v brew &>/dev/null; then
+            brew install shellcheck
+          else
+            echo "shellcheck missing and no package manager to install it" >&2
+            exit 1
+          fi
+
+      - name: "Setup Bun"
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: "Install Bun dependencies"
+        shell: bash
+        run: scripts/ci/install-bun-deps.sh
+
+      - name: "Run BATS Unit Tests"
+        shell: bash
+        env:
+          AUTOMOBILE_BATS_MAX_FILE_SECONDS: "240"
+          AUTOMOBILE_BATS_UNIT_BUDGET_SECONDS: "420"
+        run: scripts/ci/run-bats.sh unit
+
+  macos-bats-integration-tests:
+    name: "macOS BATS Integration Tests"
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - name: "Install BATS"
+        shell: bash
+        run: |
+          if command -v bats &>/dev/null; then
+            echo "bats already installed: $(bats --version)"
+          elif command -v brew &>/dev/null; then
+            brew install bats-core
+          else
+            git clone --depth 1 --branch v1.14.0 https://github.com/bats-core/bats-core.git /tmp/bats-core
+            sudo /tmp/bats-core/install.sh /usr/local
+          fi
+          if command -v shellcheck &>/dev/null; then
+            echo "shellcheck already installed"
+          elif command -v brew &>/dev/null; then
+            brew install shellcheck
+          else
+            echo "shellcheck missing and no package manager to install it" >&2
+            exit 1
+          fi
+
+      - name: "Setup Bun"
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: "Install Bun dependencies"
+        shell: bash
+        run: scripts/ci/install-bun-deps.sh
+
+      - name: "Run BATS Integration Tests"
+        shell: bash
+        run: scripts/ci/run-bats.sh integration
+
+  macos-node-unit-tests:
+    name: "macOS Node Unit Tests"
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+          fetch-depth: 0
+
+      - name: "Setup Bun"
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: "Install Bun dependencies"
+        shell: bash
+        run: scripts/ci/install-bun-deps.sh
+
+      - name: "Run complete unit lane"
+        shell: bash
+        env:
+          AUTOMOBILE_TEST_MODE: "true"
+          AUTOMOBILE_TEST_WALL_TIMEOUT_SECONDS: "720"
+          AUTOMOBILE_UNIT_JUNIT_DIR: scratch/timing-unit-reports
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            unset AUTOMOBILE_TEST_WALL_TIMEOUT_SECONDS
+          fi
+          bash scripts/test-ts.sh unit
+
+  macos-node-host-integration-tests:
+    name: "macOS Node Host Integration Tests"
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - name: "Setup Bun"
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: "Install Bun dependencies"
+        shell: bash
+        run: scripts/ci/install-bun-deps.sh
+
+      - name: "Run host integration lane"
+        shell: bash
+        env:
+          AUTOMOBILE_TEST_MODE: "true"
+          AUTOMOBILE_TEST_WALL_TIMEOUT_SECONDS: "900"
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            unset AUTOMOBILE_TEST_WALL_TIMEOUT_SECONDS
+          fi
+          bash scripts/test-ts.sh integration
+
+      - name: "Run stress lane"
+        shell: bash
+        env:
+          AUTOMOBILE_TEST_MODE: "true"
+          AUTOMOBILE_TEST_WALL_TIMEOUT_SECONDS: "300"
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            unset AUTOMOBILE_TEST_WALL_TIMEOUT_SECONDS
+          fi
+          bash scripts/test-ts.sh stress
+
   build-control-proxy-apk:
     uses: ./.github/workflows/build-control-proxy-apk.yml
     secrets:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -966,7 +966,9 @@ jobs:
         # BATS pass used to run inline inside the required Fast Validation job and
         # dominated its wall-clock. It now runs as a parallel matrix leg, matching
         # merge.yml, and is gated by the required "Shell Tests" roll-up.
-        os: [ubuntu-latest, macos-latest]
+        # Keep the portable PR lane on Linux. The equivalent macOS lane runs in
+        # nightly.yml so slow hosted macOS capacity is off the merge path.
+        os: [ubuntu-latest]
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6
@@ -1039,7 +1041,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6
@@ -1232,7 +1234,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6
@@ -1278,7 +1280,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6

--- a/test/bats/pr-gate-wiring.bats
+++ b/test/bats/pr-gate-wiring.bats
@@ -121,6 +121,21 @@ wiring_requires_yq() {
   [[ "$block" == *"needs.node-host-integration-tests.result"* ]]
 }
 
+@test "portable PR matrices leave macOS coverage to nightly" {
+  wiring_requires_yq
+  local job expected
+  for job in bats-tests bats-integration-tests; do
+    run yq -r ".jobs.\"${job}\".strategy.matrix.os[]" "$WF"
+    [ "$status" -eq 0 ]
+    [ "$output" = "ubuntu-latest" ]
+  done
+  for job in node-unit-tests node-host-integration-tests; do
+    run yq -r ".jobs.\"${job}\".strategy.matrix.os[]" "$WF"
+    [ "$status" -eq 0 ]
+    [ "$output" = $'ubuntu-latest\nwindows-latest' ]
+  done
+}
+
 @test "unit, integration, and stress jobs invoke their canonical lanes" {
   local unit host bats_unit bats_integration
   unit="$(job_block node-unit-tests)"
@@ -143,6 +158,25 @@ wiring_requires_yq() {
   [[ "$(job_block node-host-integration-tests "$workflow")" == *"bash scripts/test-ts.sh stress"* ]]
   [[ "$(job_block bats-tests "$workflow")" == *"scripts/ci/run-bats.sh unit"* ]]
   [[ "$(job_block bats-integration-tests "$workflow")" == *"scripts/ci/run-bats.sh integration"* ]]
+}
+
+@test "nightly preserves the moved macOS portable test lanes" {
+  local workflow=".github/workflows/nightly.yml"
+  local bats_unit bats_integration unit host
+  bats_unit="$(job_block macos-bats-tests "$workflow")"
+  bats_integration="$(job_block macos-bats-integration-tests "$workflow")"
+  unit="$(job_block macos-node-unit-tests "$workflow")"
+  host="$(job_block macos-node-host-integration-tests "$workflow")"
+
+  for block in "$bats_unit" "$bats_integration" "$unit" "$host"; do
+    [[ "$block" == *"runs-on: macos-latest"* ]]
+    [[ "$block" == *"scripts/ci/install-bun-deps.sh"* ]]
+  done
+  [[ "$bats_unit" == *"scripts/ci/run-bats.sh unit"* ]]
+  [[ "$bats_integration" == *"scripts/ci/run-bats.sh integration"* ]]
+  [[ "$unit" == *"bash scripts/test-ts.sh unit"* ]]
+  [[ "$host" == *"bash scripts/test-ts.sh integration"* ]]
+  [[ "$host" == *"bash scripts/test-ts.sh stress"* ]]
 }
 
 @test "development installer jobs are removed from PR and merge workflows" {


### PR DESCRIPTION
## Summary

- removes `macos-latest` from the portable BATS, Node unit, and Node host-integration PR matrices
- retains equivalent macOS-only jobs in the nightly workflow, including the host lane's stress pass
- pins the separation in the PR gate-wiring BATS suite; the required **Shell Tests** rollup still waits on the Ubuntu BATS jobs

## Why

On a recent PR, macOS was the slowest and flakiest portable matrix leg: Node Unit Tests took 8.3 minutes versus Ubuntu's 2.5 minutes, and BATS Shell Tests took 10.3 minutes versus Ubuntu's 2.0 minutes. Removing those macOS legs from the PR critical path cuts the slowest BATS lane by about 8.3 minutes while retaining macOS coverage nightly.

`installer-minimal`, `mcp-build-and-test`, and `build-desktop-app` keep their macOS coverage because those lanes are platform-specific or ship macOS artifacts.

## Validation

- `bats test/bats/pr-gate-wiring.bats`
- `bash scripts/all_fast_validate_checks.sh`
- `actionlint .github/workflows/pull_request.yml .github/workflows/nightly.yml` (reports existing repository-wide custom workflow syntax/action-metadata diagnostics; this change adds none)
