### PR TITLE
fix(android): reject clearText without focused field

### DIFF
--- a/src/features/action/ClearText.ts
+++ b/src/features/action/ClearText.ts
@@ -11,6 +11,8 @@ import { IOSCtrlProxyClient } from "../observe/ios";
 import { logger } from "../../utils/logger";
 import { ANDROID_INPUT_CLASSES } from "../../utils/elementProperties";
 
+export const DEVICE_TIMESTAMP_SECOND_GRANULARITY_MARGIN_MS = 1000;
+
 export function getFocusedTextLength(
   viewHierarchy: ViewHierarchyResult,
   parser: ElementParser = new DefaultElementParser(),
@@ -150,17 +152,20 @@ export class ClearText extends BaseVisualChange {
    */
   private async executeAndroidClearText(observeResult: ObserveResult): Promise<ClearTextResult> {
     const viewHierarchy = observeResult.viewHierarchy;
-    if (viewHierarchy && !viewHierarchy.hierarchy.error && !hasFocusedTextInput(viewHierarchy, this.parser)) {
-      const refreshedViewHierarchy = (await this.observeScreen.execute({ skipWaitForFresh: false }))
-        .viewHierarchy;
-      if (refreshedViewHierarchy && !refreshedViewHierarchy.hierarchy.error) {
-        if (!hasFocusedTextInput(refreshedViewHierarchy, this.parser)) {
-          return {
-            success: false,
-            error: "No focused editable node found",
-          };
-        }
+    let fallbackObserveResult = observeResult;
+    if (
+      viewHierarchy &&
+      !viewHierarchy.hierarchy.error &&
+      !hasFocusedTextInput(viewHierarchy, this.parser)
+    ) {
+      const refreshedObserveResult = await this.refreshFocusedTextInputObservation(viewHierarchy);
+      if (!refreshedObserveResult) {
+        return {
+          success: false,
+          error: "No focused editable node found",
+        };
       }
+      fallbackObserveResult = refreshedObserveResult;
     }
 
     // Use accessibility service (fastest method, ~50-80ms vs ~200-500ms for ADB deletes)
@@ -178,7 +183,37 @@ export class ClearText extends BaseVisualChange {
     logger.warn(
       `[ClearText] Accessibility service clear failed: ${a11yResult.error}, falling back to ADB`,
     );
-    return this.executeAdbClearText(observeResult);
+    return this.executeAdbClearText(fallbackObserveResult);
+  }
+
+  private async refreshFocusedTextInputObservation(
+    viewHierarchy: ViewHierarchyResult,
+  ): Promise<ObserveResult | undefined> {
+    let minTimestamp: number;
+    if (typeof viewHierarchy.updatedAt === "number") {
+      minTimestamp = viewHierarchy.updatedAt + 1;
+    } else {
+      const timestampResult = await this.adb.getDeviceTimestampMsWithSource();
+      if (timestampResult.source === "host") {
+        return undefined;
+      }
+      minTimestamp =
+        timestampResult.source === "device-seconds"
+          ? timestampResult.timestampMs + DEVICE_TIMESTAMP_SECOND_GRANULARITY_MARGIN_MS
+          : timestampResult.timestampMs;
+    }
+
+    const refreshedObserveResult = await this.observeScreen.execute({
+      skipWaitForFresh: false,
+      minTimestamp,
+    });
+    const refreshedViewHierarchy = refreshedObserveResult.viewHierarchy;
+    return refreshedObserveResult.freshness?.isFresh !== false &&
+      refreshedViewHierarchy &&
+      !refreshedViewHierarchy.hierarchy.error &&
+      hasFocusedTextInput(refreshedViewHierarchy, this.parser)
+      ? refreshedObserveResult
+      : undefined;
   }
 
   /**

--- a/src/features/action/ClearText.ts
+++ b/src/features/action/ClearText.ts
@@ -158,14 +158,25 @@ export class ClearText extends BaseVisualChange {
       !viewHierarchy.hierarchy.error &&
       !hasFocusedTextInput(viewHierarchy, this.parser)
     ) {
-      const refreshedObserveResult = await this.refreshFocusedTextInputObservation(viewHierarchy);
-      if (!refreshedObserveResult) {
+      const refreshedObserveResult = await this.refreshFocusedTextInputObservation(
+        viewHierarchy,
+      ).catch((error: unknown) => {
+        logger.warn("[ClearText] Focus refresh unavailable; trying live clearing", error);
+        return undefined;
+      });
+      if (
+        refreshedObserveResult?.viewHierarchy &&
+        !hasFocusedTextInput(refreshedObserveResult.viewHierarchy, this.parser)
+      ) {
         return {
           success: false,
           error: "No focused editable node found",
         };
       }
-      fallbackObserveResult = refreshedObserveResult;
+      fallbackObserveResult = refreshedObserveResult ?? {
+        ...observeResult,
+        viewHierarchy: undefined,
+      };
     }
 
     // Use accessibility service (fastest method, ~50-80ms vs ~200-500ms for ADB deletes)
@@ -186,6 +197,7 @@ export class ClearText extends BaseVisualChange {
     return this.executeAdbClearText(fallbackObserveResult);
   }
 
+  /** Returns a fresh usable hierarchy, or undefined when focus cannot be determined. */
   private async refreshFocusedTextInputObservation(
     viewHierarchy: ViewHierarchyResult,
   ): Promise<ObserveResult | undefined> {
@@ -210,8 +222,7 @@ export class ClearText extends BaseVisualChange {
     const refreshedViewHierarchy = refreshedObserveResult.viewHierarchy;
     return refreshedObserveResult.freshness?.isFresh !== false &&
       refreshedViewHierarchy &&
-      !refreshedViewHierarchy.hierarchy.error &&
-      hasFocusedTextInput(refreshedViewHierarchy, this.parser)
+      !refreshedViewHierarchy.hierarchy.error
       ? refreshedObserveResult
       : undefined;
   }

--- a/src/features/action/ClearText.ts
+++ b/src/features/action/ClearText.ts
@@ -149,6 +149,16 @@ export class ClearText extends BaseVisualChange {
    * Falls back to ADB delete key events if a11y service is unavailable.
    */
   private async executeAndroidClearText(observeResult: ObserveResult): Promise<ClearTextResult> {
+    if (
+      observeResult.viewHierarchy &&
+      !hasFocusedTextInput(observeResult.viewHierarchy, this.parser)
+    ) {
+      return {
+        success: false,
+        error: "No focused editable node found",
+      };
+    }
+
     // Use accessibility service (fastest method, ~50-80ms vs ~200-500ms for ADB deletes)
     const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
     const a11yResult = await a11yClient.requestClearText();

--- a/src/features/action/ClearText.ts
+++ b/src/features/action/ClearText.ts
@@ -149,14 +149,18 @@ export class ClearText extends BaseVisualChange {
    * Falls back to ADB delete key events if a11y service is unavailable.
    */
   private async executeAndroidClearText(observeResult: ObserveResult): Promise<ClearTextResult> {
-    if (
-      observeResult.viewHierarchy &&
-      !hasFocusedTextInput(observeResult.viewHierarchy, this.parser)
-    ) {
-      return {
-        success: false,
-        error: "No focused editable node found",
-      };
+    const viewHierarchy = observeResult.viewHierarchy;
+    if (viewHierarchy && !viewHierarchy.hierarchy.error && !hasFocusedTextInput(viewHierarchy, this.parser)) {
+      const refreshedViewHierarchy = (await this.observeScreen.execute({ skipWaitForFresh: false }))
+        .viewHierarchy;
+      if (refreshedViewHierarchy && !refreshedViewHierarchy.hierarchy.error) {
+        if (!hasFocusedTextInput(refreshedViewHierarchy, this.parser)) {
+          return {
+            success: false,
+            error: "No focused editable node found",
+          };
+        }
+      }
     }
 
     // Use accessibility service (fastest method, ~50-80ms vs ~200-500ms for ADB deletes)

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -19,7 +19,12 @@ import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/A
 import { AdbCommandTimeoutError } from "../../utils/android-cmdline-tools/AdbClient";
 import { resolveAutoInputMode } from "./resolveAutoInputMode";
 import { serverConfig } from "../../utils/ServerConfig";
-import { clearTextWithKeyEvents, getFocusedTextLength, hasFocusedTextInput } from "./ClearText";
+import {
+  clearTextWithKeyEvents,
+  DEVICE_TIMESTAMP_SECOND_GRANULARITY_MARGIN_MS,
+  getFocusedTextLength,
+  hasFocusedTextInput,
+} from "./ClearText";
 import {
   ANDROID_KEYCOMBINATION_MIN_API_LEVEL,
   asciiKeyEventNeedsKeyCombination,
@@ -73,8 +78,6 @@ const defaultTargetFocuserFactory: TextInputTargetFocuserFactory = (device) => (
     };
   },
 });
-
-const DEVICE_TIMESTAMP_SECOND_GRANULARITY_MARGIN_MS = 1000;
 
 export type AppendKeyEventValidator = (
   timeoutMs?: number,

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -1092,6 +1092,10 @@ export class CtrlProxyHierarchy {
 
     const converted: any = {};
 
+    if (node.actions) {
+      converted.actions = node.actions;
+    }
+
     // Copy over all properties
     if (node.text) {
       converted.text = node.text;

--- a/src/features/observe/android/types.ts
+++ b/src/features/observe/android/types.ts
@@ -47,6 +47,7 @@ export const quoteForAdbArg = (value: string): string => {
  * Interface for accessibility service node format
  */
 export interface AccessibilityNode {
+  actions?: string[];
   text?: string;
   "content-desc"?: string;
   "resource-id"?: string;

--- a/test/features/action/ClearText.adbFallback.test.ts
+++ b/test/features/action/ClearText.adbFallback.test.ts
@@ -46,6 +46,7 @@ describe("ClearText Android ADB fallback", () => {
     screenSize: { width: 1080, height: 1920 },
     systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
     viewHierarchy: {
+      updatedAt: 100,
       hierarchy: {
         node: {
           $: {
@@ -109,7 +110,9 @@ describe("ClearText Android ADB fallback", () => {
 
   test("rejects an accessibility success when no editable field remains focused after refresh", async () => {
     const result = await runClearText(noFocusedFieldObserve(), (clearText) => {
-      refreshSpy = spyOn(clearText.observeScreen, "execute").mockResolvedValue(noFocusedFieldObserve());
+      refreshSpy = spyOn(clearText.observeScreen, "execute").mockResolvedValue(
+        noFocusedFieldObserve(),
+      );
     });
 
     expect(result).toEqual({
@@ -127,7 +130,47 @@ describe("ClearText Android ADB fallback", () => {
     });
 
     expect(result.success).toBe(true);
-    expect(refreshSpy).toHaveBeenCalledWith({ skipWaitForFresh: false });
+    expect(refreshSpy).toHaveBeenCalledWith({ skipWaitForFresh: false, minTimestamp: 101 });
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
+  });
+
+  test("uses the refreshed focused field for the ADB fallback when a11y clear fails", async () => {
+    fakeA11yService.setClearTextResult({
+      success: false,
+      totalTimeMs: 0,
+      error: "no focused node",
+    });
+
+    const result = await runClearText(noFocusedFieldObserve(), (clearText) => {
+      refreshSpy = spyOn(clearText.observeScreen, "execute").mockResolvedValue(
+        focusedFieldObserve("hello"),
+      );
+    });
+
+    expect(result.success).toBe(true);
+    expect(fakeAdb.getExecutedCommands()).toEqual([
+      "shell input keyevent KEYCODE_MOVE_END",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+    ]);
+  });
+
+  test("does not treat a stale refreshed hierarchy as proof that no field is focused", async () => {
+    const staleNoFocusObserve = {
+      ...noFocusedFieldObserve(),
+      freshness: { isFresh: false },
+    };
+    const result = await runClearText(noFocusedFieldObserve(), (clearText) => {
+      refreshSpy = spyOn(clearText.observeScreen, "execute").mockResolvedValue(staleNoFocusObserve);
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "No focused editable node found",
+    });
     expect(fakeAdb.getExecutedCommands()).toEqual([]);
   });
 

--- a/test/features/action/ClearText.adbFallback.test.ts
+++ b/test/features/action/ClearText.adbFallback.test.ts
@@ -19,7 +19,7 @@ describe("ClearText Android ADB fallback", () => {
   let refreshSpy: ReturnType<typeof spyOn> | null = null;
 
   const focusedFieldObserve = (text: string): ObserveResult => ({
-    timestamp: Date.now(),
+    timestamp: 0,
     screenSize: { width: 1080, height: 1920 },
     systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
     viewHierarchy: {
@@ -36,13 +36,13 @@ describe("ClearText Android ADB fallback", () => {
   });
 
   const noHierarchyObserve = (): ObserveResult => ({
-    timestamp: Date.now(),
+    timestamp: 0,
     screenSize: { width: 1080, height: 1920 },
     systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
   });
 
   const noFocusedFieldObserve = (): ObserveResult => ({
-    timestamp: Date.now(),
+    timestamp: 0,
     screenSize: { width: 1080, height: 1920 },
     systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
     viewHierarchy: {
@@ -60,7 +60,7 @@ describe("ClearText Android ADB fallback", () => {
   });
 
   const hierarchyErrorObserve = (): ObserveResult => ({
-    timestamp: Date.now(),
+    timestamp: 0,
     screenSize: { width: 1080, height: 1920 },
     systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
     viewHierarchy: {
@@ -167,11 +167,50 @@ describe("ClearText Android ADB fallback", () => {
       refreshSpy = spyOn(clearText.observeScreen, "execute").mockResolvedValue(staleNoFocusObserve);
     });
 
-    expect(result).toEqual({
-      success: false,
-      error: "No focused editable node found",
-    });
+    expect(result.success).toBe(true);
     expect(fakeAdb.getExecutedCommands()).toEqual([]);
+  });
+
+  test.each([noHierarchyObserve(), hierarchyErrorObserve()])(
+    "preserves live clearing when the refreshed hierarchy is unavailable: %j",
+    async (refreshed) => {
+      const result = await runClearText(noFocusedFieldObserve(), (clearText) => {
+        refreshSpy = spyOn(clearText.observeScreen, "execute").mockResolvedValue(refreshed);
+      });
+      expect(result.success).toBe(true);
+      expect(fakeAdb.getExecutedCommands()).toEqual([]);
+    },
+  );
+
+  test("preserves live clearing when only a host timestamp is available", async () => {
+    const observation = noFocusedFieldObserve();
+    delete observation.viewHierarchy!.updatedAt;
+    fakeAdb.setDeviceTimestampSource("host");
+    const result = await runClearText(observation);
+    expect(result.success).toBe(true);
+  });
+
+  test("preserves live clearing when the refresh throws", async () => {
+    const result = await runClearText(noFocusedFieldObserve(), (clearText) => {
+      refreshSpy = spyOn(clearText.observeScreen, "execute").mockRejectedValue(
+        new Error("disconnected"),
+      );
+    });
+    expect(result.success).toBe(true);
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
+  });
+
+  test("uses the unavailable-hierarchy fallback after an inconclusive refresh", async () => {
+    fakeA11yService.setClearTextResult({ success: false, totalTimeMs: 0, error: "unavailable" });
+    const result = await runClearText(noFocusedFieldObserve(), (clearText) => {
+      refreshSpy = spyOn(clearText.observeScreen, "execute").mockResolvedValue(
+        noHierarchyObserve(),
+      );
+    });
+    expect(result.success).toBe(true);
+    expect(
+      fakeAdb.getExecutedCommands().filter((command) => command.endsWith("KEYCODE_DEL")),
+    ).toHaveLength(200);
   });
 
   test("preserves the accessibility path when the hierarchy contains an error", async () => {

--- a/test/features/action/ClearText.adbFallback.test.ts
+++ b/test/features/action/ClearText.adbFallback.test.ts
@@ -16,6 +16,7 @@ describe("ClearText Android ADB fallback", () => {
   let fakeA11yService: FakeCtrlProxy;
   let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
   let observedSpy: ReturnType<typeof spyOn> | null = null;
+  let refreshSpy: ReturnType<typeof spyOn> | null = null;
 
   const focusedFieldObserve = (text: string): ObserveResult => ({
     timestamp: Date.now(),
@@ -57,7 +58,19 @@ describe("ClearText Android ADB fallback", () => {
     },
   });
 
-  const runClearText = (observeResult: ObserveResult) => {
+  const hierarchyErrorObserve = (): ObserveResult => ({
+    timestamp: Date.now(),
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    viewHierarchy: {
+      hierarchy: { error: "Accessibility hierarchy unavailable" },
+    } as any,
+  });
+
+  const runClearText = (
+    observeResult: ObserveResult,
+    configure?: (clearText: ClearText) => void,
+  ) => {
     const clearText = new ClearText(device, fakeAdb as any);
     observedSpy = spyOn(
       clearText as unknown as {
@@ -65,6 +78,7 @@ describe("ClearText Android ADB fallback", () => {
       },
       "observedInteraction",
     ).mockImplementation(async (fn: (o: ObserveResult) => Promise<unknown>) => fn(observeResult));
+    configure?.(clearText);
     return clearText.execute();
   };
 
@@ -79,8 +93,10 @@ describe("ClearText Android ADB fallback", () => {
   afterEach(() => {
     getInstanceSpy?.mockRestore();
     observedSpy?.mockRestore();
+    refreshSpy?.mockRestore();
     getInstanceSpy = null;
     observedSpy = null;
+    refreshSpy = null;
   });
 
   test("clears via the accessibility service and never touches ADB when a11y succeeds", async () => {
@@ -91,13 +107,34 @@ describe("ClearText Android ADB fallback", () => {
     expect(fakeAdb.getExecutedCommands()).toEqual([]);
   });
 
-  test("rejects an accessibility success when no editable field is focused", async () => {
-    const result = await runClearText(noFocusedFieldObserve());
+  test("rejects an accessibility success when no editable field remains focused after refresh", async () => {
+    const result = await runClearText(noFocusedFieldObserve(), (clearText) => {
+      refreshSpy = spyOn(clearText.observeScreen, "execute").mockResolvedValue(noFocusedFieldObserve());
+    });
 
     expect(result).toEqual({
       success: false,
       error: "No focused editable node found",
     });
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
+  });
+
+  test("uses a refreshed focused field before accepting accessibility success", async () => {
+    const result = await runClearText(noFocusedFieldObserve(), (clearText) => {
+      refreshSpy = spyOn(clearText.observeScreen, "execute").mockResolvedValue(
+        focusedFieldObserve("hello"),
+      );
+    });
+
+    expect(result.success).toBe(true);
+    expect(refreshSpy).toHaveBeenCalledWith({ skipWaitForFresh: false });
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
+  });
+
+  test("preserves the accessibility path when the hierarchy contains an error", async () => {
+    const result = await runClearText(hierarchyErrorObserve());
+
+    expect(result.success).toBe(true);
     expect(fakeAdb.getExecutedCommands()).toEqual([]);
   });
 

--- a/test/features/action/ClearText.adbFallback.test.ts
+++ b/test/features/action/ClearText.adbFallback.test.ts
@@ -40,6 +40,23 @@ describe("ClearText Android ADB fallback", () => {
     systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
   });
 
+  const noFocusedFieldObserve = (): ObserveResult => ({
+    timestamp: Date.now(),
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    viewHierarchy: {
+      hierarchy: {
+        node: {
+          $: {
+            class: "android.widget.TextView",
+            focused: "false",
+            text: "Home",
+          },
+        },
+      },
+    },
+  });
+
   const runClearText = (observeResult: ObserveResult) => {
     const clearText = new ClearText(device, fakeAdb as any);
     observedSpy = spyOn(
@@ -71,6 +88,16 @@ describe("ClearText Android ADB fallback", () => {
     const result = await runClearText(focusedFieldObserve("hello"));
 
     expect(result.success).toBe(true);
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
+  });
+
+  test("rejects an accessibility success when no editable field is focused", async () => {
+    const result = await runClearText(noFocusedFieldObserve());
+
+    expect(result).toEqual({
+      success: false,
+      error: "No focused editable node found",
+    });
     expect(fakeAdb.getExecutedCommands()).toEqual([]);
   });
 

--- a/test/features/observe/android/ctrlProxyHierarchySemanticLinks.test.ts
+++ b/test/features/observe/android/ctrlProxyHierarchySemanticLinks.test.ts
@@ -3,6 +3,7 @@ import { CtrlProxyHierarchy } from "../../../../src/features/observe/android/Ctr
 import type { HierarchyDelegateContext } from "../../../../src/features/observe/android/types";
 import { RequestManager } from "../../../../src/utils/RequestManager";
 import { FakeTimer } from "../../../fakes/FakeTimer";
+import { hasFocusedTextInput } from "../../../../src/features/action/ClearText";
 
 function createHierarchy(): CtrlProxyHierarchy {
   const timer = new FakeTimer();
@@ -23,6 +24,17 @@ function createHierarchy(): CtrlProxyHierarchy {
 }
 
 describe("CtrlProxyHierarchy semantic links", () => {
+  test("preserves text actions so focused custom controls remain editable after conversion", () => {
+    const result = createHierarchy().convertToViewHierarchyResult({
+      hierarchy: {
+        className: "custom.Container",
+        node: { className: "custom.Editor", focused: "true", actions: ["set_text"] },
+      },
+      updatedAt: 1,
+    });
+    expect(hasFocusedTextInput(result)).toBe(true);
+  });
+
   test("retains Android runner semantic-link metadata in the converted hierarchy", () => {
     const result = createHierarchy().convertToViewHierarchyResult({
       hierarchy: {


### PR DESCRIPTION
## Summary

- reject Android `clearText` when the observed hierarchy has no focused editable field
- preserve the accessibility and ADB fallback behavior for focused and unavailable hierarchies
- add regression coverage for the previous false-success path

## Validation

- `bun test test/features/action/ClearText.adbFallback.test.ts`
- `bun run lint`
- `bun run build`
- `bun run turbo:validate`

Closes [#6733](https://github.com/kaeawc/auto-mobile/issues/6733)
