### PR TITLE
fix(ios): accept display names in capability lookup

### DIFF
--- a/src/features/utility/iosSimulatorCapabilities.ts
+++ b/src/features/utility/iosSimulatorCapabilities.ts
@@ -56,8 +56,8 @@ const DEVICE_TYPE_PREFIX = "com.apple.CoreSimulator.SimDeviceType.";
 const RUNTIME_PREFIX = "com.apple.CoreSimulator.SimRuntime.";
 
 /** CoreSimulator device families that expose BiometricKit (Touch ID / Face ID). */
-const BIOMETRIC_DEVICE_FAMILY_PATTERN = /^(iPhone|iPad)[-.]/i;
-const IOS_RUNTIME_PATTERN = /^iOS[-.]/i;
+const BIOMETRIC_DEVICE_FAMILY_PATTERN = /^(iPhone|iPad)[\s.-]/i;
+const IOS_RUNTIME_PATTERN = /^iOS[\s.-]/i;
 
 function stripPrefix(value: string, prefix: string): string {
   return value.startsWith(prefix) ? value.slice(prefix.length) : value;

--- a/test/features/utility/iosSimulatorCapabilities.test.ts
+++ b/test/features/utility/iosSimulatorCapabilities.test.ts
@@ -100,4 +100,16 @@ describe("iOS Simulator capabilities", () => {
 
     expect(report.selection.valid).toBe(true);
   });
+
+  test("accepts human-readable device type and runtime names emitted by device discovery", () => {
+    const report = computeIosSimulatorCapabilities({
+      deviceType: "iPhone 17 Pro Max",
+      runtime: "iOS 26.2",
+    });
+
+    expect(report.selection).toEqual({ valid: true });
+    expect(findIosSimulatorCapability(report, "biometrics.enrollment")).toMatchObject({
+      state: "supported",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Accept whitespace-separated iPhone, iPad, and iOS display names in the iOS Simulator capability validator.
- Cover the display-name values emitted by device discovery.

## Validation

- `AUTOMOBILE_LOG_DIR=/private/tmp/auto-mobile-issue-6731-logs bun test test/features/utility/iosSimulatorCapabilities.test.ts`
- `bun run lint -- src/features/utility/iosSimulatorCapabilities.ts test/features/utility/iosSimulatorCapabilities.test.ts`
- `AUTOMOBILE_LOG_DIR=/private/tmp/auto-mobile-issue-6731-logs bun run build`

Fixes [#6731](https://github.com/kaeawc/auto-mobile/issues/6731).
