### PR TITLE
docs(tools): correct sendKeys/inputText default state after 0.0.68

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -31,7 +31,7 @@ the exact arguments supported by your connection.
 | ↔️ <code>dragAndDrop</code>   | Drags one element to another.                                        |
 | 🤏 <code>pinchOn</code>       | Pinches to zoom.                                                     |
 | ⌨️ <code>sendKeys</code>      | Runs ordered text, clear, raw-key, and semantic-key commands.        |
-| ⌨️ <code>inputText</code>     | Legacy text input retained for compatibility.                        |
+| ⌨️ <code>inputText</code>     | Legacy text input retained for compatibility; disabled by default.   |
 | 🧩 <code>setUIState</code>    | Sets multiple form fields to a desired state.                        |
 | 🗑️ <code>clearText</code>     | Legacy focused-input clear; disabled by default.                     |
 | ✨ <code>selectAllText</code> | Selects all text in the focused input.                               |
@@ -66,9 +66,11 @@ standalone `{ "action": "clear" }` command clears the focused field. Execution
 stops on the first failure and returns compact command metadata plus the final
 observation without copying type-command text into the metadata.
 
-`sendKeys` becomes default-enabled when the bundled CtrlProxy artifacts reach
-0.0.68. Until then, `inputText` remains the default compatibility path; a local
-fresh CtrlProxy can use `sendKeys` after explicitly enabling it.
+`sendKeys` is the default text-input path on any AutoMobile release whose
+CtrlProxy artifacts are 0.0.68 or newer, which is the case for current releases.
+On older pinned releases `inputText` and `clearText` are default-enabled instead
+and `sendKeys` is off; enable `sendKeys` there explicitly with `setToolEnabled`
+or `--enable-tool sendKeys`.
 
 ??? note "Pinch rotation semantics"
 


### PR DESCRIPTION
## Summary

`docs/tools.md` described a pre-0.0.68 world: it said `sendKeys` *"becomes* default-enabled when the bundled CtrlProxy artifacts reach 0.0.68"* and that *"until then, `inputText` remains the default compatibility path."* That threshold has since shipped — `RELEASE_CHECKSUM_REGISTRY[0]` in [`src/constants/release.ts`](../blob/main/src/constants/release.ts) is now `0.0.68`, and `"latest"` resolves to that entry, so [`isSendKeysReleased()`](../blob/main/src/features/action/SendKeys.ts) (`SEND_KEYS_MIN_RELEASE = "0.0.68"`) returns `true` by default.

That means, on current releases:
- `sendKeys` is registered with `defaultEnabled: sendKeysReleased` → **enabled**
- `inputText` and `clearText` are registered with `defaultEnabled: !sendKeysReleased` → **disabled**

as asserted by [`test/server/tools/list.integration.test.ts`](../blob/main/test/server/tools/list.integration.test.ts) (`toolNames` contains `sendKeys`, not `inputText`/`clearText` when `isSendKeysReleased()`).

This PR rewrites the gating note in present tense and marks the `inputText` table row *"disabled by default"* (matching the existing `clearText` and `imeAction` rows). Docs-only, one topic.

## Bug / Regression Context

- **Observed symptom:** `docs/tools.md` told users `inputText` was the default text-input tool and `sendKeys` was gated off, the reverse of current default behavior.

## Validation

- [x] `scripts/all_fast_validate_checks.sh --only mkdocs-nav` passes (coupled docs check)
- [x] Docs-only diff (no source/schema/link/code-fence changes); build/test jobs are skipped for docs-only PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPQqe5RnYTZtZun4mET9jG

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPQqe5RnYTZtZun4mET9jG)_