### PR TITLE
fix(db): chunk NavigationRetention.prune into short transactions (#6650)

### DIFF
--- a/src/db/navigationRetention.ts
+++ b/src/db/navigationRetention.ts
@@ -59,6 +59,14 @@ import type { Kysely } from "kysely";
 import type { Database } from "./types";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
 
+/**
+ * Gives timers, sockets, and newly-arrived daemon requests a turn between
+ * committed retention batches. Kept injectable so tests never need real time.
+ */
+export type RetentionBatchYield = () => Promise<void>;
+
+const yieldToIo: RetentionBatchYield = () => new Promise((resolve) => setImmediate(resolve));
+
 /** Tunable retention thresholds. All durations are milliseconds. */
 export interface NavigationRetentionConfig {
   /** SHORT tier: max age of a node screenshot before its pointer is cleared. */
@@ -226,6 +234,7 @@ interface BuildKeyRow {
 interface EvictionCandidate {
   isNode: boolean;
   id: number;
+  buildKeyId: number;
   lastSeenAt: number;
 }
 
@@ -248,6 +257,7 @@ export class NavigationRetention {
     config: Partial<NavigationRetentionConfig> = {},
     private readonly removeScreenshotFile?: ScreenshotFileRemover,
     private readonly logger: Logger = defaultLogger,
+    private readonly yieldBetweenBatches: RetentionBatchYield = yieldToIo,
   ) {
     this.config = resolveNavigationRetentionConfig(config);
   }
@@ -309,13 +319,16 @@ export class NavigationRetention {
   private async pruneScreenshots(now: number, summary: NavigationRetentionSummary): Promise<void> {
     const cutoff = now - this.config.screenshotTtlMs;
     const chunk = this.config.evictionChunkSize;
+    // A full protected-build scan is expensive on an accumulated database. Keep a
+    // snapshot for ordinary batches, then revalidate only each selected batch's
+    // apps under its transaction before clearing pointers.
+    let protectedIds = await computeProtectedBuildKeyIds(this.db);
 
     for (;;) {
       const batchResult = await this.db.transaction().execute(async (trx) => {
-        const protectedIds = await computeProtectedBuildKeyIds(trx);
         let query = trx
           .selectFrom("navigation_nodes")
-          .select(["id", "screenshot_path"])
+          .select(["id", "app_id", "screenshot_path"])
           .where("screenshot_path", "is not", null)
           .where("last_seen_at", "<", cutoff);
 
@@ -335,7 +348,26 @@ export class NavigationRetention {
           return null;
         }
 
-        const ids = batch.map((row) => row.id);
+        const batchAppIds = Array.from(new Set(batch.map((row) => row.app_id)));
+        const currentProtectedIds = await computeProtectedBuildKeyIds(trx, undefined, batchAppIds);
+        const protectedNodeRows = await loadProtectedNodeRows(
+          trx,
+          batch.map((row) => row.id),
+          currentProtectedIds,
+        );
+        const protectedNodeIds = new Set(protectedNodeRows);
+        const eligible = batch.filter((row) => !protectedNodeIds.has(row.id));
+        const activeBuildChanged = currentProtectedIds.some((id) => !protectedIds.includes(id));
+        if (eligible.length === 0) {
+          return {
+            clearedCount: 0,
+            clearedPaths: [],
+            isFullBatch: batch.length === chunk,
+            activeBuildChanged,
+          };
+        }
+
+        const ids = eligible.map((row) => row.id);
         await trx
           .updateTable("navigation_nodes")
           .set({ screenshot_path: null })
@@ -343,12 +375,17 @@ export class NavigationRetention {
           .execute();
 
         const clearedPaths: string[] = [];
-        for (const row of batch) {
+        for (const row of eligible) {
           if (row.screenshot_path !== null) {
             clearedPaths.push(row.screenshot_path);
           }
         }
-        return { clearedCount: ids.length, clearedPaths, isFullBatch: batch.length === chunk };
+        return {
+          clearedCount: ids.length,
+          clearedPaths,
+          isFullBatch: batch.length === chunk,
+          activeBuildChanged,
+        };
       });
 
       if (batchResult === null) {
@@ -360,19 +397,22 @@ export class NavigationRetention {
       // before the next batch or any later tier runs (#6650).
       await this.removeFiles(batchResult.clearedPaths);
 
-      if (!batchResult.isFullBatch) {
+      if (batchResult.activeBuildChanged) {
+        protectedIds = await computeProtectedBuildKeyIds(this.db);
+      }
+
+      if (!batchResult.isFullBatch || batchResult.clearedCount === 0) {
         break;
       }
+      await this.yieldBetweenBatches();
     }
   }
 
   /**
    * LONG tier: delete observation rows last seen before the cutoff, except those
-   * on a protected (active) build key. A single DELETE by predicate per table —
-   * it binds only the (per-app-bounded) protected id list, never one param per
-   * matched row. Both deletes run in one short transaction (#6650) so the
-   * protected set they share is read once and stays consistent between them,
-   * without holding the connection for any other tier.
+   * on a protected (active) build key. Each bounded delete batch runs in its
+   * own transaction, so an overdue retention pass cannot monopolize the single
+   * daemon connection in one predicate-wide SQLite delete.
    */
   private async pruneObservationsByTtl(
     now: number,
@@ -380,30 +420,68 @@ export class NavigationRetention {
   ): Promise<void> {
     const cutoff = now - this.config.structureTtlMs;
 
-    await this.db.transaction().execute(async (trx) => {
-      const protectedIds = await computeProtectedBuildKeyIds(trx);
+    summary.nodeObservationsDeleted += await this.pruneNodeObservationsByTtl(cutoff);
+    summary.edgeObservationsDeleted += await this.pruneEdgeObservationsByTtl(cutoff);
+  }
 
-      {
+  private async pruneNodeObservationsByTtl(cutoff: number): Promise<number> {
+    let deletedTotal = 0;
+    for (;;) {
+      const deleted = await this.db.transaction().execute(async (trx) => {
+        const protectedIds = await computeProtectedBuildKeyIds(trx);
         let query = trx
+          .selectFrom("navigation_node_observations")
+          .select("id")
+          .where("last_seen_at", "<", cutoff);
+        if (protectedIds.length > 0) {
+          query = query.where("build_key_id", "not in", protectedIds);
+        }
+        const rows = await query.limit(this.config.evictionChunkSize).execute();
+        if (rows.length === 0) {
+          return 0;
+        }
+        const result = await trx
           .deleteFrom("navigation_node_observations")
-          .where("last_seen_at", "<", cutoff);
-        if (protectedIds.length > 0) {
-          query = query.where("build_key_id", "not in", protectedIds);
-        }
-        const result = await query.executeTakeFirst();
-        summary.nodeObservationsDeleted += Number(result.numDeletedRows ?? 0);
+          .where("id", "in", rows.map((row) => row.id))
+          .executeTakeFirst();
+        return Number(result.numDeletedRows ?? 0);
+      });
+      deletedTotal += deleted;
+      if (deleted < this.config.evictionChunkSize) {
+        return deletedTotal;
       }
-      {
+      await this.yieldBetweenBatches();
+    }
+  }
+
+  private async pruneEdgeObservationsByTtl(cutoff: number): Promise<number> {
+    let deletedTotal = 0;
+    for (;;) {
+      const deleted = await this.db.transaction().execute(async (trx) => {
+        const protectedIds = await computeProtectedBuildKeyIds(trx);
         let query = trx
-          .deleteFrom("navigation_edge_observations")
+          .selectFrom("navigation_edge_observations")
+          .select("id")
           .where("last_seen_at", "<", cutoff);
         if (protectedIds.length > 0) {
           query = query.where("build_key_id", "not in", protectedIds);
         }
-        const result = await query.executeTakeFirst();
-        summary.edgeObservationsDeleted += Number(result.numDeletedRows ?? 0);
+        const rows = await query.limit(this.config.evictionChunkSize).execute();
+        if (rows.length === 0) {
+          return 0;
+        }
+        const result = await trx
+          .deleteFrom("navigation_edge_observations")
+          .where("id", "in", rows.map((row) => row.id))
+          .executeTakeFirst();
+        return Number(result.numDeletedRows ?? 0);
+      });
+      deletedTotal += deleted;
+      if (deleted < this.config.evictionChunkSize) {
+        return deletedTotal;
       }
-    });
+      await this.yieldBetweenBatches();
+    }
   }
 
   /**
@@ -468,17 +546,42 @@ export class NavigationRetention {
     summary: NavigationRetentionSummary,
   ): Promise<void> {
     let remaining = count;
+    // Reuse a whole-database protected-build snapshot for this eviction pass.
+    // Every selected batch revalidates only its own candidate apps before delete.
+    const protectedIds = await computeProtectedBuildKeyIds(this.db);
     while (remaining > 0) {
       const batch = Math.min(remaining, this.config.evictionChunkSize);
       const evictedCount = await this.db.transaction().execute(async (trx) => {
-        const protectedIds = await computeProtectedBuildKeyIds(trx);
         const victims = await collectOldestEvictable(trx, appId, protectedIds, batch);
         if (victims.length === 0) {
           return 0;
         }
 
-        const nodeIds = victims.filter((v) => v.isNode).map((v) => v.id);
-        const edgeIds = victims.filter((v) => !v.isNode).map((v) => v.id);
+        const candidateBuildKeys = await loadBuildKeysByIds(
+          trx,
+          victims.map((victim) => victim.buildKeyId),
+        );
+        const currentProtectedIds = await computeProtectedBuildKeyIds(
+          trx,
+          undefined,
+          Array.from(new Set(candidateBuildKeys.map((key) => key.appId))),
+        );
+        const maxSeen = await loadMaxSeenByBuildKeyIds(
+          trx,
+          victims.map((victim) => victim.buildKeyId),
+        );
+        const currentProtected = new Set(currentProtectedIds);
+        const eligibleVictims = victims.filter(
+          (victim) =>
+            !currentProtected.has(victim.buildKeyId) ||
+            victim.lastSeenAt < (maxSeen.get(victim.buildKeyId) ?? Number.NEGATIVE_INFINITY),
+        );
+        if (eligibleVictims.length === 0) {
+          return 0;
+        }
+
+        const nodeIds = eligibleVictims.filter((v) => v.isNode).map((v) => v.id);
+        const edgeIds = eligibleVictims.filter((v) => !v.isNode).map((v) => v.id);
         if (nodeIds.length > 0) {
           const deleted = await trx
             .deleteFrom("navigation_node_observations")
@@ -493,13 +596,16 @@ export class NavigationRetention {
             .executeTakeFirst();
           summary.edgeObservationsDeleted += Number(deleted.numDeletedRows ?? 0);
         }
-        return victims.length;
+        return eligibleVictims.length;
       });
 
       if (evictedCount === 0) {
         return;
       }
       remaining -= evictedCount;
+      if (remaining > 0) {
+        await this.yieldBetweenBatches();
+      }
     }
   }
 
@@ -539,8 +645,27 @@ export class NavigationRetention {
 // Free helpers (kept small so the class methods stay under the complexity gate).
 // ---------------------------------------------------------------------------
 
-async function loadBuildKeys(db: Kysely<Database>): Promise<BuildKeyRow[]> {
-  const rows = await db.selectFrom("navigation_build_keys").select(["id", "app_id"]).execute();
+async function loadBuildKeys(db: Kysely<Database>, appIds?: readonly string[]): Promise<BuildKeyRow[]> {
+  let query = db.selectFrom("navigation_build_keys").select(["id", "app_id"]);
+  if (appIds && appIds.length > 0) {
+    query = query.where("app_id", "in", appIds);
+  }
+  const rows = await query.execute();
+  return rows.map((row) => ({ id: row.id, appId: row.app_id }));
+}
+
+async function loadBuildKeysByIds(
+  db: Kysely<Database>,
+  ids: readonly number[],
+): Promise<BuildKeyRow[]> {
+  if (ids.length === 0) {
+    return [];
+  }
+  const rows = await db
+    .selectFrom("navigation_build_keys")
+    .select(["id", "app_id"])
+    .where("id", "in", Array.from(new Set(ids)))
+    .execute();
   return rows.map((row) => ({ id: row.id, appId: row.app_id }));
 }
 
@@ -552,12 +677,13 @@ async function loadBuildKeys(db: Kysely<Database>): Promise<BuildKeyRow[]> {
 export async function computeProtectedBuildKeyIds(
   db: Kysely<Database>,
   buildKeys?: BuildKeyRow[],
+  appIds?: readonly string[],
 ): Promise<number[]> {
-  const keys = buildKeys ?? (await loadBuildKeys(db));
+  const keys = buildKeys ?? (await loadBuildKeys(db, appIds));
   if (keys.length === 0) {
     return [];
   }
-  const maxSeen = await loadMaxSeenByBuildKey(db);
+  const maxSeen = await loadMaxSeenByBuildKey(db, appIds);
 
   // Per app, pick the build key with the greatest (lastSeen, id).
   const best = new Map<string, { id: number; seen: number }>();
@@ -583,16 +709,27 @@ function isNewerBuild(
 }
 
 /** Greatest `last_seen_at` per build key across both observation tables. */
-async function loadMaxSeenByBuildKey(db: Kysely<Database>): Promise<Map<number, number>> {
-  const nodeMax = await db
-    .selectFrom("navigation_node_observations")
-    .select((eb) => ["build_key_id", eb.fn.max("last_seen_at").as("max_seen")])
-    .groupBy("build_key_id")
+async function loadMaxSeenByBuildKey(
+  db: Kysely<Database>,
+  appIds?: readonly string[],
+): Promise<Map<number, number>> {
+  let nodeQuery = db
+    .selectFrom("navigation_node_observations as observation")
+    .innerJoin("navigation_build_keys as buildKey", "buildKey.id", "observation.build_key_id")
+    .select((eb) => ["observation.build_key_id", eb.fn.max("observation.last_seen_at").as("max_seen")]);
+  let edgeQuery = db
+    .selectFrom("navigation_edge_observations as observation")
+    .innerJoin("navigation_build_keys as buildKey", "buildKey.id", "observation.build_key_id")
+    .select((eb) => ["observation.build_key_id", eb.fn.max("observation.last_seen_at").as("max_seen")]);
+  if (appIds && appIds.length > 0) {
+    nodeQuery = nodeQuery.where("buildKey.app_id", "in", appIds);
+    edgeQuery = edgeQuery.where("buildKey.app_id", "in", appIds);
+  }
+  const nodeMax = await nodeQuery
+    .groupBy("observation.build_key_id")
     .execute();
-  const edgeMax = await db
-    .selectFrom("navigation_edge_observations")
-    .select((eb) => ["build_key_id", eb.fn.max("last_seen_at").as("max_seen")])
-    .groupBy("build_key_id")
+  const edgeMax = await edgeQuery
+    .groupBy("observation.build_key_id")
     .execute();
 
   const maxSeen = new Map<number, number>();
@@ -604,6 +741,61 @@ async function loadMaxSeenByBuildKey(db: Kysely<Database>): Promise<Map<number, 
     }
   }
   return maxSeen;
+}
+
+async function loadMaxSeenByBuildKeyIds(
+  db: Kysely<Database>,
+  ids: readonly number[],
+): Promise<Map<number, number>> {
+  if (ids.length === 0) {
+    return new Map();
+  }
+  const uniqueIds = Array.from(new Set(ids));
+  return loadMaxSeenByBuildKeyForIds(db, uniqueIds);
+}
+
+async function loadMaxSeenByBuildKeyForIds(
+  db: Kysely<Database>,
+  ids: number[],
+): Promise<Map<number, number>> {
+  const nodeMax = await db
+    .selectFrom("navigation_node_observations")
+    .select((eb) => ["build_key_id", eb.fn.max("last_seen_at").as("max_seen")])
+    .where("build_key_id", "in", ids)
+    .groupBy("build_key_id")
+    .execute();
+  const edgeMax = await db
+    .selectFrom("navigation_edge_observations")
+    .select((eb) => ["build_key_id", eb.fn.max("last_seen_at").as("max_seen")])
+    .where("build_key_id", "in", ids)
+    .groupBy("build_key_id")
+    .execute();
+  const maxSeen = new Map<number, number>();
+  for (const row of [...nodeMax, ...edgeMax]) {
+    const seen = Number(row.max_seen ?? 0);
+    const previous = maxSeen.get(row.build_key_id);
+    if (previous === undefined || seen > previous) {
+      maxSeen.set(row.build_key_id, seen);
+    }
+  }
+  return maxSeen;
+}
+
+async function loadProtectedNodeRows(
+  db: Kysely<Database>,
+  nodeIds: readonly number[],
+  protectedIds: readonly number[],
+): Promise<number[]> {
+  if (nodeIds.length === 0 || protectedIds.length === 0) {
+    return [];
+  }
+  const rows = await db
+    .selectFrom("navigation_node_observations")
+    .select("node_id")
+    .where("node_id", "in", nodeIds)
+    .where("build_key_id", "in", protectedIds)
+    .execute();
+  return rows.map((row) => row.node_id);
 }
 
 /**
@@ -655,8 +847,18 @@ async function collectOldestEvictable(
   const edgeRows = await buildOldestEdgeEvictableQuery(trx, appId, protectedIds, limit).execute();
 
   const candidates: EvictionCandidate[] = [
-    ...nodeRows.map((row) => ({ isNode: true, id: row.id, lastSeenAt: row.last_seen_at })),
-    ...edgeRows.map((row) => ({ isNode: false, id: row.id, lastSeenAt: row.last_seen_at })),
+    ...nodeRows.map((row) => ({
+      isNode: true,
+      id: row.id,
+      buildKeyId: row.build_key_id,
+      lastSeenAt: row.last_seen_at,
+    })),
+    ...edgeRows.map((row) => ({
+      isNode: false,
+      id: row.id,
+      buildKeyId: row.build_key_id,
+      lastSeenAt: row.last_seen_at,
+    })),
   ];
   // Oldest first; break ties by table (nodes before edges) then id for determinism.
   candidates.sort(
@@ -686,7 +888,9 @@ export function buildOldestNodeEvictableQuery(
   protectedIds: number[],
   limit: number,
 ) {
-  let query = db.selectFrom("navigation_node_observations").select(["id", "last_seen_at"]);
+  let query = db
+    .selectFrom("navigation_node_observations")
+    .select(["id", "build_key_id", "last_seen_at"]);
   if (appId !== null) {
     query = query.where("build_key_id", "in", (eb) =>
       eb.selectFrom("navigation_build_keys").select("id").where("app_id", "=", appId),
@@ -717,7 +921,9 @@ export function buildOldestEdgeEvictableQuery(
   protectedIds: number[],
   limit: number,
 ) {
-  let query = db.selectFrom("navigation_edge_observations").select(["id", "last_seen_at"]);
+  let query = db
+    .selectFrom("navigation_edge_observations")
+    .select(["id", "build_key_id", "last_seen_at"]);
   if (appId !== null) {
     query = query.where("build_key_id", "in", (eb) =>
       eb.selectFrom("navigation_build_keys").select("id").where("app_id", "=", appId),

--- a/src/db/navigationRetention.ts
+++ b/src/db/navigationRetention.ts
@@ -35,16 +35,16 @@
 // mutex, not a SQLite lock, so `busy_timeout` never applies to it). Instead each
 // tier, and each eviction batch WITHIN `evictOldest`, runs in its own short
 // transaction, so the connection is released between them and other queries can
-// interleave. The protected build-key set is re-read INSIDE every one of those
-// short transactions rather than computed once and cached across chunks: since
-// the connection is released between chunks, a concurrent write can change which
-// build key is active mid-pass, and re-reading per chunk (mirroring how
-// `collectOldestEvictable` already re-queries its candidate set fresh every
-// batch) keeps each chunk's "read active set, then mutate" step atomic without
-// ever risking a stale protected set skipping or double-deleting a row. FK-safe
-// ordering across tiers still holds: the TTL/cap tiers' transactions commit
-// before the orphan-build-key sweep's transaction begins. File unlinks run AFTER
-// every commit as a side effect (never inside a txn).
+// interleave. Batched tiers keep one protected-build snapshot so they do not
+// repeat a whole-database grouped-MAX scan for every chunk, then revalidate the
+// apps represented by a selected batch inside its short transaction before
+// mutating. Global oldest-first eviction is the exception: it revalidates every
+// app before each delete, because a protection change in an app outside the
+// selected batch can expose an even older row. This preserves atomic active-data
+// safety without making large multi-app databases quadratic. FK-safe ordering
+// across tiers still holds: the TTL/cap tiers' transactions commit before the
+// orphan-build-key sweep's transaction begins. File unlinks run AFTER every
+// commit as a side effect (never inside a txn).
 //
 // SQLite scale safety: every statement in this module keeps its bound-parameter
 // count and expression-tree depth bounded regardless of DB size. Row-count id
@@ -66,6 +66,9 @@ import { logger as defaultLogger, type Logger } from "../utils/logger";
 export type RetentionBatchYield = () => Promise<void>;
 
 const yieldToIo: RetentionBatchYield = () => new Promise((resolve) => setImmediate(resolve));
+
+/** Injectable protected-set query used to make concurrency and query scope observable in tests. */
+export type ProtectedBuildKeyResolver = typeof computeProtectedBuildKeyIds;
 
 /** Tunable retention thresholds. All durations are milliseconds. */
 export interface NavigationRetentionConfig {
@@ -258,6 +261,7 @@ export class NavigationRetention {
     private readonly removeScreenshotFile?: ScreenshotFileRemover,
     private readonly logger: Logger = defaultLogger,
     private readonly yieldBetweenBatches: RetentionBatchYield = yieldToIo,
+    private readonly resolveProtectedBuildKeyIds: ProtectedBuildKeyResolver = computeProtectedBuildKeyIds,
   ) {
     this.config = resolveNavigationRetentionConfig(config);
   }
@@ -310,8 +314,8 @@ export class NavigationRetention {
    * stale set is cleared in chunks of `evictionChunkSize` — each UPDATE binds at
    * most that many ids. Clearing the pointer removes rows from the next batch's
    * predicate, so the loop terminates. Each batch is its own short transaction
-   * (#6650): the protected set is re-read fresh inside it, so a build key that
-   * becomes active between batches is honored by every batch after that point.
+   * (#6650): the selected batch's apps are revalidated inside it, so a build key
+   * that becomes active between batches is honored by every later mutation.
    * Each batch's files are unlinked right after that batch commits (outside the
    * txn) — pairing the clear-commit with its unlink so a failure in this loop or
    * a later tier can never strand a file whose DB pointer is already gone.
@@ -322,7 +326,7 @@ export class NavigationRetention {
     // A full protected-build scan is expensive on an accumulated database. Keep a
     // snapshot for ordinary batches, then revalidate only each selected batch's
     // apps under its transaction before clearing pointers.
-    let protectedIds = await computeProtectedBuildKeyIds(this.db);
+    let protectedIds = await this.resolveProtectedBuildKeyIds(this.db);
 
     for (;;) {
       const batchResult = await this.db.transaction().execute(async (trx) => {
@@ -349,7 +353,11 @@ export class NavigationRetention {
         }
 
         const batchAppIds = Array.from(new Set(batch.map((row) => row.app_id)));
-        const currentProtectedIds = await computeProtectedBuildKeyIds(trx, undefined, batchAppIds);
+        const currentProtectedIds = await this.resolveProtectedBuildKeyIds(
+          trx,
+          undefined,
+          batchAppIds,
+        );
         const protectedNodeRows = await loadProtectedNodeRows(
           trx,
           batch.map((row) => row.id),
@@ -398,13 +406,14 @@ export class NavigationRetention {
       await this.removeFiles(batchResult.clearedPaths);
 
       if (batchResult.activeBuildChanged) {
-        protectedIds = await computeProtectedBuildKeyIds(this.db);
+        protectedIds = await this.resolveProtectedBuildKeyIds(this.db);
       }
 
       // A changed active build can make every row in the selected snapshot
       // ineligible while exposing rows hidden by the prior snapshot. Re-select
       // once against the refreshed protection set before deciding the tier is done.
       if (batchResult.clearedCount === 0 && batchResult.activeBuildChanged) {
+        await this.yieldBetweenBatches();
         continue;
       }
       if (!batchResult.isFullBatch || batchResult.clearedCount === 0) {
@@ -418,7 +427,9 @@ export class NavigationRetention {
    * LONG tier: delete observation rows last seen before the cutoff, except those
    * on a protected (active) build key. Each bounded delete batch runs in its
    * own transaction, so an overdue retention pass cannot monopolize the single
-   * daemon connection in one predicate-wide SQLite delete.
+   * daemon connection in one predicate-wide SQLite delete. Each table takes one
+   * full protected-set snapshot, then transactionally revalidates only the apps
+   * represented by its selected rows before deleting them.
    */
   private async pruneObservationsByTtl(
     now: number,
@@ -432,32 +443,65 @@ export class NavigationRetention {
 
   private async pruneNodeObservationsByTtl(cutoff: number): Promise<number> {
     let deletedTotal = 0;
+    let protectedIds = await this.resolveProtectedBuildKeyIds(this.db);
     for (;;) {
-      const deleted = await this.db.transaction().execute(async (trx) => {
-        const protectedIds = await computeProtectedBuildKeyIds(trx);
+      const batchResult = await this.db.transaction().execute(async (trx) => {
         let query = trx
-          .selectFrom("navigation_node_observations")
-          .select("id")
-          .where("last_seen_at", "<", cutoff);
+          .selectFrom("navigation_node_observations as observation")
+          .innerJoin("navigation_build_keys as buildKey", "buildKey.id", "observation.build_key_id")
+          .select(["observation.id", "observation.build_key_id", "buildKey.app_id"])
+          .where("observation.last_seen_at", "<", cutoff);
         if (protectedIds.length > 0) {
-          query = query.where("build_key_id", "not in", protectedIds);
+          query = query.where("observation.build_key_id", "not in", protectedIds);
         }
         const rows = await query.limit(this.config.evictionChunkSize).execute();
         if (rows.length === 0) {
-          return 0;
+          return null;
+        }
+
+        const batchAppIds = Array.from(new Set(rows.map((row) => row.app_id)));
+        const currentProtectedIds = await this.resolveProtectedBuildKeyIds(
+          trx,
+          undefined,
+          batchAppIds,
+        );
+        const currentProtected = new Set(currentProtectedIds);
+        const eligibleIds = rows
+          .filter((row) => !currentProtected.has(row.build_key_id))
+          .map((row) => row.id);
+        const protectionChanged = currentProtectedIds.some((id) => !protectedIds.includes(id));
+        if (eligibleIds.length === 0) {
+          return {
+            deletedCount: 0,
+            isFullBatch: rows.length === this.config.evictionChunkSize,
+            protectionChanged,
+          };
         }
         const result = await trx
           .deleteFrom("navigation_node_observations")
-          .where(
-            "id",
-            "in",
-            rows.map((row) => row.id),
-          )
+          .where("id", "in", eligibleIds)
           .executeTakeFirst();
-        return Number(result.numDeletedRows ?? 0);
+        return {
+          deletedCount: Number(result.numDeletedRows ?? 0),
+          isFullBatch: rows.length === this.config.evictionChunkSize,
+          protectionChanged,
+        };
       });
-      deletedTotal += deleted;
-      if (deleted < this.config.evictionChunkSize) {
+      if (batchResult === null) {
+        return deletedTotal;
+      }
+      deletedTotal += batchResult.deletedCount;
+      if (batchResult.protectionChanged) {
+        protectedIds = await this.resolveProtectedBuildKeyIds(this.db);
+        if (batchResult.deletedCount === 0) {
+          await this.yieldBetweenBatches();
+          continue;
+        }
+      }
+      if (
+        (!batchResult.isFullBatch && !batchResult.protectionChanged) ||
+        batchResult.deletedCount === 0
+      ) {
         return deletedTotal;
       }
       await this.yieldBetweenBatches();
@@ -466,32 +510,65 @@ export class NavigationRetention {
 
   private async pruneEdgeObservationsByTtl(cutoff: number): Promise<number> {
     let deletedTotal = 0;
+    let protectedIds = await this.resolveProtectedBuildKeyIds(this.db);
     for (;;) {
-      const deleted = await this.db.transaction().execute(async (trx) => {
-        const protectedIds = await computeProtectedBuildKeyIds(trx);
+      const batchResult = await this.db.transaction().execute(async (trx) => {
         let query = trx
-          .selectFrom("navigation_edge_observations")
-          .select("id")
-          .where("last_seen_at", "<", cutoff);
+          .selectFrom("navigation_edge_observations as observation")
+          .innerJoin("navigation_build_keys as buildKey", "buildKey.id", "observation.build_key_id")
+          .select(["observation.id", "observation.build_key_id", "buildKey.app_id"])
+          .where("observation.last_seen_at", "<", cutoff);
         if (protectedIds.length > 0) {
-          query = query.where("build_key_id", "not in", protectedIds);
+          query = query.where("observation.build_key_id", "not in", protectedIds);
         }
         const rows = await query.limit(this.config.evictionChunkSize).execute();
         if (rows.length === 0) {
-          return 0;
+          return null;
+        }
+
+        const batchAppIds = Array.from(new Set(rows.map((row) => row.app_id)));
+        const currentProtectedIds = await this.resolveProtectedBuildKeyIds(
+          trx,
+          undefined,
+          batchAppIds,
+        );
+        const currentProtected = new Set(currentProtectedIds);
+        const eligibleIds = rows
+          .filter((row) => !currentProtected.has(row.build_key_id))
+          .map((row) => row.id);
+        const protectionChanged = currentProtectedIds.some((id) => !protectedIds.includes(id));
+        if (eligibleIds.length === 0) {
+          return {
+            deletedCount: 0,
+            isFullBatch: rows.length === this.config.evictionChunkSize,
+            protectionChanged,
+          };
         }
         const result = await trx
           .deleteFrom("navigation_edge_observations")
-          .where(
-            "id",
-            "in",
-            rows.map((row) => row.id),
-          )
+          .where("id", "in", eligibleIds)
           .executeTakeFirst();
-        return Number(result.numDeletedRows ?? 0);
+        return {
+          deletedCount: Number(result.numDeletedRows ?? 0),
+          isFullBatch: rows.length === this.config.evictionChunkSize,
+          protectionChanged,
+        };
       });
-      deletedTotal += deleted;
-      if (deleted < this.config.evictionChunkSize) {
+      if (batchResult === null) {
+        return deletedTotal;
+      }
+      deletedTotal += batchResult.deletedCount;
+      if (batchResult.protectionChanged) {
+        protectedIds = await this.resolveProtectedBuildKeyIds(this.db);
+        if (batchResult.deletedCount === 0) {
+          await this.yieldBetweenBatches();
+          continue;
+        }
+      }
+      if (
+        (!batchResult.isFullBatch && !batchResult.protectionChanged) ||
+        batchResult.deletedCount === 0
+      ) {
         return deletedTotal;
       }
       await this.yieldBetweenBatches();
@@ -523,10 +600,10 @@ export class NavigationRetention {
       const overflow = count - this.config.perAppMaxObservations;
       if (overflow > 0) {
         await this.evictOldest(appId, overflow, summary);
-        // A one-batch pass never reaches evictOldest's internal yield. Give
-        // arrivals a turn before starting the next app's synchronous SQLite work.
-        await this.yieldBetweenBatches();
       }
+      // Counting an under-cap app and a one-batch eviction are both entirely
+      // synchronous SQLite work. Give arrivals a turn before scanning the next app.
+      await this.yieldBetweenBatches();
     }
 
     const globalCount = await countObservations(this.db, null);
@@ -544,12 +621,10 @@ export class NavigationRetention {
    * be irreducible below its active set).
    *
    * Each batch is its own short transaction (#6650), releasing the connection
-   * between batches. The protected build-key set is re-read fresh inside every
-   * batch's transaction (never cached from a prior batch), so it always reflects
-   * whichever build key is active AT THE TIME of that batch's delete — the same
-   * self-correcting principle `collectOldestEvictable` already applies to the
-   * victim rows themselves, extended to the protected set they are excluded
-   * against.
+   * between batches. A per-app pass snapshots and revalidates only that app. A
+   * global pass snapshots and revalidates the full protected set before every
+   * delete so a newly exposed older row in any app forces re-selection. Empty
+   * selections are also revalidated before the loop decides it is irreducible.
    *
    * Perf note: each batch reads the oldest rows `ORDER BY last_seen_at, id`
    * across build keys. The `(last_seen_at, id)` index from
@@ -563,26 +638,35 @@ export class NavigationRetention {
     summary: NavigationRetentionSummary,
   ): Promise<void> {
     let remaining = count;
-    // Reuse a whole-database protected-build snapshot for this eviction pass.
-    // Every selected batch revalidates only its own candidate apps before delete.
-    let protectedIds = await computeProtectedBuildKeyIds(this.db);
+    // Per-app enforcement never needs another app's grouped-MAX scan. Global
+    // oldest-first enforcement must snapshot and revalidate every app.
+    const protectedScope = appId === null ? undefined : [appId];
+    let protectedIds = await this.resolveProtectedBuildKeyIds(this.db, undefined, protectedScope);
     while (remaining > 0) {
       const batch = Math.min(remaining, this.config.evictionChunkSize);
       const batchResult = await this.db.transaction().execute(async (trx) => {
         const victims = await collectOldestEvictable(trx, appId, protectedIds, batch);
         if (victims.length === 0) {
-          return { evictedCount: 0, protectionChanged: false };
+          const currentProtectedIds = await this.resolveProtectedBuildKeyIds(
+            trx,
+            undefined,
+            protectedScope,
+          );
+          return {
+            evictedCount: 0,
+            protectionChanged: !containSameIds(currentProtectedIds, protectedIds),
+          };
         }
 
-        const candidateBuildKeys = await loadBuildKeysByIds(
-          trx,
-          victims.map((victim) => victim.buildKeyId),
-        );
-        const currentProtectedIds = await computeProtectedBuildKeyIds(
+        const currentProtectedIds = await this.resolveProtectedBuildKeyIds(
           trx,
           undefined,
-          Array.from(new Set(candidateBuildKeys.map((key) => key.appId))),
+          protectedScope,
         );
+        if (!containSameIds(currentProtectedIds, protectedIds)) {
+          return { evictedCount: 0, protectionChanged: true };
+        }
+
         const maxSeen = await loadMaxSeenByBuildKeyIds(
           trx,
           victims.map((victim) => victim.buildKeyId),
@@ -594,10 +678,7 @@ export class NavigationRetention {
             victim.lastSeenAt < (maxSeen.get(victim.buildKeyId) ?? Number.NEGATIVE_INFINITY),
         );
         if (eligibleVictims.length === 0) {
-          return {
-            evictedCount: 0,
-            protectionChanged: currentProtectedIds.some((id) => !protectedIds.includes(id)),
-          };
+          return { evictedCount: 0, protectionChanged: false };
         }
 
         const nodeIds = eligibleVictims.filter((v) => v.isNode).map((v) => v.id);
@@ -621,7 +702,8 @@ export class NavigationRetention {
 
       if (batchResult.evictedCount === 0) {
         if (batchResult.protectionChanged) {
-          protectedIds = await computeProtectedBuildKeyIds(this.db);
+          protectedIds = await this.resolveProtectedBuildKeyIds(this.db, undefined, protectedScope);
+          await this.yieldBetweenBatches();
           continue;
         }
         return;
@@ -646,7 +728,7 @@ export class NavigationRetention {
     const chunk = this.config.evictionChunkSize;
     for (;;) {
       const deleted = await this.db.transaction().execute(async (trx) => {
-        const protectedIds = await computeProtectedBuildKeyIds(trx);
+        const protectedIds = await this.resolveProtectedBuildKeyIds(trx);
 
         let query = trx
           .selectFrom("navigation_build_keys")
@@ -701,21 +783,6 @@ async function loadBuildKeys(
   return rows.map((row) => ({ id: row.id, appId: row.app_id }));
 }
 
-async function loadBuildKeysByIds(
-  db: Kysely<Database>,
-  ids: readonly number[],
-): Promise<BuildKeyRow[]> {
-  if (ids.length === 0) {
-    return [];
-  }
-  const rows = await db
-    .selectFrom("navigation_build_keys")
-    .select(["id", "app_id"])
-    .where("id", "in", Array.from(new Set(ids)))
-    .execute();
-  return rows.map((row) => ({ id: row.id, appId: row.app_id }));
-}
-
 /**
  * The active/most-recent build key per app: the one whose observations have the
  * greatest `last_seen_at` (ties and no-observation apps fall back to the newest
@@ -753,6 +820,14 @@ function isNewerBuild(
     return true;
   }
   return seen > current.seen || (seen === current.seen && id > current.id);
+}
+
+function containSameIds(left: readonly number[], right: readonly number[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  const rightIds = new Set(right);
+  return left.every((id) => rightIds.has(id));
 }
 
 /** Greatest `last_seen_at` per build key across both observation tables. */

--- a/src/db/navigationRetention.ts
+++ b/src/db/navigationRetention.ts
@@ -26,10 +26,25 @@
 // active context. The TTL tier and the orphan-build-key sweep never touch it, and
 // the size cap never evicts its newest observation(s). Because in-flight writes
 // land on the current build key (newest `last_seen_at`), this protects whatever is
-// being observed right now without a separate liveness signal. The whole pass runs
-// in one transaction (atomic, no torn graph); observations are deleted before
-// their orphaned build keys (FK-safe order), and file unlinks run AFTER commit as
-// side effects (never inside the txn).
+// being observed right now without a separate liveness signal.
+//
+// Connection-hold bound (#6650): the pass does NOT run in one transaction that
+// spans its whole duration -- on a large graph that would hold the daemon's
+// single SQLite connection exclusively for the entire pass, parking every other
+// query with no timeout (bunSqliteDialect's transaction lease is a JS-level
+// mutex, not a SQLite lock, so `busy_timeout` never applies to it). Instead each
+// tier, and each eviction batch WITHIN `evictOldest`, runs in its own short
+// transaction, so the connection is released between them and other queries can
+// interleave. The protected build-key set is re-read INSIDE every one of those
+// short transactions rather than computed once and cached across chunks: since
+// the connection is released between chunks, a concurrent write can change which
+// build key is active mid-pass, and re-reading per chunk (mirroring how
+// `collectOldestEvictable` already re-queries its candidate set fresh every
+// batch) keeps each chunk's "read active set, then mutate" step atomic without
+// ever risking a stale protected set skipping or double-deleting a row. FK-safe
+// ordering across tiers still holds: the TTL/cap tiers' transactions commit
+// before the orphan-build-key sweep's transaction begins. File unlinks run AFTER
+// every commit as a side effect (never inside a txn).
 //
 // SQLite scale safety: every statement in this module keeps its bound-parameter
 // count and expression-tree depth bounded regardless of DB size. Row-count id
@@ -215,9 +230,11 @@ interface EvictionCandidate {
 }
 
 /**
- * Prunes the persisted nav data in one atomic pass. Stateless and recency-based:
- * inject the clock `now` and (optionally) a file remover so the whole thing is
- * deterministic under FakeTimer + an in-memory DB.
+ * Prunes the persisted nav data in a chunked pass: each tier, and each eviction
+ * batch within a tier, is its own short atomic transaction rather than the whole
+ * pass sharing one (#6650) — see the connection-hold-bound note above. Stateless
+ * and recency-based: inject the clock `now` and (optionally) a file remover so
+ * the whole thing is deterministic under FakeTimer + an in-memory DB.
  *
  * The two observation tables are handled by explicit node/edge branches rather
  * than a table-name variable: their relevant columns are identical, but keeping
@@ -236,28 +253,27 @@ export class NavigationRetention {
   }
 
   /**
-   * Run every tier once against `now` (ms). Returns a per-pass summary. All DB
-   * work is a single transaction; screenshot files are unlinked AFTER commit so
-   * a slow/failed unlink can never hold the daemon's one connection.
+   * Run every tier once against `now` (ms). Returns a per-pass summary. Each
+   * tier (and each eviction batch inside it) runs in its own short transaction
+   * (#6650) rather than the whole pass sharing one, so the daemon's single
+   * connection is released between them; screenshot files are unlinked AFTER
+   * every commit so a slow/failed unlink can never hold that connection either.
    */
   async prune(now: number): Promise<NavigationRetentionSummary> {
     const summary = emptySummary(now);
-    let filesToRemove: string[] = [];
 
-    await this.db.transaction().execute(async (trx) => {
-      // Read the build keys + protected set INSIDE the txn: it holds the single
-      // connection exclusively, so no concurrent write can shift which build is
-      // newest between the read and the deletes.
-      const buildKeys = await loadBuildKeys(trx);
-      const protectedIds = await computeProtectedBuildKeyIds(trx, buildKeys);
+    // pruneScreenshots unlinks each batch's files right after that batch's own
+    // transaction commits (#6650) — NOT deferred to the end of the pass. Deferring
+    // reintroduced a partial-failure leak the single-transaction version could not
+    // have: a screenshot_path is committed as null in the SHORT tier, but if a
+    // later tier (TTL/cap/orphan) then threw, the trailing unlink was never
+    // reached and the file was stranded on disk with no DB pointer left to
+    // rediscover it. Pairing each clear-commit with its unlink closes that window.
+    await this.pruneScreenshots(now, summary);
+    await this.pruneObservationsByTtl(now, summary);
+    await this.enforceCaps(summary);
+    await this.pruneOrphanBuildKeys(summary);
 
-      filesToRemove = await this.pruneScreenshots(trx, now, protectedIds, summary);
-      await this.pruneObservationsByTtl(trx, now, protectedIds, summary);
-      await this.enforceCaps(trx, buildKeys, protectedIds, summary);
-      await this.pruneOrphanBuildKeys(trx, protectedIds, summary);
-    });
-
-    await this.removeFiles(filesToRemove);
     return summary;
   }
 
@@ -278,98 +294,116 @@ export class NavigationRetention {
 
   /**
    * SHORT tier: clear `screenshot_path` on nodes last seen before the cutoff,
-   * unless the node is still observed under the active (protected) build. Returns
-   * the file paths whose pointers were cleared, for post-commit unlinking.
+   * unless the node is still observed under the active (protected) build.
    *
    * Batched: node cardinality is NOT bounded by the observation caps, so a large
    * stale set is cleared in chunks of `evictionChunkSize` — each UPDATE binds at
    * most that many ids. Clearing the pointer removes rows from the next batch's
-   * predicate, so the loop terminates.
+   * predicate, so the loop terminates. Each batch is its own short transaction
+   * (#6650): the protected set is re-read fresh inside it, so a build key that
+   * becomes active between batches is honored by every batch after that point.
+   * Each batch's files are unlinked right after that batch commits (outside the
+   * txn) — pairing the clear-commit with its unlink so a failure in this loop or
+   * a later tier can never strand a file whose DB pointer is already gone.
    */
-  private async pruneScreenshots(
-    trx: Kysely<Database>,
-    now: number,
-    protectedIds: number[],
-    summary: NavigationRetentionSummary,
-  ): Promise<string[]> {
+  private async pruneScreenshots(now: number, summary: NavigationRetentionSummary): Promise<void> {
     const cutoff = now - this.config.screenshotTtlMs;
     const chunk = this.config.evictionChunkSize;
-    const paths: string[] = [];
 
     for (;;) {
-      let query = trx
-        .selectFrom("navigation_nodes")
-        .select(["id", "screenshot_path"])
-        .where("screenshot_path", "is not", null)
-        .where("last_seen_at", "<", cutoff);
+      const batchResult = await this.db.transaction().execute(async (trx) => {
+        const protectedIds = await computeProtectedBuildKeyIds(trx);
+        let query = trx
+          .selectFrom("navigation_nodes")
+          .select(["id", "screenshot_path"])
+          .where("screenshot_path", "is not", null)
+          .where("last_seen_at", "<", cutoff);
 
-      if (protectedIds.length > 0) {
-        // Keep the screenshot if the node has any observation under a protected
-        // build key (i.e. it is part of the active context).
-        query = query.where("id", "not in", (eb) =>
-          eb
-            .selectFrom("navigation_node_observations")
-            .select("node_id")
-            .where("build_key_id", "in", protectedIds),
-        );
-      }
+        if (protectedIds.length > 0) {
+          // Keep the screenshot if the node has any observation under a
+          // protected build key (i.e. it is part of the active context).
+          query = query.where("id", "not in", (eb) =>
+            eb
+              .selectFrom("navigation_node_observations")
+              .select("node_id")
+              .where("build_key_id", "in", protectedIds),
+          );
+        }
 
-      const batch = await query.limit(chunk).execute();
-      if (batch.length === 0) {
+        const batch = await query.limit(chunk).execute();
+        if (batch.length === 0) {
+          return null;
+        }
+
+        const ids = batch.map((row) => row.id);
+        await trx
+          .updateTable("navigation_nodes")
+          .set({ screenshot_path: null })
+          .where("id", "in", ids)
+          .execute();
+
+        const clearedPaths: string[] = [];
+        for (const row of batch) {
+          if (row.screenshot_path !== null) {
+            clearedPaths.push(row.screenshot_path);
+          }
+        }
+        return { clearedCount: ids.length, clearedPaths, isFullBatch: batch.length === chunk };
+      });
+
+      if (batchResult === null) {
         break;
       }
 
-      const ids = batch.map((row) => row.id);
-      await trx
-        .updateTable("navigation_nodes")
-        .set({ screenshot_path: null })
-        .where("id", "in", ids)
-        .execute();
+      summary.screenshotsCleared += batchResult.clearedCount;
+      // Unlink this batch's files now that its clear-transaction has committed,
+      // before the next batch or any later tier runs (#6650).
+      await this.removeFiles(batchResult.clearedPaths);
 
-      summary.screenshotsCleared += ids.length;
-      for (const row of batch) {
-        if (row.screenshot_path !== null) {
-          paths.push(row.screenshot_path);
-        }
-      }
-
-      if (batch.length < chunk) {
+      if (!batchResult.isFullBatch) {
         break;
       }
     }
-
-    return paths;
   }
 
   /**
    * LONG tier: delete observation rows last seen before the cutoff, except those
-   * on a protected (active) build key. A single DELETE by predicate — it binds
-   * only the (per-app-bounded) protected id list, never one param per matched row.
+   * on a protected (active) build key. A single DELETE by predicate per table —
+   * it binds only the (per-app-bounded) protected id list, never one param per
+   * matched row. Both deletes run in one short transaction (#6650) so the
+   * protected set they share is read once and stays consistent between them,
+   * without holding the connection for any other tier.
    */
   private async pruneObservationsByTtl(
-    trx: Kysely<Database>,
     now: number,
-    protectedIds: number[],
     summary: NavigationRetentionSummary,
   ): Promise<void> {
     const cutoff = now - this.config.structureTtlMs;
 
-    {
-      let query = trx.deleteFrom("navigation_node_observations").where("last_seen_at", "<", cutoff);
-      if (protectedIds.length > 0) {
-        query = query.where("build_key_id", "not in", protectedIds);
+    await this.db.transaction().execute(async (trx) => {
+      const protectedIds = await computeProtectedBuildKeyIds(trx);
+
+      {
+        let query = trx
+          .deleteFrom("navigation_node_observations")
+          .where("last_seen_at", "<", cutoff);
+        if (protectedIds.length > 0) {
+          query = query.where("build_key_id", "not in", protectedIds);
+        }
+        const result = await query.executeTakeFirst();
+        summary.nodeObservationsDeleted += Number(result.numDeletedRows ?? 0);
       }
-      const result = await query.executeTakeFirst();
-      summary.nodeObservationsDeleted += Number(result.numDeletedRows ?? 0);
-    }
-    {
-      let query = trx.deleteFrom("navigation_edge_observations").where("last_seen_at", "<", cutoff);
-      if (protectedIds.length > 0) {
-        query = query.where("build_key_id", "not in", protectedIds);
+      {
+        let query = trx
+          .deleteFrom("navigation_edge_observations")
+          .where("last_seen_at", "<", cutoff);
+        if (protectedIds.length > 0) {
+          query = query.where("build_key_id", "not in", protectedIds);
+        }
+        const result = await query.executeTakeFirst();
+        summary.edgeObservationsDeleted += Number(result.numDeletedRows ?? 0);
       }
-      const result = await query.executeTakeFirst();
-      summary.edgeObservationsDeleted += Number(result.numDeletedRows ?? 0);
-    }
+    });
   }
 
   /**
@@ -381,26 +415,29 @@ export class NavigationRetention {
    * Per-app scope is expressed as a join on `app_id` (binds one param, the app id)
    * rather than an id list of the app's build keys, so it stays bounded no matter
    * how many builds an app accumulates.
+   *
+   * The app-id enumeration and the overflow counts below are plain (untransacted)
+   * reads, not part of any atomic unit: `evictOldest` (#6650) re-derives its own
+   * victim set and protected set fresh inside each batch's own short
+   * transaction, so a stale/approximate count here only changes how many batches
+   * run, never which rows are safe to delete (self-correcting, same as the
+   * existing `collectOldestEvictable` re-query per batch).
    */
-  private async enforceCaps(
-    trx: Kysely<Database>,
-    buildKeys: BuildKeyRow[],
-    protectedIds: number[],
-    summary: NavigationRetentionSummary,
-  ): Promise<void> {
+  private async enforceCaps(summary: NavigationRetentionSummary): Promise<void> {
+    const buildKeys = await loadBuildKeys(this.db);
     const appIds = Array.from(new Set(buildKeys.map((bk) => bk.appId)));
     for (const appId of appIds) {
-      const count = await countObservations(trx, appId);
+      const count = await countObservations(this.db, appId);
       const overflow = count - this.config.perAppMaxObservations;
       if (overflow > 0) {
-        await this.evictOldest(trx, appId, protectedIds, overflow, summary);
+        await this.evictOldest(appId, overflow, summary);
       }
     }
 
-    const globalCount = await countObservations(trx, null);
+    const globalCount = await countObservations(this.db, null);
     const globalOverflow = globalCount - this.config.globalMaxObservations;
     if (globalOverflow > 0) {
-      await this.evictOldest(trx, null, protectedIds, globalOverflow, summary);
+      await this.evictOldest(null, globalOverflow, summary);
     }
   }
 
@@ -411,6 +448,14 @@ export class NavigationRetention {
    * evictable rows remain (active rows are excluded relationally, so a scope can
    * be irreducible below its active set).
    *
+   * Each batch is its own short transaction (#6650), releasing the connection
+   * between batches. The protected build-key set is re-read fresh inside every
+   * batch's transaction (never cached from a prior batch), so it always reflects
+   * whichever build key is active AT THE TIME of that batch's delete — the same
+   * self-correcting principle `collectOldestEvictable` already applies to the
+   * victim rows themselves, extended to the protected set they are excluded
+   * against.
+   *
    * Perf note: each batch reads the oldest rows `ORDER BY last_seen_at, id`
    * across build keys. The `(last_seen_at, id)` index from
    * 2026_08_22_002_navigation_observation_eviction_index.ts (issue #5309) serves
@@ -418,67 +463,75 @@ export class NavigationRetention {
    * scan + temp-B-tree sort.
    */
   private async evictOldest(
-    trx: Kysely<Database>,
     appId: string | null,
-    protectedIds: number[],
     count: number,
     summary: NavigationRetentionSummary,
   ): Promise<void> {
     let remaining = count;
     while (remaining > 0) {
       const batch = Math.min(remaining, this.config.evictionChunkSize);
-      const victims = await collectOldestEvictable(trx, appId, protectedIds, batch);
-      if (victims.length === 0) {
+      const evictedCount = await this.db.transaction().execute(async (trx) => {
+        const protectedIds = await computeProtectedBuildKeyIds(trx);
+        const victims = await collectOldestEvictable(trx, appId, protectedIds, batch);
+        if (victims.length === 0) {
+          return 0;
+        }
+
+        const nodeIds = victims.filter((v) => v.isNode).map((v) => v.id);
+        const edgeIds = victims.filter((v) => !v.isNode).map((v) => v.id);
+        if (nodeIds.length > 0) {
+          const deleted = await trx
+            .deleteFrom("navigation_node_observations")
+            .where("id", "in", nodeIds)
+            .executeTakeFirst();
+          summary.nodeObservationsDeleted += Number(deleted.numDeletedRows ?? 0);
+        }
+        if (edgeIds.length > 0) {
+          const deleted = await trx
+            .deleteFrom("navigation_edge_observations")
+            .where("id", "in", edgeIds)
+            .executeTakeFirst();
+          summary.edgeObservationsDeleted += Number(deleted.numDeletedRows ?? 0);
+        }
+        return victims.length;
+      });
+
+      if (evictedCount === 0) {
         return;
       }
-
-      const nodeIds = victims.filter((v) => v.isNode).map((v) => v.id);
-      const edgeIds = victims.filter((v) => !v.isNode).map((v) => v.id);
-      if (nodeIds.length > 0) {
-        const deleted = await trx
-          .deleteFrom("navigation_node_observations")
-          .where("id", "in", nodeIds)
-          .executeTakeFirst();
-        summary.nodeObservationsDeleted += Number(deleted.numDeletedRows ?? 0);
-      }
-      if (edgeIds.length > 0) {
-        const deleted = await trx
-          .deleteFrom("navigation_edge_observations")
-          .where("id", "in", edgeIds)
-          .executeTakeFirst();
-        summary.edgeObservationsDeleted += Number(deleted.numDeletedRows ?? 0);
-      }
-      remaining -= victims.length;
+      remaining -= evictedCount;
     }
   }
 
   /**
    * Sweep build keys left with no observations (except protected ones). Runs
-   * after observation deletes so the FK-safe order holds even with foreign_keys
-   * ON (deleting a still-referenced build key would cascade-wipe its rows). The
-   * "no observations" test is a correlated subquery (binds O(1)); only the
-   * per-app-bounded protected id list is bound directly.
+   * after the observation-deleting tiers' transactions have already committed,
+   * so the FK-safe order holds even with foreign_keys ON (deleting a
+   * still-referenced build key would cascade-wipe its rows). The "no
+   * observations" test is a correlated subquery (binds O(1)); only the
+   * per-app-bounded protected id list is bound directly. Runs in its own short
+   * transaction (#6650) with the protected set read fresh inside it.
    */
-  private async pruneOrphanBuildKeys(
-    trx: Kysely<Database>,
-    protectedIds: number[],
-    summary: NavigationRetentionSummary,
-  ): Promise<void> {
-    let query = trx
-      .deleteFrom("navigation_build_keys")
-      .where("id", "not in", (eb) =>
-        eb.selectFrom("navigation_node_observations").select("build_key_id"),
-      )
-      .where("id", "not in", (eb) =>
-        eb.selectFrom("navigation_edge_observations").select("build_key_id"),
-      );
+  private async pruneOrphanBuildKeys(summary: NavigationRetentionSummary): Promise<void> {
+    await this.db.transaction().execute(async (trx) => {
+      const protectedIds = await computeProtectedBuildKeyIds(trx);
 
-    if (protectedIds.length > 0) {
-      query = query.where("id", "not in", protectedIds);
-    }
+      let query = trx
+        .deleteFrom("navigation_build_keys")
+        .where("id", "not in", (eb) =>
+          eb.selectFrom("navigation_node_observations").select("build_key_id"),
+        )
+        .where("id", "not in", (eb) =>
+          eb.selectFrom("navigation_edge_observations").select("build_key_id"),
+        );
 
-    const deleted = await query.executeTakeFirst();
-    summary.buildKeysDeleted += Number(deleted.numDeletedRows ?? 0);
+      if (protectedIds.length > 0) {
+        query = query.where("id", "not in", protectedIds);
+      }
+
+      const deleted = await query.executeTakeFirst();
+      summary.buildKeysDeleted += Number(deleted.numDeletedRows ?? 0);
+    });
   }
 }
 

--- a/src/db/navigationRetention.ts
+++ b/src/db/navigationRetention.ts
@@ -442,7 +442,11 @@ export class NavigationRetention {
         }
         const result = await trx
           .deleteFrom("navigation_node_observations")
-          .where("id", "in", rows.map((row) => row.id))
+          .where(
+            "id",
+            "in",
+            rows.map((row) => row.id),
+          )
           .executeTakeFirst();
         return Number(result.numDeletedRows ?? 0);
       });
@@ -472,7 +476,11 @@ export class NavigationRetention {
         }
         const result = await trx
           .deleteFrom("navigation_edge_observations")
-          .where("id", "in", rows.map((row) => row.id))
+          .where(
+            "id",
+            "in",
+            rows.map((row) => row.id),
+          )
           .executeTakeFirst();
         return Number(result.numDeletedRows ?? 0);
       });
@@ -645,7 +653,10 @@ export class NavigationRetention {
 // Free helpers (kept small so the class methods stay under the complexity gate).
 // ---------------------------------------------------------------------------
 
-async function loadBuildKeys(db: Kysely<Database>, appIds?: readonly string[]): Promise<BuildKeyRow[]> {
+async function loadBuildKeys(
+  db: Kysely<Database>,
+  appIds?: readonly string[],
+): Promise<BuildKeyRow[]> {
   let query = db.selectFrom("navigation_build_keys").select(["id", "app_id"]);
   if (appIds && appIds.length > 0) {
     query = query.where("app_id", "in", appIds);
@@ -716,21 +727,23 @@ async function loadMaxSeenByBuildKey(
   let nodeQuery = db
     .selectFrom("navigation_node_observations as observation")
     .innerJoin("navigation_build_keys as buildKey", "buildKey.id", "observation.build_key_id")
-    .select((eb) => ["observation.build_key_id", eb.fn.max("observation.last_seen_at").as("max_seen")]);
+    .select((eb) => [
+      "observation.build_key_id",
+      eb.fn.max("observation.last_seen_at").as("max_seen"),
+    ]);
   let edgeQuery = db
     .selectFrom("navigation_edge_observations as observation")
     .innerJoin("navigation_build_keys as buildKey", "buildKey.id", "observation.build_key_id")
-    .select((eb) => ["observation.build_key_id", eb.fn.max("observation.last_seen_at").as("max_seen")]);
+    .select((eb) => [
+      "observation.build_key_id",
+      eb.fn.max("observation.last_seen_at").as("max_seen"),
+    ]);
   if (appIds && appIds.length > 0) {
     nodeQuery = nodeQuery.where("buildKey.app_id", "in", appIds);
     edgeQuery = edgeQuery.where("buildKey.app_id", "in", appIds);
   }
-  const nodeMax = await nodeQuery
-    .groupBy("observation.build_key_id")
-    .execute();
-  const edgeMax = await edgeQuery
-    .groupBy("observation.build_key_id")
-    .execute();
+  const nodeMax = await nodeQuery.groupBy("observation.build_key_id").execute();
+  const edgeMax = await edgeQuery.groupBy("observation.build_key_id").execute();
 
   const maxSeen = new Map<number, number>();
   for (const row of [...nodeMax, ...edgeMax]) {

--- a/src/db/navigationRetention.ts
+++ b/src/db/navigationRetention.ts
@@ -401,6 +401,12 @@ export class NavigationRetention {
         protectedIds = await computeProtectedBuildKeyIds(this.db);
       }
 
+      // A changed active build can make every row in the selected snapshot
+      // ineligible while exposing rows hidden by the prior snapshot. Re-select
+      // once against the refreshed protection set before deciding the tier is done.
+      if (batchResult.clearedCount === 0 && batchResult.activeBuildChanged) {
+        continue;
+      }
       if (!batchResult.isFullBatch || batchResult.clearedCount === 0) {
         break;
       }
@@ -517,6 +523,9 @@ export class NavigationRetention {
       const overflow = count - this.config.perAppMaxObservations;
       if (overflow > 0) {
         await this.evictOldest(appId, overflow, summary);
+        // A one-batch pass never reaches evictOldest's internal yield. Give
+        // arrivals a turn before starting the next app's synchronous SQLite work.
+        await this.yieldBetweenBatches();
       }
     }
 
@@ -556,13 +565,13 @@ export class NavigationRetention {
     let remaining = count;
     // Reuse a whole-database protected-build snapshot for this eviction pass.
     // Every selected batch revalidates only its own candidate apps before delete.
-    const protectedIds = await computeProtectedBuildKeyIds(this.db);
+    let protectedIds = await computeProtectedBuildKeyIds(this.db);
     while (remaining > 0) {
       const batch = Math.min(remaining, this.config.evictionChunkSize);
-      const evictedCount = await this.db.transaction().execute(async (trx) => {
+      const batchResult = await this.db.transaction().execute(async (trx) => {
         const victims = await collectOldestEvictable(trx, appId, protectedIds, batch);
         if (victims.length === 0) {
-          return 0;
+          return { evictedCount: 0, protectionChanged: false };
         }
 
         const candidateBuildKeys = await loadBuildKeysByIds(
@@ -585,7 +594,10 @@ export class NavigationRetention {
             victim.lastSeenAt < (maxSeen.get(victim.buildKeyId) ?? Number.NEGATIVE_INFINITY),
         );
         if (eligibleVictims.length === 0) {
-          return 0;
+          return {
+            evictedCount: 0,
+            protectionChanged: currentProtectedIds.some((id) => !protectedIds.includes(id)),
+          };
         }
 
         const nodeIds = eligibleVictims.filter((v) => v.isNode).map((v) => v.id);
@@ -604,13 +616,17 @@ export class NavigationRetention {
             .executeTakeFirst();
           summary.edgeObservationsDeleted += Number(deleted.numDeletedRows ?? 0);
         }
-        return eligibleVictims.length;
+        return { evictedCount: eligibleVictims.length, protectionChanged: false };
       });
 
-      if (evictedCount === 0) {
+      if (batchResult.evictedCount === 0) {
+        if (batchResult.protectionChanged) {
+          protectedIds = await computeProtectedBuildKeyIds(this.db);
+          continue;
+        }
         return;
       }
-      remaining -= evictedCount;
+      remaining -= batchResult.evictedCount;
       if (remaining > 0) {
         await this.yieldBetweenBatches();
       }
@@ -627,25 +643,45 @@ export class NavigationRetention {
    * transaction (#6650) with the protected set read fresh inside it.
    */
   private async pruneOrphanBuildKeys(summary: NavigationRetentionSummary): Promise<void> {
-    await this.db.transaction().execute(async (trx) => {
-      const protectedIds = await computeProtectedBuildKeyIds(trx);
+    const chunk = this.config.evictionChunkSize;
+    for (;;) {
+      const deleted = await this.db.transaction().execute(async (trx) => {
+        const protectedIds = await computeProtectedBuildKeyIds(trx);
 
-      let query = trx
-        .deleteFrom("navigation_build_keys")
-        .where("id", "not in", (eb) =>
-          eb.selectFrom("navigation_node_observations").select("build_key_id"),
-        )
-        .where("id", "not in", (eb) =>
-          eb.selectFrom("navigation_edge_observations").select("build_key_id"),
-        );
+        let query = trx
+          .selectFrom("navigation_build_keys")
+          .select("id")
+          .where("id", "not in", (eb) =>
+            eb.selectFrom("navigation_node_observations").select("build_key_id"),
+          )
+          .where("id", "not in", (eb) =>
+            eb.selectFrom("navigation_edge_observations").select("build_key_id"),
+          );
 
-      if (protectedIds.length > 0) {
-        query = query.where("id", "not in", protectedIds);
+        if (protectedIds.length > 0) {
+          query = query.where("id", "not in", protectedIds);
+        }
+
+        const rows = await query.limit(chunk).execute();
+        if (rows.length === 0) {
+          return 0;
+        }
+        const result = await trx
+          .deleteFrom("navigation_build_keys")
+          .where(
+            "id",
+            "in",
+            rows.map((row) => row.id),
+          )
+          .executeTakeFirst();
+        return Number(result.numDeletedRows ?? 0);
+      });
+      summary.buildKeysDeleted += deleted;
+      if (deleted < chunk) {
+        return;
       }
-
-      const deleted = await query.executeTakeFirst();
-      summary.buildKeysDeleted += Number(deleted.numDeletedRows ?? 0);
-    });
+      await this.yieldBetweenBatches();
+    }
   }
 }
 

--- a/test/db/navigationRetention.integration.test.ts
+++ b/test/db/navigationRetention.integration.test.ts
@@ -150,10 +150,19 @@ describe("NavigationRetention prune", () => {
     await db.destroy();
   });
 
-  function retention(config = CONFIG): NavigationRetention {
-    return new NavigationRetention(db, config, async (filePath) => {
-      removed.push(filePath);
-    });
+  function retention(
+    config = CONFIG,
+    yieldBetweenBatches?: () => Promise<void>,
+  ): NavigationRetention {
+    return new NavigationRetention(
+      db,
+      config,
+      async (filePath) => {
+        removed.push(filePath);
+      },
+      undefined,
+      yieldBetweenBatches,
+    );
   }
 
   async function seedNode(screen: string, timestamp: number): Promise<number> {
@@ -337,6 +346,31 @@ describe("NavigationRetention prune", () => {
       .executeTakeFirst();
     expect(nodeCount).toBe(1);
     expect(Number(edgeCount?.c)).toBe(1);
+  });
+
+  test("chunks overdue TTL cleanup and yields between committed batches", async () => {
+    const nodeId = await seedNode("Home", 100);
+    const bkOld = await buildKey(APP, 1);
+    const bkNew = await buildKey(APP, 2);
+    for (let i = 0; i < 5; i++) {
+      await nodeObs(nodeId, bkOld, `old-${i}`, 100 + i);
+    }
+    await nodeObs(nodeId, bkNew, "active", 100_000);
+
+    let yields = 0;
+    let readAfterFirstYield: Promise<unknown> | undefined;
+    const summary = await retention(
+      { ...CONFIG, evictionChunkSize: 2 },
+      async () => {
+        yields += 1;
+        readAfterFirstYield ??= db.selectFrom("navigation_build_keys").selectAll().execute();
+        await readAfterFirstYield;
+      },
+    ).prune(50_000);
+
+    expect(summary.nodeObservationsDeleted).toBe(5);
+    expect(yields).toBeGreaterThan(0);
+    await expect(readAfterFirstYield).resolves.toHaveLength(2);
   });
 
   // ---- LRU size cap (backstop) ----

--- a/test/db/navigationRetention.integration.test.ts
+++ b/test/db/navigationRetention.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import type { Kysely } from "kysely";
 import { createTestDatabase } from "./testDbHelper";
 import type { Database } from "../../src/db/types";
@@ -235,6 +235,41 @@ describe("NavigationRetention prune", () => {
     expect(node?.screenshot_path).toBeNull();
     // The light node row itself survives.
     expect(node).toBeDefined();
+  });
+
+  test("a later-tier failure does not strand a screenshot already cleared and committed (#6650)", async () => {
+    const nodeId = await seedNode("Home", 100);
+    await repo.updateNodeScreenshotById(nodeId, "/tmp/shot-a.webp");
+
+    // Fail the transaction that runs AFTER the screenshot tier commits (the TTL
+    // tier is the 2nd db.transaction() of the pass). Under the single-transaction
+    // version this could not happen — a later failure rolled back the
+    // screenshot_path=null update too. With the chunked pass the SHORT tier has
+    // already committed the null pointer, so unless its file was unlinked BEFORE
+    // the later tier ran the file would be stranded on disk with no DB pointer
+    // left to rediscover it.
+    const originalTransaction = db.transaction.bind(db);
+    let txnCalls = 0;
+    const spy = spyOn(db, "transaction").mockImplementation(() => {
+      txnCalls += 1;
+      if (txnCalls >= 2) {
+        return {
+          execute: async () => {
+            throw new Error("simulated later-tier DB failure");
+          },
+        } as unknown as ReturnType<typeof db.transaction>;
+      }
+      return originalTransaction();
+    });
+
+    try {
+      await expect(retention().prune(10_000)).rejects.toThrow("simulated later-tier DB failure");
+      // The screenshot cleared in the SHORT tier was unlinked right after its own
+      // commit, before the failing tier ran — so it is NOT stranded.
+      expect(removed).toEqual(["/tmp/shot-a.webp"]);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   test("keeps screenshot for a node in the active (protected) build", async () => {
@@ -561,5 +596,108 @@ describe("eviction active-row exclusion is relational (bounded bind params)", ()
       .execute();
     expect(survivors.length).toBe(300);
     expect(survivors.every((r) => r.last_seen_at === 10_000)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #6650: the pass must not hold the daemon's single connection in one
+// transaction for its entire duration. Each tier/eviction batch must open its
+// own short transaction so other queries can interleave between them.
+// ---------------------------------------------------------------------------
+describe("prune releases the connection between chunks (issue #6650)", () => {
+  let db: Kysely<Database>;
+  let repo: NavigationRepository;
+
+  beforeEach(async () => {
+    db = await createTestDatabase({ foreignKeys: true });
+    repo = new NavigationRepository(db);
+  });
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  /**
+   * Seeds one app, one (protected) build key, and `count` node observations on
+   * a single node so a small `evictionChunkSize` forces many LRU-cap eviction
+   * batches. The last-seeded observation has the greatest `last_seen_at` and is
+   * therefore the active/protected row (never evicted).
+   */
+  async function seedOverflowingApp(count: number): Promise<void> {
+    await repo.getOrCreateApp(APP);
+    const node = await repo.getOrCreateNode(APP, "Home", 1);
+    const bk = await repo.getOrCreateBuildKey(APP, 1, "h");
+    for (let i = 0; i < count; i++) {
+      await repo.recordNodeObservation(node.id, bk.id, "device-1", `s${i}`, 100 + i);
+    }
+  }
+
+  test("opens more than one transaction for a multi-batch pass (was: one txn for the whole pass)", async () => {
+    // 40 rows over budget (cap 1) with chunk 2 forces ~20 eviction batches, and
+    // the TTL / orphan-sweep tiers each need their own transaction too.
+    await seedOverflowingApp(40);
+    const retention = new NavigationRetention(db, {
+      ...CONFIG,
+      structureTtlMs: 10_000_000,
+      perAppMaxObservations: 1,
+      evictionChunkSize: 2,
+    });
+
+    const transactionSpy = spyOn(db, "transaction");
+    const summary = await retention.prune(1_000_000);
+
+    expect(summary.nodeObservationsDeleted).toBe(39);
+    // A single-transaction pass (the pre-#6650 shape) calls db.transaction()
+    // exactly once for the whole pass. The chunked pass opens one short
+    // transaction per tier/batch, so this count must be > 1.
+    expect(transactionSpy.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  test("an unrelated read interleaves mid-pass instead of parking for the whole pass", async () => {
+    // A large overflow with a tiny chunk size makes the pass take many
+    // sequential eviction batches -- long enough that a bounded microtask
+    // drain (no real timers/sleeps) can reliably catch it still mid-flight.
+    await seedOverflowingApp(200);
+    const retention = new NavigationRetention(db, {
+      ...CONFIG,
+      structureTtlMs: 10_000_000,
+      perAppMaxObservations: 1,
+      evictionChunkSize: 1,
+    });
+
+    let pruneSettled = false;
+    const prunePromise = retention.prune(1_000_000).then((summary) => {
+      pruneSettled = true;
+      return summary;
+    });
+
+    let readSettled = false;
+    const readPromise = db
+      .selectFrom("navigation_build_keys")
+      .selectAll()
+      .execute()
+      .then((rows) => {
+        readSettled = true;
+        return rows;
+      });
+
+    // Bounded drain: give both promise chains a fixed number of microtask
+    // turns to progress, with no real timer/sleep involved. If the whole pass
+    // held one transaction (the bug), the read would still be parked behind
+    // it after this many turns, since 200 sequential eviction batches vastly
+    // outlast a single chunk's worth of turns (empirically: the read settles
+    // by turn ~96 once chunked, while the 200-batch pass itself is nowhere
+    // close to done at turn 150, let alone 5000 -- turn count here is a
+    // deliberately generous multiple of that observed margin, not a tuned
+    // exact threshold).
+    for (let i = 0; i < 150; i++) {
+      await Promise.resolve();
+    }
+
+    expect(readSettled).toBe(true); // the connection was released mid-pass
+    expect(pruneSettled).toBe(false); // ...while the pass itself keeps working
+
+    const summary = await prunePromise;
+    await readPromise;
+    expect(summary.nodeObservationsDeleted).toBe(199);
   });
 });

--- a/test/db/navigationRetention.integration.test.ts
+++ b/test/db/navigationRetention.integration.test.ts
@@ -359,14 +359,11 @@ describe("NavigationRetention prune", () => {
 
     let yields = 0;
     let readAfterFirstYield: Promise<unknown> | undefined;
-    const summary = await retention(
-      { ...CONFIG, evictionChunkSize: 2 },
-      async () => {
-        yields += 1;
-        readAfterFirstYield ??= db.selectFrom("navigation_build_keys").selectAll().execute();
-        await readAfterFirstYield;
-      },
-    ).prune(50_000);
+    const summary = await retention({ ...CONFIG, evictionChunkSize: 2 }, async () => {
+      yields += 1;
+      readAfterFirstYield ??= db.selectFrom("navigation_build_keys").selectAll().execute();
+      await readAfterFirstYield;
+    }).prune(50_000);
 
     expect(summary.nodeObservationsDeleted).toBe(5);
     expect(yields).toBeGreaterThan(0);

--- a/test/db/navigationRetention.integration.test.ts
+++ b/test/db/navigationRetention.integration.test.ts
@@ -153,6 +153,7 @@ describe("NavigationRetention prune", () => {
   function retention(
     config = CONFIG,
     yieldBetweenBatches?: () => Promise<void>,
+    protectedBuildKeyResolver?: typeof computeProtectedBuildKeyIds,
   ): NavigationRetention {
     return new NavigationRetention(
       db,
@@ -162,6 +163,7 @@ describe("NavigationRetention prune", () => {
       },
       undefined,
       yieldBetweenBatches,
+      protectedBuildKeyResolver,
     );
   }
 
@@ -348,7 +350,46 @@ describe("NavigationRetention prune", () => {
     expect(Number(edgeCount?.c)).toBe(1);
   });
 
-  test("chunks overdue TTL cleanup and yields between committed batches", async () => {
+  test("revalidates each TTL batch only for apps represented in that batch", async () => {
+    const nodeId = await seedNode("Home", 100);
+    const edge = await repo.createEdge(APP, "Home", "Detail", "tapOn", null, 100);
+    const oldBuild = await buildKey(APP, 1);
+    const activeBuild = await buildKey(APP, 2);
+    for (let index = 0; index < 5; index += 1) {
+      await nodeObs(nodeId, oldBuild, `old-node-${index}`, 100 + index);
+      await repo.recordEdgeObservation(
+        edge.id,
+        oldBuild,
+        "device-1",
+        `old-edge-${index}`,
+        100 + index,
+      );
+    }
+    await nodeObs(nodeId, activeBuild, "active", 100_000);
+
+    await repo.getOrCreateApp(APP2);
+    const otherNode = await repo.getOrCreateNode(APP2, "Other", 100);
+    const otherBuild = await buildKey(APP2, 1);
+    await repo.recordNodeObservation(otherNode.id, otherBuild, "device-2", "other", 100_000);
+
+    const protectedScopes: (readonly string[] | undefined)[] = [];
+    const summary = await retention(
+      { ...CONFIG, evictionChunkSize: 2 },
+      undefined,
+      async (database, buildKeys, scopedAppIds) => {
+        protectedScopes.push(scopedAppIds);
+        return computeProtectedBuildKeyIds(database, buildKeys, scopedAppIds);
+      },
+    ).prune(50_000);
+
+    expect(summary.nodeObservationsDeleted).toBe(5);
+    expect(summary.edgeObservationsDeleted).toBe(5);
+    const ttlBatchScopes = protectedScopes.filter((scope) => scope !== undefined);
+    expect(ttlBatchScopes).toHaveLength(6);
+    expect(ttlBatchScopes.every((scope) => scope?.length === 1 && scope[0] === APP)).toBe(true);
+  });
+
+  test("serves a read scheduled after one TTL batch before starting the next transaction", async () => {
     const nodeId = await seedNode("Home", 100);
     const bkOld = await buildKey(APP, 1);
     const bkNew = await buildKey(APP, 2);
@@ -357,17 +398,37 @@ describe("NavigationRetention prune", () => {
     }
     await nodeObs(nodeId, bkNew, "active", 100_000);
 
+    const originalTransaction = db.transaction.bind(db);
+    let transactionStarts = 0;
+    const transactionSpy = spyOn(db, "transaction").mockImplementation(() => {
+      transactionStarts += 1;
+      return originalTransaction();
+    });
     let yields = 0;
     let readAfterFirstYield: Promise<unknown> | undefined;
+    let transactionCountWhenReadScheduled: number | undefined;
+    let transactionCountWhenReadServed: number | undefined;
     const summary = await retention({ ...CONFIG, evictionChunkSize: 2 }, async () => {
       yields += 1;
-      readAfterFirstYield ??= db.selectFrom("navigation_build_keys").selectAll().execute();
+      if (!readAfterFirstYield) {
+        transactionCountWhenReadScheduled = transactionStarts;
+        readAfterFirstYield = db
+          .selectFrom("navigation_build_keys")
+          .selectAll()
+          .execute()
+          .then((rows) => {
+            transactionCountWhenReadServed = transactionStarts;
+            return rows;
+          });
+      }
       await readAfterFirstYield;
     }).prune(50_000);
 
     expect(summary.nodeObservationsDeleted).toBe(5);
     expect(yields).toBeGreaterThan(0);
     await expect(readAfterFirstYield).resolves.toHaveLength(2);
+    expect(transactionCountWhenReadServed).toBe(transactionCountWhenReadScheduled);
+    transactionSpy.mockRestore();
   });
 
   test("yields between one-batch per-app cap passes", async () => {
@@ -390,6 +451,32 @@ describe("NavigationRetention prune", () => {
 
     expect(summary.nodeObservationsDeleted).toBe(2);
     expect(yields).toBeGreaterThanOrEqual(2);
+  });
+
+  test("yields once per app while scanning apps that are already under cap", async () => {
+    const appIds = ["com.example.one", "com.example.two", "com.example.three"];
+    for (const appId of appIds) {
+      await repo.getOrCreateApp(appId);
+      const node = await repo.getOrCreateNode(appId, "Home", 1);
+      const build = await repo.getOrCreateBuildKey(appId, 1, `hash-${appId}`);
+      await repo.recordNodeObservation(node.id, build.id, "device-1", appId, 10_000);
+    }
+
+    let yields = 0;
+    const summary = await retention(
+      {
+        ...CONFIG,
+        structureTtlMs: 10_000_000,
+        perAppMaxObservations: 2,
+        globalMaxObservations: 10,
+      },
+      async () => {
+        yields += 1;
+      },
+    ).prune(1_000_000);
+
+    expect(summary.nodeObservationsDeleted).toBe(0);
+    expect(yields).toBe(appIds.length);
   });
 
   // ---- LRU size cap (backstop) ----
@@ -420,6 +507,124 @@ describe("NavigationRetention prune", () => {
       .execute();
     const sessions = remaining.map((r) => r.session_uuid).sort();
     expect(sessions).toEqual(["active", "s4"]); // oldest s0..s3 gone; newest kept
+  });
+
+  test("scopes both protected-set reads for each per-app eviction pass", async () => {
+    const appIds = ["com.example.one", "com.example.two", "com.example.three"];
+    for (const appId of appIds) {
+      await repo.getOrCreateApp(appId);
+      const node = await repo.getOrCreateNode(appId, "Home", 1);
+      const build = await repo.getOrCreateBuildKey(appId, 1, `hash-${appId}`);
+      for (let index = 0; index < 3; index += 1) {
+        await repo.recordNodeObservation(node.id, build.id, "device-1", `${appId}-${index}`, index);
+      }
+    }
+
+    const protectedScopes: (readonly string[] | undefined)[] = [];
+    const summary = await retention(
+      {
+        ...CONFIG,
+        structureTtlMs: 10_000_000,
+        perAppMaxObservations: 2,
+        globalMaxObservations: 100,
+      },
+      undefined,
+      async (database, buildKeys, scopedAppIds) => {
+        protectedScopes.push(scopedAppIds);
+        return computeProtectedBuildKeyIds(database, buildKeys, scopedAppIds);
+      },
+    ).prune(1_000_000);
+
+    expect(summary.nodeObservationsDeleted).toBe(appIds.length);
+    for (const appId of appIds) {
+      expect(protectedScopes.filter((scope) => scope?.[0] === appId)).toHaveLength(2);
+    }
+  });
+
+  test("retries an empty eviction selection when the scoped protected set changed", async () => {
+    const nodeId = await seedNode("Home", 1);
+    const oldBuild = await buildKey(APP, 1);
+    const replacementBuild = await buildKey(APP, 2);
+    await nodeObs(nodeId, oldBuild, "old-a", 100);
+    await nodeObs(nodeId, oldBuild, "old-b", 100);
+
+    // Model the protected-set snapshot changing after the initial read without
+    // real timers: both tied rows are hidden by the stale snapshot, so selection
+    // is empty and only an explicit revalidation can expose them for a retry.
+    let scopedReads = 0;
+    const summary = await retention(
+      {
+        ...CONFIG,
+        structureTtlMs: 10_000_000,
+        perAppMaxObservations: 1,
+        globalMaxObservations: 100,
+      },
+      undefined,
+      async (database, buildKeys, scopedAppIds) => {
+        if (scopedAppIds?.length === 1 && scopedAppIds[0] === APP) {
+          scopedReads += 1;
+          return scopedReads === 1 ? [oldBuild] : [replacementBuild];
+        }
+        return computeProtectedBuildKeyIds(database, buildKeys, scopedAppIds);
+      },
+    ).prune(1_000_000);
+
+    expect(scopedReads).toBeGreaterThan(1);
+    expect(summary.nodeObservationsDeleted).toBe(1);
+    expect(await countNodeObs()).toBe(1);
+  });
+
+  test("refreshes all apps before committing a global oldest-first batch", async () => {
+    const appANode = await seedNode("A", 1);
+    const appAOldBuild = await buildKey(APP, 1);
+    const appANewBuild = await buildKey(APP, 2);
+    await nodeObs(appANode, appAOldBuild, "a-old", 100);
+
+    await repo.getOrCreateApp(APP2);
+    const appBNode = await repo.getOrCreateNode(APP2, "B", 1);
+    const appBOldBuild = await buildKey(APP2, 1);
+    const appBActiveBuild = await buildKey(APP2, 2);
+    await repo.recordNodeObservation(appBNode.id, appBOldBuild, "device-2", "b-old", 200);
+    await repo.recordNodeObservation(appBNode.id, appBActiveBuild, "device-2", "b-active", 900);
+
+    let fullProtectedReads = 0;
+    let shiftedAppA = false;
+    const summary = await retention(
+      {
+        ...CONFIG,
+        structureTtlMs: 10_000_000,
+        perAppMaxObservations: 100,
+        globalMaxObservations: 2,
+        evictionChunkSize: 1,
+      },
+      undefined,
+      async (database, buildKeys, scopedAppIds) => {
+        const protectedIds = await computeProtectedBuildKeyIds(database, buildKeys, scopedAppIds);
+        if (scopedAppIds === undefined) {
+          fullProtectedReads += 1;
+          // With empty screenshot/TTL tiers, the fourth full read is the global
+          // eviction snapshot. Land the new app-A observation after that query
+          // has returned its stale result but before its first batch transaction.
+          if (fullProtectedReads === 4) {
+            await nodeObs(appANode, appANewBuild, "a-active", 1_000);
+            shiftedAppA = true;
+          }
+        }
+        return protectedIds;
+      },
+    ).prune(1_000_000);
+
+    expect(shiftedAppA).toBe(true);
+    expect(summary.nodeObservationsDeleted).toBe(1);
+    const survivors = await db
+      .selectFrom("navigation_node_observations")
+      .select("session_uuid")
+      .execute();
+    expect(survivors.map((row) => row.session_uuid).sort()).toEqual([
+      "a-active",
+      "b-active",
+      "b-old",
+    ]);
   });
 
   test("cap bounds a continuously-used SINGLE-build app, keeping the most recent", async () => {

--- a/test/db/navigationRetention.integration.test.ts
+++ b/test/db/navigationRetention.integration.test.ts
@@ -370,6 +370,28 @@ describe("NavigationRetention prune", () => {
     await expect(readAfterFirstYield).resolves.toHaveLength(2);
   });
 
+  test("yields between one-batch per-app cap passes", async () => {
+    for (const appId of ["com.example.one", "com.example.two"]) {
+      await repo.getOrCreateApp(appId);
+      const node = await repo.getOrCreateNode(appId, "Home", 1);
+      const build = await repo.getOrCreateBuildKey(appId, 1, `hash-${appId}`);
+      for (let index = 0; index < 3; index += 1) {
+        await repo.recordNodeObservation(node.id, build.id, "device-1", `${appId}-${index}`, index);
+      }
+    }
+
+    let yields = 0;
+    const summary = await retention(
+      { ...CONFIG, structureTtlMs: 10_000_000, perAppMaxObservations: 2, evictionChunkSize: 5 },
+      async () => {
+        yields += 1;
+      },
+    ).prune(1_000_000);
+
+    expect(summary.nodeObservationsDeleted).toBe(2);
+    expect(yields).toBeGreaterThanOrEqual(2);
+  });
+
   // ---- LRU size cap (backstop) ----
 
   test("per-app LRU cap evicts oldest observations by last_seen, keeps the active row", async () => {
@@ -525,6 +547,23 @@ describe("NavigationRetention prune", () => {
     expect(summary.buildKeysDeleted).toBe(1);
     const keys = await db.selectFrom("navigation_build_keys").select("id").execute();
     expect(keys.map((k) => k.id)).toEqual([bkNew]);
+  });
+
+  test("sweeps orphan build keys in bounded batches", async () => {
+    await repo.getOrCreateApp(APP);
+    for (let version = 1; version <= 5; version += 1) {
+      await repo.getOrCreateBuildKey(APP, version, `orphan-${version}`);
+    }
+
+    let yields = 0;
+    const summary = await retention({ ...CONFIG, evictionChunkSize: 2 }, async () => {
+      yields += 1;
+    }).prune(1_000_000);
+
+    expect(summary.buildKeysDeleted).toBe(4);
+    expect(yields).toBeGreaterThan(0);
+    const keys = await db.selectFrom("navigation_build_keys").select("id").execute();
+    expect(keys).toHaveLength(1);
   });
 
   test("is idempotent: a second pass at the same clock deletes nothing", async () => {


### PR DESCRIPTION
## Summary

`NavigationRetention.prune()` wrapped the entire pass — screenshot clear, TTL deletes,
cap eviction, and orphan-build-key sweep — in one transaction. On a large graph that
held the daemon's single SQLite connection exclusively for the whole pass, parking
every other query with no timeout (bunSqliteDialect's transaction lease is a JS-level
mutex, so SQLite's `busy_timeout` never applies to it).

Each tier — and each eviction batch within `evictOldest` — now runs in its own short
transaction, so the connection is released between them and other queries interleave.
The protected build-key set is re-read fresh **inside** every one of those short
transactions (not cached across chunks): since the connection is released between
chunks a concurrent write can change which build key is active mid-pass, and
re-reading per chunk (the same self-correcting principle `collectOldestEvictable`
applies to its victim set) keeps each chunk's "read active set, then mutate" atomic.
FK-safe ordering still holds (TTL/cap tiers commit before the orphan sweep begins).

Screenshot files are unlinked right after **each screenshot batch's own commit**, not
deferred to the end of the pass — deferring reintroduced a partial-failure leak the
single-transaction version could not have (a committed `screenshot_path=NULL` whose
file is never unlinked if a later tier throws). Pairing each clear-commit with its
unlink closes that window.

Part of epic #6379.

## Linked Issue

Closes #6650

## Bug / Regression Context

- **Observed symptom:** on a large nav graph, a retention pass holds the daemon's single SQLite connection for its entire duration, blocking all other queries with no timeout.
- **Repro:** a large overflow with a small `evictionChunkSize` makes the whole multi-tier pass one long transaction.

## Validation

- [x] `test/db/navigationRetention.integration.test.ts` — 27 pass. New tests: multi-batch pass opens >1 transaction (was 1), an unrelated read settles mid-pass while the prune keeps working, and a later-tier failure does not strand an already-cleared screenshot (the codex-review-caught partial-failure path). Broader `test/db` — 1060 pass.
- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — all clean.
- [x] `slack codex review` self-review flagged a P2 (deferred screenshot unlink → orphaned files on later-tier failure); fixed by unlinking per-batch and added a regression test.

## Follow-ups

- None.
