### PR TITLE
perf(cache): single-flight CachingContentHashProvider.resolveContentHash (#6654)

### DIFF
--- a/src/utils/ContentHashProvider.ts
+++ b/src/utils/ContentHashProvider.ts
@@ -54,6 +54,11 @@ export class CachingContentHashProvider implements ContentHashProvider {
   // started before an invalidate must NOT repopulate the cache with a stale hash,
   // so a result is only cached when the generation is unchanged since it began.
   private readonly generation = new Map<string, number>();
+  // Single-flight: concurrent resolveContentHash calls for the same key share this
+  // in-flight promise instead of each starting their own (expensive) computeHash
+  // (#6654). Cleared once the computation settles (success or failure) so a later
+  // call recomputes rather than being poisoned by a stale/failed entry.
+  private readonly inFlight = new Map<string, Promise<string | null>>();
 
   constructor(private readonly hasher: AppContentHasher) {}
 
@@ -67,6 +72,23 @@ export class CachingContentHashProvider implements ContentHashProvider {
     if (cached !== undefined) {
       return cached;
     }
+    const existing = this.inFlight.get(key);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const promise = this.computeAndCache(device, packageId, versionCode, key).finally(() => {
+      this.inFlight.delete(key);
+    });
+    this.inFlight.set(key, promise);
+    return promise;
+  }
+
+  private async computeAndCache(
+    device: BootedDevice,
+    packageId: string,
+    versionCode: number,
+    key: string,
+  ): Promise<string | null> {
     const genKey = `${device.deviceId}::${packageId}`;
     const startGeneration = this.generation.get(genKey) ?? 0;
     try {

--- a/src/utils/ContentHashProvider.ts
+++ b/src/utils/ContentHashProvider.ts
@@ -77,7 +77,12 @@ export class CachingContentHashProvider implements ContentHashProvider {
       return existing;
     }
     const promise = this.computeAndCache(device, packageId, versionCode, key).finally(() => {
-      this.inFlight.delete(key);
+      // An invalidation can remove this entry and a later caller can start a
+      // fresh computation for the same key. Do not let the older computation's
+      // cleanup erase that newer in-flight promise.
+      if (this.inFlight.get(key) === promise) {
+        this.inFlight.delete(key);
+      }
     });
     this.inFlight.set(key, promise);
     return promise;
@@ -116,6 +121,14 @@ export class CachingContentHashProvider implements ContentHashProvider {
     for (const key of this.cache.keys()) {
       if (key.startsWith(prefix)) {
         this.cache.delete(key);
+      }
+    }
+    // A post-invalidation caller must not share work that began against the
+    // previous install generation. The older caller can still receive its own
+    // best-effort result, but new callers recompute from the updated package.
+    for (const key of this.inFlight.keys()) {
+      if (key.startsWith(prefix)) {
+        this.inFlight.delete(key);
       }
     }
   }

--- a/test/utils/contentHashProvider.test.ts
+++ b/test/utils/contentHashProvider.test.ts
@@ -274,6 +274,40 @@ describe("CachingContentHashProvider", () => {
     );
     expect(computeCalls).toBe(2);
   });
+
+  test("an older completion cannot remove an in-flight replacement after invalidate", async () => {
+    let releaseStale: (value: string) => void = () => {};
+    let releaseFresh: (value: string) => void = () => {};
+    let computeCalls = 0;
+    const hasher: AppContentHasher = {
+      async computeHash() {
+        computeCalls += 1;
+        return new Promise<string>((resolve) => {
+          if (computeCalls === 1) {
+            releaseStale = resolve;
+          } else {
+            releaseFresh = resolve;
+          }
+        });
+      },
+    };
+    const provider = new CachingContentHashProvider(hasher);
+
+    const stale = provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    provider.invalidate("emu-1", "com.example.app");
+    const fresh = provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    expect(computeCalls).toBe(2);
+
+    releaseStale("sha256:STALE");
+    expect(await stale).toBe("sha256:STALE");
+
+    // The stale completion must leave the replacement flight available to callers.
+    const later = provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    expect(computeCalls).toBe(2);
+    releaseFresh("sha256:FRESH");
+    expect(await fresh).toBe("sha256:FRESH");
+    expect(await later).toBe("sha256:FRESH");
+  });
 });
 
 describe("parsePmPathOutput", () => {

--- a/test/utils/contentHashProvider.test.ts
+++ b/test/utils/contentHashProvider.test.ts
@@ -269,9 +269,9 @@ describe("CachingContentHashProvider", () => {
     expect(await stale).toBe("sha256:STALE");
 
     // The old promise's finally must not clear the newer cache/in-flight state.
-    expect(
-      await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5),
-    ).toBe("sha256:FRESH");
+    expect(await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5)).toBe(
+      "sha256:FRESH",
+    );
     expect(computeCalls).toBe(2);
   });
 });

--- a/test/utils/contentHashProvider.test.ts
+++ b/test/utils/contentHashProvider.test.ts
@@ -239,6 +239,41 @@ describe("CachingContentHashProvider", () => {
     expect(result).toBe("sha256:FRESH");
     expect(computeCalls).toBe(2);
   });
+
+  test("invalidate prevents a later caller from sharing an older in-flight hash", async () => {
+    let releaseStale: (value: string) => void = () => {};
+    let computeCalls = 0;
+    const hasher: AppContentHasher = {
+      async computeHash() {
+        computeCalls += 1;
+        if (computeCalls === 1) {
+          return new Promise<string>((resolve) => {
+            releaseStale = resolve;
+          });
+        }
+        return "sha256:FRESH";
+      },
+    };
+    const provider = new CachingContentHashProvider(hasher);
+
+    const stale = provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    provider.invalidate("emu-1", "com.example.app");
+    const fresh = provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+
+    // The new caller starts fresh work immediately; it must not receive the
+    // pre-invalidation promise even though that promise has not settled yet.
+    expect(await fresh).toBe("sha256:FRESH");
+    expect(computeCalls).toBe(2);
+
+    releaseStale("sha256:STALE");
+    expect(await stale).toBe("sha256:STALE");
+
+    // The old promise's finally must not clear the newer cache/in-flight state.
+    expect(
+      await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5),
+    ).toBe("sha256:FRESH");
+    expect(computeCalls).toBe(2);
+  });
 });
 
 describe("parsePmPathOutput", () => {

--- a/test/utils/contentHashProvider.test.ts
+++ b/test/utils/contentHashProvider.test.ts
@@ -138,6 +138,79 @@ describe("CachingContentHashProvider", () => {
     expect(hasher.calls).toHaveLength(5);
   });
 
+  test("single-flight: concurrent calls for the same key share one computeHash invocation", async () => {
+    // Deferred promise: both callers race in before either has awaited computeHash,
+    // so a non-single-flight implementation would call computeHash twice (#6654).
+    let resolveHash: (value: string) => void = () => {};
+    let computeCalls = 0;
+    const hasher: AppContentHasher = {
+      async computeHash() {
+        computeCalls += 1;
+        return new Promise<string>((resolve) => {
+          resolveHash = resolve;
+        });
+      },
+    };
+    const provider = new CachingContentHashProvider(hasher);
+
+    const first = provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    const second = provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    resolveHash("sha256:SHARED");
+
+    expect(await first).toBe("sha256:SHARED");
+    expect(await second).toBe("sha256:SHARED");
+    expect(computeCalls).toBe(1);
+  });
+
+  test("single-flight: a rejected computation is not cached, so a later call retries", async () => {
+    let computeCalls = 0;
+    const hasher: AppContentHasher = {
+      async computeHash() {
+        computeCalls += 1;
+        if (computeCalls === 1) {
+          throw new Error("transient failure");
+        }
+        return "sha256:RETRIED";
+      },
+    };
+    const provider = new CachingContentHashProvider(hasher);
+
+    // Two concurrent callers share the failing in-flight computation; both get null.
+    const first = provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    const second = provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    expect(await first).toBeNull();
+    expect(await second).toBeNull();
+    expect(computeCalls).toBe(1);
+
+    // The in-flight entry was cleared on failure, so a later call retries (not poisoned).
+    const third = await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    expect(third).toBe("sha256:RETRIED");
+    expect(computeCalls).toBe(2);
+  });
+
+  test("single-flight de-duplication is scoped per key: a different key is not blocked", async () => {
+    let releaseFirst: (value: string) => void = () => {};
+    const hasher: AppContentHasher = {
+      async computeHash(_device, packageId) {
+        if (packageId === "com.example.app") {
+          return new Promise<string>((resolve) => {
+            releaseFirst = resolve;
+          });
+        }
+        return "sha256:OTHER";
+      },
+    };
+    const provider = new CachingContentHashProvider(hasher);
+
+    const blocked = provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    // A distinct key (different packageId) resolves without waiting on the in-flight one.
+    const other = await provider.resolveContentHash(fakeDevice("emu-1"), "com.other.app", 5);
+    expect(other).toBe("sha256:OTHER");
+
+    releaseFirst("sha256:FIRST");
+    expect(await blocked).toBe("sha256:FIRST");
+  });
+
   test("an in-flight resolution started before invalidate does not repopulate the cache", async () => {
     // Interleave: start resolve (blocks), invalidate, then let the old computation
     // finish — it must NOT poison the cache with the pre-update hash.


### PR DESCRIPTION
## Summary

`CachingContentHashProvider.resolveContentHash` was not single-flight: concurrent calls
for the same APK/IPA key each recomputed the expensive content hash independently.

Adds an `inFlight` `Map<string, Promise<string|null>>`: on a cache miss, an existing
in-flight promise for the key is returned; otherwise the computation is started, its
promise stored synchronously (before any await), and the entry deleted in `.finally`
once it settles. A failed computation (resolves null) is neither cached nor left in
`inFlight`, so the next call retries cleanly. The existing generation-fence (stale
in-flight result vs `invalidate()`) is untouched.

Part of epic #6379.

## Linked Issue

Closes #6654

## Validation

- [x] `test/utils/contentHashProvider.test.ts` (+property) — 22 pass. New tests: N concurrent calls for one key hash exactly once with the same result; rejected computation not cached (retries); distinct keys independent. Red first (hasher ran per-caller).
- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — all clean.

## Follow-ups
- `invalidate()` still scans the full cache; indexing it by genKey is framed as separate in the issue's scope and left out to keep this focused on single-flight.
