### PR TITLE
fix(db): wrap nav modal/scroll delete+insert in a transaction (#6656)

### DIFF
--- a/src/db/navigationRepository.ts
+++ b/src/db/navigationRepository.ts
@@ -620,12 +620,30 @@ export class NavigationRepository {
 
   /**
    * Set modal stack for a node.
+   *
+   * Wraps the delete+insert pair in a transaction (issue #6656): without it, a
+   * concurrent caller replacing the same node's modal stack can interleave
+   * DELETE/DELETE/INSERT/INSERT, transiently exposing an empty stack to a reader
+   * and racing the second INSERT into a UNIQUE(node_id, stack_level) collision.
+   * Mirrors the db.isTransaction guard in getOrCreateUIElement/linkUIElementsToEdge
+   * so a repo already bound to a caller's transaction runs the body directly
+   * instead of attempting a nested BEGIN.
    */
   async setNodeModals(nodeId: number, modalStack: string[]): Promise<void> {
     const db = this.getDb();
+    if (db.isTransaction) {
+      return this.setNodeModalsWithin(db, nodeId, modalStack);
+    }
+    return db.transaction().execute((trx) => this.setNodeModalsWithin(trx, nodeId, modalStack));
+  }
 
+  private async setNodeModalsWithin(
+    trx: Kysely<Database>,
+    nodeId: number,
+    modalStack: string[],
+  ): Promise<void> {
     // Delete existing modals
-    await db.deleteFrom("node_modals").where("node_id", "=", nodeId).execute();
+    await trx.deleteFrom("node_modals").where("node_id", "=", nodeId).execute();
 
     if (modalStack.length === 0) {
       return;
@@ -638,7 +656,7 @@ export class NavigationRepository {
       stack_level: index,
     }));
 
-    await db.insertInto("node_modals").values(values).execute();
+    await trx.insertInto("node_modals").values(values).execute();
   }
 
   /**
@@ -658,6 +676,15 @@ export class NavigationRepository {
 
   /**
    * Set modal stack for an edge (from or to position).
+   *
+   * Wraps the delete+insert pair in a transaction (issue #6656), symmetric to
+   * setNodeModals: without it, a concurrent caller replacing the same
+   * (edge_id, position) modal stack can interleave DELETE/DELETE/INSERT/INSERT,
+   * transiently exposing an empty stack to a reader and racing the second INSERT
+   * into a UNIQUE(edge_id, position, stack_level) collision. The db.isTransaction
+   * guard mirrors getOrCreateUIElement/linkUIElementsToEdge so a repo already
+   * bound to a caller's transaction runs the body directly instead of attempting
+   * a nested BEGIN.
    */
   async setEdgeModals(
     edgeId: number,
@@ -665,9 +692,22 @@ export class NavigationRepository {
     modalStack: string[],
   ): Promise<void> {
     const db = this.getDb();
+    if (db.isTransaction) {
+      return this.setEdgeModalsWithin(db, edgeId, position, modalStack);
+    }
+    return db
+      .transaction()
+      .execute((trx) => this.setEdgeModalsWithin(trx, edgeId, position, modalStack));
+  }
 
+  private async setEdgeModalsWithin(
+    trx: Kysely<Database>,
+    edgeId: number,
+    position: "from" | "to",
+    modalStack: string[],
+  ): Promise<void> {
     // Delete existing modals for this position
-    await db
+    await trx
       .deleteFrom("edge_modals")
       .where("edge_id", "=", edgeId)
       .where("position", "=", position)
@@ -685,7 +725,7 @@ export class NavigationRepository {
       stack_level: index,
     }));
 
-    await db.insertInto("edge_modals").values(values).execute();
+    await trx.insertInto("edge_modals").values(values).execute();
   }
 
   /**
@@ -706,6 +746,15 @@ export class NavigationRepository {
 
   /**
    * Set scroll position for an edge.
+   *
+   * Wraps the delete+insert pair in a transaction (issue #6656): without it, a
+   * concurrent caller replacing the same edge's scroll position can interleave
+   * DELETE/DELETE/INSERT/INSERT, transiently exposing a missing scroll position
+   * to a reader and racing the second INSERT into the scroll_positions.edge_id
+   * PRIMARY KEY collision. The db.isTransaction guard mirrors
+   * getOrCreateUIElement/linkUIElementsToEdge so a repo already bound to a
+   * caller's transaction runs the body directly instead of attempting a nested
+   * BEGIN.
    */
   async setScrollPosition(
     edgeId: number,
@@ -716,7 +765,6 @@ export class NavigationRepository {
     swipeCount?: number,
   ): Promise<void> {
     const db = this.getDb();
-
     const scrollPos: NewScrollPosition = {
       edge_id: edgeId,
       target_element_id: targetElementId,
@@ -726,10 +774,21 @@ export class NavigationRepository {
       swipe_count: swipeCount ?? null,
     };
 
-    // Upsert: delete if exists, then insert
-    await db.deleteFrom("scroll_positions").where("edge_id", "=", edgeId).execute();
+    if (db.isTransaction) {
+      return this.setScrollPositionWithin(db, edgeId, scrollPos);
+    }
+    return db.transaction().execute((trx) => this.setScrollPositionWithin(trx, edgeId, scrollPos));
+  }
 
-    await db.insertInto("scroll_positions").values(scrollPos).execute();
+  private async setScrollPositionWithin(
+    trx: Kysely<Database>,
+    edgeId: number,
+    scrollPos: NewScrollPosition,
+  ): Promise<void> {
+    // Upsert: delete if exists, then insert
+    await trx.deleteFrom("scroll_positions").where("edge_id", "=", edgeId).execute();
+
+    await trx.insertInto("scroll_positions").values(scrollPos).execute();
   }
 
   /**

--- a/test/db/navigationRepository.integration.test.ts
+++ b/test/db/navigationRepository.integration.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, afterEach, describe, expect, test } from "bun:test";
+import { beforeEach, afterEach, describe, expect, spyOn, test } from "bun:test";
 import type { Kysely } from "kysely";
 import type { Database } from "../../src/db/types";
 import { NavigationRepository } from "../../src/db/navigationRepository";
@@ -364,6 +364,125 @@ describe("NavigationRepository", () => {
       const modals = await repo.getNodeModals(node.id);
       expect(modals).toEqual(["dialog_x", "dialog_y"]);
     });
+
+    test("wraps the delete+insert pair in a single transaction (issue #6656)", async () => {
+      await repo.getOrCreateApp("com.example.app");
+      const node = await repo.getOrCreateNode("com.example.app", "Home", 1000);
+      const transactionSpy = spyOn(db, "transaction");
+
+      await repo.setNodeModals(node.id, ["dialog_a"]);
+
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not throw when called from within an existing transaction (issue #6656)", async () => {
+      await repo.getOrCreateApp("com.example.app");
+      const node = await repo.getOrCreateNode("com.example.app", "Home", 1000);
+
+      // Mirrors the db.isTransaction guard already in getOrCreateUIElement /
+      // linkUIElementsToEdge: a repo bound to a caller's open transaction must run
+      // the body directly rather than attempt a nested BEGIN.
+      await db.transaction().execute(async (trx) => {
+        await repo.withExecutor(trx).setNodeModals(node.id, ["dialog_a"]);
+      });
+
+      const modals = await repo.getNodeModals(node.id);
+      expect(modals).toEqual(["dialog_a"]);
+    });
+
+    test("N concurrent setNodeModals for the same node never reject and leave the stack fully intact (issue #6656)", async () => {
+      const N = 10;
+      await repo.getOrCreateApp("com.example.app");
+      const node = await repo.getOrCreateNode("com.example.app", "Home", 1000);
+
+      // Without the delete+insert pair wrapped in a transaction, concurrent callers
+      // can interleave DELETE/DELETE/INSERT/INSERT and hit the UNIQUE(node_id,
+      // stack_level) constraint on the second INSERT, rejecting the whole call.
+      await expect(
+        Promise.all(
+          Array.from({ length: N }, () => repo.setNodeModals(node.id, ["dialog_a", "dialog_b"])),
+        ),
+      ).resolves.toBeDefined();
+
+      const modals = await repo.getNodeModals(node.id);
+      expect(modals).toEqual(["dialog_a", "dialog_b"]);
+    });
+  });
+
+  describe("setEdgeModals / getEdgeModals", () => {
+    test("sets and retrieves modal stack for an edge position", async () => {
+      await repo.getOrCreateApp("com.example.app");
+      const edge = await repo.createEdge("com.example.app", "A", "B", "tapOn", null, 1000);
+
+      await repo.setEdgeModals(edge.id, "from", ["dialog_a", "dialog_b"]);
+
+      const modals = await repo.getEdgeModals(edge.id, "from");
+      expect(modals).toEqual(["dialog_a", "dialog_b"]);
+    });
+
+    test("replaces modal stack on second set", async () => {
+      await repo.getOrCreateApp("com.example.app");
+      const edge = await repo.createEdge("com.example.app", "A", "B", "tapOn", null, 1000);
+
+      await repo.setEdgeModals(edge.id, "from", ["dialog_a"]);
+      await repo.setEdgeModals(edge.id, "from", ["dialog_x", "dialog_y"]);
+
+      const modals = await repo.getEdgeModals(edge.id, "from");
+      expect(modals).toEqual(["dialog_x", "dialog_y"]);
+    });
+
+    test("from and to positions are independent", async () => {
+      await repo.getOrCreateApp("com.example.app");
+      const edge = await repo.createEdge("com.example.app", "A", "B", "tapOn", null, 1000);
+
+      await repo.setEdgeModals(edge.id, "from", ["dialog_from"]);
+      await repo.setEdgeModals(edge.id, "to", ["dialog_to"]);
+
+      expect(await repo.getEdgeModals(edge.id, "from")).toEqual(["dialog_from"]);
+      expect(await repo.getEdgeModals(edge.id, "to")).toEqual(["dialog_to"]);
+    });
+
+    test("wraps the delete+insert pair in a single transaction (issue #6656)", async () => {
+      await repo.getOrCreateApp("com.example.app");
+      const edge = await repo.createEdge("com.example.app", "A", "B", "tapOn", null, 1000);
+      const transactionSpy = spyOn(db, "transaction");
+
+      await repo.setEdgeModals(edge.id, "from", ["dialog_a"]);
+
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not throw when called from within an existing transaction (issue #6656)", async () => {
+      await repo.getOrCreateApp("com.example.app");
+      const edge = await repo.createEdge("com.example.app", "A", "B", "tapOn", null, 1000);
+
+      await db.transaction().execute(async (trx) => {
+        await repo.withExecutor(trx).setEdgeModals(edge.id, "from", ["dialog_a"]);
+      });
+
+      const modals = await repo.getEdgeModals(edge.id, "from");
+      expect(modals).toEqual(["dialog_a"]);
+    });
+
+    test("N concurrent setEdgeModals for the same edge+position never reject and leave the stack fully intact (issue #6656)", async () => {
+      const N = 10;
+      await repo.getOrCreateApp("com.example.app");
+      const edge = await repo.createEdge("com.example.app", "A", "B", "tapOn", null, 1000);
+
+      // Without the delete+insert pair wrapped in a transaction, concurrent callers
+      // can interleave DELETE/DELETE/INSERT/INSERT and hit the UNIQUE(edge_id,
+      // position, stack_level) constraint on the second INSERT, rejecting the call.
+      await expect(
+        Promise.all(
+          Array.from({ length: N }, () =>
+            repo.setEdgeModals(edge.id, "from", ["dialog_a", "dialog_b"]),
+          ),
+        ),
+      ).resolves.toBeDefined();
+
+      const modals = await repo.getEdgeModals(edge.id, "from");
+      expect(modals).toEqual(["dialog_a", "dialog_b"]);
+    });
   });
 
   describe("setScrollPosition / getScrollPosition", () => {
@@ -399,6 +518,67 @@ describe("NavigationRepository", () => {
 
       const scroll = await repo.getScrollPosition(edge.id);
       expect(scroll!.swipeCount).toBe(0);
+    });
+
+    test("wraps the delete+insert pair in a single transaction (issue #6656)", async () => {
+      await repo.getOrCreateApp("com.example.app");
+      const edge = await repo.createEdge("com.example.app", "A", "B", "swipeOn", null, 1000);
+      const target = await repo.getOrCreateUIElement(
+        "com.example.app",
+        { text: "Target", resourceId: "target_elem" },
+        1000,
+      );
+      const transactionSpy = spyOn(db, "transaction");
+
+      await repo.setScrollPosition(edge.id, target.id, "down");
+
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not throw when called from within an existing transaction (issue #6656)", async () => {
+      await repo.getOrCreateApp("com.example.app");
+      const edge = await repo.createEdge("com.example.app", "A", "B", "swipeOn", null, 1000);
+      const target = await repo.getOrCreateUIElement(
+        "com.example.app",
+        { text: "Target", resourceId: "target_elem" },
+        1000,
+      );
+
+      await db.transaction().execute(async (trx) => {
+        await repo.withExecutor(trx).setScrollPosition(edge.id, target.id, "down");
+      });
+
+      const scroll = await repo.getScrollPosition(edge.id);
+      expect(scroll!.targetElement.id).toBe(target.id);
+    });
+
+    test("N concurrent setScrollPosition for the same edge never reject and leave one row intact (issue #6656)", async () => {
+      const N = 10;
+      await repo.getOrCreateApp("com.example.app");
+      const edge = await repo.createEdge("com.example.app", "A", "B", "swipeOn", null, 1000);
+      const target = await repo.getOrCreateUIElement(
+        "com.example.app",
+        { text: "Target", resourceId: "target_elem" },
+        1000,
+      );
+
+      // Without the delete+insert pair wrapped in a transaction, concurrent callers
+      // can interleave DELETE/DELETE/INSERT/INSERT and hit the PRIMARY KEY(edge_id)
+      // constraint on the second INSERT, rejecting the call outright.
+      await expect(
+        Promise.all(
+          Array.from({ length: N }, () =>
+            repo.setScrollPosition(edge.id, target.id, "down", undefined, "slow", 3),
+          ),
+        ),
+      ).resolves.toBeDefined();
+
+      const scroll = await repo.getScrollPosition(edge.id);
+      expect(scroll).toBeDefined();
+      expect(scroll!.direction).toBe("down");
+      expect(scroll!.speed).toBe("slow");
+      expect(scroll!.swipeCount).toBe(3);
+      expect(scroll!.targetElement.id).toBe(target.id);
     });
   });
 


### PR DESCRIPTION
## Summary

`setNodeModals`, `setEdgeModals`, and `setScrollPosition` each did a delete-then-insert
**outside** a transaction — a concurrent reader (or a crash) between the delete and the
insert saw a torn/empty state, and concurrent writers could hit
`SQLITE_CONSTRAINT_UNIQUE` mid-sequence.

Each method's delete+insert pair is now wrapped in `db.transaction().execute(...)` via
a private `...Within(trx, ...)` helper, guarding `db.isTransaction` to run directly on
the existing executor when already inside a transaction — load-bearing, since
`NavigationGraphManager.runBothReposInTransaction` calls all three within an open
transaction (an unconditional nested `db.transaction()` would throw "Nested
transactions are not supported"). Mirrors the existing `getOrCreateUIElement` /
`linkUIElementsToEdge` idiom.

Part of epic #6379 (navigation cluster; independent of the merged #6463, which touched
`linkUIElementsToEdge` — different methods).

## Linked Issue

Closes #6656

## Validation

- [x] `test/db/navigationRepository.integration.test.ts` — 58 pass. New per-method tests: transaction-spy (delete+insert in one txn), nested-transaction (no throw via the guard), N concurrent writers never reject; plus first coverage for `setEdgeModals`/`getEdgeModals`. Red first (0 transactions / real unique-constraint interleaving). `test/db` — 1070 pass.
- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — all clean.

## Follow-ups
- None.
