### PR TITLE
perf(cache): real TTLCache cleanup + O(1) eviction, reject oversized values (#6653)

### DIFF
--- a/src/utils/cache/Cache.ts
+++ b/src/utils/cache/Cache.ts
@@ -1,4 +1,5 @@
 import { Timer, defaultTimer } from "../SystemTimer";
+import { logger } from "../logger";
 
 /**
  * Configuration for cache behavior.
@@ -21,6 +22,11 @@ interface CacheOptions {
   /**
    * Maximum total size in bytes (for size-aware caches).
    * Default: unlimited
+   *
+   * A single value whose `sizeBytes` alone exceeds this budget is rejected
+   * outright by `set()` (logged, not cached) rather than admitted and left
+   * permanently pinning `currentSizeBytes` above the budget -- no amount of
+   * evicting other entries can make room for it (issue #6653).
    */
   maxSizeBytes?: number;
 }
@@ -33,8 +39,6 @@ interface CacheEntry<T> {
   value: T;
   /** Timestamp when the entry was created */
   createdAt: number;
-  /** Timestamp when the entry was last accessed */
-  lastAccessedAt: number;
   /** Size in bytes (if tracked) */
   sizeBytes?: number;
 }
@@ -99,8 +103,18 @@ interface Cache<K, V> {
   getStats(): CacheStats;
 
   /**
-   * Remove expired entries.
-   * Called automatically on get/set, but can be called manually.
+   * Remove all currently-expired entries, in ascending creation-time order,
+   * stopping at the first entry that has not expired yet (everything created
+   * after it is at least as fresh, so it cannot be expired either). Cost is
+   * proportional to the number of expired entries removed, not the total
+   * cache size.
+   *
+   * `set()` runs this same bounded sweep automatically before every insert,
+   * and `get()`/`has()` opportunistically evict the single key they touch
+   * when it has expired -- so an unbounded key space does not accumulate
+   * expired dead weight indefinitely even if a caller never invokes
+   * `cleanup()` manually (issue #6653). Call it directly only to force an
+   * immediate full pass, e.g. before reporting memory stats.
    */
   cleanup(): number;
 }
@@ -115,9 +129,20 @@ export const DEFAULT_CACHE_OPTIONS: Required<Omit<CacheOptions, "maxSizeBytes">>
 
 /**
  * TTL-based cache implementation with LRU eviction.
+ *
+ * Two Maps track different orderings of the same key set so both eviction
+ * paths stay O(1)/bounded instead of scanning every entry (issue #6653):
+ *  - `entries` iteration order tracks access recency: a hit in `get()` moves
+ *    its key to the tail, so the front is always the least-recently-used
+ *    entry and `evictOldest()` just peeks it.
+ *  - `expiryOrder` iteration order tracks creation time ascending (a fresh
+ *    `set()` always appends, including on overwrite): the front is always
+ *    the oldest-created entry, so a TTL sweep can stop as soon as it hits a
+ *    non-expired one instead of walking the whole cache.
  */
 export class TTLCache<K, V> implements Cache<K, V> {
   private readonly entries: Map<K, CacheEntry<V>> = new Map();
+  private readonly expiryOrder: Set<K> = new Set();
   private readonly ttlMs: number;
   private readonly maxEntries: number;
   private readonly maxSizeBytes: number;
@@ -129,6 +154,11 @@ export class TTLCache<K, V> implements Cache<K, V> {
     ttlEvictions: 0,
     sizeEvictions: 0,
   };
+  // Cumulative entries touched by evictOldest()'s O(1) peek and the
+  // expiry sweep's bounded prefix walk. A test-only seam (mirrors
+  // BufferQueue.compactionWorkUnits) proving eviction/cleanup cost stays
+  // linear in entries actually evicted, never quadratic in cache size.
+  private evictionScanWork: number = 0;
 
   constructor(
     private readonly timer: Timer = defaultTimer,
@@ -150,44 +180,50 @@ export class TTLCache<K, V> implements Cache<K, V> {
     const now = this.timer.now();
     if (now - entry.createdAt >= this.ttlMs) {
       // Entry has expired
-      this.entries.delete(key);
-      this.currentSizeBytes -= entry.sizeBytes ?? 0;
+      this.removeEntry(key);
       this.stats.ttlEvictions++;
       this.stats.misses++;
       this.updateSizeStats();
       return undefined;
     }
 
-    // Update last access time for LRU
-    entry.lastAccessedAt = now;
+    // Move this key to the tail of `entries` so its iteration order tracks
+    // access recency -- see the class doc and evictOldest().
+    this.entries.delete(key);
+    this.entries.set(key, entry);
     this.stats.hits++;
     return entry.value;
   }
 
   set(key: K, value: V, sizeBytes?: number): void {
+    // Reject a value that alone exceeds the byte budget outright: no amount
+    // of evicting OTHER entries can bring currentSizeBytes back under
+    // maxSizeBytes once even one oversized value is admitted (issue #6653).
+    // Checked before any mutation so a rejected call is a complete no-op,
+    // including leaving any existing entry for this key untouched.
+    if (this.isOversizedValue(sizeBytes)) {
+      logger.warn(
+        `[TTLCache] rejecting value for key that alone exceeds maxSizeBytes ` +
+          `(${sizeBytes} > ${this.maxSizeBytes} bytes); value not cached`,
+      );
+      return;
+    }
+
     const now = this.timer.now();
 
     // Remove existing entry if present
-    const existing = this.entries.get(key);
-    if (existing) {
-      this.currentSizeBytes -= existing.sizeBytes ?? 0;
-      this.entries.delete(key);
+    if (this.entries.has(key)) {
+      this.removeEntry(key);
     }
 
-    // Check size constraints
-    if (sizeBytes !== undefined && this.maxSizeBytes !== Infinity) {
-      // Evict entries if needed to make room
-      while (this.currentSizeBytes + sizeBytes > this.maxSizeBytes && this.entries.size > 0) {
-        this.evictOldest();
-        this.stats.sizeEvictions++;
-      }
-    }
+    // Opportunistic amortized cleanup: every set() clears any already-expired
+    // prefix before considering size/count eviction, so an unbounded key
+    // space does not accumulate dead entries indefinitely even if callers
+    // never call cleanup() themselves (issue #6653). Cost is proportional to
+    // entries actually expired, not cache size -- see sweepExpiredPrefix.
+    this.sweepExpiredPrefix(now);
 
-    // Check entry count constraints (guard against maxEntries <= 0)
-    while (this.maxEntries > 0 && this.entries.size >= this.maxEntries && this.entries.size > 0) {
-      this.evictOldest();
-      this.stats.sizeEvictions++;
-    }
+    this.evictForCapacity(sizeBytes);
 
     // Skip caching if maxEntries is 0 or negative (caching disabled)
     if (this.maxEntries <= 0) {
@@ -198,11 +234,11 @@ export class TTLCache<K, V> implements Cache<K, V> {
     const entry: CacheEntry<V> = {
       value,
       createdAt: now,
-      lastAccessedAt: now,
       sizeBytes,
     };
 
     this.entries.set(key, entry);
+    this.expiryOrder.add(key);
     this.currentSizeBytes += sizeBytes ?? 0;
     this.updateSizeStats();
   }
@@ -215,8 +251,7 @@ export class TTLCache<K, V> implements Cache<K, V> {
 
     const now = this.timer.now();
     if (now - entry.createdAt >= this.ttlMs) {
-      this.entries.delete(key);
-      this.currentSizeBytes -= entry.sizeBytes ?? 0;
+      this.removeEntry(key);
       this.stats.ttlEvictions++;
       this.updateSizeStats();
       return false;
@@ -226,10 +261,8 @@ export class TTLCache<K, V> implements Cache<K, V> {
   }
 
   delete(key: K): boolean {
-    const entry = this.entries.get(key);
-    if (entry) {
-      this.currentSizeBytes -= entry.sizeBytes ?? 0;
-      this.entries.delete(key);
+    if (this.entries.has(key)) {
+      this.removeEntry(key);
       this.updateSizeStats();
       return true;
     }
@@ -238,6 +271,7 @@ export class TTLCache<K, V> implements Cache<K, V> {
 
   clear(): void {
     this.entries.clear();
+    this.expiryOrder.clear();
     this.currentSizeBytes = 0;
     this.updateSizeStats();
   }
@@ -251,20 +285,7 @@ export class TTLCache<K, V> implements Cache<K, V> {
   }
 
   cleanup(): number {
-    const now = this.timer.now();
-    let evicted = 0;
-
-    for (const [key, entry] of this.entries) {
-      if (now - entry.createdAt >= this.ttlMs) {
-        this.entries.delete(key);
-        this.currentSizeBytes -= entry.sizeBytes ?? 0;
-        this.stats.ttlEvictions++;
-        evicted++;
-      }
-    }
-
-    this.updateSizeStats();
-    return evicted;
+    return this.sweepExpiredPrefix(this.timer.now());
   }
 
   /**
@@ -281,24 +302,105 @@ export class TTLCache<K, V> implements Cache<K, V> {
     return Array.from(this.entries.keys());
   }
 
+  /**
+   * Test seam: cumulative entries touched by evictOldest()'s O(1) peek and
+   * the expiry sweep's bounded prefix walk (see the class doc and
+   * evictionScanWork). Lets tests pin eviction/cleanup cost as linear in
+   * entries actually evicted rather than quadratic in cache size, without a
+   * flaky wall-clock benchmark.
+   */
+  get evictionScanWorkUnits(): number {
+    return this.evictionScanWork;
+  }
+
+  /**
+   * Remove entries from the front of `expiryOrder` (ascending creation time)
+   * while they are expired, stopping at the first one that is not -- every
+   * entry after it was created no earlier, so it cannot be expired yet
+   * either. Cost is proportional to entries actually removed, not the total
+   * cache size (issue #6653).
+   */
+  private sweepExpiredPrefix(now: number): number {
+    let evicted = 0;
+
+    for (const key of this.expiryOrder) {
+      this.evictionScanWork++;
+      const entry = this.entries.get(key);
+      // expiryOrder and entries are kept in lockstep by every mutator below,
+      // so a missing entry here would indicate a bug rather than legitimate
+      // state -- treat it the same as "not expired" and stop.
+      if (!entry || now - entry.createdAt < this.ttlMs) {
+        break;
+      }
+      this.removeEntry(key);
+      this.stats.ttlEvictions++;
+      evicted++;
+    }
+
+    if (evicted > 0) {
+      this.updateSizeStats();
+    }
+    return evicted;
+  }
+
+  /**
+   * True when `sizeBytes` alone would exceed a finite `maxSizeBytes` budget
+   * -- no eviction of other entries could ever make room for it (issue
+   * #6653).
+   */
+  private isOversizedValue(sizeBytes: number | undefined): boolean {
+    return (
+      sizeBytes !== undefined && this.maxSizeBytes !== Infinity && sizeBytes > this.maxSizeBytes
+    );
+  }
+
+  /**
+   * Evict entries (oldest-first, O(1) each via evictOldest()) until the
+   * incoming value fits within maxSizeBytes and the entry count is under
+   * maxEntries.
+   */
+  private evictForCapacity(sizeBytes: number | undefined): void {
+    if (sizeBytes !== undefined && this.maxSizeBytes !== Infinity) {
+      while (this.currentSizeBytes + sizeBytes > this.maxSizeBytes && this.entries.size > 0) {
+        this.evictOldest();
+        this.stats.sizeEvictions++;
+      }
+    }
+
+    // Guard against maxEntries <= 0 (caching disabled; set() returns early).
+    while (this.maxEntries > 0 && this.entries.size >= this.maxEntries && this.entries.size > 0) {
+      this.evictOldest();
+      this.stats.sizeEvictions++;
+    }
+  }
+
+  /**
+   * Evict the least-recently-used entry in O(1): `entries` iteration order
+   * tracks access recency (see the class doc and get()), so the front is
+   * always the LRU key -- no scan needed to find it.
+   */
   private evictOldest(): void {
-    let oldestKey: K | undefined;
-    let oldestTime = Infinity;
-
-    for (const [key, entry] of this.entries) {
-      if (entry.lastAccessedAt < oldestTime) {
-        oldestTime = entry.lastAccessedAt;
-        oldestKey = key;
-      }
+    const oldestKey: K | undefined = this.entries.keys().next().value;
+    if (oldestKey === undefined) {
+      return;
     }
+    this.evictionScanWork++;
+    this.removeEntry(oldestKey);
+  }
 
-    if (oldestKey !== undefined) {
-      const entry = this.entries.get(oldestKey);
-      if (entry) {
-        this.currentSizeBytes -= entry.sizeBytes ?? 0;
-      }
-      this.entries.delete(oldestKey);
+  /**
+   * Remove a key from both orderings and the value store, adjusting the
+   * tracked byte total. Centralizes the bookkeeping every removal path
+   * (expiry, explicit delete, LRU eviction) must keep in sync; callers are
+   * responsible for any stats increment and updateSizeStats() call.
+   */
+  private removeEntry(key: K): void {
+    const entry = this.entries.get(key);
+    if (entry) {
+      this.currentSizeBytes -= entry.sizeBytes ?? 0;
+      this.entries.delete(key);
     }
+    this.expiryOrder.delete(key);
   }
 
   private updateSizeStats(): void {

--- a/src/utils/cache/Cache.ts
+++ b/src/utils/cache/Cache.ts
@@ -213,10 +213,6 @@ export class TTLCache<K, V> implements Cache<K, V> {
     }
 
     const now = this.timer.now();
-    if (now < this.newestCreatedAt) {
-      this.expiryOrderMayBeOutOfOrder = true;
-    }
-    this.newestCreatedAt = Math.max(this.newestCreatedAt, now);
 
     // Remove existing entry if present
     if (this.entries.has(key)) {
@@ -236,6 +232,13 @@ export class TTLCache<K, V> implements Cache<K, V> {
     if (this.maxEntries <= 0) {
       return;
     }
+
+    // Removals can reset the ordering when the cache becomes empty. Record
+    // the incoming timestamp only once those removals have finished.
+    if (now < this.newestCreatedAt) {
+      this.expiryOrderMayBeOutOfOrder = true;
+    }
+    this.newestCreatedAt = Math.max(this.newestCreatedAt, now);
 
     // Add new entry
     const entry: CacheEntry<V> = {

--- a/src/utils/cache/Cache.ts
+++ b/src/utils/cache/Cache.ts
@@ -1,5 +1,5 @@
 import { Timer, defaultTimer } from "../SystemTimer";
-import { logger } from "../logger";
+import { logger, type Logger } from "../logger";
 
 /**
  * Configuration for cache behavior.
@@ -103,11 +103,9 @@ interface Cache<K, V> {
   getStats(): CacheStats;
 
   /**
-   * Remove all currently-expired entries, in ascending creation-time order,
-   * stopping at the first entry that has not expired yet (everything created
-   * after it is at least as fresh, so it cannot be expired either). Cost is
-   * proportional to the number of expired entries removed, not the total
-   * cache size.
+   * Remove all currently-expired entries. With monotonic timestamps, this
+   * stops at the first live entry and costs only the expired prefix; after a
+   * backwards wall-clock step it scans the remaining entries for correctness.
    *
    * `set()` runs this same bounded sweep automatically before every insert,
    * and `get()`/`has()` opportunistically evict the single key they touch
@@ -135,14 +133,18 @@ export const DEFAULT_CACHE_OPTIONS: Required<Omit<CacheOptions, "maxSizeBytes">>
  *  - `entries` iteration order tracks access recency: a hit in `get()` moves
  *    its key to the tail, so the front is always the least-recently-used
  *    entry and `evictOldest()` just peeks it.
- *  - `expiryOrder` iteration order tracks creation time ascending (a fresh
- *    `set()` always appends, including on overwrite): the front is always
- *    the oldest-created entry, so a TTL sweep can stop as soon as it hits a
- *    non-expired one instead of walking the whole cache.
+ *  - `expiryOrder` iteration order tracks creation time while the injected
+ *    clock is monotonic (a fresh `set()` appends, including on overwrite), so
+ *    the front is the oldest-created entry and a TTL sweep can stop at the
+ *    first live entry. A backwards wall-clock step falls back to a full scan.
  */
 export class TTLCache<K, V> implements Cache<K, V> {
   private readonly entries: Map<K, CacheEntry<V>> = new Map();
   private readonly expiryOrder: Set<K> = new Set();
+  // Date.now() can move backwards. When it does, insertion order is no longer
+  // guaranteed to match expiration order, so a sweep must inspect every entry.
+  private newestCreatedAt = Number.NEGATIVE_INFINITY;
+  private expiryOrderMayBeOutOfOrder = false;
   private readonly ttlMs: number;
   private readonly maxEntries: number;
   private readonly maxSizeBytes: number;
@@ -163,6 +165,7 @@ export class TTLCache<K, V> implements Cache<K, V> {
   constructor(
     private readonly timer: Timer = defaultTimer,
     options?: CacheOptions,
+    private readonly log: Logger = logger,
   ) {
     this.ttlMs = options?.ttlMs ?? DEFAULT_CACHE_OPTIONS.ttlMs;
     this.maxEntries = options?.maxEntries ?? DEFAULT_CACHE_OPTIONS.maxEntries;
@@ -202,7 +205,7 @@ export class TTLCache<K, V> implements Cache<K, V> {
     // Checked before any mutation so a rejected call is a complete no-op,
     // including leaving any existing entry for this key untouched.
     if (this.isOversizedValue(sizeBytes)) {
-      logger.warn(
+      this.log.warn(
         `[TTLCache] rejecting value for key that alone exceeds maxSizeBytes ` +
           `(${sizeBytes} > ${this.maxSizeBytes} bytes); value not cached`,
       );
@@ -210,6 +213,10 @@ export class TTLCache<K, V> implements Cache<K, V> {
     }
 
     const now = this.timer.now();
+    if (now < this.newestCreatedAt) {
+      this.expiryOrderMayBeOutOfOrder = true;
+    }
+    this.newestCreatedAt = Math.max(this.newestCreatedAt, now);
 
     // Remove existing entry if present
     if (this.entries.has(key)) {
@@ -272,6 +279,8 @@ export class TTLCache<K, V> implements Cache<K, V> {
   clear(): void {
     this.entries.clear();
     this.expiryOrder.clear();
+    this.newestCreatedAt = Number.NEGATIVE_INFINITY;
+    this.expiryOrderMayBeOutOfOrder = false;
     this.currentSizeBytes = 0;
     this.updateSizeStats();
   }
@@ -314,11 +323,10 @@ export class TTLCache<K, V> implements Cache<K, V> {
   }
 
   /**
-   * Remove entries from the front of `expiryOrder` (ascending creation time)
-   * while they are expired, stopping at the first one that is not -- every
-   * entry after it was created no earlier, so it cannot be expired yet
-   * either. Cost is proportional to entries actually removed, not the total
-   * cache size (issue #6653).
+   * Remove expired entries. While timestamps are monotonic, `expiryOrder` is
+   * ascending and the sweep stops at the first live entry. A backwards
+   * wall-clock step removes that guarantee, so the sweep continues through
+   * every entry to avoid retaining a later, already-expired value.
    */
   private sweepExpiredPrefix(now: number): number {
     let evicted = 0;
@@ -326,11 +334,16 @@ export class TTLCache<K, V> implements Cache<K, V> {
     for (const key of this.expiryOrder) {
       this.evictionScanWork++;
       const entry = this.entries.get(key);
-      // expiryOrder and entries are kept in lockstep by every mutator below,
-      // so a missing entry here would indicate a bug rather than legitimate
-      // state -- treat it the same as "not expired" and stop.
-      if (!entry || now - entry.createdAt < this.ttlMs) {
-        break;
+      // expiryOrder and entries are kept in lockstep by every mutator below.
+      // Keep progressing defensively if that invariant is ever broken.
+      if (!entry) {
+        continue;
+      }
+      if (now - entry.createdAt < this.ttlMs) {
+        if (!this.expiryOrderMayBeOutOfOrder) {
+          break;
+        }
+        continue;
       }
       this.removeEntry(key);
       this.stats.ttlEvictions++;
@@ -401,6 +414,10 @@ export class TTLCache<K, V> implements Cache<K, V> {
       this.entries.delete(key);
     }
     this.expiryOrder.delete(key);
+    if (this.entries.size === 0) {
+      this.newestCreatedAt = Number.NEGATIVE_INFINITY;
+      this.expiryOrderMayBeOutOfOrder = false;
+    }
   }
 
   private updateSizeStats(): void {

--- a/src/utils/cache/Cache.ts
+++ b/src/utils/cache/Cache.ts
@@ -333,6 +333,9 @@ export class TTLCache<K, V> implements Cache<K, V> {
    */
   private sweepExpiredPrefix(now: number): number {
     let evicted = 0;
+    const fullScan = this.expiryOrderMayBeOutOfOrder;
+    let previousLiveTimestamp = Number.NEGATIVE_INFINITY;
+    let survivingDisorder = false;
 
     for (const key of this.expiryOrder) {
       this.evictionScanWork++;
@@ -343,9 +346,9 @@ export class TTLCache<K, V> implements Cache<K, V> {
         continue;
       }
       if (now - entry.createdAt < this.ttlMs) {
-        if (!this.expiryOrderMayBeOutOfOrder) {
-          break;
-        }
+        if (!fullScan) break;
+        if (entry.createdAt < previousLiveTimestamp) survivingDisorder = true;
+        previousLiveTimestamp = Math.max(previousLiveTimestamp, entry.createdAt);
         continue;
       }
       this.removeEntry(key);
@@ -353,6 +356,10 @@ export class TTLCache<K, V> implements Cache<K, V> {
       evicted++;
     }
 
+    if (fullScan) {
+      this.expiryOrderMayBeOutOfOrder = survivingDisorder;
+      this.newestCreatedAt = previousLiveTimestamp;
+    }
     if (evicted > 0) {
       this.updateSizeStats();
     }

--- a/test/utils/cache/Cache.test.ts
+++ b/test/utils/cache/Cache.test.ts
@@ -412,6 +412,7 @@ describe("TTLCache", () => {
       };
       const cacheWithWallClock = new TTLCache<string, string>(wallClock, { ttlMs: 1_000 });
 
+      for (let i = 0; i < 1000; i++) cacheWithWallClock.set(`live-${i}`, "live");
       cacheWithWallClock.set("live-first", "live");
       wallTime = 500; // a backwards Date.now() step before the next insert
       cacheWithWallClock.set("expired-second", "expired");
@@ -420,6 +421,9 @@ describe("TTLCache", () => {
       expect(cacheWithWallClock.cleanup()).toBe(1);
       expect(cacheWithWallClock.get("live-first")).toBe("live");
       expect(cacheWithWallClock.get("expired-second")).toBeUndefined();
+      const work = cacheWithWallClock.evictionScanWorkUnits;
+      cacheWithWallClock.set("after-recovery", "live");
+      expect(cacheWithWallClock.evictionScanWorkUnits - work).toBe(1);
     });
   });
 

--- a/test/utils/cache/Cache.test.ts
+++ b/test/utils/cache/Cache.test.ts
@@ -258,4 +258,142 @@ describe("TTLCache", () => {
       expect(sizedCache.size()).toBe(1);
     });
   });
+
+  // issue #6653: cleanup() was documented as automatic but nothing in src/
+  // ever invoked it, so entries in an unbounded key space (a UUID, a
+  // timestamp) accumulated dead weight forever once expired -- only reading
+  // the exact same key again after expiry ever reclaimed it.
+  describe("automatic cleanup on set() (issue #6653)", () => {
+    it("reclaims expired entries via set() alone, even for keys never re-read", () => {
+      const unboundedCache = new TTLCache<string, string>(timer, { ttlMs: 1000 });
+
+      for (let i = 0; i < 5; i++) {
+        unboundedCache.set(`old-${i}`, `value-${i}`);
+      }
+      expect(unboundedCache.size()).toBe(5);
+
+      timer.advanceTime(1000); // all 5 entries are now expired
+
+      // Fresh keys, never used before -- nothing ever reads the old keys
+      // again, so only the automatic sweep inside set() can reclaim them.
+      for (let i = 0; i < 3; i++) {
+        unboundedCache.set(`new-${i}`, `value-${i}`);
+      }
+
+      // Pre-fix, size() would be 8 (5 stale entries no one ever re-read, plus
+      // the 3 fresh ones) because nothing ever called cleanup().
+      expect(unboundedCache.size()).toBe(3);
+      expect(unboundedCache.get("old-0")).toBeUndefined();
+      expect(unboundedCache.get("new-2")).toBe("value-2");
+    });
+
+    it("size() does not grow unbounded across many inserts once entries expire", () => {
+      const unboundedCache = new TTLCache<string, number>(timer, { ttlMs: 100 });
+
+      for (let batch = 0; batch < 20; batch++) {
+        for (let i = 0; i < 10; i++) {
+          unboundedCache.set(`batch${batch}-key${i}`, i);
+        }
+        timer.advanceTime(100); // expire this whole batch before the next one
+      }
+
+      // Every batch fully expires before the next batch's first set() call
+      // runs its sweep, so at most one batch's worth of entries is ever live.
+      expect(unboundedCache.size()).toBeLessThanOrEqual(10);
+    });
+  });
+
+  describe("bounded size under a maxEntries cap across many inserts", () => {
+    it("size() never exceeds maxEntries no matter how many distinct keys are inserted", () => {
+      const capped = new TTLCache<string, number>(timer, { ttlMs: 10000, maxEntries: 5 });
+
+      for (let i = 0; i < 500; i++) {
+        capped.set(`key-${i}`, i);
+        expect(capped.size()).toBeLessThanOrEqual(5);
+      }
+      expect(capped.size()).toBe(5);
+    });
+  });
+
+  // issue #6653: evictOldest() used to do a full linear scan of every entry
+  // to find the least-recently-used key, so a size- or count-capped cache
+  // paid O(n) work per insert once full. evictionScanWorkUnits is a
+  // test-only counter (mirrors BufferQueue.compactionWorkUnits) that lets
+  // these assertions pin the fix without a flaky wall-clock benchmark.
+  describe("bounded eviction/cleanup scan work (issue #6653)", () => {
+    it("evictOldest() touches ~O(1) entries per insert under a maxEntries cap, not O(n)", () => {
+      const capped = new TTLCache<string, number>(timer, { ttlMs: 10000, maxEntries: 1 });
+      const n = 500;
+
+      for (let i = 0; i < n; i++) {
+        capped.set(`key-${i}`, i);
+      }
+
+      // Each set() after the first evicts exactly one entry via an O(1)
+      // peek, plus one O(1) peek from the expiry sweep finding a live front
+      // entry: work grows linearly with n. A per-insert O(n) scan (the
+      // pre-fix evictOldest()) would touch roughly n*(n-1)/2 entries across
+      // this loop -- 124,750 for n=500 -- which the bound below rules out.
+      expect(capped.evictionScanWorkUnits).toBeLessThanOrEqual(3 * n);
+    });
+
+    it("cleanup() stops at the first non-expired entry instead of scanning the whole cache", () => {
+      const mixedCache = new TTLCache<string, number>(timer, { ttlMs: 1000 });
+
+      // 3 entries created at t=0; will be expired once time reaches t=1000.
+      for (let i = 0; i < 3; i++) {
+        mixedCache.set(`old-${i}`, i);
+      }
+
+      timer.advanceTime(500);
+      // 200 entries created at t=500; still live at t=1000 (ttl elapses 1500).
+      for (let i = 0; i < 200; i++) {
+        mixedCache.set(`live-${i}`, i);
+      }
+
+      timer.advanceTime(500); // t=1000: old-* (age 1000) expired, live-* (age 500) not.
+
+      const before = mixedCache.evictionScanWorkUnits;
+      const evicted = mixedCache.cleanup();
+      const workDuringCleanup = mixedCache.evictionScanWorkUnits - before;
+
+      expect(evicted).toBe(3);
+      // cleanup() must stop as soon as it reaches the first live entry
+      // instead of continuing past it to scan the other 199 -- proportional
+      // to the 3 expired entries (plus the one live entry it checks and
+      // stops at), not the 203-entry cache.
+      expect(workDuringCleanup).toBeLessThanOrEqual(4);
+      expect(mixedCache.size()).toBe(200);
+    });
+  });
+
+  // issue #6653: the maxSizeBytes eviction loop stopped once entries.size
+  // reached 0 even if the single incoming value alone exceeded the budget,
+  // so an oversized value was inserted unconditionally and permanently
+  // pinned currentSizeBytes above maxSizeBytes.
+  describe("oversized single values (issue #6653)", () => {
+    it("rejects a value whose size alone exceeds maxSizeBytes, without touching other entries", () => {
+      const sizedCache = new TTLCache<string, Buffer>(timer, { ttlMs: 10000, maxSizeBytes: 100 });
+      const small = Buffer.alloc(50);
+      sizedCache.set("small", small, 50);
+
+      sizedCache.set("huge", Buffer.alloc(500), 500);
+
+      expect(sizedCache.get("huge")).toBeUndefined();
+      expect(sizedCache.get("small")).toBe(small);
+      expect(sizedCache.getCurrentSizeBytes()).toBe(50);
+      expect(sizedCache.size()).toBe(1);
+    });
+
+    it("leaves an existing entry untouched when overwriting it with an oversized value", () => {
+      const sizedCache = new TTLCache<string, Buffer>(timer, { ttlMs: 10000, maxSizeBytes: 100 });
+      const original = Buffer.alloc(50);
+      sizedCache.set("key", original, 50);
+
+      sizedCache.set("key", Buffer.alloc(500), 500);
+
+      expect(sizedCache.get("key")).toBe(original);
+      expect(sizedCache.getCurrentSizeBytes()).toBe(50);
+    });
+  });
 });

--- a/test/utils/cache/Cache.test.ts
+++ b/test/utils/cache/Cache.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { TTLCache } from "../../../src/utils/cache/Cache";
+import type { Timer } from "../../../src/utils/SystemTimer";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeLogger } from "../../fakes/FakeLogger";
 
 describe("TTLCache", () => {
   let cache: TTLCache<string, string>;
@@ -322,19 +324,27 @@ describe("TTLCache", () => {
   // these assertions pin the fix without a flaky wall-clock benchmark.
   describe("bounded eviction/cleanup scan work (issue #6653)", () => {
     it("evictOldest() touches ~O(1) entries per insert under a maxEntries cap, not O(n)", () => {
-      const capped = new TTLCache<string, number>(timer, { ttlMs: 10000, maxEntries: 1 });
+      const capacity = 128;
+      const capped = new TTLCache<string, number>(timer, { ttlMs: 10000, maxEntries: capacity });
       const n = 500;
 
+      // Warm enough resident entries that the old linear eviction scan would
+      // have substantial work to do on every following insertion.
+      for (let i = 0; i < capacity; i++) {
+        capped.set(`warm-${i}`, i);
+      }
+      const before = capped.evictionScanWorkUnits;
       for (let i = 0; i < n; i++) {
         capped.set(`key-${i}`, i);
       }
+      const workDuringEviction = capped.evictionScanWorkUnits - before;
 
-      // Each set() after the first evicts exactly one entry via an O(1)
+      // Each set evicts exactly one entry via an O(1)
       // peek, plus one O(1) peek from the expiry sweep finding a live front
-      // entry: work grows linearly with n. A per-insert O(n) scan (the
-      // pre-fix evictOldest()) would touch roughly n*(n-1)/2 entries across
-      // this loop -- 124,750 for n=500 -- which the bound below rules out.
-      expect(capped.evictionScanWorkUnits).toBeLessThanOrEqual(3 * n);
+      // entry: work grows linearly with n. A per-insert O(capacity) scan (the
+      // pre-fix evictOldest()) would touch at least 64,000 entries across this
+      // loop, which the bound below rules out.
+      expect(workDuringEviction).toBeLessThanOrEqual(2 * n);
     });
 
     it("cleanup() stops at the first non-expired entry instead of scanning the whole cache", () => {
@@ -365,6 +375,29 @@ describe("TTLCache", () => {
       expect(workDuringCleanup).toBeLessThanOrEqual(4);
       expect(mixedCache.size()).toBe(200);
     });
+
+    it("continues past a live entry after the wall clock moves backwards", () => {
+      const backingTimer = new FakeTimer();
+      let wallTime = 1_000;
+      const wallClock: Timer = {
+        sleep: (ms) => backingTimer.sleep(ms),
+        setTimeout: (callback, ms) => backingTimer.setTimeout(callback, ms),
+        clearTimeout: (handle) => backingTimer.clearTimeout(handle),
+        setInterval: (callback, ms) => backingTimer.setInterval(callback, ms),
+        clearInterval: (handle) => backingTimer.clearInterval(handle),
+        now: () => wallTime,
+      };
+      const cacheWithWallClock = new TTLCache<string, string>(wallClock, { ttlMs: 1_000 });
+
+      cacheWithWallClock.set("live-first", "live");
+      wallTime = 500; // a backwards Date.now() step before the next insert
+      cacheWithWallClock.set("expired-second", "expired");
+      wallTime = 1_600;
+
+      expect(cacheWithWallClock.cleanup()).toBe(1);
+      expect(cacheWithWallClock.get("live-first")).toBe("live");
+      expect(cacheWithWallClock.get("expired-second")).toBeUndefined();
+    });
   });
 
   // issue #6653: the maxSizeBytes eviction loop stopped once entries.size
@@ -373,7 +406,12 @@ describe("TTLCache", () => {
   // pinned currentSizeBytes above maxSizeBytes.
   describe("oversized single values (issue #6653)", () => {
     it("rejects a value whose size alone exceeds maxSizeBytes, without touching other entries", () => {
-      const sizedCache = new TTLCache<string, Buffer>(timer, { ttlMs: 10000, maxSizeBytes: 100 });
+      const log = new FakeLogger();
+      const sizedCache = new TTLCache<string, Buffer>(
+        timer,
+        { ttlMs: 10000, maxSizeBytes: 100 },
+        log,
+      );
       const small = Buffer.alloc(50);
       sizedCache.set("small", small, 50);
 
@@ -383,10 +421,16 @@ describe("TTLCache", () => {
       expect(sizedCache.get("small")).toBe(small);
       expect(sizedCache.getCurrentSizeBytes()).toBe(50);
       expect(sizedCache.size()).toBe(1);
+      expect(log.at("warn")).toHaveLength(1);
+      expect(log.at("warn")[0]?.message).toContain("rejecting value");
     });
 
     it("leaves an existing entry untouched when overwriting it with an oversized value", () => {
-      const sizedCache = new TTLCache<string, Buffer>(timer, { ttlMs: 10000, maxSizeBytes: 100 });
+      const sizedCache = new TTLCache<string, Buffer>(
+        timer,
+        { ttlMs: 10000, maxSizeBytes: 100 },
+        new FakeLogger(),
+      );
       const original = Buffer.alloc(50);
       sizedCache.set("key", original, 50);
 

--- a/test/utils/cache/Cache.test.ts
+++ b/test/utils/cache/Cache.test.ts
@@ -323,6 +323,29 @@ describe("TTLCache", () => {
   // test-only counter (mirrors BufferQueue.compactionWorkUnits) that lets
   // these assertions pin the fix without a flaky wall-clock benchmark.
   describe("bounded eviction/cleanup scan work (issue #6653)", () => {
+    it.each(["sweep", "overwrite", "capacity"])(
+      "retains clock ordering after %s removes the last entry",
+      (removal) => {
+        const wallClock = new FakeTimer();
+        const cache = new TTLCache<string, string>(
+          wallClock,
+          { ttlMs: 1000, maxSizeBytes: 2 },
+          new FakeLogger(),
+        );
+        wallClock.advanceTime(1000);
+        cache.set("old", "old", removal === "capacity" ? 2 : 1);
+        wallClock.advanceTime(removal === "sweep" ? 1000 : 100);
+        const liveKey = removal === "overwrite" ? "old" : "new";
+        cache.set(liveKey, "live", 1);
+        wallClock.advanceTime(-500);
+        cache.set("second", "expired", 1);
+        wallClock.advanceTime(1100);
+
+        expect(cache.cleanup()).toBe(1);
+        expect(cache.keys()).toEqual([liveKey]);
+      },
+    );
+
     it("evictOldest() touches ~O(1) entries per insert under a maxEntries cap, not O(n)", () => {
       const capacity = 128;
       const capped = new TTLCache<string, number>(timer, { ttlMs: 10000, maxEntries: capacity });


### PR DESCRIPTION
## Summary

`TTLCache.cleanup()` was documented as called automatically on get/set, but `set()`
never invoked it and `get()`/`has()` only evicted the single key they touched — so
expired entries under an unbounded key space accumulated. And size-capped eviction
scanned the whole `entries` map for the min `lastAccessedAt` on every insert (**O(n)**).

`set()` now runs a bounded amortized sweep of expired entries before inserting. Two
orderings are tracked: `entries` (Map) doubles as LRU order (a `get()` hit re-inserts
at the tail), and a new `expiryOrder` set gives creation-time order. `evictOldest()`
peeks `entries.keys().next()` (**O(1)**) instead of a full scan; the sweep walks
`expiryOrder` front-to-back and stops at the first live entry, so cost is proportional
to entries actually expired, not cache size. `CacheEntry.lastAccessedAt` (now redundant)
was removed. Oversized single values (size alone > `maxSizeBytes`) are rejected with a
`logger.warn` instead of being cached and immediately violating the budget.

Part of epic #6379.

## Linked Issue

Closes #6653

## Validation

- [x] `test/utils/cache/Cache.test.ts` — 32 pass. New tests (FakeTimer): sweep-on-set, bounded size under `maxEntries`, an `evictionScanWorkUnits` seam pinning bounded/amortized cost (500 inserts under cap 1 touch ~1k entries, not ~125k), oversized-value rejection. Red first (6/7 failed). Downstream `TTLCache` consumers (AccessibilityDetector, AdbClient, etc.) — 81 pass.
- [x] `bun run format:check`, `bun run lint` (extracted helpers to stay under the complexity ratchet), `bun run typecheck` — all clean.

## Follow-ups
- `DEFAULT_CACHE_OPTIONS.maxEntries` stays `Infinity` per the issue's guidance (unbounded key spaces are now safe via the sweep, not a bigger default).
