### PR TITLE
fix(db): keep retention amortization counter armed during an in-flight cleanup (#6657)

### DIFF
--- a/src/db/eventRetention.ts
+++ b/src/db/eventRetention.ts
@@ -35,11 +35,15 @@ export async function pruneEventTableByCount(
   if (state.insertsSinceCleanup < checkInterval) {
     return;
   }
-  state.insertsSinceCleanup = 0;
 
+  // Only reset the counter once we've committed to running the cleanup body.
+  // If a cleanup is already in progress, leave the counter at-or-above
+  // `checkInterval` so the very next insert re-checks this gate instead of
+  // silently re-arming a fresh `checkInterval`-insert countdown (#6657).
   if (state.cleanupInProgress) {
     return;
   }
+  state.insertsSinceCleanup = 0;
   state.cleanupInProgress = true;
   try {
     const resolvedDb = db ?? (getDatabase() as unknown as Kysely<Database>);

--- a/src/db/rowCapRetention.ts
+++ b/src/db/rowCapRetention.ts
@@ -109,11 +109,15 @@ export async function runAmortizedRetention(
   if (state.insertsSinceCleanup < checkInterval) {
     return;
   }
-  state.insertsSinceCleanup = 0;
 
+  // Only reset the counter once we've committed to running the cleanup body.
+  // If a cleanup is already in progress, leave the counter at-or-above
+  // `checkInterval` so the very next insert re-checks this gate instead of
+  // silently re-arming a fresh `checkInterval`-insert countdown (#6657).
   if (state.cleanupInProgress) {
     return;
   }
+  state.insertsSinceCleanup = 0;
   state.cleanupInProgress = true;
   try {
     await runCleanup();

--- a/test/db/eventRetention.integration.test.ts
+++ b/test/db/eventRetention.integration.test.ts
@@ -213,6 +213,54 @@ describe("event repository retention (#2799)", () => {
     }
   });
 
+  describe("counter is not reset when a cleanup is already in progress (#6657)", () => {
+    test("a bailed-out call while a cleanup is in flight leaves the counter armed for the next insert", async () => {
+      const { db, sqls } = await createInstrumentedTestDatabase();
+      try {
+        const checkInterval = 3;
+        const state = createRetentionState();
+        // One insert away from tripping the gate.
+        state.insertsSinceCleanup = checkInterval - 1;
+
+        // This insert trips the gate and starts (but does not finish) the
+        // async cleanup body — it is parked on the real DB's count(*) query.
+        const first = pruneEventTableByCount(db, "log_events", state, 1000, checkInterval);
+
+        // A burst of checkInterval-worth of further inserts lands before that
+        // cleanup resolves. Each is fired without awaiting the prior one, so
+        // they run synchronously up to their own guard check while `first`
+        // is still parked on its own `await` — the exact interleaving from a
+        // sustained write burst.
+        const burst: Promise<void>[] = [];
+        for (let i = 0; i < checkInterval; i++) {
+          burst.push(pruneEventTableByCount(db, "log_events", state, 1000, checkInterval));
+        }
+
+        // Buggy behavior: the counter was zeroed by `first` before the
+        // in-progress check, so every burst call above would already have
+        // re-tripped and re-zeroed it, ending near 0 (well under
+        // checkInterval) and silently discarding the in-flight cleanup's
+        // gate. Fixed behavior: none of the bailed-out burst calls reset the
+        // counter, so it stays >= checkInterval.
+        expect(state.cleanupInProgress).toBe(true);
+        expect(state.insertsSinceCleanup).toBeGreaterThanOrEqual(checkInterval);
+
+        await Promise.all(burst);
+        await first;
+        expect(state.cleanupInProgress).toBe(false);
+
+        // With the counter left armed, the very next insert retries the gate
+        // immediately rather than waiting another full checkInterval.
+        sqls.length = 0;
+        await pruneEventTableByCount(db, "log_events", state, 1000, checkInterval);
+        expect(countOccurrences(sqls, "count(")).toBe(1);
+        expect(state.insertsSinceCleanup).toBe(0);
+      } finally {
+        await db.destroy();
+      }
+    });
+  });
+
   describe("batched multi-row INSERT (#3138)", () => {
     const BATCH_REPOS = [
       {

--- a/test/db/rowCapRetention.integration.test.ts
+++ b/test/db/rowCapRetention.integration.test.ts
@@ -88,6 +88,55 @@ describe("runAmortizedRetention (#3435/#3436/#3440)", () => {
     expect(maxConcurrent).toBe(1);
   });
 
+  test("a bailed-out call while a cleanup is in flight leaves the counter armed for the next insert (#6657)", async () => {
+    const state = createRowCapRetentionState();
+    const checkInterval = 3;
+    let runs = 0;
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const body = async (): Promise<void> => {
+      runs++;
+      await gate;
+    };
+
+    // One insert away from tripping the gate.
+    state.insertsSinceCleanup = checkInterval - 1;
+
+    // This call trips the gate and parks inside the cleanup body (on `gate`).
+    const first = runAmortizedRetention(state, body, checkInterval);
+
+    // A burst of checkInterval-worth of further inserts lands before that
+    // cleanup resolves. Each is fired without awaiting the prior one, so they
+    // run synchronously up to their own guard check while `first` is still
+    // parked — the exact interleaving from a sustained write burst.
+    const burst: Promise<void>[] = [];
+    for (let i = 0; i < checkInterval; i++) {
+      burst.push(runAmortizedRetention(state, body, checkInterval));
+    }
+
+    // Buggy behavior: the counter is zeroed before the in-progress check, so
+    // every burst call above would already have re-tripped and re-zeroed it,
+    // ending near 0 (well under checkInterval) and silently discarding the
+    // in-flight cleanup's gate. Fixed behavior: none of the bailed-out burst
+    // calls reset the counter, so it stays >= checkInterval.
+    expect(state.cleanupInProgress).toBe(true);
+    expect(state.insertsSinceCleanup).toBeGreaterThanOrEqual(checkInterval);
+    expect(runs).toBe(1); // only the in-flight cleanup has run so far
+
+    release();
+    await Promise.all(burst);
+    await first;
+    expect(state.cleanupInProgress).toBe(false);
+
+    // With the counter left armed, the very next insert retries the gate
+    // immediately rather than waiting another full checkInterval.
+    await runAmortizedRetention(state, body, checkInterval);
+    expect(runs).toBe(2);
+    expect(state.insertsSinceCleanup).toBe(0);
+  });
+
   test("releases the guard even when the cleanup body throws", async () => {
     const state = createRowCapRetentionState();
 


### PR DESCRIPTION
## Summary

`pruneEventTableByCount` (`eventRetention.ts`) and `runAmortizedRetention`
(`rowCapRetention.ts`) each reset `state.insertsSinceCleanup = 0` immediately after the
counter tripped `checkInterval`, **before** checking `state.cleanupInProgress`. So a call
that then bailed out because a cleanup was already running had already discarded the
counter — silently re-arming a fresh `checkInterval`-insert delay and **dropping the gate**
under sustained write bursts.

Moving the reset to **after** the `if (state.cleanupInProgress) return;` guard means it
only runs on the branch that actually starts a cleanup. A bail-out now leaves the counter
at-or-above `checkInterval`, so the very next insert re-checks the guard immediately.
Identical reorder in both files (independent copies — deduplication is the separate #6702).

Part of epic #6379 (retention cluster head; #6464 and #6702 build on this).

## Linked Issue

Closes #6657

## Validation

- [x] `test/db/eventRetention.integration.test.ts` + `test/db/rowCapRetention.integration.test.ts` — 50 pass. New per-file test: inject a small `checkInterval`, park a first call mid-cleanup, fire a synchronous burst, assert the counter stays armed (≥ `checkInterval`) rather than reset to 0. Red first (counter was 0). Full `test/db` — 1060 pass.
- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — all clean.

## Follow-ups
- Scoped strictly to the counter-vs-guard ordering; the eventRetention/rowCapRetention duplication (#6702) and new-table retention (#6464) are separate.
