### PR TITLE
fix(logging): bounded close policy for closeLogStream so it can't hang forever (#6700)

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -334,7 +334,6 @@ export function closeLogStream(
     // hang this promise forever.
     const onError = (error: Error): void => {
       pendingError = error;
-      stream.destroy?.(error);
       timeoutHandle = timer.setTimeout(() => {
         settle(() =>
           reject(
@@ -345,6 +344,13 @@ export function closeLogStream(
           ),
         );
       }, timeoutMs);
+      // Let every listener record the error before a synchronous destroy can
+      // emit close (concurrent close callers may share this stream).
+      queueMicrotask(() => {
+        if (!settled) {
+          stream.destroy?.(error);
+        }
+      });
     };
     const onClose = (): void => settle(() => (pendingError ? reject(pendingError) : resolve()));
     stream.once("error", onError);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -11,6 +11,8 @@ import {
   resolveAutomobileLogSink,
   writeEmergencyLog,
 } from "./loggingConfig";
+import { Timer, defaultTimer } from "./SystemTimer";
+import { toActionableError } from "../models/ActionableError";
 
 export {
   parseAutomobileLogFormat,
@@ -246,7 +248,22 @@ interface EndableLogStream {
   // Node/Bun WriteStreams expose this once the fd has actually been released.
   // Optional so plain EventEmitter fakes that never set it still type-check.
   readonly closed?: boolean;
+  // Node/Bun WriteStreams (via Writable) expose this. Called only on the
+  // error-without-close path below, to nudge a stalled fd toward release
+  // rather than passively waiting on a `close` that may never come. Optional
+  // so plain EventEmitter fakes that never implement it still type-check.
+  destroy?(error?: Error): void;
 }
+
+// Bounds how long closeLogStream() waits for the confirming `close` once an
+// `error` has been observed during shutdown. `error` does not guarantee the
+// fd was released (see the doc above closeLogStream) -- explicitly destroying
+// the stream nudges a stalled descriptor toward release, but a supported
+// runtime that changes this ordering (or a genuinely wedged descriptor) must
+// not hang the caller -- and therefore log rotation / process shutdown --
+// forever (issue #6700). Chosen generously: rotation and shutdown are not
+// latency-sensitive, so this only ever matters on the already-broken path.
+export const CLOSE_LOG_STREAM_TIMEOUT_MS = 5_000;
 
 /**
  * Resolves once a log stream has ACTUALLY closed (its file descriptor
@@ -272,14 +289,33 @@ interface EndableLogStream {
  *    `logger.close()` / `closeAfterFlush()`) never emits a second `close` —
  *    Node/Bun only fire it once per stream — so waiting for a listener would
  *    hang forever. Check `closed` up front and resolve immediately.
+ *
+ * Bounded close policy (issue #6700): the ordering above is the observed
+ * contract on the runtimes this was verified against, not a guarantee the
+ * platform makes. If a supported runtime (or an already-broken stream) emits
+ * `error` and then never emits `close`, this must not hang the caller
+ * forever. So once an `error` is observed, this (a) explicitly `destroy()`s
+ * the stream if it exposes that method, nudging a stalled fd toward release,
+ * and (b) starts a bounded timer. The `close` listener stays authoritative —
+ * a `close` that arrives before the bound (whether from the normal shutdown
+ * or as a result of the `destroy()` call) still settles exactly as before,
+ * rejecting with the recorded error. Only if `close` never arrives within
+ * `timeoutMs` does this reject with an actionable timeout instead of hanging.
+ * Deliberately does NOT settle immediately on `error` alone — that would
+ * recreate the fd race fixed by #6149.
  */
-export function closeLogStream(stream: EndableLogStream): Promise<void> {
+export function closeLogStream(
+  stream: EndableLogStream,
+  timer: Timer = defaultTimer,
+  timeoutMs: number = CLOSE_LOG_STREAM_TIMEOUT_MS,
+): Promise<void> {
   if (stream.closed) {
     return Promise.resolve();
   }
   return new Promise((resolve, reject) => {
     let settled = false;
     let pendingError: Error | undefined;
+    let timeoutHandle: NodeJS.Timeout | undefined;
     const settle = (run: () => void): void => {
       if (settled) {
         return;
@@ -287,12 +323,28 @@ export function closeLogStream(stream: EndableLogStream): Promise<void> {
       settled = true;
       stream.off("error", onError);
       stream.off("close", onClose);
+      if (timeoutHandle !== undefined) {
+        timer.clearTimeout(timeoutHandle);
+      }
       run();
     };
     // Do NOT settle here — only record the error and keep waiting for the
-    // `close` that confirms the fd is actually released.
+    // `close` that confirms the fd is actually released. Do arm the bounded
+    // fallback below so an error that is never followed by `close` cannot
+    // hang this promise forever.
     const onError = (error: Error): void => {
       pendingError = error;
+      stream.destroy?.(error);
+      timeoutHandle = timer.setTimeout(() => {
+        settle(() =>
+          reject(
+            toActionableError(
+              error,
+              `Log stream did not emit 'close' within ${timeoutMs}ms of a shutdown error — the file descriptor may still be held`,
+            ),
+          ),
+        );
+      }, timeoutMs);
     };
     const onClose = (): void => settle(() => (pendingError ? reject(pendingError) : resolve()));
     stream.once("error", onError);

--- a/test/utils/logger-close.integration.test.ts
+++ b/test/utils/logger-close.integration.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeLogStream } from "../../src/utils/logger";
+
+describe("real fs.WriteStream close ordering contract (#6700)", () => {
+  /**
+   * Records the ACTUAL event ordering a real `fs.WriteStream` delivers on
+   * this runtime, so a Bun/Node upgrade that reorders finish/error/close (or
+   * flips `closed` early) fails this test directly instead of surfacing only
+   * as a mysterious rotation/shutdown hang.
+   */
+  test("end() sequences finish before close, and 'closed' only flips once 'close' fires", async () => {
+    const dir = fs.mkdtempSync(join(tmpdir(), "am-logger-close-contract-"));
+    const target = join(dir, "contract.log");
+    const stream = fs.createWriteStream(target, { flags: "a" });
+    try {
+      const events: string[] = [];
+      let errorSeen: Error | undefined;
+      stream.on("error", (error: Error) => {
+        errorSeen = error;
+        events.push("error");
+      });
+      const closedAtFinish = new Promise<boolean>((resolve) => {
+        stream.once("finish", () => {
+          events.push("finish");
+          resolve(stream.closed ?? false);
+        });
+      });
+      const closeEvent = new Promise<void>((resolve) => {
+        stream.once("close", () => {
+          events.push("close");
+          resolve();
+        });
+      });
+
+      stream.write("contract line\n");
+      stream.end();
+
+      await closeEvent;
+
+      expect(errorSeen).toBeUndefined();
+      // The fd must NOT be released yet when `finish` fires — only `close`
+      // confirms that. If a runtime upgrade flips this, closeLogStream's
+      // close-before-reopen guarantee (#6149) no longer holds.
+      expect(await closedAtFinish).toBeFalse();
+      expect(stream.closed).toBeTrue();
+      expect(events).toEqual(["finish", "close"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("closeLogStream resolves against a real WriteStream once the fd is actually released", async () => {
+    const dir = fs.mkdtempSync(join(tmpdir(), "am-logger-close-contract-"));
+    const target = join(dir, "contract-real.log");
+    const stream = fs.createWriteStream(target, { flags: "a" });
+    try {
+      stream.write("line\n");
+      await closeLogStream(stream);
+      expect(stream.closed).toBeTrue();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/utils/logger-close.test.ts
+++ b/test/utils/logger-close.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { closeLogStream } from "../../src/utils/logger";
+import { ActionableError } from "../../src/models/ActionableError";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 /**
  * Models a WriteStream's shutdown the way the runtime actually sequences it:
@@ -117,5 +122,152 @@ describe("closeLogStream (#6149)", () => {
     stream.emitClose();
 
     await expect(closeLogStream(stream)).resolves.toBeUndefined();
+  });
+});
+
+describe("closeLogStream bounded close policy (#6700)", () => {
+  /**
+   * Emits `error` after `end()` and NEVER emits `close` — models a supported
+   * runtime that breaks the finish/error/close ordering `closeLogStream`
+   * depends on (see its doc comment). Also records every `destroy()` call so
+   * tests can assert the injected policy explicitly tries to force descriptor
+   * release rather than passively waiting on a `close` that never arrives.
+   */
+  class NeverClosesAfterErrorStream extends EventEmitter {
+    closed = false;
+    destroyCalls: Array<Error | undefined> = [];
+
+    end(): void {
+      queueMicrotask(() => this.emit("error", new Error("write failed, fd wedged")));
+    }
+
+    destroy(error?: Error): void {
+      this.destroyCalls.push(error);
+      // Worst case: even an explicit destroy does not release the fd on this
+      // (hypothetical) runtime — `close` still never arrives.
+    }
+  }
+
+  test("rejects with a bounded ActionableError instead of hanging when 'close' never follows an error", async () => {
+    const stream = new NeverClosesAfterErrorStream();
+    const timer = new FakeTimer();
+    const timeoutMs = 5_000;
+    let settled = false;
+    let rejection: unknown;
+    const close = closeLogStream(stream, timer, timeoutMs).catch((error) => {
+      settled = true;
+      rejection = error;
+      throw error;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    // The error alone must not settle the promise — settling here would
+    // recreate the fd race #6149 fixed. It must, however, have already tried
+    // to force the descriptor closed.
+    expect(settled).toBeFalse();
+    expect(stream.destroyCalls).toHaveLength(1);
+    expect(stream.destroyCalls[0]).toBeInstanceOf(Error);
+
+    // Still short of the bound: must remain pending.
+    timer.advanceTime(timeoutMs - 1);
+    await Promise.resolve();
+    expect(settled).toBeFalse();
+
+    // Crossing the bound with no confirming `close` must reject with an
+    // actionable timeout rather than hang forever.
+    timer.advanceTime(1);
+    await expect(close).rejects.toBeInstanceOf(ActionableError);
+    expect(settled).toBeTrue();
+    expect((rejection as Error).message).toContain("close");
+  });
+
+  test("still rejects with the recorded error, not the timeout, when 'close' arrives before the bound", async () => {
+    // A policy that always waits out the full bound (instead of treating
+    // `close` as authoritative) would delay every ordinary error->close
+    // shutdown by the full timeout. Guard against that regression.
+    class ClosesShortlyAfterDestroy extends EventEmitter {
+      closed = false;
+      end(): void {
+        queueMicrotask(() => this.emit("error", new Error("transient")));
+      }
+      destroy(): void {
+        queueMicrotask(() => {
+          this.closed = true;
+          this.emit("close");
+        });
+      }
+    }
+    const stream = new ClosesShortlyAfterDestroy();
+    const timer = new FakeTimer();
+
+    const close = closeLogStream(stream, timer, 5_000);
+
+    await expect(close).rejects.toThrow("transient");
+    // The bounded fallback timer must have been armed and then cleared by
+    // the confirming `close`, not left pending or fired.
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+});
+
+describe("real fs.WriteStream close ordering contract (#6700)", () => {
+  /**
+   * Records the ACTUAL event ordering a real `fs.WriteStream` delivers on
+   * this runtime, so a Bun/Node upgrade that reorders finish/error/close (or
+   * flips `closed` early) fails this test directly instead of surfacing only
+   * as a mysterious rotation/shutdown hang.
+   */
+  test("end() sequences finish before close, and 'closed' only flips once 'close' fires", async () => {
+    const dir = fs.mkdtempSync(join(tmpdir(), "am-logger-close-contract-"));
+    const target = join(dir, "contract.log");
+    const stream = fs.createWriteStream(target, { flags: "a" });
+    try {
+      const events: string[] = [];
+      let errorSeen: Error | undefined;
+      stream.on("error", (error: Error) => {
+        errorSeen = error;
+        events.push("error");
+      });
+      const closedAtFinish = new Promise<boolean>((resolve) => {
+        stream.once("finish", () => {
+          events.push("finish");
+          resolve(stream.closed ?? false);
+        });
+      });
+      const closeEvent = new Promise<void>((resolve) => {
+        stream.once("close", () => {
+          events.push("close");
+          resolve();
+        });
+      });
+
+      stream.write("contract line\n");
+      stream.end();
+
+      await closeEvent;
+
+      expect(errorSeen).toBeUndefined();
+      // The fd must NOT be released yet when `finish` fires — only `close`
+      // confirms that. If a runtime upgrade flips this, closeLogStream's
+      // close-before-reopen guarantee (#6149) no longer holds.
+      expect(await closedAtFinish).toBeFalse();
+      expect(stream.closed).toBeTrue();
+      expect(events).toEqual(["finish", "close"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("closeLogStream resolves against a real WriteStream once the fd is actually released", async () => {
+    const dir = fs.mkdtempSync(join(tmpdir(), "am-logger-close-contract-"));
+    const target = join(dir, "contract-real.log");
+    const stream = fs.createWriteStream(target, { flags: "a" });
+    try {
+      stream.write("line\n");
+      await closeLogStream(stream);
+      expect(stream.closed).toBeTrue();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/utils/logger-close.test.ts
+++ b/test/utils/logger-close.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
-import fs from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { closeLogStream } from "../../src/utils/logger";
 import { ActionableError } from "../../src/models/ActionableError";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -207,67 +204,5 @@ describe("closeLogStream bounded close policy (#6700)", () => {
     // The bounded fallback timer must have been armed and then cleared by
     // the confirming `close`, not left pending or fired.
     expect(timer.getPendingTimeoutCount()).toBe(0);
-  });
-});
-
-describe("real fs.WriteStream close ordering contract (#6700)", () => {
-  /**
-   * Records the ACTUAL event ordering a real `fs.WriteStream` delivers on
-   * this runtime, so a Bun/Node upgrade that reorders finish/error/close (or
-   * flips `closed` early) fails this test directly instead of surfacing only
-   * as a mysterious rotation/shutdown hang.
-   */
-  test("end() sequences finish before close, and 'closed' only flips once 'close' fires", async () => {
-    const dir = fs.mkdtempSync(join(tmpdir(), "am-logger-close-contract-"));
-    const target = join(dir, "contract.log");
-    const stream = fs.createWriteStream(target, { flags: "a" });
-    try {
-      const events: string[] = [];
-      let errorSeen: Error | undefined;
-      stream.on("error", (error: Error) => {
-        errorSeen = error;
-        events.push("error");
-      });
-      const closedAtFinish = new Promise<boolean>((resolve) => {
-        stream.once("finish", () => {
-          events.push("finish");
-          resolve(stream.closed ?? false);
-        });
-      });
-      const closeEvent = new Promise<void>((resolve) => {
-        stream.once("close", () => {
-          events.push("close");
-          resolve();
-        });
-      });
-
-      stream.write("contract line\n");
-      stream.end();
-
-      await closeEvent;
-
-      expect(errorSeen).toBeUndefined();
-      // The fd must NOT be released yet when `finish` fires — only `close`
-      // confirms that. If a runtime upgrade flips this, closeLogStream's
-      // close-before-reopen guarantee (#6149) no longer holds.
-      expect(await closedAtFinish).toBeFalse();
-      expect(stream.closed).toBeTrue();
-      expect(events).toEqual(["finish", "close"]);
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("closeLogStream resolves against a real WriteStream once the fd is actually released", async () => {
-    const dir = fs.mkdtempSync(join(tmpdir(), "am-logger-close-contract-"));
-    const target = join(dir, "contract-real.log");
-    const stream = fs.createWriteStream(target, { flags: "a" });
-    try {
-      stream.write("line\n");
-      await closeLogStream(stream);
-      expect(stream.closed).toBeTrue();
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
   });
 });

--- a/test/utils/logger-close.test.ts
+++ b/test/utils/logger-close.test.ts
@@ -123,6 +123,26 @@ describe("closeLogStream (#6149)", () => {
 });
 
 describe("closeLogStream bounded close policy (#6700)", () => {
+  test("clears the timeout when destroy closes synchronously", async () => {
+    class SynchronousCloseStream extends FakeLogStream {
+      destroy(): void {
+        this.emitClose();
+      }
+    }
+    const stream = new SynchronousCloseStream();
+    const timer = new FakeTimer();
+    const error = new Error("close failed");
+    const close = closeLogStream(stream, timer);
+    const concurrentClose = closeLogStream(stream, timer);
+    const outcomes = Promise.allSettled([close, concurrentClose]);
+    stream.failClose(error);
+    expect(await outcomes).toEqual([
+      { status: "rejected", reason: error },
+      { status: "rejected", reason: error },
+    ]);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
   /**
    * Emits `error` after `end()` and NEVER emits `close` — models a supported
    * runtime that breaks the finish/error/close ordering `closeLogStream`


### PR DESCRIPTION
## Summary

`closeLogStream` waits for the WriteStream `close` event and deliberately does **not**
settle on `error` (avoiding the #6149 fd-race where rotation reopens a path before the
old fd is released). But if a supported runtime emits `error` without a following
`close`, nothing settles the promise — and `rotateLogFile` / `closeAfterFlush` await it,
so log rotation or shutdown can hang forever with no timeout and no diagnostic.

Adds an injected, bounded close policy: an injected `Timer` + `timeoutMs`
(`CLOSE_LOG_STREAM_TIMEOUT_MS`, default 5s). `onClose` stays authoritative and settles
exactly as before (clearing the timer), so a prompt close never waits out the bound and
the #6149 no-settle-on-error behavior is preserved. On `error`, it additionally calls
`stream.destroy?.(error)` to nudge the descriptor toward release and arms the timer;
only if `close` never arrives within `timeoutMs` does it reject with a
`toActionableError`-wrapped timeout instead of hanging. The `closed` fast path is
untouched.

Part of epic #6379. Scoped to `closeLogStream` — `checkAndRotateLog`/rotation (#6651,
merged) is untouched.

## Linked Issue

Closes #6700

## Validation

- [x] `test/utils/logger-close.test.ts` — 8 pass. New: a fake stream that errors and never closes settles with a **bounded** rejection under FakeTimer (was an indefinite hang — RED confirmed via a real-timer repro), plus a real `fs.WriteStream` contract test pinning `finish`/`close` ordering + `closed` timing on this runtime (fails loudly if a Bun upgrade changes it, by design). Full logger suite — 66 pass.
- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — all clean.

## Follow-ups
- `CLOSE_LOG_STREAM_TIMEOUT_MS` (5s) is generous (rotation/shutdown aren't latency-sensitive); a latency-sensitive caller can pass its own `timeoutMs`.
