### PR TITLE
fix(perf): PerformanceTracker fork() so concurrent branches don't misparent timings (#6706)

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1066,9 +1066,15 @@ export class RealObserveScreen implements ObserveScreen {
             ),
           );
           if (!skipBackStack) {
+            // Fork: collectBackStack's own perf.track() calls run concurrently
+            // with the wakefulness/deviceLock tracks above on this same
+            // Promise.all. A shared tracker's cursor is ambient mutable state,
+            // so without a fork, block-open/close activity deep in the back
+            // stack collector could misparent (or wrongly pop) the sibling
+            // tracks' timings (issue #6706).
             parallelTasks.push(
               perf.track("backStack", () =>
-                this.deviceStateCollector.collectBackStack(result, perf, signal),
+                this.deviceStateCollector.collectBackStack(result, perf.fork(), signal),
               ),
             );
           }
@@ -1089,9 +1095,12 @@ export class RealObserveScreen implements ObserveScreen {
             ),
           ];
           if (!skipBackStack) {
+            // Fork for the same reason as the branch above (issue #6706):
+            // this track runs concurrently with the wakefulness/deviceLock
+            // tracks on the same shared tracker.
             tasks.push(
               perf.track("backStack", () =>
-                this.deviceStateCollector.collectBackStack(result, perf, signal),
+                this.deviceStateCollector.collectBackStack(result, perf.fork(), signal),
               ),
             );
           }

--- a/src/utils/PerformanceTracker.ts
+++ b/src/utils/PerformanceTracker.ts
@@ -104,28 +104,62 @@ export interface PerformanceTracker {
    * @param name - Operation name (must match startOperation)
    */
   endOperation(name: string): void;
+
+  /**
+   * Return an independent branch-scoped tracker anchored to the block that
+   * is current right now. Call this before spawning concurrent work (e.g.
+   * one of several `Promise.all` branches) that may open or close its own
+   * nested `serial`/`parallel` blocks.
+   *
+   * Without forking, every branch shares one mutable cursor: one branch
+   * opening a nested block moves where a sibling branch's `track()`/`end()`
+   * lands, misparenting timings or letting one branch pop a block another
+   * branch opened (issue #6706). A fork's own `serial`/`parallel`/`track`/
+   * `end` calls move only its own cursor -- entries recorded through the
+   * fork are appended to the same shared parent block, but nesting further
+   * inside the fork never affects the tracker that produced it (or any of
+   * its other forks).
+   */
+  fork(): PerformanceTracker;
 }
 
 /**
  * Default implementation of performance tracking
  */
 export class DefaultPerformanceTracker implements PerformanceTracker {
-  private root: TimingBlock;
   private current: TimingBlock;
   private timer: Timer;
+  /**
+   * The block this instance must never close past. For the top-level
+   * tracker this is the implicit root (`parent === null`), so it never
+   * changes existing behavior. For a `fork()`, it is the block that was
+   * current at fork time -- `end()`/`getTimings()` on the fork stop there
+   * instead of climbing (and closing) blocks that belong to the tracker it
+   * was forked from.
+   */
+  private readonly floor: TimingBlock;
 
-  constructor(timer: Timer = defaultTimer) {
+  constructor(timer: Timer = defaultTimer, anchor?: TimingBlock) {
     this.timer = timer;
-    const startMs = this.timer.now();
-    // Initialize with a root serial block
-    this.root = {
-      name: "root",
-      type: "serial",
-      startMs,
-      entries: [],
-      parent: null,
-    };
-    this.current = this.root;
+    if (anchor) {
+      this.floor = anchor;
+      this.current = anchor;
+    } else {
+      // Initialize with a root serial block
+      const root: TimingBlock = {
+        name: "root",
+        type: "serial",
+        startMs: this.timer.now(),
+        entries: [],
+        parent: null,
+      };
+      this.floor = root;
+      this.current = root;
+    }
+  }
+
+  fork(): PerformanceTracker {
+    return new DefaultPerformanceTracker(this.timer, this.current);
   }
 
   serial(name: string): PerformanceTracker {
@@ -154,42 +188,50 @@ export class DefaultPerformanceTracker implements PerformanceTracker {
 
   async track<T>(name: string, fn: () => Promise<T>): Promise<T> {
     const startMs = this.timer.now();
+    // Capture the parent block NOW, synchronously, rather than reading
+    // `this.current` again once `fn` settles. `this.current` is mutable
+    // ambient state; if another concurrent branch on this same instance (or
+    // a caller that forgot to fork) opens/closes blocks while `fn` is
+    // in-flight, the block that was current at settle time may no longer be
+    // the one this call actually started under (issue #6706).
+    const parentBlock = this.current;
     try {
       return await fn();
     } finally {
       const durationMs = this.timer.now() - startMs;
       const entry: TimingEntry = { name, durationMs };
 
-      if (Array.isArray(this.current.entries)) {
+      if (Array.isArray(parentBlock.entries)) {
         // Serial block - push to array
-        this.current.entries.push(entry);
+        parentBlock.entries.push(entry);
       } else {
         // Parallel block - add to object
-        this.current.entries[name] = entry;
+        parentBlock.entries[name] = entry;
       }
     }
   }
 
   trackSync<T>(name: string, fn: () => T): T {
     const startMs = this.timer.now();
+    const parentBlock = this.current;
     try {
       return fn();
     } finally {
       const durationMs = this.timer.now() - startMs;
       const entry: TimingEntry = { name, durationMs };
 
-      if (Array.isArray(this.current.entries)) {
+      if (Array.isArray(parentBlock.entries)) {
         // Serial block - push to array
-        this.current.entries.push(entry);
+        parentBlock.entries.push(entry);
       } else {
         // Parallel block - add to object
-        this.current.entries[name] = entry;
+        parentBlock.entries[name] = entry;
       }
     }
   }
 
   end(): PerformanceTracker {
-    if (this.current.parent) {
+    if (this.current !== this.floor && this.current.parent) {
       const durationMs = this.timer.now() - this.current.startMs;
       const entry: TimingEntry = {
         name: this.current.name,
@@ -209,13 +251,16 @@ export class DefaultPerformanceTracker implements PerformanceTracker {
   }
 
   getTimings(): TimingData | null {
-    // Close any unclosed blocks
-    while (this.current.parent) {
+    // Close any unclosed blocks, but never past this instance's floor: a
+    // fork must not finalize blocks owned by the tracker it was forked
+    // from (or by a sibling fork).
+    while (this.current !== this.floor && this.current.parent) {
       this.end();
     }
 
-    // Return the root's entries
-    return this.root.entries as TimingData;
+    // Return the floor's entries (the true root for the top-level tracker;
+    // the anchor block for a fork).
+    return this.floor.entries as TimingData;
   }
 
   isEnabled(): boolean {
@@ -316,6 +361,11 @@ export class NoOpPerformanceTracker implements PerformanceTracker {
 
   endOperation(_name: string): void {
     // No-op
+  }
+
+  fork(): PerformanceTracker {
+    // No state to isolate -- every method above is already a pass-through.
+    return this;
   }
 }
 

--- a/test/utils/PerformanceTracker.test.ts
+++ b/test/utils/PerformanceTracker.test.ts
@@ -157,6 +157,85 @@ describe("PerformanceTracker", function () {
       expect(timings).toHaveLength(1);
       expect(timings[0].name).toBe("unclosed");
     });
+
+    // Issue #6706: a single mutable `current` cursor, shared ambiently across
+    // concurrent branches, misparents timings when one branch opens a nested
+    // block while a sibling branch is still in flight on the same tracker.
+    describe("concurrent branches (issue #6706)", function () {
+      test("a branch opening a nested block does not misparent a concurrent sibling's timing", async function () {
+        tracker.parallel("root");
+
+        // Branch A gets its own independent cursor, anchored to whatever is
+        // current right now ("root"). Opening a nested block on the fork
+        // must not move the tracker's own cursor out from under branch B.
+        const branchA = tracker.fork();
+        const parkedA = deferred();
+        let endedA = false;
+
+        const branchAPromise = (async () => {
+          branchA.serial("A-child");
+          await parkedA.promise;
+          branchA.end();
+          endedA = true;
+        })();
+
+        // Branch A has opened "A-child" and is now parked awaiting
+        // parkedA.promise -- it has NOT called end() yet. Branch B runs to
+        // completion on the ORIGINAL tracker while that block is still open.
+        expect(endedA).toBe(false);
+        tracker.trackSync("B", () => {
+          fakeTimer.advanceTime(1);
+        });
+
+        // Release branch A and let it close its own block.
+        parkedA.resolve();
+        await branchAPromise;
+        expect(endedA).toBe(true);
+
+        tracker.end(); // close "root"
+
+        const timings = tracker.getTimings() as TimingEntry[];
+        expect(timings).toHaveLength(1);
+
+        const root = timings[0];
+        expect(root.name).toBe("root");
+        const rootChildren = root.children as Record<string, TimingEntry>;
+        expect(Array.isArray(rootChildren)).toBe(false);
+
+        // B must be root's sibling entry, not nested inside A-child.
+        expect(Object.keys(rootChildren).sort()).toEqual(["A-child", "B"]);
+
+        const aChild = rootChildren["A-child"];
+        expect(aChild).toBeDefined();
+        const aChildChildren = aChild.children as TimingEntry[];
+        expect(Array.isArray(aChildChildren)).toBe(true);
+        expect(aChildChildren).toHaveLength(0);
+
+        expect(rootChildren["B"]).toBeDefined();
+        expect(rootChildren["B"].name).toBe("B");
+      });
+
+      test("ending a fork does not close a block owned by the tracker it was forked from", function () {
+        tracker.parallel("root");
+        const branchA = tracker.fork();
+
+        // The fork never opened anything of its own, so it is already at its
+        // floor ("root"). end() on it must be a no-op rather than reaching
+        // past its floor and closing "root" out from under the tracker that
+        // produced it.
+        branchA.end();
+        branchA.end();
+
+        tracker.trackSync("stillInsideRoot", () => {});
+        tracker.end();
+
+        const timings = tracker.getTimings() as TimingEntry[];
+        expect(timings).toHaveLength(1);
+        expect(timings[0].name).toBe("root");
+        const rootChildren = timings[0].children as Record<string, TimingEntry>;
+        expect(Object.keys(rootChildren)).toEqual(["stillInsideRoot"]);
+      });
+    });
   });
 
   describe("NoOpPerformanceTracker", function () {
@@ -496,4 +575,16 @@ async function trackWithDelay(
   });
   timer.advanceTime(ms);
   await promise;
+}
+
+/**
+ * A promise plus its own resolve function, for parking a branch mid-flight
+ * without relying on real timers.
+ */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
 }


### PR DESCRIPTION
## Summary

`DefaultPerformanceTracker` tracked nesting with one mutable process-local `current`
cursor. `track()` captured only its start time and, when its async callback settled,
appended to whichever block was `this.current` at that **later** instant — so when
production code passes one tracker into concurrent work (e.g. `ObserveScreen.collectAllData`'s
`Promise.all` branches), one branch's timings were misparented under a block another
branch had opened, and `end()` could pop a block a sibling opened, corrupting the
`--debug-perf` tree. (Diagnostics-only, but misleading.)

Makes block ownership explicit:
- **`fork()`** (new) returns an independent tracker anchored to the current block, with
  its own `current` cursor and a `floor` — its `serial`/`parallel`/`end`/`track` move only
  its own cursor and can never pop/mutate a block owned by the parent or a sibling fork.
- `track()`/`trackSync()` capture the parent block **at invocation** and append there.
- `NoOpPerformanceTracker.fork()` returns `this`; `ObserveScreen` forks `perf` for the
  concurrent backStack branch.

No global mutex — branches stay concurrent. Part of epic #6379.

## Linked Issue

Closes #6706

## Validation

- [x] `test/utils/PerformanceTracker.test.ts` — 31 pass. New concurrent-branch tests; **red first**: a naive `fork()` returning `this` reproduced the issue exactly (B lands under `A-child` instead of as root's sibling; pop order corrupted). `test/utils` (3029) + `test/features/observe` (2488) + `test/features/action` — all pass.
- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — all clean.

## Follow-ups
- `addExternalTiming`/`startOperation`/`endOperation` still use the ambient cursor (nothing in scope exercises them across concurrent branches); a future concurrent caller of those should `fork()` first.
