### PR TITLE
refactor(db): extract shared amortized-retention gate (#6702)

### DIFF
--- a/src/db/eventRepositoryBase.ts
+++ b/src/db/eventRepositoryBase.ts
@@ -6,6 +6,7 @@ import {
   type EventRetentionState,
   type EventTableName,
 } from "./eventRetention";
+import { createAmortizedRetentionState } from "./retentionGate";
 
 export type { EventRetentionState, EventTableName } from "./eventRetention";
 
@@ -21,9 +22,7 @@ export function getDb(db?: Kysely<Database>): Kysely<Database> {
 }
 
 /** A fresh, isolated retention counter for one event repository. */
-export function createEventRetentionState(): EventRetentionState {
-  return { cleanupInProgress: false, insertsSinceCleanup: 0 };
-}
+export const createEventRetentionState: () => EventRetentionState = createAmortizedRetentionState;
 
 /**
  * Parameterized retention wrapper shared by the six event repositories, whose

--- a/src/db/eventRetention.ts
+++ b/src/db/eventRetention.ts
@@ -3,6 +3,7 @@ import type { Database } from "./types";
 import type { EVENT_TABLES } from "./eventTables";
 import { getDatabase } from "./database";
 import { logger } from "../utils/logger";
+import { runAmortizedRetentionGate, type AmortizedRetentionState } from "./retentionGate";
 
 export const RETENTION_MAX_ROWS = 10_000;
 
@@ -13,10 +14,8 @@ export const CLEANUP_CHECK_INTERVAL = 256;
 
 export type EventTableName = (typeof EVENT_TABLES)[number];
 
-export interface EventRetentionState {
-  cleanupInProgress: boolean;
-  insertsSinceCleanup: number;
-}
+/** @deprecated Alias of the shared {@link AmortizedRetentionState} (#6702). */
+export type EventRetentionState = AmortizedRetentionState;
 
 export async function pruneEventTableByCount(
   db: Kysely<Database> | undefined,
@@ -29,62 +28,54 @@ export async function pruneEventTableByCount(
   // every `checkInterval` rows rather than every `checkInterval` batches.
   inserted: number = 1,
 ): Promise<void> {
-  // The counter is bumped synchronously on every call, so retention still fires
-  // deterministically every N inserts without putting a scan on the hot path.
-  state.insertsSinceCleanup += inserted;
-  if (state.insertsSinceCleanup < checkInterval) {
-    return;
-  }
+  // The counter/guard state machine is shared with rowCapRetention.ts (#6702);
+  // this wrapper owns only the event-specific cleanup body and its
+  // logging-and-swallowing error policy (CLAUDE.md convention #2).
+  await runAmortizedRetentionGate(
+    state,
+    async () => {
+      try {
+        const resolvedDb = db ?? (getDatabase() as unknown as Kysely<Database>);
+        const count = await resolvedDb
+          .selectFrom(table)
+          .select(resolvedDb.fn.countAll().as("count"))
+          .executeTakeFirstOrThrow();
 
-  // Only reset the counter once we've committed to running the cleanup body.
-  // If a cleanup is already in progress, leave the counter at-or-above
-  // `checkInterval` so the very next insert re-checks this gate instead of
-  // silently re-arming a fresh `checkInterval`-insert countdown (#6657).
-  if (state.cleanupInProgress) {
-    return;
-  }
-  state.insertsSinceCleanup = 0;
-  state.cleanupInProgress = true;
-  try {
-    const resolvedDb = db ?? (getDatabase() as unknown as Kysely<Database>);
-    const count = await resolvedDb
-      .selectFrom(table)
-      .select(resolvedDb.fn.countAll().as("count"))
-      .executeTakeFirstOrThrow();
+        if (Number(count.count) > maxRows) {
+          // Canonical retention idiom (#3137): pick the Nth-newest row as the
+          // threshold (offset maxRows - 1) and delete everything strictly older,
+          // breaking cutoff-timestamp ties on the monotonic `id`. This trims to
+          // *exactly* maxRows rows and deterministically prunes same-timestamp rows,
+          // unlike the prior `offset(maxRows)` + `timestamp < cutoff` form, which
+          // retained maxRows + 1 rows and could never remove rows equal to the
+          // cutoff timestamp (a burst of same-millisecond events at the cutoff could
+          // retain more than maxRows).
+          const threshold = await resolvedDb
+            .selectFrom(table)
+            .select(["id", "timestamp"])
+            .orderBy("timestamp", "desc")
+            .orderBy("id", "desc")
+            .limit(1)
+            .offset(maxRows - 1)
+            .executeTakeFirst();
 
-    if (Number(count.count) > maxRows) {
-      // Canonical retention idiom (#3137): pick the Nth-newest row as the
-      // threshold (offset maxRows - 1) and delete everything strictly older,
-      // breaking cutoff-timestamp ties on the monotonic `id`. This trims to
-      // *exactly* maxRows rows and deterministically prunes same-timestamp rows,
-      // unlike the prior `offset(maxRows)` + `timestamp < cutoff` form, which
-      // retained maxRows + 1 rows and could never remove rows equal to the
-      // cutoff timestamp (a burst of same-millisecond events at the cutoff could
-      // retain more than maxRows).
-      const threshold = await resolvedDb
-        .selectFrom(table)
-        .select(["id", "timestamp"])
-        .orderBy("timestamp", "desc")
-        .orderBy("id", "desc")
-        .limit(1)
-        .offset(maxRows - 1)
-        .executeTakeFirst();
-
-      if (threshold) {
-        await resolvedDb
-          .deleteFrom(table)
-          .where((eb) =>
-            eb.or([
-              eb("timestamp", "<", threshold.timestamp),
-              eb.and([eb("timestamp", "=", threshold.timestamp), eb("id", "<", threshold.id)]),
-            ]),
-          )
-          .execute();
+          if (threshold) {
+            await resolvedDb
+              .deleteFrom(table)
+              .where((eb) =>
+                eb.or([
+                  eb("timestamp", "<", threshold.timestamp),
+                  eb.and([eb("timestamp", "=", threshold.timestamp), eb("id", "<", threshold.id)]),
+                ]),
+              )
+              .execute();
+          }
+        }
+      } catch (error) {
+        logger.warn(`${table} retention cleanup failed: ${error}`, error);
       }
-    }
-  } catch (error) {
-    logger.warn(`${table} retention cleanup failed: ${error}`, error);
-  } finally {
-    state.cleanupInProgress = false;
-  }
+    },
+    checkInterval,
+    inserted,
+  );
 }

--- a/src/db/retentionGate.ts
+++ b/src/db/retentionGate.ts
@@ -1,0 +1,60 @@
+// Shared amortized single-flight gate for row-cap retention cleanups (#6702).
+//
+// `eventRetention.ts` and `rowCapRetention.ts` each drove a byte-identical copy
+// of this state machine: bump a counter on every insert, skip until the counter
+// reaches `checkInterval`, and guard the cleanup body so overlapping calls never
+// run concurrently. The duplication let the same counter-reset-before-in-progress
+// bug (#6657) exist in both copies and require two separate fixes. This module is
+// the single implementation both now delegate to.
+
+/** Amortization counter + single-flight guard for one retained table/state owner. */
+export interface AmortizedRetentionState {
+  cleanupInProgress: boolean;
+  insertsSinceCleanup: number;
+}
+
+/** A fresh, zeroed amortization counter/guard pair. */
+export function createAmortizedRetentionState(): AmortizedRetentionState {
+  return { cleanupInProgress: false, insertsSinceCleanup: 0 };
+}
+
+/**
+ * Amortize `runCleanup` across inserts: bump `state.insertsSinceCleanup` by
+ * `inserted`, and only invoke `runCleanup` once the counter reaches
+ * `checkInterval` AND no cleanup is already in flight.
+ *
+ * The counter is bumped synchronously on every call so cleanup still fires
+ * deterministically every `checkInterval` inserts without putting a scan on the
+ * hot path. Critically, the counter is only reset once we've committed to
+ * running the cleanup body: if a cleanup is already in progress, the counter is
+ * left at-or-above `checkInterval` so the very next call re-checks this gate
+ * instead of silently re-arming a fresh `checkInterval`-insert countdown
+ * (#6657).
+ *
+ * `runCleanup` errors propagate to the caller — this gate does not own error
+ * handling policy. The guard is released via `finally` regardless of success or
+ * failure, so a caller that wants to swallow/log cleanup failures must do so
+ * inside `runCleanup` itself.
+ */
+export async function runAmortizedRetentionGate(
+  state: AmortizedRetentionState,
+  runCleanup: () => Promise<void>,
+  checkInterval: number,
+  inserted: number = 1,
+): Promise<void> {
+  state.insertsSinceCleanup += inserted;
+  if (state.insertsSinceCleanup < checkInterval) {
+    return;
+  }
+
+  if (state.cleanupInProgress) {
+    return;
+  }
+  state.insertsSinceCleanup = 0;
+  state.cleanupInProgress = true;
+  try {
+    await runCleanup();
+  } finally {
+    state.cleanupInProgress = false;
+  }
+}

--- a/src/db/rowCapRetention.ts
+++ b/src/db/rowCapRetention.ts
@@ -15,6 +15,11 @@
 
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
+import {
+  createAmortizedRetentionState,
+  runAmortizedRetentionGate,
+  type AmortizedRetentionState,
+} from "./retentionGate";
 
 // Run the cleanup body at most once per this many inserts. Worst-case overshoot
 // is bounded (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against a 10k
@@ -87,51 +92,28 @@ export async function pruneTableByRowCap(
   return Number(deleted.numDeletedRows ?? 0);
 }
 
-export interface RowCapRetentionState {
-  cleanupInProgress: boolean;
-  insertsSinceCleanup: number;
-}
+/** @deprecated Alias of the shared {@link AmortizedRetentionState} (#6702). */
+export type RowCapRetentionState = AmortizedRetentionState;
 
-export function createRowCapRetentionState(): RowCapRetentionState {
-  return { cleanupInProgress: false, insertsSinceCleanup: 0 };
-}
+export const createRowCapRetentionState = createAmortizedRetentionState;
 
 /**
  * Amortize a retention cleanup body across inserts.
  *
- * The counter is bumped synchronously on every call so cleanup still fires
- * deterministically every `checkInterval` inserts without putting the scan on
- * the hot path. When the gate trips, `runCleanup` runs behind an in-progress
- * guard that drops overlapping calls (the next insert will re-arm the gate).
- * `runCleanup` is expected to swallow its own errors; this wrapper only manages
- * the amortization counter and the guard.
+ * Delegates the counter/guard state machine to the shared
+ * {@link runAmortizedRetentionGate} (#6702) — this wrapper only fixes
+ * `inserted` at `1`, since these repos insert one capped row per call, so —
+ * unlike the batched event repositories — there is no per-batch insert count
+ * to thread through. `runCleanup` is expected to swallow its own errors;
+ * errors it does not swallow propagate to the caller.
  *
  * `checkInterval` is injectable so unit tests can trip the gate without 256
- * calls. (These repos insert one capped row per call, so — unlike the batched
- * event repositories — there is no per-batch insert count to thread through.)
+ * calls.
  */
 export async function runAmortizedRetention(
   state: RowCapRetentionState,
   runCleanup: () => Promise<void>,
   checkInterval: number = CLEANUP_CHECK_INTERVAL,
 ): Promise<void> {
-  state.insertsSinceCleanup += 1;
-  if (state.insertsSinceCleanup < checkInterval) {
-    return;
-  }
-
-  // Only reset the counter once we've committed to running the cleanup body.
-  // If a cleanup is already in progress, leave the counter at-or-above
-  // `checkInterval` so the very next insert re-checks this gate instead of
-  // silently re-arming a fresh `checkInterval`-insert countdown (#6657).
-  if (state.cleanupInProgress) {
-    return;
-  }
-  state.insertsSinceCleanup = 0;
-  state.cleanupInProgress = true;
-  try {
-    await runCleanup();
-  } finally {
-    state.cleanupInProgress = false;
-  }
+  await runAmortizedRetentionGate(state, runCleanup, checkInterval);
 }

--- a/test/db/retentionGate.test.ts
+++ b/test/db/retentionGate.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createAmortizedRetentionState,
+  runAmortizedRetentionGate,
+} from "../../src/db/retentionGate";
+
+/**
+ * Direct unit coverage for the shared amortized single-flight gate (#6702) that
+ * `eventRetention.ts` (`pruneEventTableByCount`) and `rowCapRetention.ts`
+ * (`runAmortizedRetention`) both now delegate to, so the counter/guard state
+ * machine is pinned exactly once instead of split across the two callers'
+ * integration suites. These tests cover:
+ *   1. counter bumps advance by `inserted` (default 1, and an explicit batch
+ *      size for the event-repository caller),
+ *   2. the gate fires the cleanup body at most once per `checkInterval`,
+ *   3. the in-progress guard drops overlapping runs and is released via
+ *      `finally` even when the cleanup body throws,
+ *   4. the #6657 invariant: a cleanup already in flight leaves the counter
+ *      armed rather than letting a bailed-out call silently re-zero it.
+ */
+describe("runAmortizedRetentionGate (#6702)", () => {
+  test("fires the cleanup body at most once per checkInterval calls", async () => {
+    const state = createAmortizedRetentionState();
+    let runs = 0;
+    const interval = 5;
+
+    for (let i = 0; i < interval - 1; i++) {
+      await runAmortizedRetentionGate(
+        state,
+        async () => {
+          runs++;
+        },
+        interval,
+      );
+    }
+    expect(runs).toBe(0);
+
+    await runAmortizedRetentionGate(
+      state,
+      async () => {
+        runs++;
+      },
+      interval,
+    );
+    expect(runs).toBe(1);
+    expect(state.insertsSinceCleanup).toBe(0);
+  });
+
+  test("a single call reporting a batch `inserted` count immediately arms the gate", async () => {
+    const state = createAmortizedRetentionState();
+    let runs = 0;
+    const interval = 5;
+
+    // Fewer than the interval: no-op.
+    await runAmortizedRetentionGate(
+      state,
+      async () => {
+        runs++;
+      },
+      interval,
+      interval - 1,
+    );
+    expect(runs).toBe(0);
+    expect(state.insertsSinceCleanup).toBe(interval - 1);
+
+    // The remaining single insert tips it over the interval.
+    await runAmortizedRetentionGate(
+      state,
+      async () => {
+        runs++;
+      },
+      interval,
+      1,
+    );
+    expect(runs).toBe(1);
+  });
+
+  test("the in-progress guard drops an overlapping run", async () => {
+    const state = createAmortizedRetentionState();
+    let running = 0;
+    let maxConcurrent = 0;
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const body = async (): Promise<void> => {
+      running++;
+      maxConcurrent = Math.max(maxConcurrent, running);
+      await gate;
+      running--;
+    };
+
+    const first = runAmortizedRetentionGate(state, body, 1);
+    const second = runAmortizedRetentionGate(state, body, 1);
+
+    release();
+    await Promise.all([first, second]);
+
+    expect(maxConcurrent).toBe(1);
+  });
+
+  test("a bailed-out call while a cleanup is in flight leaves the counter armed for the next insert (#6657)", async () => {
+    const state = createAmortizedRetentionState();
+    const checkInterval = 3;
+    let runs = 0;
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const body = async (): Promise<void> => {
+      runs++;
+      await gate;
+    };
+
+    // One insert away from tripping the gate.
+    state.insertsSinceCleanup = checkInterval - 1;
+
+    // This call trips the gate and parks inside the cleanup body (on `gate`).
+    const first = runAmortizedRetentionGate(state, body, checkInterval);
+
+    // A burst of checkInterval-worth of further inserts lands before that
+    // cleanup resolves. Each is fired without awaiting the prior one, so they
+    // run synchronously up to their own guard check while `first` is still
+    // parked — the exact interleaving from a sustained write burst.
+    const burst: Promise<void>[] = [];
+    for (let i = 0; i < checkInterval; i++) {
+      burst.push(runAmortizedRetentionGate(state, body, checkInterval));
+    }
+
+    // Buggy behavior: the counter is zeroed before the in-progress check, so
+    // every burst call above would already have re-tripped and re-zeroed it,
+    // ending near 0 (well under checkInterval) and silently discarding the
+    // in-flight cleanup's gate. Fixed behavior: none of the bailed-out burst
+    // calls reset the counter, so it stays >= checkInterval.
+    expect(state.cleanupInProgress).toBe(true);
+    expect(state.insertsSinceCleanup).toBeGreaterThanOrEqual(checkInterval);
+    expect(runs).toBe(1); // only the in-flight cleanup has run so far
+
+    release();
+    await Promise.all(burst);
+    await first;
+    expect(state.cleanupInProgress).toBe(false);
+
+    // With the counter left armed, the very next insert retries the gate
+    // immediately rather than waiting another full checkInterval.
+    await runAmortizedRetentionGate(state, body, checkInterval);
+    expect(runs).toBe(2);
+    expect(state.insertsSinceCleanup).toBe(0);
+  });
+
+  test("propagates a cleanup body error but still releases the guard", async () => {
+    const state = createAmortizedRetentionState();
+
+    await expect(
+      runAmortizedRetentionGate(
+        state,
+        async () => {
+          throw new Error("boom");
+        },
+        1,
+      ),
+    ).rejects.toThrow("boom");
+
+    expect(state.cleanupInProgress).toBe(false);
+
+    let ran = false;
+    await runAmortizedRetentionGate(
+      state,
+      async () => {
+        ran = true;
+      },
+      1,
+    );
+    expect(ran).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`eventRetention` (`pruneEventTableByCount`) and `rowCapRetention` (`runAmortizedRetention`)
carried byte-identical copies of the amortized row-cap state machine: bump a per-table
insert counter, no-op under the interval, **leave the counter armed if a cleanup is
already in flight** (the #6657 fix), else reset + set the guard + run cleanup + release
the guard in `finally`.

Extracted one canonical implementation into `retentionGate.ts`
(`AmortizedRetentionState`, `createAmortizedRetentionState`, `runAmortizedRetentionGate`);
both modules delegate, and `eventRepositoryBase.createEventRetentionState` too. **No
exported signatures changed**, so the six event repos and row-cap repos need no changes.
The #6657 counter-ordering invariant and the #6464 `RowCapTable` set are preserved
exactly.

Part of epic #6379 (retention cluster). **Stacked on #6464** → #6657; GitHub retargets to
`main` as those merge.

## Linked Issue

Closes #6702

## Validation

- [x] New `test/db/retentionGate.test.ts` unit-tests the shared gate in isolation (counter bumps incl. batch `inserted`, interval trigger, in-flight-guard-keeps-counter-armed = the #6657 invariant, error propagation + guard release). Existing `eventRetention`/`rowCapRetention`/`rowCapRetentionTrim` suites pass **unchanged** (behavior-preservation net) — 59 pass; 8 dependent repo suites — 159 pass; full `test/db` — 1077 pass.
- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — all clean.

## Follow-ups
- The two `@deprecated` type aliases (`EventRetentionState`, `RowCapRetentionState`) are kept as trivial aliases of `AmortizedRetentionState` for API stability.
