### PR TITLE
perf(db): FIFO admission for the SQLite connection, no broadcast, bounded fairness (#6699)

### DIFF
--- a/src/db/bunSqliteDialect.ts
+++ b/src/db/bunSqliteDialect.ts
@@ -164,14 +164,34 @@ class BunSqliteDriver implements Driver {
   }
 }
 
+// One parked operation in the FIFO admission queue (#6699). `kind` decides the
+// admission rule: a "txn" needs exclusive access (no owner, no active queries)
+// and blocks everything behind it until it can run; a "query" runs as soon as no
+// transaction holds the connection, concurrently with other queued queries.
+interface AdmissionWaiter {
+  kind: "txn" | "query";
+  owner: symbol;
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
 export class BunSqliteConnectionState {
   readonly #databaseSource: BunDatabase | (() => BunDatabase);
   readonly #beforeQuery?: () => Promise<void>;
   #db: BunDatabase | null = null;
   #transactionOwner: symbol | null = null;
-  #pendingTransactions = 0;
   #activeQueries = 0;
-  #waiters: Array<() => void> = [];
+  // FIFO admission queue over the singleton connection (#6699). Replaces the old
+  // broadcast waiter array: each state change wakes only the next eligible
+  // waiter — one transaction (exclusively) or a run of consecutive queries
+  // (concurrent reads) — via #pump, never the whole queue. Admission is strictly
+  // first-come, so a sustained transaction stream cannot starve an earlier-queued
+  // query (it queues ahead of later transactions), and a sustained query stream
+  // cannot starve an earlier-queued transaction (later queries queue behind it).
+  #queue: Array<AdmissionWaiter> = [];
+  // Test seam: cumulative waiter resolutions. Pins that one completion resumes
+  // only the eligible waiter(s), not every parked operation (the old herd).
+  #resumeCount = 0;
   #statementCache = new Map<string, BunStatement>();
   #closed = false;
   readonly #maxRetryAttempts: number;
@@ -213,7 +233,7 @@ export class BunSqliteConnectionState {
       this.#closed ||
       !this.#db ||
       this.#transactionOwner !== null ||
-      this.#pendingTransactions > 0 ||
+      this.#queue.length > 0 ||
       this.#activeQueries > 0
     ) {
       return;
@@ -228,19 +248,22 @@ export class BunSqliteConnectionState {
 
   async beginTransaction(owner: symbol): Promise<void> {
     this.#assertOpen();
-    this.#pendingTransactions += 1;
-    try {
-      await this.#reserveTransaction(owner);
-    } finally {
-      this.#pendingTransactions -= 1;
-      this.#notifyWaiters();
+    // A nested beginTransaction on a lease that already holds the lock would wait
+    // forever for itself (deadlocking the daemon's only connection); fail fast
+    // with a clear error, mirroring the old #reserveTransaction carve-out.
+    if (this.#transactionOwner === owner) {
+      throw new ActionableError("Nested transactions are not supported by BunSqliteDialect");
     }
+    // Queue for exclusive access. #pump admits this waiter (setting
+    // #transactionOwner to `owner`) only once no owner holds the lock and no
+    // query is active, and only when it reaches the front of the FIFO.
+    await this.#acquire("txn", owner);
 
     try {
       await this.executeQuery(CompiledQuery.raw("begin"), owner);
     } catch (error) {
       this.#transactionOwner = null;
-      this.#notifyWaiters();
+      this.#pump();
       throw error;
     }
   }
@@ -291,7 +314,7 @@ export class BunSqliteConnectionState {
       }
     } finally {
       this.#activeQueries -= 1;
-      this.#notifyWaiters();
+      this.#pump();
     }
   }
 
@@ -442,7 +465,9 @@ export class BunSqliteConnectionState {
       this.#db.close();
       this.#db = null;
     }
-    this.#notifyWaiters();
+    // #closed is set above, so #pump now drains the queue by rejecting every
+    // parked waiter with the closed-database error instead of admitting it.
+    this.#pump();
   }
 
   #getDatabase(): BunDatabase {
@@ -507,57 +532,91 @@ export class BunSqliteConnectionState {
     }
   }
 
-  async #reserveTransaction(owner: symbol): Promise<void> {
-    // A nested beginTransaction on a lease that already holds the transaction
-    // lock would busy-loop forever here (the owner waiting for itself to
-    // release), deadlocking the daemon's only DB connection. Mirror
-    // #enterQuery's `=== owner` carve-out by failing fast with a clear error
-    // instead. The caller (beginTransaction) still decrements
-    // #pendingTransactions and wakes waiters in its finally, so no counter leak.
-    if (this.#transactionOwner === owner) {
-      throw new ActionableError("Nested transactions are not supported by BunSqliteDialect");
-    }
-    while (this.#transactionOwner !== null || this.#activeQueries > 0) {
-      this.#assertOpen();
-      await this.#waitForStateChange();
-    }
-    this.#assertOpen();
-    this.#transactionOwner = owner;
-  }
-
   async #enterQuery(owner: symbol): Promise<void> {
-    while (
-      (this.#transactionOwner !== null && this.#transactionOwner !== owner) ||
-      (this.#transactionOwner === null && this.#pendingTransactions > 0)
-    ) {
-      // Bail if the handle closed while queued so a parked query can't spin
-      // forever after shutdown (issue #2792). Thrown before the activeQueries
-      // increment, so no counter is leaked.
-      this.#assertOpen();
-      await this.#waitForStateChange();
+    // A statement issued by the lease that currently holds the transaction is
+    // part of that transaction's own body (begin/commit/rollback plus the work
+    // between them, all routed through executeQuery with the holding owner). It
+    // bypasses the queue so the transaction can make progress while it holds the
+    // connection exclusively.
+    if (this.#transactionOwner === owner) {
+      this.#activeQueries += 1;
+      return;
     }
-    this.#activeQueries += 1;
+    // Otherwise queue behind anything already waiting; #pump increments
+    // #activeQueries when (and only when) it admits this waiter.
+    await this.#acquire("query", owner);
   }
 
   #clearTransactionOwner(owner: symbol): void {
     if (this.#transactionOwner === owner) {
       this.#transactionOwner = null;
-      this.#notifyWaiters();
+      this.#pump();
     }
   }
 
-  async #waitForStateChange(): Promise<void> {
-    await new Promise<void>((resolve) => {
-      this.#waiters.push(resolve);
+  // Park a transaction reservation or a query at the back of the FIFO admission
+  // queue and wait until #pump admits it (or rejects it because the connection
+  // closed while it waited, preserving the shutdown-safety of the old
+  // #assertOpen re-check, issue #2792). #pump is the sole authority that mutates
+  // #transactionOwner / #activeQueries on admission, so a resolved waiter may
+  // proceed immediately without re-checking any predicate.
+  #acquire(kind: AdmissionWaiter["kind"], owner: symbol): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.#queue.push({ kind, owner, resolve, reject });
+      this.#pump();
     });
   }
 
-  #notifyWaiters(): void {
-    const waiters = this.#waiters;
-    this.#waiters = [];
-    for (const waiter of waiters) {
-      waiter();
+  // Admit as many front waiters as can proceed right now, resolving ONLY those
+  // — never broadcasting to the whole queue (the old #notifyWaiters thundering
+  // herd, issue #6699). Strict FIFO: a head transaction that cannot run yet
+  // blocks everything behind it, so it is never starved by a later query stream,
+  // and an earlier-queued query is never starved by a later transaction stream.
+  #pump(): void {
+    while (this.#queue.length > 0) {
+      const front = this.#queue[0];
+      if (this.#closed) {
+        this.#queue.shift();
+        this.#resumeCount += 1;
+        front.reject(new Error("Cannot use a closed database"));
+        continue;
+      }
+      if (front.kind === "txn") {
+        // A transaction needs exclusive access: no owner holds the lock and no
+        // query is in flight. If it cannot run yet it stays at the head, blocking
+        // later operations until it can (FIFO fairness / no transaction starvation).
+        if (this.#transactionOwner === null && this.#activeQueries === 0) {
+          this.#queue.shift();
+          this.#transactionOwner = front.owner;
+          this.#resumeCount += 1;
+          front.resolve();
+        }
+        // Either a transaction now holds the connection exclusively, or the head
+        // transaction is still blocked; nothing behind it proceeds either way.
+        return;
+      }
+      // Head is a query: it runs as soon as no transaction holds the lock.
+      // Consecutive head queries are concurrent reads, so keep admitting them.
+      if (this.#transactionOwner === null) {
+        this.#queue.shift();
+        this.#activeQueries += 1;
+        this.#resumeCount += 1;
+        front.resolve();
+        continue;
+      }
+      // A transaction holds the connection; queries wait behind it.
+      return;
     }
+  }
+
+  /** Test seam (#6699): cumulative waiter resolutions across the queue's life. */
+  get resumeCount(): number {
+    return this.#resumeCount;
+  }
+
+  /** Test seam (#6699): operations currently parked in the admission queue. */
+  get queuedWaiterCount(): number {
+    return this.#queue.length;
   }
 }
 

--- a/test/db/bunSqliteDialect.integration.test.ts
+++ b/test/db/bunSqliteDialect.integration.test.ts
@@ -650,3 +650,96 @@ describe("BunSqliteConnectionState — close-time database maintenance", () => {
     expect(opened).toBe(false);
   });
 });
+
+describe("BunSqliteConnectionState — FIFO admission fairness + no thundering herd (#6699)", () => {
+  test("one completion resumes only the eligible waiters and preserves FIFO across queries and transactions", async () => {
+    const state = makeState(new FakeDatabase());
+
+    // Hold a transaction open so every later operation must queue behind it.
+    const holder = Symbol("holder");
+    await state.beginTransaction(holder);
+
+    const order: string[] = [];
+    const q1 = state.executeQuery(rawQuery("select 1"), Symbol("q1")).then(() => {
+      order.push("q1");
+    });
+    const t2 = Symbol("t2");
+    const txn2 = state.beginTransaction(t2).then(async () => {
+      order.push("t2");
+      await state.commitTransaction(t2);
+    });
+    const q3 = state.executeQuery(rawQuery("select 1"), Symbol("q3")).then(() => {
+      order.push("q3");
+    });
+
+    await Promise.resolve();
+    expect(state.queuedWaiterCount).toBe(3); // all three parked behind the held txn
+
+    const resumesBefore = state.resumeCount;
+    // Releasing the holder runs exactly one #pump. It admits only q1 (the head
+    // query); t2 (a transaction) is then blocked by q1's now-active query, and q3
+    // is behind t2 in FIFO — so neither is woken. The old broadcast #notifyWaiters
+    // resolved all three every time, forcing t2 and q3 to re-park.
+    await state.commitTransaction(holder);
+    await Promise.resolve();
+    expect(state.resumeCount - resumesBefore).toBe(1);
+    expect(state.queuedWaiterCount).toBe(2);
+
+    await withTimeout(Promise.all([q1, txn2, q3]), 1000);
+    // FIFO: q1 (queued before t2) beats the transaction; q3 (queued after t2) runs
+    // after it — an earlier query is not starved by a later transaction, and a
+    // transaction is not starved by a later query.
+    expect(order).toEqual(["q1", "t2", "q3"]);
+  });
+
+  test("an earlier-queued query is not starved by a sustained later transaction stream", async () => {
+    const state = makeState(new FakeDatabase());
+
+    const holder = Symbol("holder");
+    await state.beginTransaction(holder);
+
+    const order: string[] = [];
+    const qEarly = state.executeQuery(rawQuery("select 1"), Symbol("qEarly")).then(() => {
+      order.push("qEarly");
+    });
+    // Three transactions queued AFTER qEarly — a sustained transaction stream.
+    const txns = [Symbol("tA"), Symbol("tB"), Symbol("tC")].map((owner, index) =>
+      state.beginTransaction(owner).then(async () => {
+        order.push(`t${index}`);
+        await state.commitTransaction(owner);
+      }),
+    );
+
+    await Promise.resolve();
+    await state.commitTransaction(holder);
+
+    await withTimeout(Promise.all([qEarly, ...txns]), 2000);
+    // qEarly was queued first, so despite three later transactions it admits
+    // before any of them — the transaction preference is bounded by FIFO order,
+    // not unbounded as it was when a query yielded to every pending transaction.
+    expect(order[0]).toBe("qEarly");
+  });
+
+  test("a transaction queued before a query still runs first (bounded transaction preference preserved)", async () => {
+    const state = makeState(new FakeDatabase());
+
+    const holder = Symbol("holder");
+    await state.beginTransaction(holder);
+
+    const order: string[] = [];
+    const tEarly = Symbol("tEarly");
+    const txnEarly = state.beginTransaction(tEarly).then(async () => {
+      order.push("tEarly");
+      await state.commitTransaction(tEarly);
+    });
+    const qLate = state.executeQuery(rawQuery("select 1"), Symbol("qLate")).then(() => {
+      order.push("qLate");
+    });
+
+    await Promise.resolve();
+    await state.commitTransaction(holder);
+
+    await withTimeout(Promise.all([txnEarly, qLate]), 1000);
+    expect(order).toEqual(["tEarly", "qLate"]);
+  });
+});


### PR DESCRIPTION
## Summary

`BunSqliteConnectionState` coordinated all leases over the daemon's singleton SQLite
connection with a shared `#waiters` array that `#notifyWaiters` **drained and resolved in
full on every statement completion**. With M parked queries and N pending transactions,
each completion woke all M+N — one progressed, the rest re-parked (a thundering herd
scaling with parked operations, not admittable ones). The admission rule also gave every
pending transaction priority over every query (`#enterQuery` waited while
`#pendingTransactions > 0`), so a sustained transaction stream could **starve** an
earlier-queued read with no fairness bound.

Replaces the broadcast array with an explicit **FIFO admission queue**; `#pump` is the
sole authority that sets `#transactionOwner`/`#activeQueries` on admission:
- `#pump` resolves **only** the waiters that can proceed now — one transaction
  (exclusively) or a run of consecutive head queries (concurrent reads) — and never wakes
  a waiter that would immediately re-park.
- Strict FIFO gives **symmetric bounded fairness**: a head transaction that can't run yet
  blocks what's behind it (never starved by a later query stream); a query queued ahead
  of a transaction admits first (never starved by a later transaction stream). The
  transaction owner's own statements still bypass the queue.
- On close, `#pump` drains the queue by rejecting each parked waiter with the
  closed-database error (preserves the `#2792` shutdown safety).

`#pendingTransactions` is removed (the queue subsumes it). Part of epic #6379.
**Stacked on #6649** (`work/issue-6649-cached-stmt-pragma`); retargets to `main` when it merges.

## Linked Issue

Closes #6699

## Validation

- [x] New tests (`test/db/bunSqliteDialect.integration.test.ts`) via `resumeCount`/`queuedWaiterCount` seams: one completion resumes only the eligible waiter(s) (old broadcast woke all); FIFO across mixed query/transaction waiters (`[q1, t2, q3]`); an earlier query isn't starved by a sustained later transaction stream; a transaction queued before a query still runs first (bounded preference preserved). These fail against the old global-transaction-priority behavior.
- [x] Existing coverage green: bunSqliteDialect + database integration (37), incl. the "pending transaction before later query" atomicity test. Broad `test/db` — 1062 pass, 0 fail.
- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — all clean.

## Follow-ups
- None.
