### PR TITLE
refactor(db): unify repository getDb() on one synchronous migration-gating contract (#6703)

### DIFF
--- a/src/db/deviceLockRepository.ts
+++ b/src/db/deviceLockRepository.ts
@@ -1,5 +1,5 @@
 import { type Kysely, sql } from "kysely";
-import { ensureMigrations, getDatabase } from "./database";
+import { getDatabase } from "./database";
 import type { Database } from "./types";
 import { logger } from "../utils/logger";
 
@@ -18,12 +18,12 @@ export class DeviceLockRepository {
     this.db = db ?? null;
   }
 
-  private async getDb(): Promise<Kysely<Database>> {
-    if (this.db) {
-      return this.db;
-    }
-    await ensureMigrations();
-    return getDatabase();
+  // Migration gating is owned by startup (ensureMigrations) plus the app dialect
+  // first-query gate (waitForMigrationsBeforeQuery, #6703); a repository helper
+  // must NOT await ensureMigrations itself. Resolve the injected executor, else
+  // the singleton, synchronously.
+  private getDb(): Kysely<Database> {
+    return this.db ?? getDatabase();
   }
 
   /** The credential remembered for a device, or null when none is recorded. */

--- a/src/db/deviceSessionRepository.ts
+++ b/src/db/deviceSessionRepository.ts
@@ -1,5 +1,5 @@
 import type { Kysely } from "kysely";
-import { ensureMigrations, getDatabase } from "./database";
+import { getDatabase } from "./database";
 import type { Database, DeviceSession, DeviceSessionStatus, NewDeviceSession } from "./types";
 import { logger } from "../utils/logger";
 import type { Platform } from "../models";
@@ -54,12 +54,12 @@ export class DeviceSessionRepository {
     this.db = db ?? null;
   }
 
-  private async getDb(): Promise<Kysely<Database>> {
-    if (this.db) {
-      return this.db;
-    }
-    await ensureMigrations();
-    return getDatabase();
+  // Migration gating is owned by startup (ensureMigrations) plus the app dialect
+  // first-query gate (waitForMigrationsBeforeQuery, #6703); a repository helper
+  // must NOT await ensureMigrations itself. Resolve the injected executor, else
+  // the singleton, synchronously.
+  private getDb(): Kysely<Database> {
+    return this.db ?? getDatabase();
   }
 
   async upsertActiveSession(record: DeviceSessionRecord): Promise<void> {

--- a/src/db/deviceSnapshotRepository.ts
+++ b/src/db/deviceSnapshotRepository.ts
@@ -1,5 +1,5 @@
 import type { Kysely } from "kysely";
-import { ensureMigrations, getDatabase } from "./database";
+import { getDatabase } from "./database";
 import type { DeviceSnapshotManifest, DeviceSnapshotMetadata, DeviceSnapshotType } from "../models";
 import type {
   Database,
@@ -96,12 +96,12 @@ export class DeviceSnapshotRepository {
     this.db = db ?? null;
   }
 
-  private async getDb(): Promise<Kysely<Database>> {
-    if (this.db) {
-      return this.db;
-    }
-    await ensureMigrations();
-    return getDatabase();
+  // Migration gating is owned by startup (ensureMigrations) plus the app dialect
+  // first-query gate (waitForMigrationsBeforeQuery, #6703); a repository helper
+  // must NOT await ensureMigrations itself. Resolve the injected executor, else
+  // the singleton, synchronously.
+  private getDb(): Kysely<Database> {
+    return this.db ?? getDatabase();
   }
 
   async insertSnapshot(record: DeviceSnapshotRecord): Promise<void> {

--- a/src/db/installedAppsRepository.ts
+++ b/src/db/installedAppsRepository.ts
@@ -1,5 +1,5 @@
 import type { Kysely } from "kysely";
-import { getDatabase, ensureMigrations } from "./database";
+import { getDatabase } from "./database";
 import type { Database, InstalledApp as DbInstalledApp, NewInstalledApp } from "./types";
 
 export interface InstalledAppsStore {
@@ -35,12 +35,12 @@ export class InstalledAppsRepository implements InstalledAppsStore {
     this.db = db ?? null;
   }
 
-  private async getDb(): Promise<Kysely<Database>> {
-    if (this.db) {
-      return this.db;
-    }
-    await ensureMigrations();
-    return getDatabase();
+  // Migration gating is owned by startup (ensureMigrations) plus the app dialect
+  // first-query gate (waitForMigrationsBeforeQuery, #6703); a repository helper
+  // must NOT await ensureMigrations itself. Resolve the injected executor, else
+  // the singleton, synchronously.
+  private getDb(): Kysely<Database> {
+    return this.db ?? getDatabase();
   }
 
   async getLatestVerification(deviceId: string): Promise<number | null> {

--- a/src/db/keyedJsonConfigRepository.ts
+++ b/src/db/keyedJsonConfigRepository.ts
@@ -1,7 +1,7 @@
 import type { Kysely } from "kysely";
 import type { AppearanceConfig, DeviceSnapshotConfig, VideoRecordingConfig } from "../models";
 import { logger, type Logger } from "../utils/logger";
-import { ensureMigrations, getDatabase } from "./database";
+import { getDatabase } from "./database";
 import type { Database } from "./types";
 
 const CONFIG_KEY = "global";
@@ -58,12 +58,12 @@ export class KeyedJsonConfigRepository<TConfig> implements ConfigRepository<TCon
     this.logger = options.logger ?? logger;
   }
 
-  private async getDb(): Promise<Kysely<Database>> {
-    if (this.db) {
-      return this.db;
-    }
-    await ensureMigrations();
-    return getDatabase();
+  // Migration gating is owned by startup (ensureMigrations) plus the app dialect
+  // first-query gate (waitForMigrationsBeforeQuery, #6703); a repository helper
+  // must NOT await ensureMigrations itself. Resolve the injected executor, else
+  // the singleton, synchronously.
+  private getDb(): Kysely<Database> {
+    return this.db ?? getDatabase();
   }
 
   async getConfig(): Promise<TConfig | null> {

--- a/src/db/toolSelectionProfileProvenanceRepository.ts
+++ b/src/db/toolSelectionProfileProvenanceRepository.ts
@@ -1,5 +1,5 @@
 import type { Kysely } from "kysely";
-import { ensureMigrations, getDatabase } from "./database";
+import { getDatabase } from "./database";
 import type { Database } from "./types";
 import { logger } from "../utils/logger";
 
@@ -41,12 +41,12 @@ export class ToolSelectionProfileProvenanceRepository implements ToolSelectionPr
     this.db = db ?? null;
   }
 
-  private async getDb(): Promise<Kysely<Database>> {
-    if (this.db) {
-      return this.db;
-    }
-    await ensureMigrations();
-    return getDatabase();
+  // Migration gating is owned by startup (ensureMigrations) plus the app dialect
+  // first-query gate (waitForMigrationsBeforeQuery, #6703); a repository helper
+  // must NOT await ensureMigrations itself. Resolve the injected executor, else
+  // the singleton, synchronously.
+  private getDb(): Kysely<Database> {
+    return this.db ?? getDatabase();
   }
 
   /** Record a minted profile uuid. Idempotent: re-inserting the same uuid is a no-op. */

--- a/src/db/videoRecordingRepository.ts
+++ b/src/db/videoRecordingRepository.ts
@@ -1,5 +1,5 @@
 import type { Kysely, SelectQueryBuilder } from "kysely";
-import { ensureMigrations, getDatabase } from "./database";
+import { getDatabase } from "./database";
 import type {
   VideoFormat,
   VideoRecordingConfig,
@@ -179,12 +179,12 @@ export class VideoRecordingRepository {
     this.db = db ?? null;
   }
 
-  private async getDb(): Promise<Kysely<Database>> {
-    if (this.db) {
-      return this.db;
-    }
-    await ensureMigrations();
-    return getDatabase();
+  // Migration gating is owned by startup (ensureMigrations) plus the app dialect
+  // first-query gate (waitForMigrationsBeforeQuery, #6703); a repository helper
+  // must NOT await ensureMigrations itself. Resolve the injected executor, else
+  // the singleton, synchronously.
+  private getDb(): Kysely<Database> {
+    return this.db ?? getDatabase();
   }
 
   async insertRecording(record: VideoRecordingRecord): Promise<void> {

--- a/test/db/keyedJsonConfigRepository.integration.test.ts
+++ b/test/db/keyedJsonConfigRepository.integration.test.ts
@@ -136,8 +136,37 @@ describe("KeyedJsonConfigRepository", () => {
 
       await repo.setConfig({ theme: "dark" });
 
-      expect(ensureMigrationsSpy).toHaveBeenCalledTimes(1);
+      // #6703: the repository helper resolves the default database lazily on the
+      // first operation (getDatabase, once) but no longer awaits ensureMigrations
+      // itself — migration gating is owned by startup + the application dialect's
+      // waitForMigrationsBeforeQuery first-query gate, so every repository follows
+      // one contract instead of two.
+      expect(ensureMigrationsSpy).toHaveBeenCalledTimes(0);
       expect(getDatabaseSpy).toHaveBeenCalledTimes(1);
+      expect(await db.selectFrom("appearance_configs").selectAll().execute()).toHaveLength(1);
+    } finally {
+      ensureMigrationsSpy.mockRestore();
+      getDatabaseSpy.mockRestore();
+    }
+  });
+
+  test("an injected executor resolves without touching the default database or migrations (#6703)", async () => {
+    const ensureMigrationsSpy = spyOn(databaseModule, "ensureMigrations").mockResolvedValue();
+    const getDatabaseSpy = spyOn(databaseModule, "getDatabase");
+
+    try {
+      // Built with an injected executor: the unified sync getDb() contract resolves
+      // that executor directly and never touches the global singleton or migration
+      // gating — the other side of the one contract the singleton test pins.
+      const repo = new KeyedJsonConfigRepository<{ theme: string }>({
+        tableName: "appearance_configs",
+        db,
+      });
+
+      await repo.setConfig({ theme: "light" });
+
+      expect(getDatabaseSpy).toHaveBeenCalledTimes(0);
+      expect(ensureMigrationsSpy).toHaveBeenCalledTimes(0);
       expect(await db.selectFrom("appearance_configs").selectAll().execute()).toHaveLength(1);
     } finally {
       ensureMigrationsSpy.mockRestore();


### PR DESCRIPTION
## Summary

Repository `getDb()` helpers used **two** migration contracts: some were `async getDb()`
that awaited `ensureMigrations()` themselves; others synchronously returned
`getDatabase()` and relied on the application dialect's `waitForMigrationsBeforeQuery`
first-query gate. Both worked only because that dialect gate is load-bearing, but the
divergence produced inconsistent startup error shapes (explicit `ensureMigrations`
rejection vs a dialect-rewrapped `Query failed: ...`), unnecessary async plumbing, and no
canonical rule for new repositories.

Adopt the issue's preferred **single contract**: startup owns migrations
(`DatabaseInitializer`/daemon init still await `ensureMigrations`, unchanged — failures
stay fatal before serving), the dialect remains the universal first-query safety net, and
repository `getDb()` helpers resolve **synchronously** (injected executor if present, else
`getDatabase()`). Converted the seven async helpers to
`private getDb(): Kysely<Database> { return this.db ?? getDatabase(); }` with a documented
comment and dropped their now-unused `ensureMigrations` imports. Existing
`await this.getDb().<chain>.execute()` call sites stay correct (the `await` binds the
chain's promise). No repository base class added (per the issue).

Part of epic #6379. **Stacked on #6464**; retargets to `main` as the retention stack merges.

## Linked Issue

Closes #6703

## Validation

- [x] Converted repos: deviceSession, deviceLock, installedApps, keyedJsonConfig, deviceSnapshot, videoRecording, toolSelectionProfileProvenance. `DatabaseInitializer` (startup owner) and already-sync repos untouched.
- [x] Updated the keyedJsonConfig "defers default database resolution" test to the new contract (lazy `getDatabase` once; no repo-level `ensureMigrations`) and added an injected-executor test asserting neither the singleton nor migrations are touched.
- [x] `bun test test/db` — 1073 pass, 0 fail (broad, since this touches many repos). `bun run format:check`, `bun run lint`, `bun run typecheck` — all clean.

## Follow-ups
- None.
