### PR TITLE
fix(db): release per-device installed-apps cache bookkeeping on pool removal (#6704)

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -6665,6 +6665,12 @@ export class DevicePool {
           .track(() => this.installedAppsRepository.clearDeviceSession(deviceId))
           .then(() => undefined),
       );
+      // The device has left the pool for good, so forget its per-device
+      // cache-coherence bookkeeping now that the final invalidation above has
+      // drained — otherwise the coordinator retains a generation entry for every
+      // device id the daemon ever saw (#6704). releaseDevice is generation-safe:
+      // a rebuild that predates it cannot commit, and a reused serial starts clean.
+      await getInstalledAppsCacheWriteCoordinator().releaseDevice(deviceId);
       logger.info(`[DevicePool] Cleared installed apps cache for device ${deviceId}`);
     } catch (error) {
       logger.warn(`Failed to clear device session cache for ${deviceId}: ${error}`);

--- a/src/db/installedAppsCacheWriteCoordinator.ts
+++ b/src/db/installedAppsCacheWriteCoordinator.ts
@@ -21,7 +21,7 @@ export interface InstalledAppsCacheWriteCoordinator {
    * while this call was waiting on the device's write tail. Safe to call from
    * a hot path that reuses device ids: a reused id simply starts clean.
    */
-  releaseDevice(deviceId: string): Promise<void>;
+  releaseDevice(deviceId: string, expectedGeneration?: number): Promise<void>;
 }
 
 export class PerDeviceInstalledAppsCacheWriteCoordinator implements InstalledAppsCacheWriteCoordinator {
@@ -92,7 +92,10 @@ export class PerDeviceInstalledAppsCacheWriteCoordinator implements InstalledApp
     return generation;
   }
 
-  async releaseDevice(deviceId: string): Promise<void> {
+  async releaseDevice(deviceId: string, expectedGeneration?: number): Promise<void> {
+    if (expectedGeneration !== undefined && this.generations.get(deviceId) !== expectedGeneration) {
+      return;
+    }
     // Fence: bump the generation the same way invalidate() does, so a rebuild
     // that already captured an older generation cannot later commit against
     // this device id even if it is reused before cleanup below runs.

--- a/src/db/installedAppsCacheWriteCoordinator.ts
+++ b/src/db/installedAppsCacheWriteCoordinator.ts
@@ -28,11 +28,20 @@ export class PerDeviceInstalledAppsCacheWriteCoordinator implements InstalledApp
   private generations = new Map<string, number>();
   private dirtyGenerations = new Map<string, number>();
   private tails = new Map<string, Promise<unknown>>();
+  private releasing = new Map<string, number>();
+  private nextGeneration = 0;
 
   constructor(private readonly getBarrier: () => DbWriteBarrier = getDbWriteBarrier) {}
 
   beginRebuild(deviceId: string): number {
-    return this.generations.get(deviceId) ?? 0;
+    const current = this.generations.get(deviceId);
+    if (current === undefined || this.releasing.has(deviceId)) {
+      const generation = ++this.nextGeneration;
+      this.generations.set(deviceId, generation);
+      this.releasing.delete(deviceId);
+      return generation;
+    }
+    return current;
   }
 
   isDirty(deviceId: string): boolean {
@@ -40,7 +49,7 @@ export class PerDeviceInstalledAppsCacheWriteCoordinator implements InstalledApp
   }
 
   markRebuilt(deviceId: string, generation: number): boolean {
-    if ((this.generations.get(deviceId) ?? 0) !== generation) {
+    if (this.generations.get(deviceId) !== generation) {
       return false;
     }
     this.dirtyGenerations.delete(deviceId);
@@ -53,7 +62,7 @@ export class PerDeviceInstalledAppsCacheWriteCoordinator implements InstalledApp
     write: () => Promise<void>,
   ): Promise<boolean> {
     return this.enqueue(deviceId, async () => {
-      if ((this.generations.get(deviceId) ?? 0) !== generation) {
+      if (this.generations.get(deviceId) !== generation) {
         return false;
       }
       await write();
@@ -74,8 +83,9 @@ export class PerDeviceInstalledAppsCacheWriteCoordinator implements InstalledApp
   }
 
   invalidateWithoutWrite(deviceId: string): number {
-    const generation = (this.generations.get(deviceId) ?? 0) + 1;
+    const generation = ++this.nextGeneration;
     this.generations.set(deviceId, generation);
+    this.releasing.delete(deviceId);
     // A failed stale-marker write leaves old DB rows physically fresh. Keep the
     // cache bypassed until ListInstalledApps successfully commits a replacement.
     this.dirtyGenerations.set(deviceId, generation);
@@ -87,6 +97,7 @@ export class PerDeviceInstalledAppsCacheWriteCoordinator implements InstalledApp
     // that already captured an older generation cannot later commit against
     // this device id even if it is reused before cleanup below runs.
     const fenceGeneration = this.invalidateWithoutWrite(deviceId);
+    this.releasing.set(deviceId, fenceGeneration);
 
     // Drain: wait behind any write already queued for this device (including
     // the final invalidate() write this call is expected to follow) before
@@ -100,6 +111,7 @@ export class PerDeviceInstalledAppsCacheWriteCoordinator implements InstalledApp
     if (this.generations.get(deviceId) === fenceGeneration) {
       this.generations.delete(deviceId);
       this.dirtyGenerations.delete(deviceId);
+      this.releasing.delete(deviceId);
     }
   }
 

--- a/src/db/installedAppsCacheWriteCoordinator.ts
+++ b/src/db/installedAppsCacheWriteCoordinator.ts
@@ -11,8 +11,17 @@ export interface InstalledAppsCacheWriteCoordinator {
   commitRebuild(deviceId: string, generation: number, write: () => Promise<void>): Promise<boolean>;
   isDirty(deviceId: string): boolean;
   markRebuilt(deviceId: string, generation: number): boolean;
-  invalidateWithoutWrite(deviceId: string): void;
+  invalidateWithoutWrite(deviceId: string): number;
   invalidate(deviceId: string, write: () => Promise<void>): Promise<void>;
+  /**
+   * Permanently forgets a device identifier once the caller is certain it is
+   * gone (e.g. after pool removal's final `invalidate()` has drained). Fences
+   * out any rebuild whose captured generation predates this call, then only
+   * deletes the per-device bookkeeping if nothing bumped the generation again
+   * while this call was waiting on the device's write tail. Safe to call from
+   * a hot path that reuses device ids: a reused id simply starts clean.
+   */
+  releaseDevice(deviceId: string): Promise<void>;
 }
 
 export class PerDeviceInstalledAppsCacheWriteCoordinator implements InstalledAppsCacheWriteCoordinator {
@@ -64,12 +73,49 @@ export class PerDeviceInstalledAppsCacheWriteCoordinator implements InstalledApp
     }
   }
 
-  invalidateWithoutWrite(deviceId: string): void {
+  invalidateWithoutWrite(deviceId: string): number {
     const generation = (this.generations.get(deviceId) ?? 0) + 1;
     this.generations.set(deviceId, generation);
     // A failed stale-marker write leaves old DB rows physically fresh. Keep the
     // cache bypassed until ListInstalledApps successfully commits a replacement.
     this.dirtyGenerations.set(deviceId, generation);
+    return generation;
+  }
+
+  async releaseDevice(deviceId: string): Promise<void> {
+    // Fence: bump the generation the same way invalidate() does, so a rebuild
+    // that already captured an older generation cannot later commit against
+    // this device id even if it is reused before cleanup below runs.
+    const fenceGeneration = this.invalidateWithoutWrite(deviceId);
+
+    // Drain: wait behind any write already queued for this device (including
+    // the final invalidate() write this call is expected to follow) before
+    // treating the device as idle.
+    await this.enqueue(deviceId, async () => undefined);
+
+    // Delete only if no newer work bumped the generation again while this
+    // call was waiting on the tail above (e.g. the device id was reused and
+    // invalidated/rebuilt in the meantime). Leaving the entries in that case
+    // keeps them for that newer generation instead of resetting it to 0.
+    if (this.generations.get(deviceId) === fenceGeneration) {
+      this.generations.delete(deviceId);
+      this.dirtyGenerations.delete(deviceId);
+    }
+  }
+
+  /**
+   * Test-only diagnostic: number of device identifiers with any retained
+   * bookkeeping (generation, dirty-generation, or in-flight tail). Not part
+   * of the {@link InstalledAppsCacheWriteCoordinator} interface — production
+   * callers have no use for it.
+   */
+  trackedDeviceCount(): number {
+    const deviceIds = new Set<string>([
+      ...this.generations.keys(),
+      ...this.dirtyGenerations.keys(),
+      ...this.tails.keys(),
+    ]);
+    return deviceIds.size;
   }
 
   private async enqueue<T>(deviceId: string, work: () => Promise<T>): Promise<T> {

--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -1047,7 +1047,6 @@ async function getAppMetadataResource(
     return cached.content;
   }
 
-  const cacheGeneration = getInstalledAppsCacheWriteCoordinator().beginRebuild(deviceId);
   const device = await findBootedDevice(deviceId);
   if (!device) {
     return {
@@ -1057,6 +1056,7 @@ async function getAppMetadataResource(
     };
   }
 
+  const cacheGeneration = getInstalledAppsCacheWriteCoordinator().beginRebuild(deviceId);
   try {
     const iosSource = device.platform === "ios" ? createIosMetadataSource(device) : null;
     const getMetadata = new GetAppMetadata(device, undefined, iosSource);

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2230,10 +2230,12 @@ async function shutdownDevice(
 
       const cleanup = clearInstalledAppsAfterShutdown(dependencies, device.deviceId);
       const notification = cleanup.then(async (cacheCleared) => {
+        const coordinator = getInstalledAppsCacheWriteCoordinator();
+        const generation = cacheCleared ? coordinator.beginRebuild(device.deviceId) : undefined;
         await notifyResourcesAfterShutdown(dependencies);
         // Failed persistence must keep the dirty fence across device-ID reuse.
         if (cacheCleared) {
-          await getInstalledAppsCacheWriteCoordinator().releaseDevice(device.deviceId);
+          await coordinator.releaseDevice(device.deviceId, generation);
         }
       });
       // Keep late cleanup visible to DB shutdown without blocking a later

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -874,15 +874,17 @@ async function defaultStopAndroidObservers(device: BootedDevice): Promise<void> 
 async function clearInstalledAppsAfterShutdown(
   dependencies: DeviceToolsDependencies,
   deviceId: string,
-): Promise<void> {
+): Promise<boolean> {
   try {
     await dependencies.clearInstalledAppsForDevice(deviceId);
+    return true;
   } catch (error) {
     // The device is already stopped; the next app verification refreshes stale cache rows.
     logger.warn(
       `[DeviceTools] Failed to clear installed apps for ${deviceId} after shutdown: ${error}`,
       error,
     );
+    return false;
   }
 }
 
@@ -2227,9 +2229,12 @@ async function shutdownDevice(
       unregisterDirectSessionsForDevice(device.deviceId);
 
       const cleanup = clearInstalledAppsAfterShutdown(dependencies, device.deviceId);
-      const notification = cleanup.then(async () => {
+      const notification = cleanup.then(async (cacheCleared) => {
         await notifyResourcesAfterShutdown(dependencies);
-        await getInstalledAppsCacheWriteCoordinator().releaseDevice(device.deviceId);
+        // Failed persistence must keep the dirty fence across device-ID reuse.
+        if (cacheCleared) {
+          await getInstalledAppsCacheWriteCoordinator().releaseDevice(device.deviceId);
+        }
       });
       // Keep late cleanup visible to DB shutdown without blocking a later
       // device teardown retry if resource notification never settles.
@@ -2241,7 +2246,9 @@ async function shutdownDevice(
         "cleanup",
         "installed-app cleanup did not complete",
         strictDeadline,
-        async () => await cleanup,
+        async () => {
+          await cleanup;
+        },
       );
       await runPostShutdownStep(
         shutdownContext,

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2226,13 +2226,22 @@ async function shutdownDevice(
       await shutdownReservation?.release();
       unregisterDirectSessionsForDevice(device.deviceId);
 
+      const cleanup = clearInstalledAppsAfterShutdown(dependencies, device.deviceId);
+      const notification = cleanup.then(async () => {
+        await notifyResourcesAfterShutdown(dependencies);
+        await getInstalledAppsCacheWriteCoordinator().releaseDevice(device.deviceId);
+      });
+      // Keep late cleanup visible to DB shutdown without blocking a later
+      // device teardown retry if resource notification never settles.
+      void getDbWriteBarrier().trackExisting(notification);
+
       await runPostShutdownStep(
         shutdownContext,
         perf,
         "cleanup",
         "installed-app cleanup did not complete",
         strictDeadline,
-        async () => await clearInstalledAppsAfterShutdown(dependencies, device.deviceId),
+        async () => await cleanup,
       );
       await runPostShutdownStep(
         shutdownContext,
@@ -2240,7 +2249,7 @@ async function shutdownDevice(
         "notifyResources",
         "resource notification did not complete",
         strictDeadline,
-        async () => await notifyResourcesAfterShutdown(dependencies),
+        async () => await notification,
       );
 
       perf.end();

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2230,11 +2230,24 @@ async function shutdownDevice(
 
       const cleanup = clearInstalledAppsAfterShutdown(dependencies, device.deviceId);
       const notification = cleanup.then(async (cacheCleared) => {
-        const coordinator = getInstalledAppsCacheWriteCoordinator();
-        const generation = cacheCleared ? coordinator.beginRebuild(device.deviceId) : undefined;
         await notifyResourcesAfterShutdown(dependencies);
         // Failed persistence must keep the dirty fence across device-ID reuse.
         if (cacheCleared) {
+          const coordinator = getInstalledAppsCacheWriteCoordinator();
+          // Capture the expected generation AFTER the notification above, not
+          // before. For a device with a registered app resource,
+          // notifyResourcesAfterShutdown() -> syncInstalledAppResources()
+          // (src/server/appResources.ts) invalidates this same, already-gone
+          // device again as part of the SAME shutdown flow. Capturing the
+          // generation earlier meant that expected, self-triggered
+          // invalidation always advanced it past what releaseDevice's
+          // expected-generation guard held, so the guard always mismatched
+          // and release always no-opped -- leaking the exact per-device
+          // bookkeeping (#6704) this fix exists to release, for every killed
+          // device that had a registered app resource. beginRebuild() is a
+          // synchronous read here (the generation is already assigned), so
+          // there is no await between it and releaseDevice() below.
+          const generation = coordinator.beginRebuild(device.deviceId);
           await coordinator.releaseDevice(device.deviceId, generation);
         }
       });

--- a/test/db/installedAppsCacheWriteCoordinator.integration.test.ts
+++ b/test/db/installedAppsCacheWriteCoordinator.integration.test.ts
@@ -172,9 +172,7 @@ describe("PerDeviceInstalledAppsCacheWriteCoordinator", () => {
     const coordinator = new PerDeviceInstalledAppsCacheWriteCoordinator();
     const deviceId = "released-device-stale";
 
-    // The device was used (invalidated at least once), so its generation is >= 1
-    // when a lagging rebuild captures it.
-    await coordinator.invalidate(deviceId, async () => undefined);
+    // Capture the very first token before any invalidation.
     const generation = coordinator.beginRebuild(deviceId);
 
     // Pool removal releases the device before the lagging rebuild commits.
@@ -199,9 +197,9 @@ describe("PerDeviceInstalledAppsCacheWriteCoordinator", () => {
     expect(coordinator.trackedDeviceCount()).toBe(0);
     expect(coordinator.isDirty(deviceId)).toBe(false);
 
-    // Reused serial: a fresh rebuild at generation 0 commits normally.
+    // Reused serial: a fresh incarnation commits normally.
     const generation = coordinator.beginRebuild(deviceId);
-    expect(generation).toBe(0);
+    expect(generation).toBeGreaterThan(0);
     const writes: string[] = [];
     await expect(
       coordinator.commitRebuild(deviceId, generation, async () => {
@@ -209,5 +207,30 @@ describe("PerDeviceInstalledAppsCacheWriteCoordinator", () => {
       }),
     ).resolves.toBe(true);
     expect(writes).toEqual(["fresh"]);
+  });
+
+  test("preserves a rebuild queued after the release drain marker", async () => {
+    const coordinator = new PerDeviceInstalledAppsCacheWriteCoordinator();
+    const deviceId = "reused-during-release";
+    let finishWrite!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      finishWrite = resolve;
+    });
+    const original = coordinator.beginRebuild(deviceId);
+    const first = coordinator.commitRebuild(deviceId, original, () => blocked);
+    await Promise.resolve();
+    await Promise.resolve();
+    const release = coordinator.releaseDevice(deviceId);
+    const fresh = coordinator.beginRebuild(deviceId);
+    const writes: string[] = [];
+    const rebuild = coordinator.commitRebuild(deviceId, fresh, async () => {
+      writes.push("fresh");
+    });
+    finishWrite();
+    await first;
+    await release;
+    expect(await rebuild).toBe(true);
+    expect(writes).toEqual(["fresh"]);
+    expect(await coordinator.commitRebuild(deviceId, original, async () => {})).toBe(false);
   });
 });

--- a/test/db/installedAppsCacheWriteCoordinator.integration.test.ts
+++ b/test/db/installedAppsCacheWriteCoordinator.integration.test.ts
@@ -150,6 +150,21 @@ describe("PerDeviceInstalledAppsCacheWriteCoordinator", () => {
     expect(coordinator.isDirty(deviceId)).toBe(false);
   });
 
+  test("late release cannot discard a replacement invalidation fence", async () => {
+    const coordinator = new PerDeviceInstalledAppsCacheWriteCoordinator();
+    await coordinator.invalidate("reused", async () => {});
+    const retired = coordinator.beginRebuild("reused");
+    await expect(
+      coordinator.invalidate("reused", async () => {
+        throw new Error("replacement invalidation failed");
+      }),
+    ).rejects.toThrow("replacement invalidation failed");
+    const replacement = coordinator.beginRebuild("reused");
+    await coordinator.releaseDevice("reused", retired);
+    expect(coordinator.isDirty("reused")).toBe(true);
+    expect(await coordinator.commitRebuild("reused", replacement, async () => {})).toBe(true);
+  });
+
   test("releaseDevice returns the tracked-device count to zero across many unique ids (#6704)", async () => {
     const coordinator = new PerDeviceInstalledAppsCacheWriteCoordinator();
     const deviceIds = Array.from({ length: 50 }, (_, index) => `released-device-${index}`);

--- a/test/db/installedAppsCacheWriteCoordinator.integration.test.ts
+++ b/test/db/installedAppsCacheWriteCoordinator.integration.test.ts
@@ -149,4 +149,65 @@ describe("PerDeviceInstalledAppsCacheWriteCoordinator", () => {
     expect(coordinator.markRebuilt(deviceId, generation)).toBe(true);
     expect(coordinator.isDirty(deviceId)).toBe(false);
   });
+
+  test("releaseDevice returns the tracked-device count to zero across many unique ids (#6704)", async () => {
+    const coordinator = new PerDeviceInstalledAppsCacheWriteCoordinator();
+    const deviceIds = Array.from({ length: 50 }, (_, index) => `released-device-${index}`);
+
+    // Simulate pool removal for each: a final invalidate() (which leaves a
+    // generation + dirty entry), then release.
+    for (const deviceId of deviceIds) {
+      await coordinator.invalidate(deviceId, async () => undefined);
+    }
+    expect(coordinator.trackedDeviceCount()).toBe(deviceIds.length);
+
+    for (const deviceId of deviceIds) {
+      await coordinator.releaseDevice(deviceId);
+    }
+    // No idle per-device state retained after every device is released.
+    expect(coordinator.trackedDeviceCount()).toBe(0);
+  });
+
+  test("a rebuild captured before releaseDevice cannot commit afterward (#6704)", async () => {
+    const coordinator = new PerDeviceInstalledAppsCacheWriteCoordinator();
+    const deviceId = "released-device-stale";
+
+    // The device was used (invalidated at least once), so its generation is >= 1
+    // when a lagging rebuild captures it.
+    await coordinator.invalidate(deviceId, async () => undefined);
+    const generation = coordinator.beginRebuild(deviceId);
+
+    // Pool removal releases the device before the lagging rebuild commits.
+    await coordinator.releaseDevice(deviceId);
+
+    const writes: string[] = [];
+    const staleRebuild = coordinator.commitRebuild(deviceId, generation, async () => {
+      writes.push("stale");
+    });
+    await expect(staleRebuild).resolves.toBe(false);
+    expect(writes).toEqual([]);
+    // The fenced attempt leaked no bookkeeping.
+    expect(coordinator.trackedDeviceCount()).toBe(0);
+  });
+
+  test("re-adding a released device id starts from clean state (#6704)", async () => {
+    const coordinator = new PerDeviceInstalledAppsCacheWriteCoordinator();
+    const deviceId = "released-device-reuse";
+
+    await coordinator.invalidate(deviceId, async () => undefined);
+    await coordinator.releaseDevice(deviceId);
+    expect(coordinator.trackedDeviceCount()).toBe(0);
+    expect(coordinator.isDirty(deviceId)).toBe(false);
+
+    // Reused serial: a fresh rebuild at generation 0 commits normally.
+    const generation = coordinator.beginRebuild(deviceId);
+    expect(generation).toBe(0);
+    const writes: string[] = [];
+    await expect(
+      coordinator.commitRebuild(deviceId, generation, async () => {
+        writes.push("fresh");
+      }),
+    ).resolves.toBe(true);
+    expect(writes).toEqual(["fresh"]);
+  });
 });

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -21,6 +21,7 @@ import { getAbortSignal, runWithAbortSignal } from "../../src/utils/AbortContext
 import { runWithToolSelectionContext } from "../../src/features/toolSelection/toolSelectionContext";
 import { IOSCtrlProxyManager } from "../../src/utils/IOSCtrlProxyManager";
 import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
+import { getInstalledAppsCacheWriteCoordinator } from "../../src/db/installedAppsCacheWriteCoordinator";
 import { executionTracker } from "../../src/server/executionTracker";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
@@ -546,6 +547,7 @@ describe("killDevice handler", () => {
   });
 
   test("a successful explicit shutdown does not reboot the emulator", async () => {
+    const coordinator = getInstalledAppsCacheWriteCoordinator();
     const timer = new FakeTimer();
     const deviceSessionRepository = new FakeDeviceSessionRepository();
     const successfulManager = new SuccessfulKillDeviceManager();
@@ -553,10 +555,12 @@ describe("killDevice handler", () => {
     setDeviceToolsDependencies({
       deviceManagerFactory: () => successfulManager,
       notifyResourcesChanged: async () => {
+        await coordinator.invalidate("emulator-5554", async () => undefined);
         throw new Error("resource notification failed");
       },
       ensureCtrlProxyReady: async () => {},
       clearInstalledAppsForDevice: async () => {
+        await coordinator.invalidate("emulator-5554", async () => undefined);
         throw new Error("cache cleanup failed");
       },
     });
@@ -597,6 +601,7 @@ describe("killDevice handler", () => {
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(successfulManager.getCallCount("startDevice")).toBe(1);
+    expect(coordinator.isDirty("emulator-5554")).toBe(false);
     expect(pool.getDevice("emulator-5554")).toBeNull();
     expect(sessionManager.getTerminalReleaseSnapshot("session-1")).toMatchObject({
       sessionId: "session-1",

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -601,7 +601,7 @@ describe("killDevice handler", () => {
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(successfulManager.getCallCount("startDevice")).toBe(1);
-    expect(coordinator.isDirty("emulator-5554")).toBe(false);
+    expect(coordinator.isDirty("emulator-5554")).toBe(true);
     expect(pool.getDevice("emulator-5554")).toBeNull();
     expect(sessionManager.getTerminalReleaseSnapshot("session-1")).toMatchObject({
       sessionId: "session-1",

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -26,6 +26,7 @@ import {
   setDeviceToolsDependencies,
 } from "../../src/server/deviceTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
+import { getInstalledAppsCacheWriteCoordinator } from "../../src/db/installedAppsCacheWriteCoordinator";
 import {
   resetVideoRecordingManagerDependencies,
   setVideoRecordingManagerDependencies,
@@ -1653,6 +1654,11 @@ describe("deleteDevice handler", () => {
   });
 
   test("returns by the teardown deadline when post-stop cleanup does not settle", async () => {
+    const coordinator = getInstalledAppsCacheWriteCoordinator();
+    let finishCleanup!: () => void;
+    const pendingCleanup = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
     const timer = new FakeTimer();
     const device: BootedDevice = {
       platform: "ios",
@@ -1667,8 +1673,9 @@ describe("deleteDevice handler", () => {
       clearInstalledAppsForDevice: async () => {
         cleanupCalls++;
         if (cleanupCalls === 1) {
-          await new Promise<void>(() => {});
+          await pendingCleanup;
         }
+        await coordinator.invalidate(device.deviceId, async () => undefined);
       },
     });
 
@@ -1693,6 +1700,9 @@ describe("deleteDevice handler", () => {
     const retry = responseBody(await teardownTool().handler(args));
     expect(retry.state).toBe("destroyed");
     expect(manager.destroyRequests).toHaveLength(1);
+    finishCleanup();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(coordinator.isDirty(device.deviceId)).toBe(false);
   });
 
   test("holds the stable lifecycle lease until a late shutdown command settles", async () => {

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -1705,6 +1705,65 @@ describe("deleteDevice handler", () => {
     expect(coordinator.isDirty(device.deviceId)).toBe(false);
   });
 
+  test("releases per-device installed-apps bookkeeping when the shutdown notification itself re-invalidates the device (#6704)", async () => {
+    // Reproduces the Codex P1 finding on PR #6765: a normally killed device
+    // with a registered app resource gets invalidated TWICE during its own
+    // shutdown teardown — once by clearInstalledAppsForDevice, and again by
+    // defaultNotifyResourcesChanged()'s syncInstalledAppResources(), whose
+    // disappeared-device branch (src/server/appResources.ts) invalidates the
+    // same device because it vanished from the booted-device list. If the
+    // expected generation passed to releaseDevice is captured BEFORE that
+    // second, self-triggered invalidation, releaseDevice's expected-generation
+    // guard always mismatches and the release always no-ops — leaking the
+    // exact per-device bookkeeping (#6704) this PR exists to fix, for every
+    // killed device that has a registered app resource.
+    const coordinator = getInstalledAppsCacheWriteCoordinator();
+    const device: BootedDevice = {
+      platform: "ios",
+      name: "iPhone 16",
+      deviceId: "IOS-DEVICE-REGISTERED-RESOURCE",
+    };
+    manager.setBootedDevices("ios", [device]);
+    manager.setDeviceImages("ios", [{ ...device, isRunning: true }]);
+    // syncInstalledAppResources() (src/server/appResources.ts) only
+    // invalidates a disappeared device ONCE: its first pass unregisters the
+    // device's app resource, so a later pass -- e.g. the teardown tool's own
+    // separate post-verification notification -- finds nothing left to
+    // invalidate. Mirror that one-shot semantics rather than invalidating on
+    // every call.
+    let alreadyInvalidatedByNotification = false;
+    setDeviceToolsDependencies({
+      clearInstalledAppsForDevice: async (deviceId: string) => {
+        await coordinator.invalidate(deviceId, async () => undefined);
+      },
+      notifyResourcesChanged: async () => {
+        if (alreadyInvalidatedByNotification) {
+          return;
+        }
+        alreadyInvalidatedByNotification = true;
+        // Mirrors appResources.ts's disappeared-device branch: by the time
+        // this runs the device is already gone from the booted-device list,
+        // so syncInstalledAppResources() invalidates it again as part of the
+        // SAME shutdown's resource-change notification.
+        await coordinator.invalidate(device.deviceId, async () => undefined);
+      },
+    });
+
+    const body = responseBody(
+      await teardownTool().handler(request("ios", device.deviceId, device.name)),
+    );
+    expect(body.state).toBe("destroyed");
+
+    // The teardown's post-shutdown cleanup/notification chain is tracked via
+    // the DB write barrier rather than awaited inline; give it a few turns
+    // to settle.
+    for (let i = 0; i < 3; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    expect(coordinator.isDirty(device.deviceId)).toBe(false);
+  });
+
   test("holds the stable lifecycle lease until a late shutdown command settles", async () => {
     const timer = new FakeTimer();
     const lifecycleCoordinator = new InMemoryVirtualDeviceLifecycleCoordinator(timer);


### PR DESCRIPTION
## Summary

`PerDeviceInstalledAppsCacheWriteCoordinator` kept three per-device maps (`generations`,
`dirtyGenerations`, `tails`). `tails` is cleared when the last queued write settles and
`dirtyGenerations` after a rebuild's `markRebuilt`, but **`generations` was never
removed** — and pool removal's final `invalidate()` bumps the generation and marks the
device dirty with no subsequent rebuild, so a removed device left entries forever. A
long-lived daemon connected to many physical / ephemeral / simulator devices accumulated
bookkeeping for every identifier it ever saw.

Adds a **generation-safe** `releaseDevice(deviceId)`:
1. **Fence** — bump the generation the same way `invalidate` does, so a rebuild holding
   an older generation can never commit against a reused id.
2. **Drain** — wait behind the device's write tail.
3. **Delete** the per-device state only if no newer work bumped the generation again
   while draining (a reused-and-reinvalidated id keeps its newer state).

`DevicePool.clearDeviceSessionCache` (the pool-removal path) calls `releaseDevice` after
its final `invalidate()` drains, so state is freed exactly when the device is permanently
gone; a reused serial starts clean.

Part of epic #6379.

## Linked Issue

Closes #6704

## Bug / Regression Context

- **Observed symptom:** the coordinator's `generations`/`dirtyGenerations` maps grow monotonically — one entry per unique device serial/UDID the daemon ever saw, never released.
- **Repro:** remove many distinct devices from the pool; the coordinator retains bookkeeping for each.

## Validation

- [x] `test/db/installedAppsCacheWriteCoordinator.integration.test.ts` — 8 pass. New tests (via a `trackedDeviceCount()` diagnostic seam): releasing many unique ids returns the tracked count to **0**; a rebuild captured before release **cannot commit** afterward (generation-safe); a re-added serial starts clean. Existing invalidation-ordering/fencing tests unchanged. Broad `test/db` — 1061 pass; `devicePool` — 169 pass.
- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — all clean.

## Follow-ups
- None.
