### PR TITLE
ci: route macOS installer-minimal to the self-hosted runner

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1050,6 +1050,9 @@ jobs:
     needs: detect-changes
     env:
       RUN_INSTALLER: ${{ needs.detect-changes.outputs.docs_only != 'true' }}
+      # Minimal setup must not restart a daemon owned by the persistent runner
+      # account. The product default remains to migrate stale daemons for users.
+      AUTOMOBILE_SKIP_STALE_DAEMON_MIGRATION: "true"
       # ffmpeg is a large, slow install (it has timed out this job) and video
       # recording is not exercised here — skip it.
       AUTOMOBILE_INSTALL_SKIP_FFMPEG: "true"
@@ -1068,6 +1071,14 @@ jobs:
         with:
           lfs: false
 
+      - name: "Confirm clean installer fixture"
+        if: env.RUN_INSTALLER == 'true'
+        shell: bash
+        run: |
+          # .mcp.json is ignored and is the only artifact the minimal preset
+          # creates in this fresh checkout. Refuse to clean a pre-existing file.
+          test ! -e .mcp.json
+
       - name: "Run Installer (minimal)"
         if: env.RUN_INSTALLER == 'true'
         shell: bash
@@ -1082,17 +1093,22 @@ jobs:
           echo "INSTALL_EXIT_CODE=${install_status}" >> "$GITHUB_ENV"
           exit 0
 
-      - name: "Run Uninstaller"
+      - name: "Remove generated project MCP configuration"
         if: env.RUN_INSTALLER == 'true'
         shell: bash
         continue-on-error: true
         run: |
           set -uo pipefail
           set +e
-          bash ./scripts/uninstall.sh --all --force 2>&1 | tee ci-logs/uninstaller.log
-          uninstall_status=${PIPESTATUS[0]}
+          if ! jq -e '.mcpServers["auto-mobile"]' .mcp.json >/dev/null; then
+            echo "Minimal installer did not create the expected project MCP configuration" >&2
+            cleanup_status=1
+          else
+            rm -f .mcp.json
+            cleanup_status=0
+          fi
           set -e
-          echo "UNINSTALL_EXIT_CODE=${uninstall_status}" >> "$GITHUB_ENV"
+          echo "UNINSTALL_EXIT_CODE=${cleanup_status}" >> "$GITHUB_ENV"
           exit 0
 
       - name: "Upload Logs"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1075,9 +1075,15 @@ jobs:
         if: env.RUN_INSTALLER == 'true'
         shell: bash
         run: |
-          # .mcp.json is ignored and is the only artifact the minimal preset
-          # creates in this fresh checkout. Refuse to clean a pre-existing file.
-          test ! -e .mcp.json
+          # Refuse pre-existing files or symlinked parents before allowing cleanup
+          # of any project target supported by the minimal installer.
+          for directory in .codex .cursor .vscode; do
+            test ! -L "$directory"
+          done
+          for config in .mcp.json .codex/config.toml .cursor/mcp.json .vscode/mcp.json; do
+            test ! -e "$config"
+            test ! -L "$config"
+          done
 
       - name: "Run Installer (minimal)"
         if: env.RUN_INSTALLER == 'true'
@@ -1100,12 +1106,19 @@ jobs:
         run: |
           set -uo pipefail
           set +e
-          if ! jq -e '.mcpServers["auto-mobile"]' .mcp.json >/dev/null; then
-            echo "Minimal installer did not create the expected project MCP configuration" >&2
-            cleanup_status=1
-          else
-            rm -f .mcp.json
-            cleanup_status=0
+          # No client installed is a valid installer outcome. Each target was
+          # absent before this run, so remove only files this run could create.
+          cleanup_status=0
+          for directory in .codex .cursor .vscode; do
+            if [[ -L "$directory" ]]; then
+              echo "Refusing cleanup through symlink: $directory" >&2
+              cleanup_status=1
+            fi
+          done
+          if [[ "$cleanup_status" -eq 0 ]]; then
+            for config in .mcp.json .codex/config.toml .cursor/mcp.json .vscode/mcp.json; do
+              rm -f -- "$config" || cleanup_status=1
+            done
           fi
           set -e
           echo "UNINSTALL_EXIT_CODE=${cleanup_status}" >> "$GITHUB_ENV"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1039,7 +1039,14 @@ jobs:
   installer-minimal:
     timeout-minutes: 20
     name: "Installer Minimal (${{ matrix.os }})"
-    runs-on: ${{ matrix.os }}
+    # The macOS installer path remains per-PR coverage. For kaeawc-authored PRs,
+    # send just that matrix leg to the idle Apple Silicon runner to avoid the
+    # GitHub-hosted macOS queue; Ubuntu and every other author stay hosted. This
+    # is a required check, so automobile-mac must remain online and awake: GitHub
+    # cannot fall back to a hosted runner after a self-hosted job has queued. The
+    # author guard is a default, not a security boundary; all_external_contributors
+    # fork-PR approval policy is the gate for untrusted workflow changes.
+    runs-on: ${{ (matrix.os == 'macos-latest' && github.event.pull_request.user.login == 'kaeawc') && fromJSON('["self-hosted", "automobile-mac"]') || matrix.os }}
     needs: detect-changes
     env:
       RUN_INSTALLER: ${{ needs.detect-changes.outputs.docs_only != 'true' }}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3580,6 +3580,11 @@ migrate_stale_daemon() {
     # Note: this only checks the default socket path. Daemons started with
     # AUTOMOBILE_DAEMON_SOCKET_PATH overrides (benchmarks, XCTest) manage
     # their own lifecycle and are not affected by the installer.
+    if [[ "${AUTOMOBILE_SKIP_STALE_DAEMON_MIGRATION:-false}" == "true" ]]; then
+        log_info "Skipping stale daemon migration (AUTOMOBILE_SKIP_STALE_DAEMON_MIGRATION=true)"
+        return 0
+    fi
+
     if ! is_daemon_running; then
         return 0
     fi

--- a/test/bats/install-daemon-migration.bats
+++ b/test/bats/install-daemon-migration.bats
@@ -3,6 +3,7 @@
 @test "stale daemon migration can be disabled for an isolated installer run" {
   run env AUTOMOBILE_SKIP_STALE_DAEMON_MIGRATION=true INSTALL_SH_SOURCE_ONLY=true bash -c '
     source scripts/install.sh
+    log_info() { printf "%s\n" "$1"; }
     is_daemon_running() {
       echo "daemon probe must not run" >&2
       return 1

--- a/test/bats/install-daemon-migration.bats
+++ b/test/bats/install-daemon-migration.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+@test "stale daemon migration can be disabled for an isolated installer run" {
+  run env AUTOMOBILE_SKIP_STALE_DAEMON_MIGRATION=true INSTALL_SH_SOURCE_ONLY=true bash -c '
+    source scripts/install.sh
+    is_daemon_running() {
+      echo "daemon probe must not run" >&2
+      return 1
+    }
+    migrate_stale_daemon
+  '
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Skipping stale daemon migration"* ]]
+  [[ "$output" != *"daemon probe must not run"* ]]
+}

--- a/test/bats/install-daemon-migration.bats
+++ b/test/bats/install-daemon-migration.bats
@@ -2,14 +2,14 @@
 
 @test "stale daemon migration can be disabled for an isolated installer run" {
   run env AUTOMOBILE_SKIP_STALE_DAEMON_MIGRATION=true INSTALL_SH_SOURCE_ONLY=true bash -c '
-    source scripts/install.sh
+    source "$1"
     log_info() { printf "%s\n" "$1"; }
     is_daemon_running() {
       echo "daemon probe must not run" >&2
       return 1
     }
     migrate_stale_daemon
-  '
+  ' _ "${BATS_TEST_DIRNAME}/../../scripts/install.sh"
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"Skipping stale daemon migration"* ]]

--- a/test/scripts/spmRootToolchainWorkflow.test.ts
+++ b/test/scripts/spmRootToolchainWorkflow.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { spawnSync } from "node:child_process";
 import { loadJobSteps, loadJobs, stepNamed } from "../helpers/workflowSteps";
 
 describe("root SPM toolchain floor workflow", () => {
@@ -48,10 +52,58 @@ describe("root SPM toolchain floor workflow", () => {
     const cleanup = stepNamed(steps, "Remove generated project MCP configuration");
 
     expect(jobs["installer-minimal"]?.env?.AUTOMOBILE_SKIP_STALE_DAEMON_MIGRATION).toBe("true");
-    expect(fixture?.run).toContain("test ! -e .mcp.json");
-    expect(cleanup?.run).toContain(".mcpServers[\"auto-mobile\"]");
-    expect(cleanup?.run).toContain("rm -f .mcp.json");
+    expect(fixture?.run).toContain('test ! -e "$config"');
+    expect(cleanup?.run).toContain(".codex/config.toml .cursor/mcp.json .vscode/mcp.json");
+    expect(cleanup?.run).toContain('rm -f -- "$config"');
     expect(cleanup?.run).not.toContain("uninstall.sh");
+  });
+
+  for (const target of [
+    ".mcp.json",
+    ".codex/config.toml",
+    ".cursor/mcp.json",
+    ".vscode/mcp.json",
+    null,
+  ]) {
+    test.skipIf(process.platform === "win32")(
+      `cleanup preserves unrelated files for ${target ?? "no client"}`,
+      () => {
+        const steps = loadJobSteps(".github/workflows/pull_request.yml", "installer-minimal");
+        const prepare = stepNamed(steps, "Confirm clean installer fixture")!.run!;
+        const cleanup = stepNamed(steps, "Remove generated project MCP configuration")!.run!;
+        const root = mkdtempSync(join(tmpdir(), "installer-cleanup-"));
+        try {
+          const env = { ...process.env, GITHUB_ENV: join(root, "result") };
+          writeFileSync(join(root, "unrelated"), "preserve");
+          expect(spawnSync("bash", ["-e", "-c", prepare], { cwd: root, env }).status).toBe(0);
+          if (target) {
+            mkdirSync(dirname(join(root, target)), { recursive: true });
+            writeFileSync(join(root, target), "generated fixture");
+            expect(spawnSync("bash", ["-e", "-c", prepare], { cwd: root, env }).status).not.toBe(0);
+          }
+          expect(spawnSync("bash", ["-e", "-c", cleanup], { cwd: root, env }).status).toBe(0);
+          if (target) expect(existsSync(join(root, target))).toBe(false);
+          expect(existsSync(join(root, "unrelated"))).toBe(true);
+        } finally {
+          rmSync(root, { recursive: true, force: true });
+        }
+      },
+    );
+  }
+
+  test.skipIf(process.platform === "win32")("fixture rejects symlinked client directories", () => {
+    const prepare = stepNamed(
+      loadJobSteps(".github/workflows/pull_request.yml", "installer-minimal"),
+      "Confirm clean installer fixture",
+    )!.run!;
+    const root = mkdtempSync(join(tmpdir(), "installer-symlink-"));
+    try {
+      mkdirSync(join(root, "outside"));
+      symlinkSync(join(root, "outside"), join(root, ".codex"), "dir");
+      expect(spawnSync("bash", ["-e", "-c", prepare], { cwd: root }).status).not.toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test("pins the Swift package matrix to its configured Xcode floor", () => {

--- a/test/scripts/spmRootToolchainWorkflow.test.ts
+++ b/test/scripts/spmRootToolchainWorkflow.test.ts
@@ -2,11 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { loadJobSteps, loadJobs, stepNamed } from "../helpers/workflowSteps";
 
 describe("root SPM toolchain floor workflow", () => {
-  // swiftlint is a deliberate, documented exception to the "PR jobs stay hosted"
-  // rule: it is the cheapest PR job to self-host (checkout + lint script only, no
-  // secrets, no Xcode toolchain, no simulator), so kaeawc-authored PRs route it to
-  // the self-hosted runner. Every other PR job must stay on a GitHub-hosted runner.
-  const SELF_HOSTED_PR_EXCEPTIONS = new Set(["swiftlint"]);
+  // The documented SwiftLint exception and the macOS-only installer-minimal matrix
+  // leg route kaeawc-authored PRs to the self-hosted runner. Every other PR job
+  // stays on a GitHub-hosted runner.
+  const SELF_HOSTED_PR_EXCEPTIONS = new Set(["swiftlint", "installer-minimal"]);
 
   test("keeps every non-excepted pull-request job off the self-hosted runner", () => {
     const jobs = loadJobs(".github/workflows/pull_request.yml");
@@ -30,6 +29,16 @@ describe("root SPM toolchain floor workflow", () => {
     expect(runsOn).toContain("github.event.pull_request.user.login == 'kaeawc'");
     // Fallback to a GitHub-hosted runner for every other author.
     expect(runsOn).toContain("macos-26");
+  });
+
+  test("routes only kaeawc's macOS installer-minimal leg to the self-hosted runner", () => {
+    const jobs = loadJobs(".github/workflows/pull_request.yml");
+    const runsOn = JSON.stringify(jobs["installer-minimal"]?.["runs-on"] ?? "");
+
+    expect(runsOn).toContain("matrix.os == 'macos-latest'");
+    expect(runsOn).toContain("github.event.pull_request.user.login == 'kaeawc'");
+    expect(runsOn).toContain("automobile-mac");
+    expect(runsOn).toContain("|| matrix.os");
   });
 
   test("pins the Swift package matrix to its configured Xcode floor", () => {

--- a/test/scripts/spmRootToolchainWorkflow.test.ts
+++ b/test/scripts/spmRootToolchainWorkflow.test.ts
@@ -41,6 +41,19 @@ describe("root SPM toolchain floor workflow", () => {
     expect(runsOn).toContain("|| matrix.os");
   });
 
+  test("isolates installer side effects on the persistent runner", () => {
+    const jobs = loadJobs(".github/workflows/pull_request.yml");
+    const steps = loadJobSteps(".github/workflows/pull_request.yml", "installer-minimal");
+    const fixture = stepNamed(steps, "Confirm clean installer fixture");
+    const cleanup = stepNamed(steps, "Remove generated project MCP configuration");
+
+    expect(jobs["installer-minimal"]?.env?.AUTOMOBILE_SKIP_STALE_DAEMON_MIGRATION).toBe("true");
+    expect(fixture?.run).toContain("test ! -e .mcp.json");
+    expect(cleanup?.run).toContain(".mcpServers[\"auto-mobile\"]");
+    expect(cleanup?.run).toContain("rm -f .mcp.json");
+    expect(cleanup?.run).not.toContain("uninstall.sh");
+  });
+
   test("pins the Swift package matrix to its configured Xcode floor", () => {
     const steps = loadJobSteps(".github/workflows/pull_request.yml", "ios-swift-packages");
     const selectXcode = stepNamed(steps, "Select Xcode ${{ matrix.config.xcode }}");


### PR DESCRIPTION
## Summary

- Route only the `installer-minimal` macOS matrix leg for `kaeawc`-authored PRs to the self-hosted Apple Silicon `automobile-mac` runner.
- Keep Ubuntu and non-`kaeawc` macOS legs on GitHub-hosted runners, preserving the existing required check name and per-PR macOS install-path coverage.
- Document and test the routing rule alongside the existing SwiftLint self-hosted precedent.
- Limit cleanup to project configuration files confirmed absent before installation: Claude, Codex, Cursor, and VS Code are supported, including runs with no detected client. Reject symlinked parents and skip stale-daemon migration on the persistent runner. This bounds cleanup but is not a disposable OS environment.

This removes the measured 7–17 minute GitHub-hosted macOS queue from the required check while retaining its roughly 0.5-minute execution. The self-hosted runner is currently online and idle, and its AC sleep policy is `sleep 0`.

## Required-runner caveat

`Installer Minimal (macos-latest)` is required. If the sole self-hosted Mac is offline or asleep, `kaeawc` PRs will wait indefinitely because GitHub cannot fall back to a hosted runner after scheduling to a self-hosted label. Keep the runner on AC and awake. The author guard is a routing default rather than a security boundary; fork-PR approval under `all_external_contributors` remains the real gate for untrusted workflow changes.

## Validation

- `bats test/bats/pr-gate-wiring.bats`
- `bats test/bats/install-daemon-migration.bats` (stubbed logging; no installed gum dependency)
- `bun run format:check`
- `AUTOMOBILE_LOG_DIR=/private/tmp/auto-mobile-route-installer-minimal-macos-logs bun test test/scripts/spmRootToolchainWorkflow.test.ts`
- `AUTOMOBILE_LOG_DIR=/private/tmp/auto-mobile-route-installer-minimal-macos-logs scripts/all_fast_validate_checks.sh`
- `actionlint .github/workflows/pull_request.yml` (known baseline failures from repository-specific `background`/`wait` workflow extensions and local action metadata; no diagnostic in this change)
