### PR TITLE
ci: move macOS Node TypeScript build off the PR critical path

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -893,9 +893,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          # - macos-latest
-          # Disabled on merge cleanup: flaky timeout in Bun tests and not required for release/docs publishing.
+          # Keep the PR-required Windows lane off scarce macOS runners; this
+          # post-merge lane preserves macOS coverage without extending PR merge time.
+          - macos-latest
           # - windows-latest
           # Disabled on merge cleanup: expensive and not required for release/docs publishing.
     steps:
@@ -913,7 +913,22 @@ jobs:
             turbo-${{ matrix.os }}-${{ hashFiles('bun.lock') }}-
             turbo-${{ matrix.os }}-
 
-      - uses: ./.github/actions/setup-auto-mobile-npm-package
+      - name: "Setup Bun"
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: "Install Bun dependencies"
+        shell: bash
+        run: scripts/ci/install-bun-deps.sh
+
+      - name: "Run complete unit lane"
+        shell: bash
+        env:
+          AUTOMOBILE_TEST_MODE: "true"
+          AUTOMOBILE_TEST_WALL_TIMEOUT_SECONDS: "720"
+          AUTOMOBILE_UNIT_JUNIT_DIR: scratch/timing-unit-reports
+        run: bash scripts/test-ts.sh unit
 
       - name: "Run Lint"
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1277,9 +1277,9 @@ jobs:
     name: "Node TypeScript Build and Test (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     needs: detect-changes
-    # The full isolated Bun suite can approach fifteen minutes on a contended
-    # hosted macOS runner. Keep the cross-platform lane intact while allowing
-    # enough headroom to finish after setup, lint, and build (issue #5328).
+    # macOS coverage runs after merge, where a scarce hosted macOS runner cannot
+    # block PRs. Keep this required PR lane on Windows alongside the separate
+    # Ubuntu coverage job below.
     timeout-minutes: 25
     env:
       RUN_MCP_BUILD_TEST: ${{ needs.detect-changes.outputs.docs_only != 'true' && needs.detect-changes.outputs.sha256_only != 'true' }}
@@ -1287,7 +1287,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
           - windows-latest
     steps:
       - name: "Skip Node TypeScript build and test"
@@ -1383,7 +1382,7 @@ jobs:
           turbo run build --output-logs=errors-only --log-order=grouped 2>&1 | tee "ci-logs/bun-build-${{ matrix.os }}.log"
 
       - name: "Run Bun image runtime smoke"
-        if: env.RUN_MCP_BUILD_TEST == 'true' && (matrix.os == 'macos-latest' || matrix.os == 'windows-latest')
+        if: env.RUN_MCP_BUILD_TEST == 'true' && matrix.os == 'windows-latest'
         run: bun run test:image:bun
 
       - name: "Upload Build/Test Logs"

--- a/test/bats/pr-gate-wiring.bats
+++ b/test/bats/pr-gate-wiring.bats
@@ -160,6 +160,23 @@ wiring_requires_yq() {
   [[ "$(job_block bats-integration-tests "$workflow")" == *"scripts/ci/run-bats.sh integration"* ]]
 }
 
+@test "macOS MCP build coverage runs after merge instead of on pull requests" {
+  wiring_requires_yq
+  local pr_mcp merge_mcp
+  pr_mcp="$(job_block mcp-build-and-test)"
+  merge_mcp="$(job_block mcp-build-and-test .github/workflows/merge.yml)"
+
+  [[ "$pr_mcp" == *"windows-latest"* ]]
+  [[ "$pr_mcp" != *"macos-latest"* ]]
+  [[ "$merge_mcp" == *"macos-latest"* ]]
+  [[ "$merge_mcp" == *"scripts/ci/install-bun-deps.sh"* ]]
+  [[ "$merge_mcp" == *"bash scripts/test-ts.sh unit"* ]]
+
+  run yq -r '.jobs.mcp-build-and-test.strategy.matrix.os[]' "$WF"
+  [ "$status" -eq 0 ]
+  [ "$output" = "windows-latest" ]
+}
+
 @test "nightly preserves the moved macOS portable test lanes" {
   local workflow=".github/workflows/nightly.yml"
   local bats_unit bats_integration unit host


### PR DESCRIPTION
## Summary

- removes `macos-latest` from the pull-request `mcp-build-and-test` matrix, leaving the required Windows lane and the separate Ubuntu coverage job intact
- moves equivalent macOS coverage to post-merge `mcp-build-and-test`, including Bun dependency installation, the unit lane, lint, and build
- removes the now-defunct `Node TypeScript Build and Test (macos-latest)` required status context from the active `green-main` repository ruleset

The GitHub-hosted macOS PR job spends about one minute working but queues for 7–20 minutes on scarce runners. Removing it from the required PR path saves that queue time from the merge-blocking critical path while retaining macOS coverage after merge.

## Validation

- `scripts/all_fast_validate_checks.sh`
- `bats test/bats/pr-gate-wiring.bats`
- `actionlint` on both edited workflows (repository-specific baseline diagnostics ignored; no new diagnostics)
