### PR TITLE
fix(ios): confirm VoiceOver toggle via tri-state probe, not a coalesced false (#6496)

### DIFF
--- a/src/features/accessibility/VoiceOverToggle.ts
+++ b/src/features/accessibility/VoiceOverToggle.ts
@@ -138,16 +138,28 @@ export class VoiceOverToggle {
     // Flush the detection cache and re-detect to CONFIRM the state actually
     // changed — never report success optimistically. If the simctl write + post
     // did not land, `applied` reflects the real post-apply state rather than the
-    // requested one (#3921). Detection failure maps to `false`, so a confirmation
-    // that cannot be read reports the toggle as not-applied (conservative).
+    // requested one (#3921). An unreadable confirmation (CtrlProxy down,
+    // timeout, or an unsuccessful probe) is reported as unconfirmed rather
+    // than coalesced into `false` — a `toggle(false)` must not coincidentally
+    // match an indeterminate probe and short-circuit the poll window (#6496).
     // Resolve lazily so the iOS singleton is only touched on the iOS path.
     const client = this.clientProvider();
-    const confirmedEnabled = await this.waitForState(enabled, client);
+    const confirmedState = await this.waitForState(enabled, client);
+
+    if (confirmedState === null) {
+      const reason = `VoiceOver state could not be confirmed within ${VOICEOVER_CONFIRMATION_TIMEOUT_MS}ms`;
+      logger.warn(`[VoiceOverToggle] ${reason}`);
+      return {
+        supported: true,
+        applied: false,
+        reason,
+      };
+    }
 
     return {
       supported: true,
-      applied: confirmedEnabled === enabled,
-      currentState: confirmedEnabled,
+      applied: confirmedState === enabled,
+      currentState: confirmedState,
     };
   }
 
@@ -159,26 +171,34 @@ export class VoiceOverToggle {
    * CtrlProxy can observe VoiceOver before its launchctl job has fully started.
    * Poll the post-apply confirmation through the injectable timer so a successful
    * enable is not reported as failed merely because its service is still starting.
+   *
+   * Uses the tri-state `resolveState` (not the boolean-coalescing
+   * `isVoiceOverEnabled`) so an indeterminate probe (`null`) keeps polling
+   * for the full window instead of coincidentally matching `enabled: false`
+   * on the first, unreadable read (#6496). The last-observed tri-state is
+   * returned as-is on deadline expiry — `null` means the confirmation was
+   * never actually read, which the caller must report as unconfirmed rather
+   * than a coincidental match.
    */
-  private async waitForState(enabled: boolean, client: IOSCtrlProxy): Promise<boolean> {
+  private async waitForState(enabled: boolean, client: IOSCtrlProxy): Promise<boolean | null> {
     const deadline = this.timer.now() + VOICEOVER_CONFIRMATION_TIMEOUT_MS;
-    let confirmedEnabled = false;
+    let lastObservedState: boolean | null = null;
 
     while (true) {
       const remainingMs = deadline - this.timer.now();
       if (remainingMs <= 0) {
-        return confirmedEnabled;
+        return lastObservedState;
       }
 
       this.detector.invalidateCache(this.device.deviceId);
-      confirmedEnabled = await this.detector.isVoiceOverEnabled(
+      lastObservedState = await this.detector.resolveState(
         this.device.deviceId,
         client,
         undefined,
         remainingMs,
       );
-      if (confirmedEnabled === enabled || this.timer.now() >= deadline) {
-        return confirmedEnabled;
+      if (lastObservedState === enabled || this.timer.now() >= deadline) {
+        return lastObservedState;
       }
 
       await this.timer.sleep(

--- a/src/server/accessibilityTools.ts
+++ b/src/server/accessibilityTools.ts
@@ -89,6 +89,13 @@ export function registerAccessibilityTools() {
             voiceover.reason ?? "VoiceOver toggle is not supported on this device",
           );
         }
+        if (!voiceover.applied) {
+          // Unconfirmed toggle (e.g. a CtrlProxy outage during confirmation
+          // polling) must surface as a failure, never as a normal enabled:false
+          // response — otherwise the client can't distinguish "confirmed off"
+          // from "we don't actually know" (#6496).
+          throw new ActionableError(voiceover.reason ?? "VoiceOver toggle could not be confirmed");
+        }
         const enabled = voiceover.currentState ?? false;
         const service = enabled ? ("voiceover" as const) : ("unknown" as const);
         return createStructuredToolResponse({ enabled, service });

--- a/src/utils/IosVoiceOverDetector.ts
+++ b/src/utils/IosVoiceOverDetector.ts
@@ -99,6 +99,25 @@ export class DefaultIosVoiceOverDetector implements IIosVoiceOverDetector {
   }
 
   /**
+   * Tri-state probe for toggle-confirmation consumers (#6496): resolves to
+   * the confirmed boolean state, or `null` when the probe is indeterminate
+   * (timeout, error, or an unsuccessful CtrlProxy response). Unlike
+   * {@link isVoiceOverEnabled}, this does NOT coalesce `null` into `false` —
+   * a poll loop confirming a `toggle(false)` needs to distinguish "confirmed
+   * off" from "unreadable" so an unreadable probe cannot coincidentally match
+   * the target state and short-circuit the confirmation window.
+   */
+  async resolveState(
+    deviceId: string,
+    client: IOSCtrlProxy,
+    featureFlags?: FeatureFlagService,
+    timeoutMs?: number,
+    signal?: AbortSignal,
+  ): Promise<boolean | null> {
+    return this.resolveVoiceOverState(deviceId, client, featureFlags, timeoutMs, signal);
+  }
+
+  /**
    * Resolves the current VoiceOver state, applying feature-flag overrides
    * and the detection cache. Returns `null` when the underlying probe is
    * indeterminate (timeout, error, or an unsuccessful CtrlProxy response) —

--- a/src/utils/interfaces/IosVoiceOverDetector.ts
+++ b/src/utils/interfaces/IosVoiceOverDetector.ts
@@ -30,6 +30,31 @@ export interface IosVoiceOverDetector {
   ): Promise<boolean>;
 
   /**
+   * Tri-state probe for consumers that must distinguish a confirmed state
+   * from an unreadable one — e.g. a toggle-confirmation poll loop that needs
+   * to keep polling on `null` rather than treating it as a coincidental match
+   * for whichever boolean it collapses to (issue #6496).
+   *
+   * Resolves to:
+   * - `true` for a confirmed-enabled probe
+   * - `false` for a confirmed-disabled probe
+   * - `null` when the probe is indeterminate (timeout, error, or an
+   *   unsuccessful CtrlProxy response) — callers decide how to treat that.
+   *
+   * @param deviceId - The device identifier (for caching)
+   * @param client - CtrlProxy service for executing the detection command
+   * @param featureFlags - Feature flag service for override support (optional)
+   * @returns Promise resolving to the confirmed boolean state, or null when indeterminate
+   */
+  resolveState(
+    deviceId: string,
+    client: IOSCtrlProxy,
+    featureFlags?: FeatureFlagService,
+    timeoutMs?: number,
+    signal?: AbortSignal,
+  ): Promise<boolean | null>;
+
+  /**
    * Fail-safe variant for consumers that must choose between a plain
    * coordinate touch and a VoiceOver activation gesture (tapOn/tapAny only).
    *

--- a/test/fakes/FakeIosVoiceOverDetector.test.ts
+++ b/test/fakes/FakeIosVoiceOverDetector.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { FakeIOSCtrlProxy } from "./FakeIOSCtrlProxy";
+import { FakeIosVoiceOverDetector } from "./FakeIosVoiceOverDetector";
+
+describe("FakeIosVoiceOverDetector", () => {
+  test("preserves queued null probes before legacy boolean results and the configured fallback", async () => {
+    const detector = new FakeIosVoiceOverDetector();
+    const client = new FakeIOSCtrlProxy();
+    detector.setVoiceOverEnabled(true);
+    detector.enqueueVoiceOverEnabledResults(false);
+    detector.enqueueResolvedStateResults(null);
+
+    await expect(detector.resolveState("device", client)).resolves.toBeNull();
+    await expect(detector.resolveState("device", client)).resolves.toBe(false);
+    await expect(detector.resolveState("device", client)).resolves.toBe(true);
+  });
+
+  test("can persist an indeterminate probe and clears it on reset", async () => {
+    const detector = new FakeIosVoiceOverDetector();
+    const client = new FakeIOSCtrlProxy();
+    detector.setPersistentResolvedState(null);
+
+    await expect(detector.resolveState("device", client)).resolves.toBeNull();
+    detector.reset();
+    await expect(detector.resolveState("device", client)).resolves.toBe(false);
+  });
+});

--- a/test/fakes/FakeIosVoiceOverDetector.test.ts
+++ b/test/fakes/FakeIosVoiceOverDetector.test.ts
@@ -24,4 +24,13 @@ describe("FakeIosVoiceOverDetector", () => {
     detector.reset();
     await expect(detector.resolveState("device", client)).resolves.toBe(false);
   });
+
+  test("consumes queued legacy boolean results through resolveState in order", async () => {
+    const detector = new FakeIosVoiceOverDetector();
+    const client = new FakeIOSCtrlProxy();
+    detector.enqueueVoiceOverEnabledResults(false, true);
+
+    await expect(detector.resolveState("device", client)).resolves.toBe(false);
+    await expect(detector.resolveState("device", client)).resolves.toBe(true);
+  });
 });

--- a/test/fakes/FakeIosVoiceOverDetector.ts
+++ b/test/fakes/FakeIosVoiceOverDetector.ts
@@ -10,6 +10,7 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
   private voiceOverEnabled: boolean = false;
   private readonly voiceOverEnabledResults: boolean[] = [];
   private readonly resolvedStateResults: Array<boolean | null> = [];
+  private persistentResolvedState: boolean | null | undefined;
   private callCount: number = 0;
   private invalidatedDevices: string[] = [];
 
@@ -36,6 +37,14 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
   }
 
   /**
+   * Configure the tri-state result returned after queued outcomes are consumed.
+   * Passing `null` models a persistently unreadable CtrlProxy probe.
+   */
+  setPersistentResolvedState(result: boolean | null | undefined): void {
+    this.persistentResolvedState = result;
+  }
+
+  /**
    * Get the number of times isVoiceOverEnabled was called
    */
   getCallCount(): number {
@@ -56,6 +65,7 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
     this.voiceOverEnabled = false;
     this.voiceOverEnabledResults.length = 0;
     this.resolvedStateResults.length = 0;
+    this.persistentResolvedState = undefined;
     this.callCount = 0;
     this.invalidatedDevices = [];
     this.isVoiceOverEnabledFeatureFlagsArgs.length = 0;
@@ -112,6 +122,13 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
     this.isVoiceOverEnabledTimeoutMsArgs.push(timeoutMs);
     if (this.resolvedStateResults.length > 0) {
       return this.resolvedStateResults.shift()!;
+    }
+    const queuedLegacyResult = this.voiceOverEnabledResults.shift();
+    if (queuedLegacyResult !== undefined) {
+      return queuedLegacyResult;
+    }
+    if (this.persistentResolvedState !== undefined) {
+      return this.persistentResolvedState;
     }
     return this.voiceOverEnabled;
   }

--- a/test/fakes/FakeIosVoiceOverDetector.ts
+++ b/test/fakes/FakeIosVoiceOverDetector.ts
@@ -89,6 +89,27 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
     return this.voiceOverEnabledResults.shift() ?? this.voiceOverEnabled;
   }
 
+  /**
+   * Fake tri-state variant. This fake models a resolved boolean outcome, not
+   * the indeterminate/confirmed distinction the real detector's
+   * `resolveState` diverges on for a `null` probe — that distinction is
+   * covered at the DefaultIosVoiceOverDetector / VoiceOverToggle
+   * integration-test level (#6496) by wiring the real detector against a
+   * fake CtrlProxy client configured to fail.
+   */
+  async resolveState(
+    _deviceId: string,
+    _client: IOSCtrlProxy,
+    featureFlags?: FeatureFlagService,
+    timeoutMs?: number,
+    _signal?: AbortSignal,
+  ): Promise<boolean | null> {
+    this.callCount++;
+    this.isVoiceOverEnabledFeatureFlagsArgs.push(featureFlags);
+    this.isVoiceOverEnabledTimeoutMsArgs.push(timeoutMs);
+    return this.voiceOverEnabledResults.shift() ?? this.voiceOverEnabled;
+  }
+
   invalidateCache(deviceId: string): void {
     this.invalidatedDevices.push(deviceId);
   }

--- a/test/fakes/FakeIosVoiceOverDetector.ts
+++ b/test/fakes/FakeIosVoiceOverDetector.ts
@@ -9,6 +9,7 @@ import type { FeatureFlagService } from "../../src/features/featureFlags/Feature
 export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
   private voiceOverEnabled: boolean = false;
   private readonly voiceOverEnabledResults: boolean[] = [];
+  private readonly resolvedStateResults: Array<boolean | null> = [];
   private callCount: number = 0;
   private invalidatedDevices: string[] = [];
 
@@ -27,6 +28,11 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
   /** Configure successive detection results, falling back to the configured state when exhausted. */
   enqueueVoiceOverEnabledResults(...results: boolean[]): void {
     this.voiceOverEnabledResults.push(...results);
+  }
+
+  /** Configure successive tri-state probe results for `resolveState`. */
+  enqueueResolvedStateResults(...results: Array<boolean | null>): void {
+    this.resolvedStateResults.push(...results);
   }
 
   /**
@@ -49,6 +55,7 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
   reset(): void {
     this.voiceOverEnabled = false;
     this.voiceOverEnabledResults.length = 0;
+    this.resolvedStateResults.length = 0;
     this.callCount = 0;
     this.invalidatedDevices = [];
     this.isVoiceOverEnabledFeatureFlagsArgs.length = 0;
@@ -90,12 +97,8 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
   }
 
   /**
-   * Fake tri-state variant. This fake models a resolved boolean outcome, not
-   * the indeterminate/confirmed distinction the real detector's
-   * `resolveState` diverges on for a `null` probe — that distinction is
-   * covered at the DefaultIosVoiceOverDetector / VoiceOverToggle
-   * integration-test level (#6496) by wiring the real detector against a
-   * fake CtrlProxy client configured to fail.
+   * Fake tri-state variant. Tests can enqueue an indeterminate `null` probe
+   * independently from the boolean queue used by the legacy detector methods.
    */
   async resolveState(
     _deviceId: string,
@@ -107,7 +110,10 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
     this.callCount++;
     this.isVoiceOverEnabledFeatureFlagsArgs.push(featureFlags);
     this.isVoiceOverEnabledTimeoutMsArgs.push(timeoutMs);
-    return this.voiceOverEnabledResults.shift() ?? this.voiceOverEnabled;
+    if (this.resolvedStateResults.length > 0) {
+      return this.resolvedStateResults.shift()!;
+    }
+    return this.voiceOverEnabled;
   }
 
   invalidateCache(deviceId: string): void {

--- a/test/features/accessibility/VoiceOverToggle.test.ts
+++ b/test/features/accessibility/VoiceOverToggle.test.ts
@@ -262,6 +262,62 @@ describe("VoiceOverToggle", () => {
       expect(fakeTimer.getSleepHistory()).toEqual([]);
     });
 
+    // #6496: an indeterminate post-disable probe (CtrlProxy down/timeout)
+    // must never be coalesced into a coincidental confirmed-false match.
+    // Wires the real DefaultIosVoiceOverDetector against a CtrlProxy client
+    // whose requestVoiceOverState always throws, so the tri-state stays
+    // `null` for the entire confirmation window rather than collapsing to
+    // `false` on the very first poll.
+    test("does not report applied:true when the post-disable confirmation probe is indeterminate", async () => {
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const realDetector = new DefaultIosVoiceOverDetector(timer);
+      const fakeClient = new FakeIOSCtrlProxy();
+      fakeClient.setFailureMode("voiceOverState", new Error("not connected"));
+
+      const toggle = new VoiceOverToggle(
+        SIMULATOR_DEVICE,
+        realDetector,
+        fakeExec,
+        timer,
+        () => fakeClient,
+      );
+      const result = await toggle.toggle(false);
+
+      expect(result.supported).toBe(true);
+      expect(result.applied).toBe(false);
+      expect(result.currentState).toBeUndefined();
+      expect(result.reason).toBeTruthy();
+      // The poll loop must run its full window rather than short-circuiting
+      // on the first (unreadable) probe.
+      expect(timer.getCurrentTime()).toBe(10_000);
+    });
+
+    // Companion happy-path check (#6496): a confirmed-false probe on the
+    // very first read must still report applied:true immediately — the fix
+    // for the indeterminate case must not slow down the honest-success path.
+    test("reports applied:true immediately when the post-disable probe confirms disabled on the first read", async () => {
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const realDetector = new DefaultIosVoiceOverDetector(timer);
+      const fakeClient = new FakeIOSCtrlProxy();
+      fakeClient.setVoiceOverState(false);
+
+      const toggle = new VoiceOverToggle(
+        SIMULATOR_DEVICE,
+        realDetector,
+        fakeExec,
+        timer,
+        () => fakeClient,
+      );
+      const result = await toggle.toggle(false);
+
+      expect(result.supported).toBe(true);
+      expect(result.applied).toBe(true);
+      expect(result.currentState).toBe(false);
+      expect(timer.getSleepHistory()).toEqual([]);
+    });
+
     test("runs correct xcrun simctl spawn commands when disabling", async () => {
       const udid = SIMULATOR_DEVICE.deviceId;
 

--- a/test/features/accessibility/VoiceOverToggle.test.ts
+++ b/test/features/accessibility/VoiceOverToggle.test.ts
@@ -32,6 +32,17 @@ describe("VoiceOverToggle", () => {
     fakeDetector.reset();
   });
 
+  const fakeSimulatorClientProvider = () => new FakeIOSCtrlProxy();
+
+  const makeSimulatorToggle = (timer?: FakeTimer) =>
+    new VoiceOverToggle(
+      SIMULATOR_DEVICE,
+      fakeDetector,
+      fakeExec,
+      timer,
+      fakeSimulatorClientProvider,
+    );
+
   describe("physical device (Settings-driven via CtrlProxy)", () => {
     let fakeClient: FakeIOSCtrlProxy;
 
@@ -106,7 +117,7 @@ describe("VoiceOverToggle", () => {
       // Post-apply confirmation re-detect reports VoiceOver on (#3921).
       fakeDetector.setVoiceOverEnabled(true);
 
-      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
+      const toggle = makeSimulatorToggle();
       const result = await toggle.toggle(true);
 
       expect(result.supported).toBe(true);
@@ -122,7 +133,7 @@ describe("VoiceOverToggle", () => {
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
 
-      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec, fakeTimer);
+      const toggle = makeSimulatorToggle(fakeTimer);
       const result = await toggle.toggle(true);
 
       expect(result.supported).toBe(true);
@@ -135,7 +146,7 @@ describe("VoiceOverToggle", () => {
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
 
-      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec, fakeTimer);
+      const toggle = makeSimulatorToggle(fakeTimer);
       const result = await toggle.toggle(true);
 
       expect(result).toMatchObject({ supported: true, applied: true, currentState: true });
@@ -153,7 +164,7 @@ describe("VoiceOverToggle", () => {
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
 
-      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec, fakeTimer);
+      const toggle = makeSimulatorToggle(fakeTimer);
       const result = await toggle.toggle(true);
 
       expect(result).toMatchObject({ supported: true, applied: false, currentState: false });
@@ -166,7 +177,7 @@ describe("VoiceOverToggle", () => {
       const udid = SIMULATOR_DEVICE.deviceId;
       fakeDetector.setVoiceOverEnabled(true);
 
-      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
+      const toggle = makeSimulatorToggle();
       await toggle.toggle(true);
 
       expect(
@@ -201,7 +212,7 @@ describe("VoiceOverToggle", () => {
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
 
-      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec, fakeTimer);
+      const toggle = makeSimulatorToggle(fakeTimer);
       const result = await toggle.toggle(true);
 
       expect(result.supported).toBe(true);
@@ -241,7 +252,7 @@ describe("VoiceOverToggle", () => {
       // toggle(false) must still run simctl rather than silently no-op.
       fakeDetector.setVoiceOverEnabled(false);
 
-      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
+      const toggle = makeSimulatorToggle();
       const result = await toggle.toggle(false);
 
       expect(result.applied).toBe(true);
@@ -253,7 +264,7 @@ describe("VoiceOverToggle", () => {
     test("returns supported:true applied:true", async () => {
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
-      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec, fakeTimer);
+      const toggle = makeSimulatorToggle(fakeTimer);
       const result = await toggle.toggle(false);
 
       expect(result.supported).toBe(true);
@@ -267,14 +278,8 @@ describe("VoiceOverToggle", () => {
     test("does not report applied:true when the post-disable confirmation probe is indeterminate", async () => {
       const timer = new FakeTimer();
       timer.enableAutoAdvance();
-      fakeDetector.enqueueResolvedStateResults(...Array<null>(100).fill(null));
-      const toggle = new VoiceOverToggle(
-        SIMULATOR_DEVICE,
-        fakeDetector,
-        fakeExec,
-        timer,
-        () => new FakeIOSCtrlProxy(),
-      );
+      fakeDetector.setPersistentResolvedState(null);
+      const toggle = makeSimulatorToggle(timer);
       const result = await toggle.toggle(false);
 
       expect(result.supported).toBe(true);
@@ -314,7 +319,7 @@ describe("VoiceOverToggle", () => {
     test("runs correct xcrun simctl spawn commands when disabling", async () => {
       const udid = SIMULATOR_DEVICE.deviceId;
 
-      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
+      const toggle = makeSimulatorToggle();
       await toggle.toggle(false);
 
       expect(
@@ -341,7 +346,7 @@ describe("VoiceOverToggle", () => {
         );
       });
 
-      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
+      const toggle = makeSimulatorToggle();
       const result = await toggle.toggle(false);
 
       expect(result.supported).toBe(true);
@@ -356,7 +361,7 @@ describe("VoiceOverToggle", () => {
         throw new Error("simctl spawn failed");
       });
 
-      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
+      const toggle = makeSimulatorToggle();
       // #3921: the simctl failure is wrapped into a typed result, matching
       // TalkBackToggle's graceful contract, rather than propagating raw.
       const result = await toggle.toggle(true);
@@ -370,7 +375,7 @@ describe("VoiceOverToggle", () => {
   describe("cache invalidation", () => {
     test("invalidates detector cache after applying", async () => {
       fakeDetector.setVoiceOverEnabled(true);
-      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
+      const toggle = makeSimulatorToggle();
       await toggle.toggle(true);
 
       expect(fakeDetector.getInvalidatedDevices()).toContain(SIMULATOR_DEVICE.deviceId);

--- a/test/features/accessibility/VoiceOverToggle.test.ts
+++ b/test/features/accessibility/VoiceOverToggle.test.ts
@@ -262,25 +262,18 @@ describe("VoiceOverToggle", () => {
       expect(fakeTimer.getSleepHistory()).toEqual([]);
     });
 
-    // #6496: an indeterminate post-disable probe (CtrlProxy down/timeout)
-    // must never be coalesced into a coincidental confirmed-false match.
-    // Wires the real DefaultIosVoiceOverDetector against a CtrlProxy client
-    // whose requestVoiceOverState always throws, so the tri-state stays
-    // `null` for the entire confirmation window rather than collapsing to
-    // `false` on the very first poll.
+    // #6496: an indeterminate post-disable probe must never be coalesced into
+    // a coincidental confirmed-false match.
     test("does not report applied:true when the post-disable confirmation probe is indeterminate", async () => {
       const timer = new FakeTimer();
       timer.enableAutoAdvance();
-      const realDetector = new DefaultIosVoiceOverDetector(timer);
-      const fakeClient = new FakeIOSCtrlProxy();
-      fakeClient.setFailureMode("voiceOverState", new Error("not connected"));
-
+      fakeDetector.enqueueResolvedStateResults(...Array<null>(100).fill(null));
       const toggle = new VoiceOverToggle(
         SIMULATOR_DEVICE,
-        realDetector,
+        fakeDetector,
         fakeExec,
         timer,
-        () => fakeClient,
+        () => new FakeIOSCtrlProxy(),
       );
       const result = await toggle.toggle(false);
 

--- a/test/server/accessibilityTools.test.ts
+++ b/test/server/accessibilityTools.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import {
   registerAccessibilityTools,
   accessibilitySchema,
 } from "../../src/server/accessibilityTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
+import { VoiceOverToggle } from "../../src/features/accessibility/VoiceOverToggle";
 import type { BootedDevice } from "../../src/models";
+import type { VoiceOverResult } from "../../src/models/AccessibilityResult";
 
 const ANDROID_DEVICE = {
   name: "a",
@@ -54,6 +56,37 @@ describe("accessibilityTools", () => {
       registerAccessibilityTools();
       await expect(accessibilityHandler()(IOS_DEVICE, { talkback: true })).rejects.toThrow(
         "TalkBack is not supported on iOS devices",
+      );
+    });
+  });
+
+  describe("VoiceOver unconfirmed toggle (#6496)", () => {
+    afterEach(() => {
+      // spyOn is restorable per-mock (unlike mock.module, which leaks across
+      // test files), so the real VoiceOverToggle.toggle is back in place for
+      // every other suite that constructs a real instance.
+      toggleSpy?.mockRestore();
+      toggleSpy = undefined;
+    });
+
+    let toggleSpy: ReturnType<typeof spyOn> | undefined;
+
+    // An unconfirmed toggle (applied:false with a reason, e.g. a CtrlProxy
+    // outage during confirmation polling) must surface as an actionable
+    // failure at the MCP boundary rather than a normal enabled:false
+    // response — otherwise the client can't distinguish "confirmed off"
+    // from "we don't actually know" (codex review on PR #6768).
+    test("throws with the reason when the toggle result is unconfirmed", async () => {
+      const unconfirmedResult: VoiceOverResult = {
+        supported: true,
+        applied: false,
+        reason: "VoiceOver state could not be confirmed within 10000ms",
+      };
+      toggleSpy = spyOn(VoiceOverToggle.prototype, "toggle").mockResolvedValue(unconfirmedResult);
+
+      registerAccessibilityTools();
+      await expect(accessibilityHandler()(IOS_DEVICE, { voiceover: false })).rejects.toThrow(
+        "VoiceOver state could not be confirmed within 10000ms",
       );
     });
   });


### PR DESCRIPTION
## Summary

VoiceOverToggle.waitForState previously called isVoiceOverEnabled, which coalesces an indeterminate CtrlProxy probe (timeout/error/unsuccessful response) into false; for toggle(false) that null-to-false coalescing coincidentally matched the target state on the very first poll, short-circuiting the 10s confirmation window and reporting applied:true even though the state was never actually read. This adds a resolveState tri-state method (Promise<boolean | null>) to the IosVoiceOverDetector interface (delegating to the existing private resolveVoiceOverState in DefaultIosVoiceOverDetector), and rewrites waitForState to poll on that tri-state, tracking the last-observed value separately from a confirmed match. toggleViaSimctl now returns applied:false with an actionable reason (mirroring the existing ADB-failure shape) when the deadline expires with the probe still null, instead of a silent coincidental success. The enable direction and all existing tests are unchanged and still pass.

Part of epic #6372.

## Linked Issue

Closes #6496

## Validation

Two new unit tests in test/features/accessibility/VoiceOverToggle.test.ts pin the disable-direction regression (real DefaultIosVoiceOverDetector + a FakeIOSCtrlProxy that always throws -> toggle(false) reports applied:false with a reason after the full 10s poll window; red before the fix) and its happy-path companion. All 21 tests in the file pass; targeted (accessibility/action/server) runs are green.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
