### PR TITLE
fix(ios): serialize simctl privacy grants for the same device (#6581)

### DIFF
--- a/src/features/action/IosSimulatorPermissions.ts
+++ b/src/features/action/IosSimulatorPermissions.ts
@@ -7,6 +7,8 @@ import {
 import type { HostCommandExecutor } from "../../utils/HostCommandExecutor";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
+import { withDeviceReadinessLock } from "../../utils/deviceReadinessLock";
+import { getAbortSignal } from "../../utils/AbortContext";
 
 export type IosSimulatorPermissionAction = "grant" | "revoke" | "reset";
 
@@ -160,6 +162,7 @@ export class IosSimulatorPermissions {
     device: BootedDevice,
     simctl: IosSimulatorPrivacyClient | null = null,
     tccReader: TccPermissionReader | null = null,
+    private readonly withPrivacyLock: typeof withDeviceReadinessLock = withDeviceReadinessLock,
   ) {
     this.device = device;
     this.simctl = simctl || new SimCtlClient(device);
@@ -211,7 +214,19 @@ export class IosSimulatorPermissions {
       };
     }
 
-    // Serialized (not Promise.all): concurrent `simctl privacy` invocations for
+    return this.withPrivacyLock(
+      `ios-privacy:${this.device.deviceId}`,
+      () => this.applyPermissions(action, normalizedAppId, normalizedPermissions),
+      { signal: getAbortSignal() },
+    );
+  }
+
+  private async applyPermissions(
+    action: IosSimulatorPermissionAction,
+    normalizedAppId: string,
+    normalizedPermissions: string[],
+  ): Promise<IosSimulatorPermissionMutationResult> {
+    // Serialized across instances and batches: concurrent `simctl privacy` invocations for
     // the same device/app race each other against the simulator's shared
     // TCC.db and against simctl's own app-relaunch side effect, producing
     // spurious per-permission failures (issue #6581). One permission's grant

--- a/src/features/action/IosSimulatorPermissions.ts
+++ b/src/features/action/IosSimulatorPermissions.ts
@@ -211,26 +211,30 @@ export class IosSimulatorPermissions {
       };
     }
 
-    const results: IosSimulatorPermissionCommandResult[] = await Promise.all(
-      normalizedPermissions.map(async (permission) => {
-        try {
-          const result = await this.simctl.executeCommandArgs([
-            "privacy",
-            this.device.deviceId,
-            action,
-            permission,
-            normalizedAppId,
-          ]);
-          return { permission, success: true, stdout: result.stdout, stderr: result.stderr };
-        } catch (error) {
-          return {
-            permission,
-            success: false,
-            error: errorMessage(error),
-          };
-        }
-      }),
-    );
+    // Serialized (not Promise.all): concurrent `simctl privacy` invocations for
+    // the same device/app race each other against the simulator's shared
+    // TCC.db and against simctl's own app-relaunch side effect, producing
+    // spurious per-permission failures (issue #6581). One permission's grant
+    // must fully apply before the next one starts.
+    const results: IosSimulatorPermissionCommandResult[] = [];
+    for (const permission of normalizedPermissions) {
+      try {
+        const result = await this.simctl.executeCommandArgs([
+          "privacy",
+          this.device.deviceId,
+          action,
+          permission,
+          normalizedAppId,
+        ]);
+        results.push({ permission, success: true, stdout: result.stdout, stderr: result.stderr });
+      } catch (error) {
+        results.push({
+          permission,
+          success: false,
+          error: errorMessage(error),
+        });
+      }
+    }
 
     const failedCount = results.filter((result) => !result.success).length;
 

--- a/test/features/action/GrantIosSimulatorPermissions.test.ts
+++ b/test/features/action/GrantIosSimulatorPermissions.test.ts
@@ -3,11 +3,51 @@ import { GrantIosSimulatorPermissions } from "../../../src/features/action/Grant
 import {
   IosSimulatorPermissions,
   SqliteTccPermissionReader,
+  type IosSimulatorPrivacyClient,
   type SqliteCommandExecutor,
   type TccPermissionReader,
 } from "../../../src/features/action/IosSimulatorPermissions";
-import type { BootedDevice } from "../../../src/models";
+import type { BootedDevice, ExecResult } from "../../../src/models";
 import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
+
+const buildExecResult = (stdout: string, stderr: string = ""): ExecResult => ({
+  stdout,
+  stderr,
+  toString: () => stdout,
+  trim: () => stdout.trim(),
+  includes: (value: string) => stdout.includes(value),
+});
+
+/**
+ * A privacy client whose `executeCommandArgs` calls never resolve on their
+ * own — the test resolves them one at a time via `resolveNext` — so ordering
+ * (does the next call start before or after the previous one resolves?) can
+ * be observed directly instead of inferred from timing (issue #6581).
+ */
+class DeferredPrivacyClient implements IosSimulatorPrivacyClient {
+  readonly startedArgs: string[][] = [];
+  private pending: Array<() => void> = [];
+
+  executeCommandArgs(args: string[]): Promise<ExecResult> {
+    this.startedArgs.push(args);
+    return new Promise<ExecResult>((resolve) => {
+      this.pending.push(() => resolve(buildExecResult("")));
+    });
+  }
+
+  /** Resolve the oldest still-pending call. Throws if none is pending. */
+  resolveNext(): void {
+    const next = this.pending.shift();
+    if (!next) {
+      throw new Error("no pending executeCommandArgs call to resolve");
+    }
+    next();
+  }
+
+  get pendingCount(): number {
+    return this.pending.length;
+  }
+}
 
 const simulatorDevice: BootedDevice = {
   name: "iPhone 16",
@@ -164,6 +204,45 @@ describe("IosSimulatorPermissions", () => {
         timeoutMs: undefined,
       },
     ]);
+  });
+
+  test("serializes per-permission simctl privacy calls for the same device (issue #6581)", async () => {
+    const deferred = new DeferredPrivacyClient();
+    const action = new IosSimulatorPermissions(simulatorDevice, deferred);
+
+    const resultPromise = action.setPermissions("grant", "com.example.app", [
+      "camera",
+      "location",
+      "contacts",
+    ]);
+
+    // Only the first call should have started; the second must not start
+    // until the first's promise resolves.
+    expect(deferred.startedArgs).toEqual([
+      ["privacy", simulatorDevice.deviceId, "grant", "camera", "com.example.app"],
+    ]);
+
+    deferred.resolveNext();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deferred.startedArgs).toEqual([
+      ["privacy", simulatorDevice.deviceId, "grant", "camera", "com.example.app"],
+      ["privacy", simulatorDevice.deviceId, "grant", "location", "com.example.app"],
+    ]);
+
+    deferred.resolveNext();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deferred.startedArgs).toEqual([
+      ["privacy", simulatorDevice.deviceId, "grant", "camera", "com.example.app"],
+      ["privacy", simulatorDevice.deviceId, "grant", "location", "com.example.app"],
+      ["privacy", simulatorDevice.deviceId, "grant", "contacts", "com.example.app"],
+    ]);
+
+    deferred.resolveNext();
+    const result = await resultPromise;
+    expect(result.success).toBe(true);
+    expect(result.changedCount).toBe(3);
   });
 
   test("queries TCC permission state and reports unknown reset rows", async () => {

--- a/test/features/action/GrantIosSimulatorPermissions.test.ts
+++ b/test/features/action/GrantIosSimulatorPermissions.test.ts
@@ -171,6 +171,33 @@ describe("GrantIosSimulatorPermissions", () => {
 });
 
 describe("IosSimulatorPermissions", () => {
+  test("serializes separate same-device instances while other devices proceed", async () => {
+    const client = new DeferredPrivacyClient();
+    const first = new IosSimulatorPermissions(simulatorDevice, client);
+    const second = new IosSimulatorPermissions(simulatorDevice, client);
+    const other = new IosSimulatorPermissions(
+      { ...simulatorDevice, deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE" },
+      client,
+    );
+    const a = first.setPermissions("grant", "com.example.a", ["camera"]);
+    const b = second.setPermissions("grant", "com.example.b", ["contacts"]);
+    const c = other.setPermissions("grant", "com.example.c", ["location"]);
+    await Promise.resolve();
+    expect(client.startedArgs.map((args) => args[4])).toEqual(["com.example.a", "com.example.c"]);
+    client.resolveNext();
+    await a;
+    await Promise.resolve();
+    expect(client.startedArgs.map((args) => args[4])).toEqual([
+      "com.example.a",
+      "com.example.c",
+      "com.example.b",
+    ]);
+    client.resolveNext();
+    client.resolveNext();
+    expect((await b).success).toBe(true);
+    expect((await c).success).toBe(true);
+  });
+
   test("revokes and resets permissions with simctl privacy", async () => {
     const simctl = new FakeSimCtlClient();
     const action = new IosSimulatorPermissions(simulatorDevice, simctl);
@@ -218,6 +245,7 @@ describe("IosSimulatorPermissions", () => {
 
     // Only the first call should have started; the second must not start
     // until the first's promise resolves.
+    await Promise.resolve();
     expect(deferred.startedArgs).toEqual([
       ["privacy", simulatorDevice.deviceId, "grant", "camera", "com.example.app"],
     ]);


### PR DESCRIPTION
## Summary

IosSimulatorPermissions.setPermissions() previously fired one simctl privacy child process per requested permission concurrently via Promise.all, letting parallel writers race against the same simulator's TCC.db and against simctl's own app-relaunch side effect, producing spurious partial-failure results in multi-permission grant calls. This replaces the concurrent map with a sequential for-of loop that awaits each executeCommandArgs call (and its per-permission try/catch, preserving the existing result shape) before starting the next, so grants for one app/device apply strictly one at a time.

Part of epic #6372.

## Linked Issue

Closes #6581

## Validation

A new test in GrantIosSimulatorPermissions.test.ts uses a deferred-promise fake IosSimulatorPrivacyClient to assert only one executeCommandArgs call is in flight at a time across three requested permissions; it was confirmed to fail red against the original concurrent implementation before the fix. Targeted run: 1429 pass / 0 fail across 90 files.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
