### PR TITLE
fix(ios): honor CORESIMULATOR_DEVICE_SET_PATH and open TCC.db read-only (#6582)

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -155,7 +155,7 @@ import {
   DAEMON_LAUNCH_CWD_ENV,
   safeProcessCwd,
   resolveStableDaemonWorkingDirectory,
-  resolvePathFromDaemonLaunchWorkingDirectory,
+  normalizeCoreSimulatorDeviceSetPathEnv,
 } from "../utils/workingDirectory";
 import { resolveAssetVersion, resolvePinnedVersion } from "../constants/release";
 import {
@@ -518,12 +518,8 @@ export class Daemon {
     logger.enableStdoutLogging();
     const stableWorkingDirectory = resolveStableDaemonWorkingDirectory();
     process.env[DAEMON_LAUNCH_CWD_ENV] ??= safeProcessCwd(stableWorkingDirectory);
-    const deviceSetPath = process.env.CORESIMULATOR_DEVICE_SET_PATH?.trim();
-    if (deviceSetPath) {
-      // Keep simctl and direct TCC reads on the same device set after chdir.
-      process.env.CORESIMULATOR_DEVICE_SET_PATH =
-        resolvePathFromDaemonLaunchWorkingDirectory(deviceSetPath);
-    }
+    // Keep simctl and direct TCC reads on the same device set after chdir (issue #6582).
+    normalizeCoreSimulatorDeviceSetPathEnv();
     process.chdir(stableWorkingDirectory);
 
     logger.info("Starting AutoMobile daemon...");

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -155,6 +155,7 @@ import {
   DAEMON_LAUNCH_CWD_ENV,
   safeProcessCwd,
   resolveStableDaemonWorkingDirectory,
+  resolvePathFromDaemonLaunchWorkingDirectory,
 } from "../utils/workingDirectory";
 import { resolveAssetVersion, resolvePinnedVersion } from "../constants/release";
 import {
@@ -517,6 +518,12 @@ export class Daemon {
     logger.enableStdoutLogging();
     const stableWorkingDirectory = resolveStableDaemonWorkingDirectory();
     process.env[DAEMON_LAUNCH_CWD_ENV] ??= safeProcessCwd(stableWorkingDirectory);
+    const deviceSetPath = process.env.CORESIMULATOR_DEVICE_SET_PATH?.trim();
+    if (deviceSetPath) {
+      // Keep simctl and direct TCC reads on the same device set after chdir.
+      process.env.CORESIMULATOR_DEVICE_SET_PATH =
+        resolvePathFromDaemonLaunchWorkingDirectory(deviceSetPath);
+    }
     process.chdir(stableWorkingDirectory);
 
     logger.info("Starting AutoMobile daemon...");

--- a/src/utils/ios-cmdline-tools/SimulatorTccSqliteClient.ts
+++ b/src/utils/ios-cmdline-tools/SimulatorTccSqliteClient.ts
@@ -6,6 +6,7 @@ import { ActionableError } from "../../models/ActionableError";
 import { DefaultHostCommandExecutor, type HostCommandExecutor } from "../HostCommandExecutor";
 import { defaultTimer, type Timer } from "../SystemTimer";
 import { isIosSimulatorUdid } from "./iosDeviceType";
+import { resolvePathFromDaemonLaunchWorkingDirectory } from "../workingDirectory";
 
 const DEFAULT_TCC_QUERY_TIMEOUT_MS = 5_000;
 const TCC_SERVICE_BY_PERMISSION = new Map<string, string>([
@@ -57,6 +58,8 @@ export interface SimulatorTccSqliteClientDependencies {
    * (e.g. CI runners that isolate simulator state per job).
    */
   deviceSetRoot?: string;
+  /** Device-set selection only; launch-directory ownership remains with the daemon. */
+  environment?: Pick<NodeJS.ProcessEnv, "CORESIMULATOR_DEVICE_SET_PATH">;
   timer?: Timer;
   timeoutMs?: number;
 }
@@ -68,10 +71,16 @@ const nodeFileSystem: TccDatabaseFileSystem = { stat };
  * when set, otherwise the default `~/Library/Developer/CoreSimulator/Devices`
  * layout. Shared by every reader that needs a simulator's per-device data
  * root (issue #6583) so the "honor a custom device set" fix lives in one
- * place instead of being re-derived per call site.
+ * place instead of being re-derived per call site. `environment` defaults to
+ * `process.env` so existing single-argument callers (e.g.
+ * `IosNotificationAuthorizationReader`) are unaffected; `SimulatorTccSqliteClient`
+ * passes an injected environment explicitly to keep the seam deterministic.
  */
-export function defaultDeviceSetRoot(homeDirectory: string): string {
-  const configured = process.env.CORESIMULATOR_DEVICE_SET_PATH?.trim();
+export function defaultDeviceSetRoot(
+  homeDirectory: string,
+  environment: { CORESIMULATOR_DEVICE_SET_PATH?: string } = process.env,
+): string {
+  const configured = environment.CORESIMULATOR_DEVICE_SET_PATH?.trim();
   return configured
     ? configured
     : join(homeDirectory, "Library", "Developer", "CoreSimulator", "Devices");
@@ -202,7 +211,10 @@ export class SimulatorTccSqliteClient implements TccPermissionReader {
     this.executor = dependencies.executor ?? new DefaultHostCommandExecutor();
     this.fileSystem = dependencies.fileSystem ?? nodeFileSystem;
     this.homeDirectory = dependencies.homeDirectory ?? homedir();
-    this.deviceSetRoot = dependencies.deviceSetRoot ?? defaultDeviceSetRoot(this.homeDirectory);
+    this.deviceSetRoot = resolvePathFromDaemonLaunchWorkingDirectory(
+      dependencies.deviceSetRoot ??
+        defaultDeviceSetRoot(this.homeDirectory, dependencies.environment ?? process.env),
+    );
     this.timer = dependencies.timer ?? defaultTimer;
     this.timeoutMs = dependencies.timeoutMs ?? DEFAULT_TCC_QUERY_TIMEOUT_MS;
   }

--- a/src/utils/ios-cmdline-tools/SimulatorTccSqliteClient.ts
+++ b/src/utils/ios-cmdline-tools/SimulatorTccSqliteClient.ts
@@ -59,7 +59,7 @@ export interface SimulatorTccSqliteClientDependencies {
    */
   deviceSetRoot?: string;
   /** Device-set selection only; launch-directory ownership remains with the daemon. */
-  environment?: Pick<NodeJS.ProcessEnv, "CORESIMULATOR_DEVICE_SET_PATH">;
+  environment?: { CORESIMULATOR_DEVICE_SET_PATH?: string };
   timer?: Timer;
   timeoutMs?: number;
 }
@@ -213,7 +213,12 @@ export class SimulatorTccSqliteClient implements TccPermissionReader {
     this.homeDirectory = dependencies.homeDirectory ?? homedir();
     this.deviceSetRoot = resolvePathFromDaemonLaunchWorkingDirectory(
       dependencies.deviceSetRoot ??
-        defaultDeviceSetRoot(this.homeDirectory, dependencies.environment ?? process.env),
+        defaultDeviceSetRoot(
+          this.homeDirectory,
+          dependencies.environment ?? {
+            CORESIMULATOR_DEVICE_SET_PATH: process.env.CORESIMULATOR_DEVICE_SET_PATH,
+          },
+        ),
     );
     this.timer = dependencies.timer ?? defaultTimer;
     this.timeoutMs = dependencies.timeoutMs ?? DEFAULT_TCC_QUERY_TIMEOUT_MS;

--- a/src/utils/ios-cmdline-tools/SimulatorTccSqliteClient.ts
+++ b/src/utils/ios-cmdline-tools/SimulatorTccSqliteClient.ts
@@ -49,6 +49,14 @@ export interface SimulatorTccSqliteClientDependencies {
   executor?: HostCommandExecutor;
   fileSystem?: TccDatabaseFileSystem;
   homeDirectory?: string;
+  /**
+   * Root directory containing the `<deviceId>/data/...` layout for a
+   * CoreSimulator device set. Defaults to `CORESIMULATOR_DEVICE_SET_PATH`
+   * when set, otherwise the default `~/Library/Developer/CoreSimulator/Devices`
+   * layout. Inject an override in tests to simulate a custom device set
+   * (e.g. CI runners that isolate simulator state per job).
+   */
+  deviceSetRoot?: string;
   timer?: Timer;
   timeoutMs?: number;
 }
@@ -122,6 +130,36 @@ function hasErrorCode(error: unknown, code: string): boolean {
   );
 }
 
+/**
+ * Classifies a sqlite3 argv execution failure into an actionable error so
+ * callers can distinguish a missing binary, a corrupted database, and a
+ * transient lock held by a live `tccd` writer from a truly unclassified
+ * failure. Throws in every branch, including the generic fallback.
+ */
+function classifySqliteExecutionError(
+  error: unknown,
+  databasePath: string,
+  deviceId: string,
+): never {
+  const detail = sqliteErrorDetail(error);
+  if (hasErrorCode(error, "ENOENT") || /\bENOENT\b|spawn sqlite3/i.test(detail)) {
+    throw new ActionableError(
+      "sqlite3 is unavailable; install the macOS SQLite command-line tool and retry",
+    );
+  }
+  if (/file is not a database|malformed database/i.test(detail)) {
+    throw new ActionableError(
+      `Simulator TCC database is malformed for ${deviceId}: ${databasePath}`,
+    );
+  }
+  if (/database is locked|database is busy|SQLITE_BUSY/i.test(detail)) {
+    throw new ActionableError(
+      `Simulator TCC database for ${deviceId} is temporarily locked by a live tccd writer; retry the read: ${detail}`,
+    );
+  }
+  throw new ActionableError(`Failed to read simulator TCC database for ${deviceId}: ${detail}`);
+}
+
 function optionalNumberField(
   row: Record<string, unknown>,
   field: "auth_value" | "allowed" | "prompt_count",
@@ -156,6 +194,7 @@ export class SimulatorTccSqliteClient implements TccPermissionReader {
   private readonly executor: HostCommandExecutor;
   private readonly fileSystem: TccDatabaseFileSystem;
   private readonly homeDirectory: string;
+  private readonly deviceSetRoot: string;
   private readonly timer: Timer;
   private readonly timeoutMs: number;
 
@@ -163,6 +202,7 @@ export class SimulatorTccSqliteClient implements TccPermissionReader {
     this.executor = dependencies.executor ?? new DefaultHostCommandExecutor();
     this.fileSystem = dependencies.fileSystem ?? nodeFileSystem;
     this.homeDirectory = dependencies.homeDirectory ?? homedir();
+    this.deviceSetRoot = dependencies.deviceSetRoot ?? defaultDeviceSetRoot(this.homeDirectory);
     this.timer = dependencies.timer ?? defaultTimer;
     this.timeoutMs = dependencies.timeoutMs ?? DEFAULT_TCC_QUERY_TIMEOUT_MS;
   }
@@ -225,11 +265,7 @@ export class SimulatorTccSqliteClient implements TccPermissionReader {
       );
     }
     const databasePath = join(
-      this.homeDirectory,
-      "Library",
-      "Developer",
-      "CoreSimulator",
-      "Devices",
+      this.deviceSetRoot,
       normalizedDeviceId,
       "data",
       "Library",
@@ -289,7 +325,9 @@ export class SimulatorTccSqliteClient implements TccPermissionReader {
     }, this.timeoutMs);
 
     try {
-      return await this.executor.executeCommand("sqlite3", args, { signal: controller.signal });
+      return await this.executor.executeCommand("sqlite3", ["-readonly", ...args], {
+        signal: controller.signal,
+      });
     } catch (error) {
       if (timedOut) {
         throw new ActionableError(
@@ -299,18 +337,7 @@ export class SimulatorTccSqliteClient implements TccPermissionReader {
       if (parentSignal?.aborted) {
         throw new ActionableError(`Reading simulator TCC database for ${deviceId} was cancelled`);
       }
-      const detail = sqliteErrorDetail(error);
-      if (hasErrorCode(error, "ENOENT") || /\bENOENT\b|spawn sqlite3/i.test(detail)) {
-        throw new ActionableError(
-          "sqlite3 is unavailable; install the macOS SQLite command-line tool and retry",
-        );
-      }
-      if (/file is not a database|malformed database/i.test(detail)) {
-        throw new ActionableError(
-          `Simulator TCC database is malformed for ${deviceId}: ${databasePath}`,
-        );
-      }
-      throw new ActionableError(`Failed to read simulator TCC database for ${deviceId}: ${detail}`);
+      classifySqliteExecutionError(error, databasePath, deviceId);
     } finally {
       this.timer.clearTimeout(timeout);
       parentSignal?.removeEventListener("abort", cancelFromParent);

--- a/src/utils/workingDirectory.ts
+++ b/src/utils/workingDirectory.ts
@@ -35,3 +35,27 @@ export function resolvePathFromDaemonLaunchWorkingDirectory(filePath: string): s
 
   return path.resolve(resolveDaemonLaunchWorkingDirectory(), filePath);
 }
+
+/**
+ * Rewrites a RELATIVE `CORESIMULATOR_DEVICE_SET_PATH` on the given env map to
+ * an absolute path anchored at the daemon launch directory, in place.
+ *
+ * Must run before `Daemon.start()` calls `process.chdir()`. Two independent
+ * consumers read this variable after startup: `SimCtlClient` (which spawns
+ * `xcrun simctl` inheriting `process.env` as-is, so CoreSimulator resolves any
+ * relative value against the process's CURRENT — post-chdir — working
+ * directory) and `SimulatorTccSqliteClient` (which falls back to reading this
+ * same variable and resolves a relative value via
+ * `resolvePathFromDaemonLaunchWorkingDirectory`, i.e. against the daemon LAUNCH
+ * directory). Left un-normalized, a relative device-set path makes the two
+ * consumers target different directories after the daemon chdirs (issue
+ * #6582). Normalizing to an absolute path here — before either consumer or the
+ * chdir runs — makes both resolve the identical directory regardless of the
+ * daemon's current working directory at read time.
+ */
+export function normalizeCoreSimulatorDeviceSetPathEnv(env: NodeJS.ProcessEnv = process.env): void {
+  const deviceSetPath = env.CORESIMULATOR_DEVICE_SET_PATH?.trim();
+  if (deviceSetPath) {
+    env.CORESIMULATOR_DEVICE_SET_PATH = resolvePathFromDaemonLaunchWorkingDirectory(deviceSetPath);
+  }
+}

--- a/src/utils/workingDirectory.ts
+++ b/src/utils/workingDirectory.ts
@@ -28,12 +28,15 @@ export function resolveDaemonLaunchWorkingDirectory(
   return launchCwd && path.isAbsolute(launchCwd) ? launchCwd : currentWorkingDirectory;
 }
 
-export function resolvePathFromDaemonLaunchWorkingDirectory(filePath: string): string {
+export function resolvePathFromDaemonLaunchWorkingDirectory(
+  filePath: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
   if (path.isAbsolute(filePath)) {
     return filePath;
   }
 
-  return path.resolve(resolveDaemonLaunchWorkingDirectory(), filePath);
+  return path.resolve(resolveDaemonLaunchWorkingDirectory(undefined, env), filePath);
 }
 
 /**
@@ -56,6 +59,11 @@ export function resolvePathFromDaemonLaunchWorkingDirectory(filePath: string): s
 export function normalizeCoreSimulatorDeviceSetPathEnv(env: NodeJS.ProcessEnv = process.env): void {
   const deviceSetPath = env.CORESIMULATOR_DEVICE_SET_PATH?.trim();
   if (deviceSetPath) {
-    env.CORESIMULATOR_DEVICE_SET_PATH = resolvePathFromDaemonLaunchWorkingDirectory(deviceSetPath);
+    // Resolve the anchor against the SAME env the path came from, so an injected
+    // env is the single source of truth for both the path and its launch cwd.
+    env.CORESIMULATOR_DEVICE_SET_PATH = resolvePathFromDaemonLaunchWorkingDirectory(
+      deviceSetPath,
+      env,
+    );
   }
 }

--- a/test/utils/ios-cmdline-tools/SimulatorTccSqliteClient.test.ts
+++ b/test/utils/ios-cmdline-tools/SimulatorTccSqliteClient.test.ts
@@ -11,6 +11,10 @@ import {
   tccServiceForPermission,
   type TccDatabaseFileSystem,
 } from "../../../src/utils/ios-cmdline-tools/SimulatorTccSqliteClient";
+import {
+  DAEMON_LAUNCH_CWD_ENV,
+  normalizeCoreSimulatorDeviceSetPathEnv,
+} from "../../../src/utils/workingDirectory";
 import { FakeTimer } from "../../fakes/FakeTimer";
 
 const DEVICE_ID = "12345678-1234-1234-1234-123456789ABC";
@@ -384,6 +388,53 @@ describe("SimulatorTccSqliteClient", () => {
         delete process.env.CORESIMULATOR_DEVICE_SET_PATH;
       } else {
         process.env.CORESIMULATOR_DEVICE_SET_PATH = previous;
+      }
+    }
+  });
+
+  test("resolves the identical device set the daemon normalized for simctl before chdir", async () => {
+    // Issue #6582: SimCtlClient spawns `xcrun simctl` inheriting `process.env`
+    // verbatim, so it sees whatever CORESIMULATOR_DEVICE_SET_PATH looks like at
+    // exec time. `Daemon.start()` normalizes a relative value to an absolute
+    // one — via normalizeCoreSimulatorDeviceSetPathEnv, anchored at the daemon
+    // launch directory — BEFORE chdir so that value stays valid no matter where
+    // the daemon's cwd ends up. This asserts the TCC reader, which falls back to
+    // reading that same env var when no deviceSetRoot/environment override is
+    // injected, resolves the exact directory simctl would inherit rather than
+    // re-resolving the raw relative value against a different directory.
+    const previousLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
+    const previousDeviceSet = process.env.CORESIMULATOR_DEVICE_SET_PATH;
+    const launchDirectory = resolve("launch-project");
+    process.env[DAEMON_LAUNCH_CWD_ENV] = launchDirectory;
+    process.env.CORESIMULATOR_DEVICE_SET_PATH = "custom-devices";
+    try {
+      normalizeCoreSimulatorDeviceSetPathEnv();
+      const deviceSetPathInheritedBySimctl = process.env.CORESIMULATOR_DEVICE_SET_PATH;
+      expect(deviceSetPathInheritedBySimctl).toBe(join(launchDirectory, "custom-devices"));
+
+      const fileSystem = new FakeTccFileSystem();
+      fileSystem.error = Object.assign(new Error("absent"), { code: "ENOENT" });
+      const client = new SimulatorTccSqliteClient({
+        executor: new FakeSqliteExecutor(),
+        fileSystem,
+      });
+
+      await expect(client.readPermissions(DEVICE_ID, "com.example.app")).rejects.toThrow(
+        "unavailable",
+      );
+      expect(fileSystem.paths).toEqual([
+        join(deviceSetPathInheritedBySimctl, DEVICE_ID, "data", "Library", "TCC", "TCC.db"),
+      ]);
+    } finally {
+      if (previousLaunchCwd === undefined) {
+        delete process.env[DAEMON_LAUNCH_CWD_ENV];
+      } else {
+        process.env[DAEMON_LAUNCH_CWD_ENV] = previousLaunchCwd;
+      }
+      if (previousDeviceSet === undefined) {
+        delete process.env.CORESIMULATOR_DEVICE_SET_PATH;
+      } else {
+        process.env.CORESIMULATOR_DEVICE_SET_PATH = previousDeviceSet;
       }
     }
   });

--- a/test/utils/ios-cmdline-tools/SimulatorTccSqliteClient.test.ts
+++ b/test/utils/ios-cmdline-tools/SimulatorTccSqliteClient.test.ts
@@ -149,9 +149,10 @@ describe("SimulatorTccSqliteClient", () => {
     expect(executor.calls).toHaveLength(2);
     expect(executor.calls[0]).toMatchObject({
       file: "sqlite3",
-      args: ["-json", databasePath, "pragma table_info(access);"],
+      args: ["-readonly", "-json", databasePath, "pragma table_info(access);"],
     });
     expect(executor.calls[1]?.args).toEqual([
+      "-readonly",
       "-json",
       "-cmd",
       ".parameter init",
@@ -166,6 +167,9 @@ describe("SimulatorTccSqliteClient", () => {
         "where client = :appId and service in (:service0);",
       ].join("\n"),
     ]);
+    for (const call of executor.calls) {
+      expect(call.args[0]).toBe("-readonly");
+    }
   });
 
   test("encodes apostrophes and quotes for sqlite dot-command parameters", async () => {
@@ -305,5 +309,76 @@ describe("SimulatorTccSqliteClient", () => {
       "Timed out after 123ms while reading simulator TCC database",
     );
     expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  test("resolves the TCC database under an injected custom device-set root", async () => {
+    const executor = new FakeSqliteExecutor();
+    const fileSystem = new FakeTccFileSystem();
+    executor.onExecute = async () =>
+      executor.calls.at(-1)?.args.at(-1) === "pragma table_info(access);"
+        ? result(JSON.stringify([{ name: "service" }, { name: "client" }]))
+        : result("[]");
+    const customDeviceSetRoot = "/Users/tester/CustomDeviceSets/ci-job-42/Devices";
+    const client = new SimulatorTccSqliteClient({
+      executor,
+      fileSystem,
+      homeDirectory: "/Users/tester",
+      deviceSetRoot: customDeviceSetRoot,
+    });
+    const expectedPath = join(customDeviceSetRoot, DEVICE_ID, "data", "Library", "TCC", "TCC.db");
+
+    await expect(client.readPermissions(DEVICE_ID, "com.example.app")).resolves.toEqual([]);
+
+    expect(fileSystem.paths).toEqual([expectedPath]);
+  });
+
+  test("honors CORESIMULATOR_DEVICE_SET_PATH when no deviceSetRoot dependency is injected", async () => {
+    const previous = process.env.CORESIMULATOR_DEVICE_SET_PATH;
+    process.env.CORESIMULATOR_DEVICE_SET_PATH = "/Volumes/CI/DeviceSets/job-7/Devices";
+    try {
+      const fileSystem = new FakeTccFileSystem();
+      fileSystem.error = Object.assign(new Error("no such file or directory"), { code: "ENOENT" });
+      const client = new SimulatorTccSqliteClient({
+        executor: new FakeSqliteExecutor(),
+        fileSystem,
+        homeDirectory: "/Users/tester",
+      });
+
+      await expect(client.readPermissions(DEVICE_ID, "com.example.app")).rejects.toThrow(
+        "Simulator TCC database is unavailable",
+      );
+
+      expect(fileSystem.paths).toEqual([
+        join("/Volumes/CI/DeviceSets/job-7/Devices", DEVICE_ID, "data", "Library", "TCC", "TCC.db"),
+      ]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CORESIMULATOR_DEVICE_SET_PATH;
+      } else {
+        process.env.CORESIMULATOR_DEVICE_SET_PATH = previous;
+      }
+    }
+  });
+
+  test("classifies a locked/busy TCC database distinctly from a corrupted one", async () => {
+    const executor = new FakeSqliteExecutor();
+    const client = new SimulatorTccSqliteClient({
+      executor,
+      fileSystem: new FakeTccFileSystem(),
+      homeDirectory: "/Users/tester",
+    });
+
+    executor.error = new Error("database is locked");
+    await expect(client.readPermissions(DEVICE_ID, "com.example.app")).rejects.toThrow(
+      /locked|busy/i,
+    );
+    await expect(client.readPermissions(DEVICE_ID, "com.example.app")).rejects.not.toThrow(
+      "Failed to read simulator TCC database",
+    );
+
+    executor.error = new Error("SQLITE_BUSY: database is busy");
+    await expect(client.readPermissions(DEVICE_ID, "com.example.app")).rejects.toThrow(
+      /locked|busy/i,
+    );
   });
 });

--- a/test/utils/ios-cmdline-tools/SimulatorTccSqliteClient.test.ts
+++ b/test/utils/ios-cmdline-tools/SimulatorTccSqliteClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import type { ExecResult } from "../../../src/models";
 import type {
   HostCommandExecutor,
@@ -92,6 +92,33 @@ describe("SimulatorTccSqliteClient", () => {
     expect(permissionForTccService("kTCCServiceUnknown")).toBe("kTCCServiceUnknown");
   });
 
+  test("resolves a relative device set from the daemon launch directory", async () => {
+    const previous = process.env.AUTOMOBILE_DAEMON_LAUNCH_CWD;
+    const launchDirectory = resolve("launch-project");
+    process.env.AUTOMOBILE_DAEMON_LAUNCH_CWD = launchDirectory;
+    try {
+      const fileSystem = new FakeTccFileSystem();
+      fileSystem.error = Object.assign(new Error("absent"), { code: "ENOENT" });
+      const client = new SimulatorTccSqliteClient({
+        executor: new FakeSqliteExecutor(),
+        fileSystem,
+        environment: { CORESIMULATOR_DEVICE_SET_PATH: "custom-devices" },
+      });
+      await expect(client.readPermissions(DEVICE_ID, "com.example.app")).rejects.toThrow(
+        "unavailable",
+      );
+      expect(fileSystem.paths).toEqual([
+        join(launchDirectory, "custom-devices", DEVICE_ID, "data/Library/TCC/TCC.db"),
+      ]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.AUTOMOBILE_DAEMON_LAUNCH_CWD;
+      } else {
+        process.env.AUTOMOBILE_DAEMON_LAUNCH_CWD = previous;
+      }
+    }
+  });
+
   test("owns TCC path resolution and issues parameterized sqlite argv queries", async () => {
     const executor = new FakeSqliteExecutor();
     const fileSystem = new FakeTccFileSystem();
@@ -121,6 +148,7 @@ describe("SimulatorTccSqliteClient", () => {
       executor,
       fileSystem,
       homeDirectory: "/Users/test user",
+      environment: {},
     });
     const databasePath = join(
       "/Users/test user",

--- a/test/utils/workingDirectory.test.ts
+++ b/test/utils/workingDirectory.test.ts
@@ -22,13 +22,14 @@ function withDaemonLaunchCwd<T>(launchDirectory: string, run: () => T): T {
 describe("normalizeCoreSimulatorDeviceSetPathEnv", () => {
   test("resolves a relative CORESIMULATOR_DEVICE_SET_PATH against the daemon launch directory", () => {
     const launchDirectory = resolve("launch-project");
-    withDaemonLaunchCwd(launchDirectory, () => {
-      const env = { CORESIMULATOR_DEVICE_SET_PATH: "custom-devices" };
+    const env = {
+      CORESIMULATOR_DEVICE_SET_PATH: "custom-devices",
+      AUTOMOBILE_DAEMON_LAUNCH_CWD: launchDirectory,
+    };
 
-      normalizeCoreSimulatorDeviceSetPathEnv(env);
+    normalizeCoreSimulatorDeviceSetPathEnv(env);
 
-      expect(env.CORESIMULATOR_DEVICE_SET_PATH).toBe(join(launchDirectory, "custom-devices"));
-    });
+    expect(env.CORESIMULATOR_DEVICE_SET_PATH).toBe(join(launchDirectory, "custom-devices"));
   });
 
   test("leaves an already-absolute CORESIMULATOR_DEVICE_SET_PATH untouched", () => {
@@ -52,6 +53,23 @@ describe("normalizeCoreSimulatorDeviceSetPathEnv", () => {
     expect(blank.CORESIMULATOR_DEVICE_SET_PATH).toBe("   ");
   });
 
+  test("anchors a relative device set to the launch cwd carried by the injected env, not ambient", () => {
+    // The injected env is the single source of truth for BOTH the device-set
+    // path and the launch directory it resolves against; an ambient
+    // AUTOMOBILE_DAEMON_LAUNCH_CWD must not override the injected one.
+    const injectedLaunch = resolve("/injected/launch/dir");
+    withDaemonLaunchCwd(resolve("/ambient/unused/dir"), () => {
+      const env = {
+        CORESIMULATOR_DEVICE_SET_PATH: "custom-devices",
+        AUTOMOBILE_DAEMON_LAUNCH_CWD: injectedLaunch,
+      };
+
+      normalizeCoreSimulatorDeviceSetPathEnv(env);
+
+      expect(env.CORESIMULATOR_DEVICE_SET_PATH).toBe(join(injectedLaunch, "custom-devices"));
+    });
+  });
+
   test("normalizing before a chdir keeps a relative device set resolvable from any later cwd", () => {
     // Regression for issue #6582: SimCtlClient spawns `xcrun simctl` inheriting
     // `process.env` verbatim, so CoreSimulator would resolve a relative
@@ -62,11 +80,12 @@ describe("normalizeCoreSimulatorDeviceSetPathEnv", () => {
     // Those two resolutions diverge unless the value is made absolute — and
     // therefore chdir-invariant — before anything reads it.
     const launchDirectory = resolve("launch-project");
-    const resolvedForEveryConsumer = withDaemonLaunchCwd(launchDirectory, () => {
-      const env = { CORESIMULATOR_DEVICE_SET_PATH: "custom-devices" };
-      normalizeCoreSimulatorDeviceSetPathEnv(env);
-      return env.CORESIMULATOR_DEVICE_SET_PATH;
-    });
+    const env = {
+      CORESIMULATOR_DEVICE_SET_PATH: "custom-devices",
+      AUTOMOBILE_DAEMON_LAUNCH_CWD: launchDirectory,
+    };
+    normalizeCoreSimulatorDeviceSetPathEnv(env);
+    const resolvedForEveryConsumer = env.CORESIMULATOR_DEVICE_SET_PATH;
 
     // Simulate reads from two different "current working directories" after a
     // daemon chdir — an already-absolute value ignores cwd entirely, so both

--- a/test/utils/workingDirectory.test.ts
+++ b/test/utils/workingDirectory.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { join, resolve } from "node:path";
+import {
+  DAEMON_LAUNCH_CWD_ENV,
+  normalizeCoreSimulatorDeviceSetPathEnv,
+} from "../../src/utils/workingDirectory";
+
+function withDaemonLaunchCwd<T>(launchDirectory: string, run: () => T): T {
+  const previous = process.env[DAEMON_LAUNCH_CWD_ENV];
+  process.env[DAEMON_LAUNCH_CWD_ENV] = launchDirectory;
+  try {
+    return run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[DAEMON_LAUNCH_CWD_ENV];
+    } else {
+      process.env[DAEMON_LAUNCH_CWD_ENV] = previous;
+    }
+  }
+}
+
+describe("normalizeCoreSimulatorDeviceSetPathEnv", () => {
+  test("resolves a relative CORESIMULATOR_DEVICE_SET_PATH against the daemon launch directory", () => {
+    const launchDirectory = resolve("launch-project");
+    withDaemonLaunchCwd(launchDirectory, () => {
+      const env = { CORESIMULATOR_DEVICE_SET_PATH: "custom-devices" };
+
+      normalizeCoreSimulatorDeviceSetPathEnv(env);
+
+      expect(env.CORESIMULATOR_DEVICE_SET_PATH).toBe(join(launchDirectory, "custom-devices"));
+    });
+  });
+
+  test("leaves an already-absolute CORESIMULATOR_DEVICE_SET_PATH untouched", () => {
+    const absolutePath = resolve("/Volumes/CI/DeviceSets/job-7/Devices");
+    withDaemonLaunchCwd(resolve("launch-project"), () => {
+      const env = { CORESIMULATOR_DEVICE_SET_PATH: absolutePath };
+
+      normalizeCoreSimulatorDeviceSetPathEnv(env);
+
+      expect(env.CORESIMULATOR_DEVICE_SET_PATH).toBe(absolutePath);
+    });
+  });
+
+  test("leaves a missing or blank CORESIMULATOR_DEVICE_SET_PATH untouched", () => {
+    const missing: { CORESIMULATOR_DEVICE_SET_PATH?: string } = {};
+    normalizeCoreSimulatorDeviceSetPathEnv(missing);
+    expect(missing.CORESIMULATOR_DEVICE_SET_PATH).toBeUndefined();
+
+    const blank = { CORESIMULATOR_DEVICE_SET_PATH: "   " };
+    normalizeCoreSimulatorDeviceSetPathEnv(blank);
+    expect(blank.CORESIMULATOR_DEVICE_SET_PATH).toBe("   ");
+  });
+
+  test("normalizing before a chdir keeps a relative device set resolvable from any later cwd", () => {
+    // Regression for issue #6582: SimCtlClient spawns `xcrun simctl` inheriting
+    // `process.env` verbatim, so CoreSimulator would resolve a relative
+    // CORESIMULATOR_DEVICE_SET_PATH against whatever the process's cwd happens
+    // to be AFTER Daemon.start() chdirs to its stable working directory. The
+    // direct TCC.db reader resolves the same raw value against the daemon
+    // LAUNCH directory instead (via resolvePathFromDaemonLaunchWorkingDirectory).
+    // Those two resolutions diverge unless the value is made absolute — and
+    // therefore chdir-invariant — before anything reads it.
+    const launchDirectory = resolve("launch-project");
+    const resolvedForEveryConsumer = withDaemonLaunchCwd(launchDirectory, () => {
+      const env = { CORESIMULATOR_DEVICE_SET_PATH: "custom-devices" };
+      normalizeCoreSimulatorDeviceSetPathEnv(env);
+      return env.CORESIMULATOR_DEVICE_SET_PATH;
+    });
+
+    // Simulate reads from two different "current working directories" after a
+    // daemon chdir — an already-absolute value ignores cwd entirely, so both
+    // reads see the identical directory.
+    expect(resolve("/unrelated/post-chdir/cwd", resolvedForEveryConsumer)).toBe(
+      resolvedForEveryConsumer,
+    );
+    expect(resolve(launchDirectory, resolvedForEveryConsumer)).toBe(resolvedForEveryConsumer);
+  });
+});


### PR DESCRIPTION
## Summary

SimulatorTccSqliteClient.resolveDatabasePath() hard-coded the default CoreSimulator device-set layout, so simulators booted under a custom device set (e.g. CI runners using CORESIMULATOR_DEVICE_SET_PATH) were looked up at the wrong path and failed with a generic unavailable error. This adds an injectable deviceSetRoot dependency defaulting to CORESIMULATOR_DEVICE_SET_PATH when set, falling back to the existing ~/Library/Developer/CoreSimulator/Devices layout otherwise. It also passes -readonly to every sqlite3 invocation so a concurrent tccd writer holding the live WAL database is never disturbed, and adds a dedicated catch branch that classifies database-locked/busy/SQLITE_BUSY failures into a distinct retry-suggesting ActionableError instead of the generic fallback. The error-classification logic was extracted into a standalone classifySqliteExecutionError() helper to keep execute()'s complexity within the oxlint ratchet.

Part of epic #6372.

## Linked Issue

Closes #6582

## Validation

TDD tests added first (red for missing -readonly flag, wrong device-set root, and generic lock message), then green. Targeted: SimulatorTccSqliteClient.test.ts 11 pass/0 fail. Broad: test/utils/ios-cmdline-tools 444 pass/0 fail, plus the only other consumer (GrantIosSimulatorPermissions.test.ts) 10 pass/0 fail.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
