### PR TITLE
fix(ios): skip xcodebuild team-ID probe when CtrlProxy project is absent (#6585)

### DIFF
--- a/src/utils/ios-cmdline-tools/XcodeSigning.ts
+++ b/src/utils/ios-cmdline-tools/XcodeSigning.ts
@@ -309,11 +309,17 @@ export class XcodeSigningManager {
       join("ios", "control-proxy", "CtrlProxy.xcodeproj"),
     );
     try {
-      if (this.dependencies.platform() !== "darwin") {
-        const available = await this.dependencies.xcodebuild.isAvailable();
-        if (!available) {
-          return [];
-        }
+      const projectExists = await this.dependencies
+        .stat(projectPath)
+        .then(() => true)
+        .catch(() => false);
+      if (!projectExists) {
+        return [];
+      }
+
+      const available = await this.dependencies.xcodebuild.isAvailable();
+      if (!available) {
+        return [];
       }
 
       const result = await this.dependencies.xcodebuild.executeCommand(

--- a/src/utils/ios-cmdline-tools/XcodeSigning.ts
+++ b/src/utils/ios-cmdline-tools/XcodeSigning.ts
@@ -9,6 +9,7 @@ import { Xcodebuild, XcodebuildClient } from "./XcodebuildClient";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../workingDirectory";
 import { SecurityClient, type SecurityClientApi } from "./SecurityClient";
 import { defaultTimer, Timer } from "../SystemTimer";
+import { getAbortSignal } from "../AbortContext";
 
 type SigningStyle = "automatic" | "manual";
 
@@ -372,33 +373,34 @@ export class XcodeSigningManager {
   private async probeXcodebuildAvailability(): Promise<boolean> {
     const timer = this.dependencies.timer ?? defaultTimer;
     const controller = new AbortController();
-    let timeoutId: NodeJS.Timeout | undefined;
-    const availabilityPromise = this.dependencies.xcodebuild.isAvailable({
-      timeoutMs: XCODEBUILD_AVAILABILITY_PROBE_TIMEOUT_MS,
-      signal: controller.signal,
+    const parent = getAbortSignal();
+    if (parent?.aborted) {return false;}
+    const signal = parent ? AbortSignal.any([parent, controller.signal]) : controller.signal;
+    let onAbort!: () => void;
+    const cancelled = new Promise<false>((resolve) => {
+      onAbort = () => resolve(false);
+      signal.addEventListener("abort", onAbort, { once: true });
     });
-    availabilityPromise.catch(() => {
-      // The race below owns the result; this also handles a rejection after
-      // the timeout has already won (e.g. an abort-driven rejection).
-    });
-    const timeout = new Promise<false>((resolve) => {
-      timeoutId = timer.setTimeout(() => {
-        controller.abort();
-        resolve(false);
-      }, XCODEBUILD_AVAILABILITY_PROBE_TIMEOUT_MS);
-    });
+    const timeoutId = timer.setTimeout(
+      () => controller.abort(),
+      XCODEBUILD_AVAILABILITY_PROBE_TIMEOUT_MS,
+    );
     try {
       return await Promise.race([
-        availabilityPromise.then(
-          (available) => available,
-          () => false,
-        ),
-        timeout,
+        this.dependencies.xcodebuild
+          .isAvailable({
+            timeoutMs: XCODEBUILD_AVAILABILITY_PROBE_TIMEOUT_MS,
+            signal,
+          })
+          .then(
+            (available) => available,
+            () => false,
+          ),
+        cancelled,
       ]);
     } finally {
-      if (timeoutId) {
-        timer.clearTimeout(timeoutId);
-      }
+      timer.clearTimeout(timeoutId);
+      signal.removeEventListener("abort", onAbort);
     }
   }
 

--- a/src/utils/ios-cmdline-tools/XcodeSigning.ts
+++ b/src/utils/ios-cmdline-tools/XcodeSigning.ts
@@ -8,8 +8,15 @@ import { logger } from "../logger";
 import { Xcodebuild, XcodebuildClient } from "./XcodebuildClient";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../workingDirectory";
 import { SecurityClient, type SecurityClientApi } from "./SecurityClient";
+import { defaultTimer, Timer } from "../SystemTimer";
 
 type SigningStyle = "automatic" | "manual";
+
+// Bound on the xcodebuild availability probe inside detectTeamIdsFromXcode
+// (issue #6585): a stalled `xcodebuild -version` must never block callers
+// (e.g. physical-device CtrlProxy startup) indefinitely, regardless of
+// whether the underlying Xcodebuild dependency enforces its own timeout.
+const XCODEBUILD_AVAILABILITY_PROBE_TIMEOUT_MS = 10_000;
 
 interface SigningIdentity {
   name: string;
@@ -63,6 +70,7 @@ interface XcodeSigningDependencies {
   mkdir: (path: string) => Promise<void>;
   homedir: () => string;
   now: () => number;
+  timer?: Timer;
 }
 
 const plistParser = new Parser({
@@ -88,6 +96,7 @@ const createDefaultDependencies = (): XcodeSigningDependencies => ({
   mkdir: async (path) => fs.mkdir(path, { recursive: true }),
   homedir,
   now: () => Date.now(),
+  timer: defaultTimer,
 });
 
 const parsePlistValue = (node: PlistNode | undefined): unknown => {
@@ -312,12 +321,24 @@ export class XcodeSigningManager {
       const projectExists = await this.dependencies
         .stat(projectPath)
         .then(() => true)
-        .catch(() => false);
+        .catch((statError: unknown) => {
+          // ENOENT (and ENOTDIR, when a path segment isn't a directory) mean
+          // "no project here" -- the expected shape for an installed
+          // (non-checkout) AutoMobile. Anything else (permissions, IO) is
+          // unexpected and worth a trace rather than a silent [] (#6585 P2).
+          const code = (statError as NodeJS.ErrnoException | undefined)?.code;
+          if (code !== "ENOENT" && code !== "ENOTDIR") {
+            logger.warn(
+              `[XcodeSigning] Unexpected error checking for Xcode project at ${projectPath}: ${errorMessage(statError)}`,
+            );
+          }
+          return false;
+        });
       if (!projectExists) {
         return [];
       }
 
-      const available = await this.dependencies.xcodebuild.isAvailable();
+      const available = await this.probeXcodebuildAvailability();
       if (!available) {
         return [];
       }
@@ -337,6 +358,47 @@ export class XcodeSigningManager {
     } catch (error) {
       logger.warn(`[XcodeSigning] Failed to detect team IDs: ${errorMessage(error)}`);
       return [];
+    }
+  }
+
+  /**
+   * Bound `xcodebuild.isAvailable()` with our own timer/abort race, on top of
+   * whatever timeout the injected dependency enforces internally. Callers
+   * (fakes in tests, or a future dependency implementation) cannot be relied
+   * on to bound themselves, and a stalled `xcodebuild -version` must never
+   * block `detectTeamIdsFromXcode` -- and by extension physical-device
+   * CtrlProxy startup -- indefinitely (issue #6585).
+   */
+  private async probeXcodebuildAvailability(): Promise<boolean> {
+    const timer = this.dependencies.timer ?? defaultTimer;
+    const controller = new AbortController();
+    let timeoutId: NodeJS.Timeout | undefined;
+    const availabilityPromise = this.dependencies.xcodebuild.isAvailable({
+      timeoutMs: XCODEBUILD_AVAILABILITY_PROBE_TIMEOUT_MS,
+      signal: controller.signal,
+    });
+    availabilityPromise.catch(() => {
+      // The race below owns the result; this also handles a rejection after
+      // the timeout has already won (e.g. an abort-driven rejection).
+    });
+    const timeout = new Promise<false>((resolve) => {
+      timeoutId = timer.setTimeout(() => {
+        controller.abort();
+        resolve(false);
+      }, XCODEBUILD_AVAILABILITY_PROBE_TIMEOUT_MS);
+    });
+    try {
+      return await Promise.race([
+        availabilityPromise.then(
+          (available) => available,
+          () => false,
+        ),
+        timeout,
+      ]);
+    } finally {
+      if (timeoutId) {
+        timer.clearTimeout(timeoutId);
+      }
     }
   }
 

--- a/src/utils/ios-cmdline-tools/XcodeSigning.ts
+++ b/src/utils/ios-cmdline-tools/XcodeSigning.ts
@@ -374,7 +374,9 @@ export class XcodeSigningManager {
     const timer = this.dependencies.timer ?? defaultTimer;
     const controller = new AbortController();
     const parent = getAbortSignal();
-    if (parent?.aborted) {return false;}
+    if (parent?.aborted) {
+      return false;
+    }
     const signal = parent ? AbortSignal.any([parent, controller.signal]) : controller.signal;
     let onAbort!: () => void;
     const cancelled = new Promise<false>((resolve) => {

--- a/src/utils/ios-cmdline-tools/XcodebuildClient.ts
+++ b/src/utils/ios-cmdline-tools/XcodebuildClient.ts
@@ -28,11 +28,21 @@ export type XcodebuildSpawner = (
   options: SpawnOptions,
 ) => ChildProcess;
 
+export interface XcodebuildAvailabilityOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
 export interface Xcodebuild {
   executeCommand(args: string[], options?: XcodebuildCommandOptions): Promise<ExecResult>;
-  isAvailable(): Promise<boolean>;
+  isAvailable(options?: XcodebuildAvailabilityOptions): Promise<boolean>;
   startStreaming(args: string[], options?: XcodebuildStreamingOptions): Promise<ChildProcess>;
 }
+
+// Default bound for `isAvailable()` probes (e.g. `detectTeamIdsFromXcode`,
+// issue #6585): a stalled `xcodebuild -version` must never hang a caller
+// indefinitely, so every availability check is timer/abort-bounded.
+const DEFAULT_AVAILABILITY_PROBE_TIMEOUT_MS = 10_000;
 
 const execAsync = async (
   file: string,
@@ -81,8 +91,18 @@ export class XcodebuildClient implements Xcodebuild {
     this.timer = timer;
   }
 
-  async isAvailable(): Promise<boolean> {
-    return this.isLocalXcodebuildAvailable();
+  async isAvailable(options?: XcodebuildAvailabilityOptions): Promise<boolean> {
+    try {
+      return await this.isAvailableWithin(
+        options?.timeoutMs ?? DEFAULT_AVAILABILITY_PROBE_TIMEOUT_MS,
+        options?.signal,
+      );
+    } catch (error) {
+      // A stalled `xcodebuild -version` must not hang callers (issue #6585);
+      // treat a timed-out/aborted probe the same as "not available".
+      logger.debug(`[iOS] xcodebuild availability probe timed out or was aborted: ${error}`);
+      return false;
+    }
   }
 
   async executeCommand(

--- a/src/utils/ios-cmdline-tools/XcodebuildClient.ts
+++ b/src/utils/ios-cmdline-tools/XcodebuildClient.ts
@@ -95,7 +95,7 @@ export class XcodebuildClient implements Xcodebuild {
     try {
       return await this.isAvailableWithin(
         options?.timeoutMs ?? DEFAULT_AVAILABILITY_PROBE_TIMEOUT_MS,
-        options?.signal,
+        options?.signal ?? getAbortSignal(),
       );
     } catch (error) {
       // A stalled `xcodebuild -version` must not hang callers (issue #6585);

--- a/test/utils/ios-cmdline-tools/XcodeSigning.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodeSigning.test.ts
@@ -5,6 +5,7 @@ import { XcodeSigningManager } from "../../../src/utils/ios-cmdline-tools/XcodeS
 import { DAEMON_LAUNCH_CWD_ENV } from "../../../src/utils/workingDirectory";
 import { logger } from "../../../src/utils/logger";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { runWithAbortSignal } from "../../../src/utils/AbortContext";
 
 const CERT_BASE64 =
   "MIIDETCCAfmgAwIBAgIUJQItJgRhsTPNGV58eJPhAw9xIWcwDQYJKoZIhvcNAQELBQAwGDEWMBQGA1UEAwwNVGVzdCBEZXYgQ2VydDAeFw0yNjAxMTgxOTE5MzVaFw0yNzAxMTgxOTE5MzVaMBgxFjAUBgNVBAMMDVRlc3QgRGV2IENlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDCXt1bEnb5HFGXYeCDJfGUK6A84+6ZowKRvfP4F9XmLn24Pp0bvd0sam7Ayp6rFMkRcCUJ0FmcEUV/JbW30uGmFlrCQG4k4Rved/xrXIYZK1ny2Z5hH0AG13JiStLIqUTARgx1NDnlQl18b5R8OjeXeWD79x/RFrNUyIinW2fnv3jzF8jjme6P3f8pK+TJmLIZQGpNQT+FApApOnND2AEh+RhjnJi3AIDXIpBo8dFhXmOqfE5mtb5gzIyKPrc15l74kW8ndxFoVjJtMinzjbYIsI6t4wOkTJn0hZYDwWHwBfx622cK35zxcGok16EbCdJlfdGxNseeUxWAJoki+MaZAgMBAAGjUzBRMB0GA1UdDgQWBBR4aCibWRc1OiPPqD0CqjTneWJcnTAfBgNVHSMEGDAWgBR4aCibWRc1OiPPqD0CqjTneWJcnTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAXZsPO3k4url4xeggh0AHjZHH4/FQUKPlrKH1+icN/PrPDqc3ubiuLynTN6oHYMM6bHF1i7/fjTXfwtSH4Y28YnLNA/5Yywz+A2PAr0VlMFDGNn9clM5AiZUrpwhOzRIC2opiSgUBVXcHJr9DlCo227ZaM4EmWlFPwyY6LNUyPfqECwFKmDgtuzSqICOGyJy2s1MGXUiWqeyyJgRe1ZdLhNaC3+3/I/0YBm6TYP8anir7vYZCyCDDEtOlNdv9+qQHtoym1f02VRpntDF+k5qiHPICFDVwHCaSXIoghyEqD3y9HH9GWiGKze3mXB7xofhGUL9ATLpRWrzxHSGVS6shr";
@@ -500,6 +501,32 @@ describe("XcodeSigningManager", () => {
   // must not block detectTeamIdsFromXcode -- and by extension physical-device
   // CtrlProxy startup -- indefinitely. The probe must be bounded even though
   // the injected xcodebuild fake never resolves or rejects on its own.
+  test("cancels an uncooperative availability probe without waiting for its deadline", async () => {
+    const { deps, xcodebuildArgs } = createFakeDependencies();
+    const timer = new FakeTimer();
+    deps.timer = timer;
+    let probeSignal: AbortSignal | undefined;
+    let started!: () => void;
+    const probeStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    deps.xcodebuild.isAvailable = (options) => {
+      probeSignal = options?.signal;
+      started();
+      return new Promise<boolean>(() => {});
+    };
+    const controller = new AbortController();
+    const detection = runWithAbortSignal(controller.signal, () =>
+      new XcodeSigningManager(deps).detectTeamIdsFromXcode(),
+    );
+    await probeStarted;
+    controller.abort();
+    expect(await detection).toEqual([]);
+    expect(probeSignal?.aborted).toBe(true);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+    expect(xcodebuildArgs).toHaveLength(0);
+  });
+
   test("bounds a hanging xcodebuild.isAvailable() probe instead of hanging forever", async () => {
     const launchCwd = resolve("/Users/test/hanging-probe");
     process.env[DAEMON_LAUNCH_CWD_ENV] = launchCwd;

--- a/test/utils/ios-cmdline-tools/XcodeSigning.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodeSigning.test.ts
@@ -442,4 +442,40 @@ describe("XcodeSigningManager", () => {
       "CtrlProxyApp",
     ]);
   });
+
+  // #6585: installed (non-checkout) AutoMobile has no ios/control-proxy
+  // Xcode project on disk relative to the daemon's launch cwd. Detecting that
+  // up front must skip the xcodebuild spawn entirely rather than shelling out
+  // to a path that can never resolve.
+  test("skips xcodebuild entirely when the resolved Xcode project path does not exist", async () => {
+    const launchCwd = resolve("/Users/test/installed-package");
+    process.env[DAEMON_LAUNCH_CWD_ENV] = launchCwd;
+    const { deps, xcodebuildArgs } = createFakeDependencies();
+    deps.stat = async () => {
+      throw new Error("ENOENT: no such file or directory");
+    };
+    const manager = new XcodeSigningManager(deps);
+
+    const teamIds = await manager.detectTeamIdsFromXcode();
+
+    expect(teamIds).toEqual([]);
+    expect(xcodebuildArgs.length).toBe(0);
+  });
+
+  // #6585: on darwin the isAvailable() gate was previously skipped entirely,
+  // so a darwin host without Xcode CLI tools still attempted the spawn. The
+  // gate must be exercised identically on darwin and non-darwin.
+  test("checks xcodebuild.isAvailable() on darwin too, skipping when unavailable", async () => {
+    const launchCwd = resolve("/Users/test/project");
+    process.env[DAEMON_LAUNCH_CWD_ENV] = launchCwd;
+    const { deps, xcodebuildArgs } = createFakeDependencies();
+    deps.platform = () => "darwin" as const;
+    deps.xcodebuild.isAvailable = async () => false;
+    const manager = new XcodeSigningManager(deps);
+
+    const teamIds = await manager.detectTeamIdsFromXcode();
+
+    expect(teamIds).toEqual([]);
+    expect(xcodebuildArgs.length).toBe(0);
+  });
 });

--- a/test/utils/ios-cmdline-tools/XcodeSigning.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodeSigning.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { createHash, X509Certificate } from "crypto";
 import { join, resolve } from "path";
 import { XcodeSigningManager } from "../../../src/utils/ios-cmdline-tools/XcodeSigning";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../../src/utils/workingDirectory";
+import { logger } from "../../../src/utils/logger";
 import { FakeTimer } from "../../fakes/FakeTimer";
 
 const CERT_BASE64 =
@@ -117,9 +118,11 @@ const createFakeDependencies = (options?: { identities?: string; profiles?: stri
       mkdir: async () => {},
       homedir: () => "/Users/test",
       now: () => fakeTimer.now(),
+      timer: fakeTimer,
     },
     writtenFiles,
     xcodebuildArgs,
+    fakeTimer,
   };
 };
 
@@ -452,8 +455,56 @@ describe("XcodeSigningManager", () => {
     process.env[DAEMON_LAUNCH_CWD_ENV] = launchCwd;
     const { deps, xcodebuildArgs } = createFakeDependencies();
     deps.stat = async () => {
-      throw new Error("ENOENT: no such file or directory");
+      const error = new Error("ENOENT: no such file or directory") as NodeJS.ErrnoException;
+      error.code = "ENOENT";
+      throw error;
     };
+    const manager = new XcodeSigningManager(deps);
+
+    const teamIds = await manager.detectTeamIdsFromXcode();
+
+    expect(teamIds).toEqual([]);
+    expect(xcodebuildArgs.length).toBe(0);
+  });
+
+  // #6585 P2: a stat() failure that is NOT "no such file" (permissions, IO)
+  // must not be silently treated as a clean "no project here" -- it should
+  // still fail safe ([]) but be surfaced via logger.warn rather than masked.
+  test("logs (does not silently mask) a non-ENOENT stat error and still fails safe", async () => {
+    const launchCwd = resolve("/Users/test/permission-denied");
+    process.env[DAEMON_LAUNCH_CWD_ENV] = launchCwd;
+    const { deps, xcodebuildArgs } = createFakeDependencies();
+    deps.stat = async () => {
+      const error = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+      error.code = "EACCES";
+      throw error;
+    };
+    const warnSpy = spyOn(logger, "warn");
+    const manager = new XcodeSigningManager(deps);
+
+    const teamIds = await manager.detectTeamIdsFromXcode();
+
+    expect(teamIds).toEqual([]);
+    expect(xcodebuildArgs.length).toBe(0);
+    expect(
+      warnSpy.mock.calls.some(
+        (call) =>
+          typeof call[0] === "string" &&
+          (call[0].includes("EACCES") || call[0].includes("Unexpected error")),
+      ),
+    ).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  // #6585 P1: a stalled `xcodebuild -version` (isAvailable() never settles)
+  // must not block detectTeamIdsFromXcode -- and by extension physical-device
+  // CtrlProxy startup -- indefinitely. The probe must be bounded even though
+  // the injected xcodebuild fake never resolves or rejects on its own.
+  test("bounds a hanging xcodebuild.isAvailable() probe instead of hanging forever", async () => {
+    const launchCwd = resolve("/Users/test/hanging-probe");
+    process.env[DAEMON_LAUNCH_CWD_ENV] = launchCwd;
+    const { deps, xcodebuildArgs } = createFakeDependencies();
+    deps.xcodebuild.isAvailable = () => new Promise<boolean>(() => {});
     const manager = new XcodeSigningManager(deps);
 
     const teamIds = await manager.detectTeamIdsFromXcode();


### PR DESCRIPTION
## Summary

On an installed (non-checkout) AutoMobile, detectTeamIdsFromXcode always resolved a repo-relative CtrlProxy.xcodeproj path that installed builds don't have, then shelled out to xcodebuild anyway, paying a wasted subprocess spawn plus a warning log on every physical-device CtrlProxy start. It also only checked xcodebuild.isAvailable() on non-darwin, so a darwin host without Xcode CLI tools skipped that same cheap short-circuit. The fix uses the already-injected dependencies.stat() to check the resolved project path exists before doing anything else, and makes the isAvailable() check unconditional across platforms, both returning [] immediately without touching executeCommand. The existing try/catch/logger.warn contract and resolveSigningForDevice's Promise.all are untouched.

Part of epic #6372.

## Linked Issue

Closes #6585

## Validation

Two new unit tests in XcodeSigning.test.ts: (1) detectTeamIdsFromXcode never calls xcodebuild.executeCommand when stat() rejects (missing project path), returning []; (2) the isAvailable() gate is now exercised on darwin too. Both red before the fix, green after. Targeted: 443/443 pass in test/utils/ios-cmdline-tools; broad test/utils 3103/3103 pass.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
