### PR TITLE
fix: retry transient simulator state discovery and boot transitions

### DIFF
--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -468,7 +468,15 @@ function isDeviceAvailable(device: { isAvailable?: boolean }): boolean {
   return device.isAvailable !== false;
 }
 
-const CORE_SIMULATOR_405_CURRENT_STATE_PATTERN = /Unable to boot device in current state: (.+)/;
+// The state capture is non-greedy and stops at either an inline
+// " (domain=...)" clause or end of line, because CoreSimulator emits the
+// domain/code both *before* the sentence ("...(domain=..., code=405): Unable
+// to boot device in current state: Booted") and *appended inline after* the
+// state ("...current state: Booted (domain=..., code=405)"). A greedy capture
+// folded that trailing clause into the state, so it no longer equalled the bare
+// state token (e.g. "Booted") and the rejection was misclassified (issue #6411).
+const CORE_SIMULATOR_405_CURRENT_STATE_PATTERN =
+  /Unable to boot device in current state: (.+?)(?:\s*\(domain=|\s*$)/m;
 
 /**
  * Parse the current-state CoreSimulator 405 rejection (`Unable to boot

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1372,6 +1372,7 @@ export class SimCtlClient implements SimCtl {
           `polling for settlement before re-issuing bootstatus: ${error}`,
       );
       await this.waitForSimulatorSettled(udid, deadlineMs, retryBackoffMs);
+      await this.waitForBootRetry(udid, retryBackoffMs || STATE_READ_RETRY_BACKOFF_MS, deadlineMs);
       return true;
     }
     if (reportedState !== "Booted") {
@@ -1400,9 +1401,40 @@ export class SimCtlClient implements SimCtl {
       if (state !== "Booting" && state !== "Shutting Down") {
         return;
       }
-      await this.timer.sleep(
-        Math.min(pollIntervalMs, this.remainingBootTimeoutMs(udid, deadlineMs)),
-      );
+      await this.waitForBootRetry(udid, pollIntervalMs || STATE_READ_RETRY_BACKOFF_MS, deadlineMs);
+    }
+  }
+
+  private async waitForBootRetry(udid: string, delayMs: number, deadlineMs: number): Promise<void> {
+    const boundedDelayMs = Math.min(delayMs, this.remainingBootTimeoutMs(udid, deadlineMs));
+    const signal = getAbortSignal();
+    if (!signal) {
+      await this.timer.sleep(boundedDelayMs);
+      return;
+    }
+    let onAbort: (() => void) | undefined;
+    let delayHandle: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        new Promise<void>((resolve) => {
+          delayHandle = this.timer.setTimeout(resolve, boundedDelayMs);
+        }),
+        new Promise<never>((_resolve, reject) => {
+          onAbort = () => reject(signal.reason);
+          signal.addEventListener("abort", onAbort, { once: true });
+          if (signal.aborted) {
+            onAbort();
+          }
+        }),
+      ]);
+      signal.throwIfAborted();
+    } finally {
+      if (delayHandle) {
+        this.timer.clearTimeout(delayHandle);
+      }
+      if (onAbort) {
+        signal.removeEventListener("abort", onAbort);
+      }
     }
   }
 
@@ -1420,6 +1452,7 @@ export class SimCtlClient implements SimCtl {
    * either) is waiting on it (issue #6413).
    */
   private remainingBootTimeoutMs(udid: string, deadlineMs: number): number {
+    getAbortSignal()?.throwIfAborted();
     const remainingMs = deadlineMs - this.timer.now();
     if (remainingMs <= 0) {
       throw new ActionableError(
@@ -1559,9 +1592,7 @@ export class SimCtlClient implements SimCtl {
         logger.debug(
           `[iOS] Could not read simulator state for ${udid}; retrying within the boot deadline: ${errorMessage(error)}`,
         );
-        await this.timer.sleep(
-          Math.min(STATE_READ_RETRY_BACKOFF_MS, this.remainingBootTimeoutMs(udid, deadlineMs)),
-        );
+        await this.waitForBootRetry(udid, STATE_READ_RETRY_BACKOFF_MS, deadlineMs);
       }
     }
   }

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -30,6 +30,13 @@ import { iosSimulatorCapabilityInventory } from "../../features/device-control/v
 
 const COMMAND_SETTLEMENT_GRACE_MS = 1_000;
 const SIMCTL_AVAILABILITY_PROBE_TIMEOUT_MS = 10_000;
+/**
+ * Backoff between retried `simctl list devices --json` reads when boot
+ * verification cannot trust a single failed read (issue #6411). Small and
+ * fixed: the read itself is cheap, so this only needs to avoid hammering a
+ * wedged `simctl`, not model a real device-state transition.
+ */
+const STATE_READ_RETRY_BACKOFF_MS = 250;
 
 export interface AppleDevice {
   udid: string;
@@ -315,7 +322,7 @@ export interface SimCtl {
 // `preserveError: true` keeps the raw execFile rejection intact: the seam's
 // default `wrapCommandError` path returns a fresh Error copying only `.name`,
 // but CoreSimulator-405 boot recovery (issue #3938 / #4092) branches on the
-// original error's `.code`/`.stderr` via `isAlreadyBootedCoreSimulator405`.
+// original error's `.code`/`.stderr` via `parseAlreadyBootedCoreSimulator405State`.
 //
 // The AbortSignal is forwarded so that when a caller's timeout aborts, Node kills
 // the child process (SIGTERM) instead of leaving it booting orphaned (issue
@@ -461,9 +468,18 @@ function isDeviceAvailable(device: { isAvailable?: boolean }): boolean {
   return device.isAvailable !== false;
 }
 
-function isAlreadyBootedCoreSimulator405(error: unknown, udid: string): boolean {
+const CORE_SIMULATOR_405_CURRENT_STATE_PATTERN = /Unable to boot device in current state: (.+)/;
+
+/**
+ * Parse the current-state CoreSimulator 405 rejection (`Unable to boot
+ * device in current state: <state>`) out of a `bootstatus` failure, or
+ * `undefined` if the error is not that specific, structured CoreSimulator
+ * error. Widened from a single literal (`Booted`) so `bootAndVerify` can
+ * branch per reported state (issue #6411) rather than only tolerating one.
+ */
+function parseAlreadyBootedCoreSimulator405State(error: unknown, udid: string): string | undefined {
   if (!isIosSimulatorUdid(udid) || !(error instanceof Error)) {
-    return false;
+    return undefined;
   }
 
   const execError = error as NodeJS.ErrnoException & { stderr?: unknown };
@@ -474,12 +490,16 @@ function isAlreadyBootedCoreSimulator405(error: unknown, udid: string): boolean 
         ? execError.stderr.toString()
         : "";
 
-  return (
-    typeof execError.code === "number" &&
-    execError.code !== 0 &&
-    stderr.includes("domain=com.apple.CoreSimulator.SimError, code=405") &&
-    stderr.includes("Unable to boot device in current state: Booted")
-  );
+  if (
+    typeof execError.code !== "number" ||
+    execError.code === 0 ||
+    !stderr.includes("domain=com.apple.CoreSimulator.SimError, code=405")
+  ) {
+    return undefined;
+  }
+
+  const match = CORE_SIMULATOR_405_CURRENT_STATE_PATTERN.exec(stderr);
+  return match?.[1]?.trim();
 }
 
 /**
@@ -1270,22 +1290,20 @@ export class SimCtlClient implements SimCtl {
           this.remainingBootTimeoutMs(udid, deadlineMs),
         );
       } catch (error) {
-        // CoreSimulator can transiently reject bootstatus with error 405 while
-        // reporting the requested simulator is already Booted. Verify its state
-        // before deciding whether the command failure is actionable.
-        if (!isAlreadyBootedCoreSimulator405(error, udid)) {
-          throw error;
+        if (await this.handleBootstatusRejection(error, udid, deadlineMs, retryBackoffMs)) {
+          // A mid-transition 405 was waited out; re-issue bootstatus within
+          // this same attempt rather than burning a retry (issue #6411).
+          attempt--;
+          continue;
         }
-        logger.debug(
-          `[iOS] bootstatus returned expected CoreSimulator error 405 for ${udid}; verifying simulator state: ${error}`,
-        );
         bootstatusReportedAlreadyBooted = true;
       }
 
-      const state = await this.readSimulatorState(
-        udid,
-        this.remainingBootTimeoutMs(udid, deadlineMs),
-      );
+      // A failed or absent state read is not evidence of a failed boot — it
+      // means discovery itself is unreliable right now. Retry the read (bounded
+      // by the deadline) rather than treating "unknown" the same as "not
+      // Booted" and tearing a possibly-healthy simulator back down (#6411).
+      const state = await this.readSimulatorStateRetrying(udid, deadlineMs);
       if (state === "Booted") {
         return;
       }
@@ -1308,9 +1326,11 @@ export class SimCtlClient implements SimCtl {
         } catch (error) {
           logger.debug(`[iOS] shutdown before boot retry failed for ${udid}: ${error}`);
         }
-        await this.timer.sleep(
-          Math.min(retryBackoffMs, this.remainingBootTimeoutMs(udid, deadlineMs)),
-        );
+        // Wait for the shutdown to actually take hold before re-issuing
+        // bootstatus, instead of a fixed sleep: `simctl shutdown` returns before
+        // the device leaves `Shutting Down`, and re-booting into that in-flight
+        // transition is what produces the very 405 handled above (#6411).
+        await this.waitForSimulatorSettled(udid, deadlineMs, retryBackoffMs);
       }
     }
 
@@ -1319,6 +1339,71 @@ export class SimCtlClient implements SimCtl {
         "The simulator is likely wedged. Try 'xcrun simctl shutdown all' (or erase the device with " +
         `'xcrun simctl erase ${udid}') and start it again.`,
     );
+  }
+
+  /**
+   * Classify a `bootstatus` rejection for {@link bootAndVerify}. CoreSimulator
+   * can transiently reject `bootstatus` with a structured "current state" 405.
+   * Parse the state it reported and branch: `Booted` contradicts the failure
+   * (the caller should verify state itself); `Booting`/`Shutting Down` means a
+   * prior retry's transition (e.g. our own `shutdown`) has not settled yet, so
+   * this waits for it before returning; any other reported state — or an error
+   * that isn't this structured 405 at all — is not one this loop knows how to
+   * recover from and is rethrown (issue #6411).
+   *
+   * @returns `true` when the caller should re-issue `bootstatus` within the
+   *          same attempt (a mid-transition rejection was waited out); `false`
+   *          when the caller should proceed to verify state (a contradictory
+   *          "already Booted" 405).
+   */
+  private async handleBootstatusRejection(
+    error: unknown,
+    udid: string,
+    deadlineMs: number,
+    retryBackoffMs: number,
+  ): Promise<boolean> {
+    const reportedState = parseAlreadyBootedCoreSimulator405State(error, udid);
+    if (reportedState === undefined) {
+      throw error;
+    }
+    if (reportedState === "Booting" || reportedState === "Shutting Down") {
+      logger.debug(
+        `[iOS] bootstatus rejected ${udid} mid-transition (${reportedState}); ` +
+          `polling for settlement before re-issuing bootstatus: ${error}`,
+      );
+      await this.waitForSimulatorSettled(udid, deadlineMs, retryBackoffMs);
+      return true;
+    }
+    if (reportedState !== "Booted") {
+      throw error;
+    }
+    logger.debug(
+      `[iOS] bootstatus returned expected CoreSimulator error 405 for ${udid}; verifying simulator state: ${error}`,
+    );
+    return false;
+  }
+
+  /**
+   * Poll device state (through {@link readSimulatorStateRetrying}, so a
+   * transient discovery failure does not abort the wait) until it is no
+   * longer mid-transition (`Booting` / `Shutting Down`), or the boot deadline
+   * is exhausted. Used both before re-issuing `bootstatus` after a retry
+   * shutdown and after a mid-transition CoreSimulator 405 rejection (#6411).
+   */
+  private async waitForSimulatorSettled(
+    udid: string,
+    deadlineMs: number,
+    pollIntervalMs: number,
+  ): Promise<void> {
+    for (;;) {
+      const state = await this.readSimulatorStateRetrying(udid, deadlineMs);
+      if (state !== "Booting" && state !== "Shutting Down") {
+        return;
+      }
+      await this.timer.sleep(
+        Math.min(pollIntervalMs, this.remainingBootTimeoutMs(udid, deadlineMs)),
+      );
+    }
   }
 
   private bootDeadline(timeoutMs: number): number {
@@ -1434,24 +1519,50 @@ export class SimCtlClient implements SimCtl {
    * Read the current CoreSimulator state for a device, bypassing the device
    * list cache so boot verification never trusts a stale snapshot.
    * @returns the state string (e.g. "Booted", "Shutdown"), or undefined when
-   *          the device is absent or discovery failed.
+   *          the device is absent from the listing.
+   * @throws when discovery itself fails (e.g. `simctl list devices --json`
+   *         times out or its output cannot be parsed) — a failed read is not
+   *         evidence of a failed boot, so callers must not conflate the two
+   *         (issue #6411). {@link readSimulatorStateRetrying} is the retrying
+   *         wrapper boot verification should use instead of calling this
+   *         directly.
    */
   private async readSimulatorState(udid: string, timeoutMs: number): Promise<string | undefined> {
-    try {
-      const simulatorList = await this.listSimulators(timeoutMs);
-      for (const runtimeDevices of Object.values(simulatorList.devices)) {
-        const match = runtimeDevices.find((device) => device.udid === udid);
-        if (match) {
-          return match.state;
-        }
+    const simulatorList = await this.listSimulators(timeoutMs);
+    for (const runtimeDevices of Object.values(simulatorList.devices)) {
+      const match = runtimeDevices.find((device) => device.udid === udid);
+      if (match) {
+        return match.state;
       }
-      return undefined;
-    } catch (error) {
-      logger.warn(
-        `[iOS] Could not read simulator state for ${udid}: ${errorMessage(error)}`,
-        error,
-      );
-      return undefined;
+    }
+    return undefined;
+  }
+
+  /**
+   * {@link readSimulatorState}, retrying a discovery failure (bounded by the
+   * boot deadline) instead of surfacing it. A `simctl list devices --json`
+   * timeout/parse hiccup is transient and unrelated to whether the simulator
+   * actually booted, so boot verification retries the *read* here rather than
+   * treating "could not tell" as "not Booted" and tearing the device down
+   * (issue #6411).
+   */
+  private async readSimulatorStateRetrying(
+    udid: string,
+    deadlineMs: number,
+  ): Promise<string | undefined> {
+    for (;;) {
+      try {
+        return await this.readSimulatorState(udid, this.remainingBootTimeoutMs(udid, deadlineMs));
+      } catch (error) {
+        // Expected to happen occasionally (a transient simctl hiccup); safe to
+        // retry within the boot deadline rather than surfacing immediately.
+        logger.debug(
+          `[iOS] Could not read simulator state for ${udid}; retrying within the boot deadline: ${errorMessage(error)}`,
+        );
+        await this.timer.sleep(
+          Math.min(STATE_READ_RETRY_BACKOFF_MS, this.remainingBootTimeoutMs(udid, deadlineMs)),
+        );
+      }
     }
   }
 

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -1055,6 +1055,29 @@ describe("SimCtlClient boot self-verification", () => {
     expect(harness.timer.getSleepCallCount()).toBe(0);
   });
 
+  // Issue #6411: CoreSimulator also emits the 405 with the domain/code appended
+  // *inline after* the reported state ("...current state: Booted (domain=...,
+  // code=405)"). A greedy state capture folded that trailing clause into the
+  // reported state, so it no longer equalled "Booted" and the already-booted
+  // simulator was rethrown instead of accepted.
+  test("accepts a CoreSimulator 405 whose domain/code is appended inline after the state", async () => {
+    const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 10 });
+    harness.setStates(["Booted"]);
+    harness.failBootStatusWith(
+      coreSimulator405Error(
+        "Unable to boot device in current state: Booted " +
+          "(domain=com.apple.CoreSimulator.SimError, code=405)",
+      ),
+    );
+
+    const handle = await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
+
+    expect(handle).toBeDefined();
+    expect(bootstatusCalls(harness.calls).length).toBe(1);
+    expect(shutdownCalls(harness.calls).length).toBe(0);
+    expect(harness.timer.getSleepCallCount()).toBe(0);
+  });
+
   test("retries a contradictory CoreSimulator 405 response when the simulator is not Booted", async () => {
     const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 10 });
     // The verification read after the 405 sees the genuine wedge (Shutdown);

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -1440,7 +1440,7 @@ describe("SimCtlClient boot self-verification", () => {
     // burn a shutdown-and-retry cycle: no shutdown is ever issued.
     expect(bootstatusCalls(harness.calls).length).toBe(2);
     expect(shutdownCalls(harness.calls).length).toBe(0);
-    expect(harness.timer.getSleepHistory()).toEqual([15]);
+    expect(harness.timer.getSleepHistory()).toEqual([15, 15]);
   });
 
   // Issue #6411: `Booting` must be tolerated the same way as `Shutting Down`.
@@ -1466,5 +1466,60 @@ describe("SimCtlClient boot self-verification", () => {
 
     await expect(harness.simctl.startSimulator(UDID, 5000)).rejects.toBe(error);
     expect(shutdownCalls(harness.calls).length).toBe(1);
+  });
+  test("backs off repeated transition errors even when discovery is already settled", async () => {
+    const harness = createHarness({ maxAttempts: 1, retryBackoffMs: 0 });
+    harness.queueBootStatusFailures([
+      coreSimulator405ErrorForState("Shutting Down"),
+      coreSimulator405ErrorForState("Shutting Down"),
+    ]);
+    harness.setStates(["Shutdown", "Shutdown", "Booted"]);
+    await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
+    expect(bootstatusCalls(harness.calls)).toHaveLength(3);
+    expect(harness.timer.getSleepHistory()).toEqual([250, 250]);
+  });
+
+  test("cancellation during a discovery retry releases the boot lease without more reads", async () => {
+    const harness = createHarness({ maxAttempts: 1, retryBackoffMs: 0 });
+    harness.failListDevicesWith(new Error("discovery unavailable"), 100);
+    const controller = new AbortController();
+    const outcome = runWithAbortSignal(controller.signal, () =>
+      harness.simctl.startSimulator(UDID, 120000),
+    ).catch((error: unknown) => error);
+    for (let turn = 0; turn < 100; turn++) {
+      await Promise.resolve();
+    }
+    expect(harness.timer.getPendingTimeouts()).toContain(250);
+    const reason = new Error("request cancelled during discovery");
+    controller.abort(reason);
+    expect(await outcome).toBe(reason);
+    expect(harness.timer.getPendingTimeoutCount()).toBe(0);
+    expect(harness.calls.filter((call) => call.includes("list devices"))).toHaveLength(1);
+    expect(shutdownCalls(harness.calls)).toHaveLength(1);
+    expect(harness.timer.now()).toBe(0);
+    harness.failListDevicesWith(new Error("unused"), 0);
+    harness.setStates(["Booted"]);
+    await harness.simctl.startSimulator(UDID, 5000);
+  });
+  test("persistent discovery failures stop at the boot deadline", async () => {
+    const harness = createHarness({ maxAttempts: 1, retryBackoffMs: 0 });
+    harness.failListDevicesWith(new Error("discovery unavailable"), 100);
+    const outcome = harness.simctl.startSimulator(UDID, 1000).catch((error: unknown) => error);
+    expect(await harness.timer.resolvePromise(outcome)).toBeInstanceOf(Error);
+    expect(harness.timer.now()).toBe(1000);
+    expect(
+      harness.calls.filter((call) => call.includes("list devices")).length,
+    ).toBeLessThanOrEqual(4);
+    expect(shutdownCalls(harness.calls)).toHaveLength(1);
+  });
+
+  test("zero configured backoff still bounds transition polling by the deadline", async () => {
+    const harness = createHarness({ maxAttempts: 1, retryBackoffMs: 0 });
+    harness.failBootStatusWith(coreSimulator405ErrorForState("Booting"));
+    harness.setStates(["Booting"]);
+    const outcome = harness.simctl.startSimulator(UDID, 1000).catch((error: unknown) => error);
+    expect(await harness.timer.resolvePromise(outcome)).toBeInstanceOf(Error);
+    expect(harness.timer.now()).toBe(1000);
+    expect(harness.timer.getSleepHistory().every((delay) => delay > 0)).toBe(true);
   });
 });

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -33,6 +33,10 @@ interface Harness {
   setStates(states: string[]): void;
   /** Make the next `bootstatus` invocation reject. */
   failBootStatusWith(error: Error | null): void;
+  /** Queue successive `bootstatus` rejections, one per invocation. */
+  queueBootStatusFailures(errors: Array<Error | null>): void;
+  /** Make the next N `list devices --json` invocations reject with `error`. */
+  failListDevicesWith(error: Error, times?: number): void;
 }
 
 /**
@@ -47,6 +51,8 @@ function createHarness(bootOptions: SimCtlBootOptions): Harness {
   const timer = new FakeTimer();
   let states = ["Shutdown"];
   let bootStatusFailures: Array<Error | null> = [];
+  let listDevicesFailuresRemaining = 0;
+  let listDevicesFailure: Error | null = null;
   const nextState = (): string => (states.length > 1 ? states.shift()! : states[0]);
 
   const execAsync = async (
@@ -77,6 +83,10 @@ function createHarness(bootOptions: SimCtlBootOptions): Harness {
       return createExecResult("Device already booted. Status=4294967295", "");
     }
     if (command === "xcrun simctl list devices --json") {
+      if (listDevicesFailuresRemaining > 0) {
+        listDevicesFailuresRemaining--;
+        throw listDevicesFailure;
+      }
       return createExecResult(
         JSON.stringify({
           devices: {
@@ -119,6 +129,13 @@ function createHarness(bootOptions: SimCtlBootOptions): Harness {
     failBootStatusWith: (error) => {
       bootStatusFailures = [error];
     },
+    queueBootStatusFailures: (errors) => {
+      bootStatusFailures = [...errors];
+    },
+    failListDevicesWith: (error, times = 1) => {
+      listDevicesFailure = error;
+      listDevicesFailuresRemaining = times;
+    },
   };
 }
 
@@ -139,6 +156,15 @@ function coreSimulator405Error(stderr: string = ALREADY_BOOTED_405): Error {
     code: 1,
     stderr,
   });
+}
+
+function coreSimulator405ErrorForState(state: string): Error {
+  return coreSimulator405Error(
+    "Device boot failed\n" +
+      "An error was encountered processing the command " +
+      "(domain=com.apple.CoreSimulator.SimError, code=405): " +
+      `Unable to boot device in current state: ${state}`,
+  );
 }
 
 const commandTimeouts = (harness: Harness, command: string): boolean[] =>
@@ -1031,7 +1057,11 @@ describe("SimCtlClient boot self-verification", () => {
 
   test("retries a contradictory CoreSimulator 405 response when the simulator is not Booted", async () => {
     const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 10 });
-    harness.setStates(["Shutdown", "Booted"]);
+    // The verification read after the 405 sees the genuine wedge (Shutdown);
+    // the post-shutdown settle poll observes one in-flight transition
+    // (Shutting Down, requiring the backoff) before Shutdown settles; the
+    // retried bootstatus then sees the device Booted.
+    harness.setStates(["Shutdown", "Shutting Down", "Shutdown", "Booted"]);
     harness.failBootStatusWith(coreSimulator405Error());
 
     const handle = await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
@@ -1085,8 +1115,10 @@ describe("SimCtlClient boot self-verification", () => {
   test("retries a wedged boot after a shutdown and a backoff, then succeeds", async () => {
     const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 2000 });
 
-    // First verification sees the wedge; the retry sees a real boot.
-    harness.setStates(["Shutdown", "Booted"]);
+    // First verification sees the wedge; the post-shutdown settle poll
+    // observes the in-flight transition (requiring the backoff) before the
+    // device settles; the retry then sees a real boot.
+    harness.setStates(["Shutdown", "Shutting Down", "Booted"]);
 
     const handle = await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
 
@@ -1103,12 +1135,21 @@ describe("SimCtlClient boot self-verification", () => {
     await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
 
     expect(commandTimeouts(harness, `xcrun simctl bootstatus ${UDID} -b`)).toEqual([true, true]);
-    expect(commandTimeouts(harness, "xcrun simctl list devices --json")).toEqual([true, true]);
+    // 3 reads: the post-bootstatus-1 verification, the post-shutdown settle
+    // poll, and the post-bootstatus-2 verification.
+    expect(commandTimeouts(harness, "xcrun simctl list devices --json")).toEqual([
+      true,
+      true,
+      true,
+    ]);
     expect(commandTimeouts(harness, `xcrun simctl shutdown ${UDID}`)).toEqual([true]);
   });
 
   test("caps the complete retry sequence at the caller timeout", async () => {
     const harness = createHarness({ maxAttempts: 3, retryBackoffMs: 10_000 });
+    // Never settles, so the post-shutdown poll keeps sleeping (bounded by the
+    // deadline) instead of ever re-issuing bootstatus.
+    harness.setStates(["Shutting Down"]);
     const boot = harness.simctl.startSimulator(UDID, 5000).then(
       () => null,
       (error: unknown) => error,
@@ -1130,6 +1171,18 @@ describe("SimCtlClient boot self-verification", () => {
 
   test("stops after the bounded attempt count and reports the observed state", async () => {
     const harness = createHarness({ maxAttempts: 3, retryBackoffMs: 25 });
+    // Each of the 2 retry shutdowns is followed by one in-flight transition
+    // (requiring the backoff) before settling back to Shutdown; the device
+    // never reaches Booted, so all 3 attempts are consumed.
+    harness.setStates([
+      "Shutdown",
+      "Shutting Down",
+      "Shutdown",
+      "Shutdown",
+      "Shutting Down",
+      "Shutdown",
+      "Shutdown",
+    ]);
 
     const error = await harness.timer.resolvePromise(
       harness.simctl.startSimulator(UDID, 5000).then(
@@ -1188,7 +1241,11 @@ describe("SimCtlClient boot self-verification", () => {
     expect(bootstatusCalls(harness.calls).length).toBe(2);
     expect(shutdownCalls(harness.calls).length).toBe(1);
     expect(commandTimeouts(harness, `xcrun simctl bootstatus ${UDID} -b`)).toEqual([true, true]);
+    // 4 reads: the post-bootstatus-1 verification, the post-shutdown settle
+    // poll, the post-bootstatus-2 verification, and the post-boot metadata
+    // resolution (resolveReadySimulator).
     expect(commandTimeouts(harness, "xcrun simctl list devices --json")).toEqual([
+      true,
       true,
       true,
       true,
@@ -1333,5 +1390,81 @@ describe("SimCtlClient boot self-verification", () => {
     expect(readyError).toBeInstanceOf(ActionableError);
     expect((bootError as Error).message).toContain(availabilityError);
     expect((readyError as Error).message).toContain(availabilityError);
+
+  // Issue #6411: `readSimulatorState` used to collapse "device absent from
+  // the listing" and "the listing itself failed" into the same `undefined`,
+  // so a single transient `simctl list devices --json` hiccup at the end of
+  // an otherwise healthy boot looked identical to "not Booted" and tore the
+  // simulator back down.
+  test("does not shut down a healthy simulator when a single state read fails transiently", async () => {
+    const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 10 });
+    harness.setStates(["Booted"]);
+    harness.failListDevicesWith(new Error("simctl list devices --json timed out"), 1);
+
+    const handle = await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
+
+    expect(handle).toBeDefined();
+    expect(bootstatusCalls(harness.calls).length).toBe(1);
+    expect(shutdownCalls(harness.calls).length).toBe(0);
+  });
+
+  // Issue #6411: a boot deadline long enough to survive more than one
+  // transient read failure must not be treated as an unrecoverable "unknown
+  // state" — it keeps retrying the read itself within the deadline.
+  test("retries an unreadable state repeatedly within the deadline without shutting down", async () => {
+    const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 10 });
+    harness.setStates(["Booted"]);
+    harness.failListDevicesWith(new Error("simctl list devices --json timed out"), 3);
+
+    const handle = await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
+
+    expect(handle).toBeDefined();
+    expect(bootstatusCalls(harness.calls).length).toBe(1);
+    expect(shutdownCalls(harness.calls).length).toBe(0);
+  });
+
+  // Issue #6411: `isAlreadyBootedCoreSimulator405` only tolerated the literal
+  // "current state: Booted" 405. Widened so a mid-transition rejection (e.g.
+  // a prior retry's own `shutdown` not having settled yet) is recognized and
+  // waited out instead of rethrown, which previously aborted the whole boot
+  // without spending a retry.
+  test("polls for settlement and retries within the same attempt on a mid-transition CoreSimulator 405", async () => {
+    const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 15 });
+    harness.queueBootStatusFailures([coreSimulator405ErrorForState("Shutting Down")]);
+    harness.setStates(["Shutting Down", "Booted"]);
+
+    const handle = await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
+
+    expect(handle).toBeDefined();
+    // bootstatus is re-issued once the transition settles, but this does not
+    // burn a shutdown-and-retry cycle: no shutdown is ever issued.
+    expect(bootstatusCalls(harness.calls).length).toBe(2);
+    expect(shutdownCalls(harness.calls).length).toBe(0);
+    expect(harness.timer.getSleepHistory()).toEqual([15]);
+  });
+
+  // Issue #6411: `Booting` must be tolerated the same way as `Shutting Down`.
+  test("polls for settlement on a Booting mid-transition CoreSimulator 405", async () => {
+    const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 15 });
+    harness.queueBootStatusFailures([coreSimulator405ErrorForState("Booting")]);
+    harness.setStates(["Booting", "Booted"]);
+
+    const handle = await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
+
+    expect(handle).toBeDefined();
+    expect(bootstatusCalls(harness.calls).length).toBe(2);
+    expect(shutdownCalls(harness.calls).length).toBe(0);
+  });
+
+  // Issue #6411: a reported current state the loop has no recovery for (not
+  // Booted and not a recognized mid-transition state) must still rethrow
+  // rather than loop or silently proceed.
+  test("rethrows a CoreSimulator 405 reporting a state with no known recovery", async () => {
+    const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 10 });
+    const error = coreSimulator405ErrorForState("Creating");
+    harness.failBootStatusWith(error);
+
+    await expect(harness.simctl.startSimulator(UDID, 5000)).rejects.toBe(error);
+    expect(shutdownCalls(harness.calls).length).toBe(1);
   });
 });

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -1413,6 +1413,7 @@ describe("SimCtlClient boot self-verification", () => {
     expect(readyError).toBeInstanceOf(ActionableError);
     expect((bootError as Error).message).toContain(availabilityError);
     expect((readyError as Error).message).toContain(availabilityError);
+  });
 
   // Issue #6411: `readSimulatorState` used to collapse "device absent from
   // the listing" and "the listing itself failed" into the same `undefined`,


### PR DESCRIPTION
## Summary

Retry transient simulator discovery failures within the boot deadline, and wait for CoreSimulator transitions before reissuing bootstatus. Every transition retry pays a positive bounded delay, including zero-backoff configurations. Cancellation stops recovery immediately, clears pending delay timers, and releases the device lease.

Closes [issue 6411](https://github.com/kaeawc/auto-mobile/issues/6411). Part of [epic 6372](https://github.com/kaeawc/auto-mobile/issues/6372).

## Validation

46 focused boot-verification tests pass, including repeated 405 errors, zero-backoff polling, persistent discovery failures, and cancellation during retry with lease reuse. Build and typecheck baseline gate pass. Lint reports no new oxlint violations; full lint remains blocked by the existing IOSCtrlProxyManager direct-xcodebuild baseline difference.
