### PR TITLE
fix(ios): reopen CtrlProxy setup gate instead of an hour-long cache (#6416)

### DIFF
--- a/scripts/local-dev/lib/ctrl-proxy-ios.sh
+++ b/scripts/local-dev/lib/ctrl-proxy-ios.sh
@@ -199,17 +199,34 @@ start_ctrl_proxy_ios() {
 
   runner_xctestrun_path="$(dirname "${xctestrun_path}")/automobile-runner-${simulator_id}.xctestrun"
   cp "${xctestrun_path}" "${runner_xctestrun_path}"
-  plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_PORT" \
-    -string "${port}" "${runner_xctestrun_path}"
-  plutil -replace "CtrlProxyUITests.EnvironmentVariables.AUTOMOBILE_DEVICE_ID" \
-    -string "${simulator_id}" "${runner_xctestrun_path}"
+  # plutil fails when the xctestrun does not carry the top-level
+  # CtrlProxyUITests key it expects (e.g. a FormatVersion 2 layout produced by
+  # a scheme with a test plan) — an unpatched xctestrun would silently launch
+  # the runner on the wrong port (issue #2731), so a patch failure must be a
+  # hard failure rather than a swallowed one.
+  if ! plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_PORT" \
+      -string "${port}" "${runner_xctestrun_path}"; then
+    log_error "Failed to patch CTRL_PROXY_IOS_PORT into runner xctestrun (CtrlProxyUITests.EnvironmentVariables keypath not found — is this a FormatVersion 1 xctestrun?)."
+    return 1
+  fi
+  if ! plutil -replace "CtrlProxyUITests.EnvironmentVariables.AUTOMOBILE_DEVICE_ID" \
+      -string "${simulator_id}" "${runner_xctestrun_path}"; then
+    log_error "Failed to patch AUTOMOBILE_DEVICE_ID into runner xctestrun."
+    return 1
+  fi
   if [[ -n "${CTRL_PROXY_IOS_BUNDLE_ID:-}" ]]; then
-    plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_BUNDLE_ID" \
-      -string "${CTRL_PROXY_IOS_BUNDLE_ID}" "${runner_xctestrun_path}"
+    if ! plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_BUNDLE_ID" \
+        -string "${CTRL_PROXY_IOS_BUNDLE_ID}" "${runner_xctestrun_path}"; then
+      log_error "Failed to patch CTRL_PROXY_IOS_BUNDLE_ID into runner xctestrun."
+      return 1
+    fi
   fi
   if [[ -n "${CTRL_PROXY_IOS_TIMEOUT:-}" ]]; then
-    plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_TIMEOUT" \
-      -string "${CTRL_PROXY_IOS_TIMEOUT}" "${runner_xctestrun_path}"
+    if ! plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_TIMEOUT" \
+        -string "${CTRL_PROXY_IOS_TIMEOUT}" "${runner_xctestrun_path}"; then
+      log_error "Failed to patch CTRL_PROXY_IOS_TIMEOUT into runner xctestrun."
+      return 1
+    fi
   fi
 
   local cmd=(

--- a/scripts/local-dev/lib/ctrl-proxy-ios.sh
+++ b/scripts/local-dev/lib/ctrl-proxy-ios.sh
@@ -206,7 +206,7 @@ start_ctrl_proxy_ios() {
   # hard failure rather than a swallowed one.
   if ! plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_PORT" \
       -string "${port}" "${runner_xctestrun_path}"; then
-    log_error "Failed to patch CTRL_PROXY_IOS_PORT into runner xctestrun (CtrlProxyUITests.EnvironmentVariables keypath not found — is this a FormatVersion 1 xctestrun?)."
+    log_error "Failed to patch CTRL_PROXY_IOS_PORT into runner xctestrun (CtrlProxyUITests.EnvironmentVariables keypath not found — FormatVersion 2 or unsupported xctestrun layout)."
     return 1
   fi
   if ! plutil -replace "CtrlProxyUITests.EnvironmentVariables.AUTOMOBILE_DEVICE_ID" \

--- a/scripts/test-ctrl-proxy-ios.sh
+++ b/scripts/test-ctrl-proxy-ios.sh
@@ -184,7 +184,7 @@ if [ "$HEALTH_RESPONSE" == "FAILED" ]; then
                         # FormatVersion 2 layout) — an unpatched xctestrun
                         # silently launches the runner on the wrong port
                         # (issue #2731), so this must be a hard failure.
-                        print_status 1 "Failed to patch runner xctestrun (CtrlProxyUITests.EnvironmentVariables keypath not found — is this a FormatVersion 1 xctestrun?)"
+                        print_status 1 "Failed to patch runner xctestrun (CtrlProxyUITests.EnvironmentVariables keypath not found — FormatVersion 2 or unsupported xctestrun layout)"
                         exit 1
                     fi
 

--- a/scripts/test-ctrl-proxy-ios.sh
+++ b/scripts/test-ctrl-proxy-ios.sh
@@ -177,8 +177,16 @@ if [ "$HEALTH_RESPONSE" == "FAILED" ]; then
                 else
                     RUNNER_XCTESTRUN_FILE="$(dirname "${XCTESTRUN_FILE}")/automobile-runner-${BOOTED_SIMULATOR}.xctestrun"
                     cp "${XCTESTRUN_FILE}" "${RUNNER_XCTESTRUN_FILE}"
-                    plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_PORT" -string "${PORT}" "${RUNNER_XCTESTRUN_FILE}"
-                    plutil -replace "CtrlProxyUITests.EnvironmentVariables.AUTOMOBILE_DEVICE_ID" -string "${BOOTED_SIMULATOR}" "${RUNNER_XCTESTRUN_FILE}"
+                    if ! plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_PORT" -string "${PORT}" "${RUNNER_XCTESTRUN_FILE}" \
+                        || ! plutil -replace "CtrlProxyUITests.EnvironmentVariables.AUTOMOBILE_DEVICE_ID" -string "${BOOTED_SIMULATOR}" "${RUNNER_XCTESTRUN_FILE}"; then
+                        # plutil fails when the xctestrun does not carry the
+                        # top-level CtrlProxyUITests key it expects (e.g. a
+                        # FormatVersion 2 layout) — an unpatched xctestrun
+                        # silently launches the runner on the wrong port
+                        # (issue #2731), so this must be a hard failure.
+                        print_status 1 "Failed to patch runner xctestrun (CtrlProxyUITests.EnvironmentVariables keypath not found — is this a FormatVersion 1 xctestrun?)"
+                        exit 1
+                    fi
 
                     print_info "Starting patched CtrlProxy iOS in background..."
 

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -478,8 +478,12 @@ export class IOSCtrlProxyBuilder {
 
       const injected = injectUITestEnvironment(root as Map<string, PlistValue>, env);
       if (injected === 0) {
+        const metadata = (root as Map<string, PlistValue>).get("__xctestrun_metadata__");
+        const formatVersion = metadata instanceof Map ? metadata.get("FormatVersion") : undefined;
+        const observedFormat = formatVersion === undefined ? "unknown" : String(formatVersion);
         throw new Error(
-          "xctestrun contains no UI-test bundle (IsUITestBundle) to receive the runner environment",
+          `xctestrun contains no UI-test bundle (IsUITestBundle) to receive the runner ` +
+            `environment (observed __xctestrun_metadata__.FormatVersion: ${observedFormat})`,
         );
       }
 

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -763,7 +763,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    */
   public resetSetupState(): void {
     this.attemptedSetup = false;
-    this.legacyCheckDone = false;
     this.clearCaches();
     logger.info("[IOSCtrlProxy] Reset setup state");
   }

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -238,6 +238,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
   // Setup state tracking
   private attemptedSetup: boolean = false;
+  // #6575: the legacy-app uninstall probe is a one-time cleanup for a
+  // long-renamed bundle ID; gate it to at most once per manager instance so
+  // repeat setup() calls (including the attemptedSetup fast path) don't pay
+  // for a redundant external-process round trip.
+  private legacyCheckDone: boolean = false;
 
   // XCUITest process state
   private xcTestProcessId: number | null = null;
@@ -758,6 +763,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    */
   public resetSetupState(): void {
     this.attemptedSetup = false;
+    this.legacyCheckDone = false;
     this.clearCaches();
     logger.info("[IOSCtrlProxy] Reset setup state");
   }
@@ -1308,6 +1314,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * This cleans up the old bundle ID left over from before the rename to CtrlProxy.
    */
   private async uninstallLegacyAppIfPresent(): Promise<void> {
+    if (this.legacyCheckDone) {
+      return;
+    }
+    this.legacyCheckDone = true;
     try {
       const simulator = this.isSimulator();
       const isInstalled = await this.deviceAppManager.getInstalledAppBundleHash(

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -217,10 +217,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private static startupOrphanRunnerReap: Promise<void> | null = null;
 
   // Cache for status checks
-  private cachedAvailability: { isAvailable: boolean; timestamp: number } | null = null;
   private cachedInstalled: { isInstalled: boolean; timestamp: number } | null = null;
   private cachedRunning: { isRunning: boolean; timestamp: number } | null = null;
-  private static readonly AVAILABILITY_CACHE_TTL = 60 * 60 * 1000; // 1 hour
   private static readonly STATUS_CACHE_TTL = 30 * 1000; // 30 seconds
   private static readonly IMPORTANT_OUTPUT_MARKERS = [
     "error",
@@ -750,7 +748,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * Clear all caches
    */
   public clearCaches(): void {
-    this.cachedAvailability = null;
     this.cachedInstalled = null;
     this.cachedRunning = null;
     logger.info("[IOSCtrlProxy] Cleared all caches");
@@ -854,27 +851,19 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   /**
-   * Check if the service is available (installed and running)
+   * Check if the service is available (installed and running).
+   *
+   * Delegates directly to isInstalled()/isRunning() rather than layering its
+   * own cache on top: isRunning() already carries the 30s STATUS_CACHE_TTL,
+   * which is the only freshness the setup() gate's comment above assumes. A
+   * separate hour-long positive cache here let a runner that died without a
+   * local child-exit event (killed externally, simulator erased, wedged but
+   * still answering /health) report "already running" for up to an hour
+   * (#6416).
    */
   public async isAvailable(): Promise<boolean> {
-    // Check cache first
-    if (this.cachedAvailability && this.cachedAvailability.isAvailable) {
-      const cacheAge = this.timer.now() - this.cachedAvailability.timestamp;
-      if (cacheAge < IOSCtrlProxyManager.AVAILABILITY_CACHE_TTL) {
-        return this.cachedAvailability.isAvailable;
-      }
-    }
-
     const [installed, running] = await Promise.all([this.isInstalled(), this.isRunning()]);
-
-    const available = installed && running;
-
-    this.cachedAvailability = {
-      isAvailable: available,
-      timestamp: this.timer.now(),
-    };
-
-    return available;
+    return installed && running;
   }
 
   // MARK: - Service Control
@@ -1208,8 +1197,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         this.xcTestProcess = null;
         // Host-control mode has no local child-exit event to clear these as a side
         // effect (handleProcessExit), so clear explicitly for both modes — otherwise
-        // cachedRunning/cachedAvailability can serve a stale positive to the next
-        // setup() for up to STATUS_CACHE_TTL (#2834 review).
+        // cachedRunning can serve a stale positive to the next setup() for up to
+        // STATUS_CACHE_TTL (#2834 review).
         this.clearCaches();
         this.processSupervisor.stop();
         await this.processSupervisor.start();

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -756,6 +756,13 @@ export class RunnerReadinessService {
       return;
     }
 
+    // A prior readiness request may have left the setup gate latched
+    // (attemptedSetup) with a stale positive from earlier in this daemon's
+    // lifetime. Reopen it before this independent request tries setup again,
+    // matching the Android path (see :265) and the connected branch above
+    // (:613) — otherwise setup() can report "already running" against a
+    // runner that died without a local child-exit event (#6416).
+    manager.resetSetupState();
     const setup = await this.runPhase(context, "runner-setup", 1, (signal) =>
       manager.setup(false, context.perf, signal, this.remainingForPhase(context, "runner-setup")),
     );

--- a/src/utils/ios-cmdline-tools/XctestrunPlist.ts
+++ b/src/utils/ios-cmdline-tools/XctestrunPlist.ts
@@ -149,8 +149,40 @@ export const buildPlist = (value: PlistValue): string => {
 };
 
 /**
+ * Recursively collect every `Map` in `value` (walking into arrays and nested
+ * dicts) whose `IsUITestBundle` key is exactly `true`.
+ *
+ * This makes the walk layout-agnostic: it finds UI-test targets whether they
+ * sit at the plist top level (FormatVersion 1, `{ <TargetName>: { ... } }`)
+ * or nested under a test-plan configuration array (FormatVersion 2,
+ * `TestConfigurations[].TestTargets[]`), without needing to branch on
+ * `__xctestrun_metadata__.FormatVersion`.
+ */
+const collectUITestTargets = (value: PlistValue): Map<string, PlistValue>[] => {
+  if (Array.isArray(value)) {
+    return value.flatMap((child) => collectUITestTargets(child));
+  }
+
+  if (!(value instanceof Map)) {
+    return [];
+  }
+
+  const targets: Map<string, PlistValue>[] = [];
+  if (value.get("IsUITestBundle") === true) {
+    targets.push(value);
+  }
+  for (const child of value.values()) {
+    targets.push(...collectUITestTargets(child));
+  }
+  return targets;
+};
+
+/**
  * Merge `env` (string key/value pairs) into the `EnvironmentVariables` dict of
- * every test target in `root` that is a UI-test bundle (`IsUITestBundle` true).
+ * every test target in `root` that is a UI-test bundle (`IsUITestBundle` true),
+ * regardless of whether it sits at the plist top level (FormatVersion 1) or
+ * nested under `TestConfigurations[].TestTargets[]` (FormatVersion 2 — the
+ * layout `xcodebuild` emits when the scheme resolves a test plan).
  *
  * Existing keys are overwritten, missing `EnvironmentVariables` dicts are
  * created, and non-UI targets are left untouched.
@@ -161,24 +193,19 @@ export const injectUITestEnvironment = (
   root: Map<string, PlistValue>,
   env: Record<string, string>,
 ): number => {
-  let injected = 0;
+  const targets = collectUITestTargets(root);
 
-  for (const value of root.values()) {
-    if (!(value instanceof Map) || value.get("IsUITestBundle") !== true) {
-      continue;
-    }
-
-    let envDict = value.get("EnvironmentVariables");
+  for (const target of targets) {
+    let envDict = target.get("EnvironmentVariables");
     if (!(envDict instanceof Map)) {
       envDict = new Map<string, PlistValue>();
-      value.set("EnvironmentVariables", envDict);
+      target.set("EnvironmentVariables", envDict);
     }
 
     for (const [key, val] of Object.entries(env)) {
       (envDict as Map<string, PlistValue>).set(key, val);
     }
-    injected += 1;
   }
 
-  return injected;
+  return targets.length;
 };

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -616,7 +616,7 @@ describe("IOSCtrlProxyBuilder", function () {
       expect(path.basename(outputPath)).toBe("automobile-runner-00008030-001E_28C1_1E.xctestrun");
     });
 
-    test("throws an actionable error when the xctestrun has no UI-test bundle (EC4)", async function () {
+    test("throws an actionable error naming the observed FormatVersion when the xctestrun has no UI-test bundle (EC4)", async function () {
       const productsDir = path.join(tempDir, "Build", "Products");
       await fs.mkdir(productsDir, { recursive: true });
       const sourcePath = path.join(productsDir, "AutoMobileTest_iphonesimulator.xctestrun");
@@ -628,6 +628,8 @@ describe("IOSCtrlProxyBuilder", function () {
           "<dict>",
           "\t<key>CtrlProxyTests</key>",
           "\t<dict><key>IsUITestBundle</key><false/></dict>",
+          "\t<key>__xctestrun_metadata__</key>",
+          "\t<dict><key>FormatVersion</key><integer>1</integer></dict>",
           "</dict>",
           "</plist>",
         ].join("\n"),
@@ -637,6 +639,61 @@ describe("IOSCtrlProxyBuilder", function () {
       await expect(
         builder.writeRunnerEnvironment(sourcePath, { CTRL_PROXY_IOS_PORT: "8767" }, "SIM"),
       ).rejects.toThrow("no UI-test bundle");
+      await expect(
+        builder.writeRunnerEnvironment(sourcePath, { CTRL_PROXY_IOS_PORT: "8767" }, "SIM"),
+      ).rejects.toThrow("FormatVersion: 1");
+    });
+
+    test("injects into a FormatVersion 2 (TestConfigurations[].TestTargets[]) xctestrun", async function () {
+      const productsDir = path.join(tempDir, "Build", "Products");
+      await fs.mkdir(productsDir, { recursive: true });
+      const sourcePath = path.join(
+        productsDir,
+        "CtrlProxyApp_iphonesimulator26.2-arm64-x86_64.xctestrun",
+      );
+      const V2_XCTESTRUN = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<plist version="1.0">',
+        "<dict>",
+        "\t<key>TestConfigurations</key>",
+        "\t<array>",
+        "\t\t<dict>",
+        "\t\t\t<key>TestTargets</key>",
+        "\t\t\t<array>",
+        "\t\t\t\t<dict>",
+        "\t\t\t\t\t<key>BlueprintName</key>",
+        "\t\t\t\t\t<string>CtrlProxyUITests</string>",
+        "\t\t\t\t\t<key>IsUITestBundle</key>",
+        "\t\t\t\t\t<true/>",
+        "\t\t\t\t\t<key>EnvironmentVariables</key>",
+        "\t\t\t\t\t<dict><key>TERM</key><string>dumb</string></dict>",
+        "\t\t\t\t</dict>",
+        "\t\t\t</array>",
+        "\t\t</dict>",
+        "\t</array>",
+        "\t<key>__xctestrun_metadata__</key>",
+        "\t<dict><key>FormatVersion</key><integer>2</integer></dict>",
+        "</dict>",
+        "</plist>",
+      ].join("\n");
+      await fs.writeFile(sourcePath, V2_XCTESTRUN);
+
+      const builder = IOSCtrlProxyBuilder.getInstance({ derivedDataPath: tempDir });
+      const outputPath = await builder.writeRunnerEnvironment(
+        sourcePath,
+        { CTRL_PROXY_IOS_PORT: "8767" },
+        "SIM-UUID",
+      );
+
+      const xml = await fs.readFile(outputPath, "utf-8");
+      const root = (await parsePlist(xml)) as Map<string, unknown>;
+      const configurations = root.get("TestConfigurations") as unknown[];
+      const configuration = configurations[0] as Map<string, unknown>;
+      const testTargets = configuration.get("TestTargets") as unknown[];
+      const uiTarget = testTargets[0] as Map<string, unknown>;
+      const env = uiTarget.get("EnvironmentVariables") as Map<string, unknown>;
+      expect(env.get("CTRL_PROXY_IOS_PORT")).toBe("8767");
+      expect(env.get("TERM")).toBe("dumb");
     });
   });
 

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1019,6 +1019,108 @@ describe("IOSCtrlProxyManager", function () {
     });
   });
 
+  // #6575: the legacy-app uninstall probe used to run on every setup() call,
+  // including the attemptedSetup fast path that exists to make repeat calls
+  // cheap. It should fire at most once per manager instance.
+  describe("legacy-app uninstall probe runs at most once per manager (#6575)", function () {
+    test("does not re-probe on a setup() call that hits the attemptedSetup fast path", async function () {
+      const fakeExecutor = new FakeProcessExecutor();
+      let healthy = false;
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(
+          healthy ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          "",
+        ),
+      );
+      let legacyProbeCount = 0;
+      const fakeDeviceAppManager = {
+        getInstalledAppBundleHash: async () => {
+          legacyProbeCount++;
+          return null;
+        },
+      } as unknown as DeviceAppManager;
+      const xcodebuild: Xcodebuild = {
+        executeCommand: async () => createExecResult("", ""),
+        isAvailable: async () => true,
+        startStreaming: async () => {
+          healthy = true;
+          return new FakeChildProcess() as unknown as ChildProcess;
+        },
+      };
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor,
+        undefined,
+        fakeDeviceAppManager,
+        undefined,
+        undefined,
+        xcodebuild,
+      );
+      fakeTimer.enableAutoAdvance();
+
+      const first = await manager.setup();
+      expect(first.success).toBe(true);
+      expect(legacyProbeCount).toBe(1);
+
+      // Second call hits the `attemptedSetup && !force` fast path.
+      const second = await manager.setup();
+      expect(second.success).toBe(true);
+      expect(legacyProbeCount).toBe(1);
+    });
+
+    test("re-arms after resetSetupState so a fresh device/session probes again", async function () {
+      const fakeExecutor = new FakeProcessExecutor();
+      let healthy = false;
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(
+          healthy ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          "",
+        ),
+      );
+      fakeExecutor.setCommandHandler("kill -0", () => {
+        throw new Error("runner is no longer running");
+      });
+      let legacyProbeCount = 0;
+      const fakeDeviceAppManager = {
+        getInstalledAppBundleHash: async () => {
+          legacyProbeCount++;
+          return null;
+        },
+      } as unknown as DeviceAppManager;
+      const xcodebuild: Xcodebuild = {
+        executeCommand: async () => createExecResult("", ""),
+        isAvailable: async () => true,
+        startStreaming: async () => {
+          healthy = true;
+          return new FakeChildProcess() as unknown as ChildProcess;
+        },
+      };
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor,
+        undefined,
+        fakeDeviceAppManager,
+        undefined,
+        undefined,
+        xcodebuild,
+      );
+      fakeTimer.enableAutoAdvance();
+
+      expect((await manager.setup()).success).toBe(true);
+      expect(legacyProbeCount).toBe(1);
+
+      healthy = false;
+      manager.resetSetupState();
+
+      expect((await manager.setup()).success).toBe(true);
+      expect(legacyProbeCount).toBe(2);
+    });
+  });
+
   // #6416: `isAvailable()` used to serve a positive answer from a 1-hour
   // `cachedAvailability` layer that `setup()`'s already-attempted gate
   // consults. A runner that dies without a local child-exit event (killed

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1070,7 +1070,7 @@ describe("IOSCtrlProxyManager", function () {
       expect(legacyProbeCount).toBe(1);
     });
 
-    test("re-arms after resetSetupState so a fresh device/session probes again", async function () {
+    test("keeps the lifetime guard latched across setup resets", async function () {
       const fakeExecutor = new FakeProcessExecutor();
       let healthy = false;
       fakeExecutor.setCommandHandler("curl -s", () =>
@@ -1117,7 +1117,7 @@ describe("IOSCtrlProxyManager", function () {
       manager.resetSetupState();
 
       expect((await manager.setup()).success).toBe(true);
-      expect(legacyProbeCount).toBe(2);
+      expect(legacyProbeCount).toBe(1);
     });
   });
 
@@ -1141,8 +1141,14 @@ describe("IOSCtrlProxyManager", function () {
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice,
         fakeTimer,
-        undefined,
+        {
+          ...createFakeBuilder(),
+          needsRebuild: async () => true,
+          build: async () => ({ success: false, message: "fake rebuild unavailable" }),
+        } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder,
         fakeExecutor,
+        undefined,
+        { getInstalledAppBundleHash: async () => null } as unknown as DeviceAppManager,
       );
 
       // First pass through the gate: attemptedSetup becomes true and the
@@ -1179,8 +1185,14 @@ describe("IOSCtrlProxyManager", function () {
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice,
         fakeTimer,
-        undefined,
+        {
+          ...createFakeBuilder(),
+          needsRebuild: async () => true,
+          build: async () => ({ success: false, message: "fake rebuild unavailable" }),
+        } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder,
         fakeExecutor,
+        undefined,
+        { getInstalledAppBundleHash: async () => null } as unknown as DeviceAppManager,
       );
 
       expect((await manager.setup()).success).toBe(true);
@@ -1206,8 +1218,14 @@ describe("IOSCtrlProxyManager", function () {
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice,
         fakeTimer,
-        undefined,
+        {
+          ...createFakeBuilder(),
+          needsRebuild: async () => true,
+          build: async () => ({ success: false, message: "fake rebuild unavailable" }),
+        } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder,
         fakeExecutor,
+        undefined,
+        { getInstalledAppBundleHash: async () => null } as unknown as DeviceAppManager,
       );
 
       expect((await manager.setup()).success).toBe(true);

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -918,11 +918,13 @@ describe("IOSCtrlProxyManager", function () {
     });
 
     test("drops a cached positive availability so a now-down runner is re-probed", async function () {
-      // isAvailable only serves a cache when it is POSITIVE, so this pins the
-      // cachedAvailability clear specifically: deleting `this.cachedAvailability = null`
-      // (or `this.cachedRunning = null`) from clearCaches leaves the stale positive and
-      // reds the final assertion. cachedInstalled has no such test here because for a
-      // simulator device isInstalled is unconditionally true — clearing it is unobservable.
+      // isAvailable() delegates directly to isRunning() (#6416 — it no longer
+      // layers its own hour-long cache on top), so this pins that clearCaches()
+      // still drops the underlying cachedRunning positive: deleting
+      // `this.cachedRunning = null` from clearCaches leaves the stale positive
+      // and reds the final assertion. cachedInstalled has no such test here
+      // because for a simulator device isInstalled is unconditionally true —
+      // clearing it is unobservable.
       const fakeExecutor = new FakeProcessExecutor();
       let healthy = true;
       fakeExecutor.setCommandHandler("curl -s", () =>
@@ -938,9 +940,9 @@ describe("IOSCtrlProxyManager", function () {
         fakeExecutor,
       );
 
-      expect(await manager.isAvailable()).toBe(true); // installed(true)+running(true) → cached positive
+      expect(await manager.isAvailable()).toBe(true); // installed(true)+running(true) → running cached positive
       healthy = false;
-      expect(await manager.isAvailable()).toBe(true); // positive availability cache is served (stale)
+      expect(await manager.isAvailable()).toBe(true); // running's own STATUS_CACHE_TTL cache is served (stale)
       manager.clearCaches();
       expect(await manager.isAvailable()).toBe(false); // caches dropped → re-probes the down runner
     });
@@ -1014,6 +1016,106 @@ describe("IOSCtrlProxyManager", function () {
 
       expect((await manager.setup()).success).toBe(true);
       expect(launchCount).toBe(2);
+    });
+  });
+
+  // #6416: `isAvailable()` used to serve a positive answer from a 1-hour
+  // `cachedAvailability` layer that `setup()`'s already-attempted gate
+  // consults. A runner that dies without a local child-exit event (killed
+  // externally, simulator erased, wedged-but-still-answering /health) is
+  // never re-probed until that hour elapses, so `setup()` keeps reporting
+  // "CtrlProxy was already running" against a dead runner. The fix removes
+  // that layer so the gate relies on `isRunning()`'s own 30s STATUS_CACHE_TTL.
+  describe("setup gate re-probes after STATUS_CACHE_TTL (#6416)", function () {
+    test("setup() re-probes and does not report success once the runner stops answering, even under an hour", async function () {
+      const fakeExecutor = new FakeProcessExecutor();
+      let healthy = true;
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(
+          healthy ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          "",
+        ),
+      );
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+      );
+
+      // First pass through the gate: attemptedSetup becomes true and the
+      // runner is genuinely up.
+      const first = await manager.setup();
+      expect(first.success).toBe(true);
+
+      // Second pass: attemptedSetup is now true, so this call goes through
+      // the isAvailable() gate and (pre-fix) populates cachedAvailability
+      // with a positive result.
+      const second = await manager.setup();
+      expect(second.success).toBe(true);
+
+      // The runner goes away without a local child-exit event. Advance past
+      // the 30s STATUS_CACHE_TTL (but nowhere near the old 1-hour window) so
+      // isRunning() is willing to re-probe.
+      healthy = false;
+      fakeTimer.advanceTime(31 * 1000);
+
+      const third = await manager.setup();
+      expect(third.success).toBe(false);
+      expect(third.message).not.toBe("CtrlProxy was already running");
+    });
+
+    test("setup() still does not report success after a full hour, pinning that the fix does not depend on the old TTL value", async function () {
+      const fakeExecutor = new FakeProcessExecutor();
+      let healthy = true;
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(
+          healthy ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          "",
+        ),
+      );
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+      );
+
+      expect((await manager.setup()).success).toBe(true);
+      expect((await manager.setup()).success).toBe(true);
+
+      healthy = false;
+      fakeTimer.advanceTime(60 * 60 * 1000 + 1000);
+
+      const result = await manager.setup();
+      expect(result.success).toBe(false);
+      expect(result.message).not.toBe("CtrlProxy was already running");
+    });
+
+    test("the fast path still short-circuits when the runner really is up", async function () {
+      const fakeExecutor = new FakeProcessExecutor();
+      const healthy = true;
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(
+          healthy ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          "",
+        ),
+      );
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+      );
+
+      expect((await manager.setup()).success).toBe(true);
+      expect((await manager.setup()).success).toBe(true);
+
+      fakeTimer.advanceTime(31 * 1000);
+
+      const result = await manager.setup();
+      expect(result.success).toBe(true);
+      expect(result.message).toBe("CtrlProxy was already running");
     });
   });
 

--- a/test/utils/RunnerReadinessService.test.ts
+++ b/test/utils/RunnerReadinessService.test.ts
@@ -156,7 +156,15 @@ class FakeIosManager implements ReadinessIosManager {
     await this.onForceRestart?.(options);
   }
 
-  resetSetupState(): void {}
+  resetSetupStateCalls = 0;
+  resetSetupStateCallOrder: number[] = [];
+  setupCallOrder: number[] = [];
+  private callSeq = 0;
+
+  resetSetupState(): void {
+    this.resetSetupStateCalls++;
+    this.resetSetupStateCallOrder.push(++this.callSeq);
+  }
 
   async setup(
     _force?: boolean,
@@ -165,6 +173,7 @@ class FakeIosManager implements ReadinessIosManager {
     minimumHealthPollDurationMs?: number,
   ) {
     this.setupCalls++;
+    this.setupCallOrder.push(++this.callSeq);
     this.setupSignal = signal;
     this.setupMinimumHealthPollDurationMs = minimumHealthPollDurationMs;
     if (this.onSetup) {
@@ -1158,6 +1167,32 @@ describe("RunnerReadinessService", () => {
     timer.advanceTime(1_000);
     await expect(ready).rejects.toThrow(/phase=runner-setup/);
     expect(iosManager.forceRestartOptions?.signal?.aborted).toBe(true);
+  });
+
+  // #6416: the disconnected branch of ensureIosReady called manager.setup()
+  // without first resetting the setup gate, unlike the connected branch
+  // (line ~613) and the Android path (RunnerReadinessService.ts:265). A prior
+  // readiness attempt can leave attemptedSetup latched with a stale positive
+  // cachedAvailability (or, post-#6416 fix, an isRunning() cache) so setup()
+  // reports "already running" against a runner that is actually gone.
+  test("resets the iOS setup gate before calling setup() on the disconnected branch", async () => {
+    const iosManager = new FakeIosManager();
+    const iosClient = new FakeReadinessClient();
+    iosClient.connected = false;
+    const { service } = createService({ iosManager, iosClient });
+
+    await service.ensureReady({
+      device: iosDevice,
+      requestedIdentity: "platform=ios deviceId=IOS-UDID",
+      totalDeadlineMs: 30_000,
+      readinessTimeoutMs: 30_000,
+    });
+
+    expect(iosManager.resetSetupStateCalls).toBe(1);
+    expect(iosManager.setupCalls).toBe(1);
+    expect(Math.min(...iosManager.resetSetupStateCallOrder)).toBeLessThan(
+      Math.min(...iosManager.setupCallOrder),
+    );
   });
 
   test("starts only the cached iOS runner when downloads are disabled", async () => {

--- a/test/utils/ios-cmdline-tools/XctestrunPlist.test.ts
+++ b/test/utils/ios-cmdline-tools/XctestrunPlist.test.ts
@@ -52,6 +52,44 @@ const SAMPLE_XCTESTRUN = `<?xml version="1.0" encoding="UTF-8"?>
 </dict>
 </plist>`;
 
+/**
+ * A minimal format-version-2 xctestrun: the layout `xcodebuild` emits when
+ * the scheme resolves a test plan. The UI-test target lives nested under
+ * `TestConfigurations[].TestTargets[]` instead of at the top level.
+ */
+const SAMPLE_XCTESTRUN_V2 = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+\t<key>TestConfigurations</key>
+\t<array>
+\t\t<dict>
+\t\t\t<key>Name</key>
+\t\t\t<string>Configuration 1</string>
+\t\t\t<key>TestTargets</key>
+\t\t\t<array>
+\t\t\t\t<dict>
+\t\t\t\t\t<key>BlueprintName</key>
+\t\t\t\t\t<string>CtrlProxyUITests</string>
+\t\t\t\t\t<key>IsUITestBundle</key>
+\t\t\t\t\t<true/>
+\t\t\t\t\t<key>EnvironmentVariables</key>
+\t\t\t\t\t<dict>
+\t\t\t\t\t\t<key>TERM</key>
+\t\t\t\t\t\t<string>dumb</string>
+\t\t\t\t\t</dict>
+\t\t\t\t</dict>
+\t\t\t</array>
+\t\t</dict>
+\t</array>
+\t<key>__xctestrun_metadata__</key>
+\t<dict>
+\t\t<key>FormatVersion</key>
+\t\t<integer>2</integer>
+\t</dict>
+</dict>
+</plist>`;
+
 function expectDict(value: unknown): Map<string, unknown> {
   expect(value).toBeInstanceOf(Map);
   return value as Map<string, unknown>;
@@ -155,6 +193,68 @@ describe("XctestrunPlist", function () {
       const root = new Map<string, unknown>([
         ["UnitTarget", new Map<string, unknown>([["IsUITestBundle", false]])],
       ]);
+      expect(injectUITestEnvironment(root, { X: "1" })).toBe(0);
+    });
+
+    test("injects into a FormatVersion 2 (TestConfigurations[].TestTargets[]) UI-test target", async function () {
+      const root = expectDict(await parsePlist(SAMPLE_XCTESTRUN_V2));
+      const count = injectUITestEnvironment(root, {
+        CTRL_PROXY_IOS_PORT: "8767",
+        AUTOMOBILE_DEVICE_ID: "SIM-UUID",
+      });
+
+      expect(count).toBe(1);
+
+      const configurations = root.get("TestConfigurations") as unknown[];
+      const configuration = expectDict(configurations[0]);
+      const testTargets = configuration.get("TestTargets") as unknown[];
+      const uiTarget = expectDict(testTargets[0]);
+      const uiEnv = expectDict(uiTarget.get("EnvironmentVariables"));
+
+      // Existing entry preserved.
+      expect(uiEnv.get("TERM")).toBe("dumb");
+      // New entries injected.
+      expect(uiEnv.get("CTRL_PROXY_IOS_PORT")).toBe("8767");
+      expect(uiEnv.get("AUTOMOBILE_DEVICE_ID")).toBe("SIM-UUID");
+    });
+
+    test("injected environment survives a buildPlist -> parsePlist round-trip at the nested v2 location", async function () {
+      const root = expectDict(await parsePlist(SAMPLE_XCTESTRUN_V2));
+      injectUITestEnvironment(root, { CTRL_PROXY_IOS_PORT: "8767" });
+      const rebuilt = buildPlist(root);
+
+      const reparsed = expectDict(await parsePlist(rebuilt));
+      const configurations = reparsed.get("TestConfigurations") as unknown[];
+      const configuration = expectDict(configurations[0]);
+      const testTargets = configuration.get("TestTargets") as unknown[];
+      const uiTarget = expectDict(testTargets[0]);
+      const uiEnv = expectDict(uiTarget.get("EnvironmentVariables"));
+
+      expect(uiEnv.get("CTRL_PROXY_IOS_PORT")).toBe("8767");
+      expect(uiEnv.get("TERM")).toBe("dumb");
+    });
+
+    test("returns 0 for a v2-shaped file with no UI-test target in either layout", async function () {
+      const root = expectDict(
+        await parsePlist(
+          [
+            '<?xml version="1.0" encoding="UTF-8"?>',
+            '<plist version="1.0">',
+            "<dict>",
+            "\t<key>TestConfigurations</key>",
+            "\t<array>",
+            "\t\t<dict>",
+            "\t\t\t<key>TestTargets</key>",
+            "\t\t\t<array>",
+            "\t\t\t\t<dict><key>IsUITestBundle</key><false/></dict>",
+            "\t\t\t</array>",
+            "\t\t</dict>",
+            "\t</array>",
+            "</dict>",
+            "</plist>",
+          ].join("\n"),
+        ),
+      );
       expect(injectUITestEnvironment(root, { X: "1" })).toBe(0);
     });
   });


### PR DESCRIPTION
## Summary

`IOSCtrlProxyManager.isAvailable()` no longer layers its own 1-hour `cachedAvailability` on top of `isRunning()`'s 30s `STATUS_CACHE_TTL` — it now delegates directly to `isInstalled()`/`isRunning()`, so `setup()`'s already-attempted gate re-probes within 30s instead of serving a stale positive for up to an hour when a runner dies without a local child-exit event. `RunnerReadinessService.ensureIosReady` calls `manager.resetSetupState()` before the disconnected-branch `manager.setup()` call, mirroring the unconditional reset the Android path already performs, closing the asymmetry where only the connected branch reopened the gate. Added FakeTimer-based unit tests in both files that were red before the fix (`setup()` falsely reporting "already running" after the runner goes down past 30s, and `ensureIosReady` not resetting the gate on the disconnected branch) and green after.

The one-time legacy-app uninstall probe stays latched (`legacyCheckDone` is no longer cleared by `resetSetupState()`), so disconnected-path recovery does not re-run it.

## Bundled sibling fixes

This branch was previously the base of a small stack; two sibling epic #6372 fixes were merged into it (via #6783 and #6784, which merged into this branch rather than into `main`), so they land together when this merges:

- **#6418** ctrlproxy(ios): xctestrun runner-environment injection now understands the FormatVersion 2 layout (`IOSCtrlProxyBuilder` / `XctestrunPlist`).
- **#6575** ctrlproxy(ios): the legacy-app uninstall probe runs at most once per manager, before the fast-path short-circuit.

Closes #6416
Closes #6418
Closes #6575

Part of the epic #6372 burndown.
