### PR TITLE
fix(ios): single-flight IOSCtrlProxyBuilder.build() to stop concurrent devices racing the shared derived-data tree (#6417)

### DIFF
--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -250,6 +250,7 @@ export class IOSCtrlProxyBuilder {
    * below, but scoped per-instance since `build()` is an instance method.
    */
   private buildInFlight: Promise<CtrlProxyIosBuildResult> | null = null;
+  private buildWaiters = 0;
 
   private constructor(
     config: Partial<CtrlProxyIosBuildConfig> = {},
@@ -629,25 +630,35 @@ export class IOSCtrlProxyBuilder {
     platform?: IOSCtrlProxyPlatform,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
   ): Promise<CtrlProxyIosBuildResult> {
-    // Single-flight: a caller that arrives while a build is already running
-    // joins that build instead of starting its own independent
-    // download-then-extract against the same shared derived-data tree
-    // (issue #6417). Cleared in `finally` so the next genuinely-new build
-    // (after this one settles) starts its own flight.
-    if (this.buildInFlight !== null) {
-      return this.buildInFlight;
+    // Keep the shared artifact flight alive until every waiter has resolved
+    // its platform paths, so another extraction cannot race those reads.
+    this.buildWaiters++;
+    this.buildInFlight ??= this.doBuild(perf);
+    try {
+      const shared = await this.buildInFlight;
+      if (!shared.success) {return shared;}
+      const buildPath = await this.getBuildProductsPath(platform ?? "simulator");
+      const xctestrunPath = await this.getXctestrunPath(platform);
+      if (!xctestrunPath) {
+        return {
+          success: false,
+          message: "Downloaded CtrlProxy bundle missing xctestrun",
+          error: "No .xctestrun file found after extraction",
+        };
+      }
+      return { ...shared, buildPath: buildPath || undefined, xctestrunPath };
+    } catch (error) {
+      return {
+        success: false,
+        message: "CtrlProxy artifact discovery failed",
+        error: errorMessage(error),
+      };
+    } finally {
+      if (--this.buildWaiters === 0) {this.buildInFlight = null;}
     }
-
-    this.buildInFlight = this.doBuild(platform, perf).finally(() => {
-      this.buildInFlight = null;
-    });
-    return this.buildInFlight;
   }
 
-  private async doBuild(
-    platform?: IOSCtrlProxyPlatform,
-    perf: PerformanceTracker = new NoOpPerformanceTracker(),
-  ): Promise<CtrlProxyIosBuildResult> {
+  private async doBuild(perf: PerformanceTracker): Promise<CtrlProxyIosBuildResult> {
     perf.serial("xcTestServiceDownload");
 
     if (isTruthyEnvValue(process.env[SKIP_CTRL_PROXY_DOWNLOAD_ENV])) {
@@ -674,24 +685,10 @@ export class IOSCtrlProxyBuilder {
 
       await this.cleanStaleXctestrunFiles();
 
-      const buildPath = await this.getBuildProductsPath(platform ?? "simulator");
-      const xctestrunPath = await this.getXctestrunPath(platform);
-
-      if (!xctestrunPath) {
-        perf.end();
-        return {
-          success: false,
-          message: "Downloaded CtrlProxy bundle missing xctestrun",
-          error: "No .xctestrun file found after extraction",
-        };
-      }
-
       perf.end();
       return {
         success: true,
         message: "CtrlProxy downloaded and extracted successfully",
-        buildPath: buildPath || undefined,
-        xctestrunPath: xctestrunPath || undefined,
       };
     } catch (error) {
       const errorMsg = errorMessage(error);

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -636,7 +636,9 @@ export class IOSCtrlProxyBuilder {
     this.buildInFlight ??= this.doBuild(perf);
     try {
       const shared = await this.buildInFlight;
-      if (!shared.success) {return shared;}
+      if (!shared.success) {
+        return shared;
+      }
       const buildPath = await this.getBuildProductsPath(platform ?? "simulator");
       const xctestrunPath = await this.getXctestrunPath(platform);
       if (!xctestrunPath) {
@@ -654,7 +656,9 @@ export class IOSCtrlProxyBuilder {
         error: errorMessage(error),
       };
     } finally {
-      if (--this.buildWaiters === 0) {this.buildInFlight = null;}
+      if (--this.buildWaiters === 0) {
+        this.buildInFlight = null;
+      }
     }
   }
 

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -237,6 +237,19 @@ export class IOSCtrlProxyBuilder {
    * swap even though there is no release-pinned baseline to compare against.
    */
   private derivedLocalRunnerSha256: Map<IOSCtrlProxyPlatform, string> = new Map();
+  /**
+   * Single-flight guard for {@link build}. `IOSCtrlProxyBuilder` is a
+   * process-wide singleton shared by every `IOSCtrlProxyManager` device
+   * instance (issue #6417): with no in-flight guard, two devices whose
+   * `needsRebuild()` both observe `true` before either has finished would
+   * each independently download-then-extract into the same
+   * `derivedDataPath`, and the second extraction's destructive
+   * `fs.rm(destination, { recursive: true, force: true })` (see
+   * `IOSCtrlProxyBundleDownloader.extractBundle`) would wipe out the tree the
+   * first just populated. Mirrors the existing static `prefetchPromise` idiom
+   * below, but scoped per-instance since `build()` is an instance method.
+   */
+  private buildInFlight: Promise<CtrlProxyIosBuildResult> | null = null;
 
   private constructor(
     config: Partial<CtrlProxyIosBuildConfig> = {},
@@ -613,6 +626,25 @@ export class IOSCtrlProxyBuilder {
    * Download and extract CtrlProxy release bundle
    */
   public async build(
+    platform?: IOSCtrlProxyPlatform,
+    perf: PerformanceTracker = new NoOpPerformanceTracker(),
+  ): Promise<CtrlProxyIosBuildResult> {
+    // Single-flight: a caller that arrives while a build is already running
+    // joins that build instead of starting its own independent
+    // download-then-extract against the same shared derived-data tree
+    // (issue #6417). Cleared in `finally` so the next genuinely-new build
+    // (after this one settles) starts its own flight.
+    if (this.buildInFlight !== null) {
+      return this.buildInFlight;
+    }
+
+    this.buildInFlight = this.doBuild(platform, perf).finally(() => {
+      this.buildInFlight = null;
+    });
+    return this.buildInFlight;
+  }
+
+  private async doBuild(
     platform?: IOSCtrlProxyPlatform,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
   ): Promise<CtrlProxyIosBuildResult> {

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -1535,6 +1535,54 @@ describe("IOSCtrlProxyBuilder", function () {
       expect(downloader.extractedPaths.length).toBe(1);
     });
 
+    test.each([false, true])(
+      "mixed platform callers resolve independently (device products: %s)",
+      async function (includeDeviceProducts) {
+        const derivedDataPath = path.join(tempDir, "DerivedData");
+        const cacheDir = path.join(tempDir, "cache");
+
+        let resolveDownload: (() => void) | undefined;
+        const downloadGate = new Promise<void>((resolve) => {
+          resolveDownload = resolve;
+        });
+
+        class DeferredDownloader extends FakeIOSCtrlProxyBundleDownloader {
+          public override async download(url: string, destination: string): Promise<void> {
+            await downloadGate;
+            await super.download(url, destination);
+          }
+        }
+
+        const downloader = new DeferredDownloader();
+        downloader.checksum = "expected-checksum";
+        downloader.includeDeviceProducts = includeDeviceProducts;
+
+        IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+        const builder = IOSCtrlProxyBuilder.getInstance(
+          { derivedDataPath, bundleCacheDir: cacheDir },
+          { downloader },
+        );
+
+        // Both calls start before either has resolved the download, so the
+        // second call must observe (and reuse) the first call's in-flight promise.
+        const firstBuild = builder.build("device");
+        const secondBuild = builder.build("simulator");
+
+        resolveDownload!();
+
+        const [firstResult, secondResult] = await Promise.all([firstBuild, secondBuild]);
+
+        expect(firstResult.success).toBe(includeDeviceProducts);
+        expect(secondResult.success).toBe(true);
+        expect(secondResult.buildPath).toContain("Debug-iphonesimulator");
+        if (includeDeviceProducts) {
+          expect(firstResult.buildPath).toContain("Debug-iphoneos");
+        }
+        expect(downloader.downloadedUrls.length).toBe(1);
+        expect(downloader.extractedPaths.length).toBe(1);
+      },
+    );
+
     test("a second concurrent build() call never invokes the downloader's destructive extractBundle a second time (#6417)", async function () {
       const derivedDataPath = path.join(tempDir, "DerivedData");
       const cacheDir = path.join(tempDir, "cache");
@@ -1591,6 +1639,31 @@ describe("IOSCtrlProxyBuilder", function () {
       expect(secondResult.success).toBe(true);
       expect(downloader.rmCount).toBe(1);
       expect(downloader.extractedPaths.length).toBe(1);
+    });
+    test("a failed shared download allows a subsequent build", async function () {
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+      const download = downloader.download.bind(downloader);
+      downloader.download = async () => {
+        throw new Error("download unavailable");
+      };
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        {
+          derivedDataPath: path.join(tempDir, "DerivedData"),
+          bundleCacheDir: path.join(tempDir, "cache"),
+        },
+        { downloader },
+      );
+      const [first, second] = await Promise.all([
+        builder.build("device"),
+        builder.build("simulator"),
+      ]);
+      expect(first.success).toBe(false);
+      expect(second.success).toBe(false);
+      downloader.download = download;
+      expect((await builder.build("simulator")).success).toBe(true);
+      expect(downloader.extractedPaths).toHaveLength(1);
     });
   });
 });

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -1493,5 +1493,104 @@ describe("IOSCtrlProxyBuilder", function () {
       expect(result.success).toBe(false);
       expect(result.error).toContain("runner binary SHA256 mismatch");
     });
+
+    test("concurrent build() calls single-flight: only one download/extract happens (#6417)", async function () {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+
+      let resolveDownload: (() => void) | undefined;
+      const downloadGate = new Promise<void>((resolve) => {
+        resolveDownload = resolve;
+      });
+
+      class DeferredDownloader extends FakeIOSCtrlProxyBundleDownloader {
+        public override async download(url: string, destination: string): Promise<void> {
+          await downloadGate;
+          await super.download(url, destination);
+        }
+      }
+
+      const downloader = new DeferredDownloader();
+      downloader.checksum = "expected-checksum";
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader },
+      );
+
+      // Both calls start before either has resolved the download, so the
+      // second call must observe (and reuse) the first call's in-flight promise.
+      const firstBuild = builder.build("simulator");
+      const secondBuild = builder.build("simulator");
+
+      resolveDownload!();
+
+      const [firstResult, secondResult] = await Promise.all([firstBuild, secondBuild]);
+
+      expect(firstResult.success).toBe(true);
+      expect(secondResult.success).toBe(true);
+      expect(secondResult).toEqual(firstResult);
+      expect(downloader.downloadedUrls.length).toBe(1);
+      expect(downloader.extractedPaths.length).toBe(1);
+    });
+
+    test("a second concurrent build() call never invokes the downloader's destructive extractBundle a second time (#6417)", async function () {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+
+      let resolveDownload: (() => void) | undefined;
+      const downloadGate = new Promise<void>((resolve) => {
+        resolveDownload = resolve;
+      });
+
+      // Mirrors the real DefaultIOSCtrlProxyBundleDownloader's destructive
+      // `fs.rm(destination, { recursive: true, force: true })` before
+      // extracting (src/utils/IOSCtrlProxyBundleDownloader.ts:67-68). Counting
+      // invocations proves the shared derived-data tree is torn down and
+      // rebuilt at most once for a pair of overlapping build() calls, which is
+      // the property that protects a live runner's on-disk bundle and any
+      // per-device runner-<deviceId>.xctestrun another caller wrote in between.
+      class DestructiveDeferredDownloader extends FakeIOSCtrlProxyBundleDownloader {
+        public rmCount = 0;
+
+        public override async download(url: string, destination: string): Promise<void> {
+          await downloadGate;
+          await super.download(url, destination);
+        }
+
+        public override async extractBundle(
+          bundlePath: string,
+          destination: string,
+        ): Promise<void> {
+          this.rmCount += 1;
+          await fs.rm(destination, { recursive: true, force: true });
+          await super.extractBundle(bundlePath, destination);
+        }
+      }
+
+      const downloader = new DestructiveDeferredDownloader();
+      downloader.checksum = "expected-checksum";
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader },
+      );
+
+      // Both calls start before either has resolved the download, so the
+      // second call must observe (and reuse) the first call's in-flight promise
+      // instead of running its own independent rm-rf + re-extract.
+      const firstBuild = builder.build("simulator");
+      const secondBuild = builder.build("simulator");
+
+      resolveDownload!();
+      const [firstResult, secondResult] = await Promise.all([firstBuild, secondBuild]);
+
+      expect(firstResult.success).toBe(true);
+      expect(secondResult.success).toBe(true);
+      expect(downloader.rmCount).toBe(1);
+      expect(downloader.extractedPaths.length).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

IOSCtrlProxyBuilder is a process-wide singleton shared by every IOSCtrlProxyManager device instance, and its build() method had no in-flight guard: two devices whose needsRebuild() both observed true before either finished would each independently download-then-extract into the same derivedDataPath, and the second extraction's destructive fs.rm(destination, {recursive:true,force:true}) would wipe out the tree the first had just populated (potentially including a live device's runner-<deviceId>.xctestrun). Fixed by adding a private buildInFlight promise field that build() checks and reuses when set, mirroring the existing static prefetchPromise pattern used by prefetchBuild(); the promise is created and cleared in a finally so a genuinely new build after the flight settles still starts fresh. Because both the on-demand build path in IOSCtrlProxyManager.setup() and the static prefetch's doPrefetch() call build() on the same shared getInstance() singleton, this single builder-level change routes both call sites through one flight with no manager-level wiring changes required. TDD: added two unit tests using the existing FakeIOSCtrlProxyBundleDownloader pattern (deferred download() plus a destructive-rm-rf-mimicking extractBundle) that fail red before the fix (observing 2 downloads/extracts for two concurrent build() calls) and pass green after.

Part of epic #6372.

## Linked Issue

Closes #6417

## Validation

Added two tests to test/utils/IOSCtrlProxyBuilder.test.ts under the "build" describe block: (1) "concurrent build() calls single-flight: only one download/extract happens (#6417)" - two build() calls issued before a deferred FakeIOSCtrlProxyBundleDownloader.download() resolves; asserts exactly 1 downloadedUrls and 1 extractedPaths entry, both results equal and successful. (2) A companion test with a downloader subclass whose extractBundle mimics the real destructive fs.rm(destination, {recursive:true,force:true}) before extracting, asserting that rm/extract count stays at 1 for the concurrent pair. Both tests failed red (received 2 instead of 1) before the fix and pass green after adding the buildInFlight single-flight guard. Full existing suite: bun test test/utils/IOSCtrlProxyBuilder.test.ts (65 pass), test/utils/IOSCtrlProxyManager.test.ts (106 pass), test/utils/IOSCtrlProxyBundleDownloader.test.ts, and the broad test/utils directory (3103 pass / 0 fail with sandbox disabled - 7 failures seen under the default sandbox were pre-existing scratch-dir/tempdir permission artifacts unrelated to this change, confirmed by an unsandboxed re-run). Gates: bun run format:check (clean), bun run lint (oxlint ratchet gate: no new violations), bun run typecheck (no new type errors vs baseline).

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
