### PR TITLE
fix(ios): stop resident xcodebuild runner inheriting the per-request abort signal (#6410)

### DIFF
--- a/src/utils/AbortContext.ts
+++ b/src/utils/AbortContext.ts
@@ -42,6 +42,18 @@ export const getAbortSignal = (): AbortSignal | undefined => {
  *
  * Returns `undefined` when neither an explicit nor an ambient signal exists, so
  * callers can forward the result straight through without a null-guard.
+ *
+ * This convention — and the `signal ?? getAbortSignal()` default it backs —
+ * is for SHORT-LIVED reads that should die with the request that issued them.
+ * It does not cover a process meant to OUTLIVE the request that started it
+ * (e.g. a shared, long-lived resident runner serving many later requests):
+ * for that case, binding the OS-level kill to the ambient request signal would
+ * let an unrelated request cancellation tear down a process still serving
+ * other work. See `XcodebuildClient.startStreaming`'s process-signal argument
+ * and `IOSCtrlProxyManager`'s `runnerAbortController` (issue #6410) for the
+ * pattern that case uses instead: the resident process's OS-level kill wiring
+ * is bound only to a signal its owner explicitly supplies, never to the
+ * ambient default.
  */
 export const combineWithAmbientAbort = (signal?: AbortSignal): AbortSignal | undefined => {
   const ambient = getAbortSignal();

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1285,37 +1285,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     // Stop iproxy tunnel if running
     await this.stopIproxyTunnel({ clearDevicePort: true });
 
-    const retiringPid =
-      this.runnerAbortController === retiringController ? this.xcTestProcessId : null;
-    const retiringChild = this.xcTestProcess;
-    let runnerTerminationError: unknown;
-    if (retiringPid) {
-      try {
-        if (await this.isOwnRunnerProcessAlive(retiringPid)) {
-          await this.processClient.terminateProcessTree(retiringPid, deadline);
-        } else {
-          logger.debug(
-            `[IOSCtrlProxy] Tracked runner PID ${retiringPid} is not an owned CtrlProxy runner; ` +
-              `clearing without terminating`,
-          );
-        }
-      } catch (error) {
-        runnerTerminationError = error;
-        logger.warn(
-          `[IOSCtrlProxy] Failed to terminate tracked CtrlProxy runner ${retiringPid}: ` +
-            `${errorMessage(error)}`,
-        );
-      }
-      if (
-        runnerTerminationError === undefined &&
-        this.xcTestProcessId === retiringPid &&
-        this.xcTestProcess === retiringChild &&
-        this.runnerAbortController === retiringController
-      ) {
-        this.xcTestProcessId = null;
-        this.xcTestProcess = null;
-      }
-    }
+    const runnerTerminationError = await this.terminateTrackedRunner(retiringController, deadline);
 
     this.clearCaches();
     this.isStopping = false;
@@ -1332,6 +1302,53 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
     PortManager.release(this.device.deviceId);
     logger.info("[IOSCtrlProxy] Service stopped");
+  }
+
+  /**
+   * Terminate the local runner tracked at the time {@link stop} began, using a
+   * single runner identity captured in `retiringController`. Returns the
+   * termination error (or `undefined` on success) so the caller decides whether
+   * to surface it. The tracking fields are cleared only when they still point at
+   * the same runner we set out to retire — an overlapping forceRestart() may have
+   * swapped in a newer runner in the meantime, which we must not clobber.
+   */
+  private async terminateTrackedRunner(
+    retiringController: AbortController | null,
+    deadline?: number,
+  ): Promise<unknown> {
+    const retiringPid =
+      this.runnerAbortController === retiringController ? this.xcTestProcessId : null;
+    const retiringChild = this.xcTestProcess;
+    if (!retiringPid) {
+      return undefined;
+    }
+    let runnerTerminationError: unknown;
+    try {
+      if (await this.isOwnRunnerProcessAlive(retiringPid)) {
+        await this.processClient.terminateProcessTree(retiringPid, deadline);
+      } else {
+        logger.debug(
+          `[IOSCtrlProxy] Tracked runner PID ${retiringPid} is not an owned CtrlProxy runner; ` +
+            `clearing without terminating`,
+        );
+      }
+    } catch (error) {
+      runnerTerminationError = error;
+      logger.warn(
+        `[IOSCtrlProxy] Failed to terminate tracked CtrlProxy runner ${retiringPid}: ` +
+          `${errorMessage(error)}`,
+      );
+    }
+    if (
+      runnerTerminationError === undefined &&
+      this.xcTestProcessId === retiringPid &&
+      this.xcTestProcess === retiringChild &&
+      this.runnerAbortController === retiringController
+    ) {
+      this.xcTestProcessId = null;
+      this.xcTestProcess = null;
+    }
+    return runnerTerminationError;
   }
 
   /**

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1250,9 +1250,39 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * Stop CtrlProxy
    */
   public async stop(deadline?: number): Promise<void> {
+    this.beginStop();
+    if (!this.useRemoteRunner()) {
+      await this.cancelAndAwaitSharedStart();
+    }
+    await this.stopTrackedService(deadline);
+  }
+
+  private beginStop(): void {
     logger.info("[IOSCtrlProxy] Stopping CtrlProxy");
     this.isStopping = true;
+    this.processSupervisor.stop();
+  }
 
+  private async cancelAndAwaitSharedStart(): Promise<void> {
+    const sharedStart = this.sharedStart;
+    if (!sharedStart || sharedStart.completed) {
+      return;
+    }
+    if (!sharedStart.teardownCommitted && !sharedStart.controller.signal.aborted) {
+      sharedStart.controller.abort(new Error("iOS CtrlProxy startup was cancelled by stop()"));
+    }
+    try {
+      await sharedStart.completion;
+    } catch (error) {
+      // A startup rejection is expected after stop cancels it; teardown below owns the runner.
+      logger.debug(`[IOSCtrlProxy] In-flight startup settled during stop: ${errorMessage(error)}`);
+    }
+  }
+
+  private async stopTrackedService(deadline?: number): Promise<void> {
+    // startInternal() may have reset this flag or restarted supervision before its
+    // completion settled. Reassert teardown state after the shared-start barrier.
+    this.isStopping = true;
     this.processSupervisor.stop();
 
     const retiringController = this.runnerAbortController;
@@ -1596,7 +1626,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   private async restartDeviceProcessAfterHostPortCollision(): Promise<void> {
-    await this.stop();
+    // This replacement runs inside startInternal()'s shared completion, so it must
+    // not wait for that same completion through public stop() or it would deadlock.
+    this.beginStop();
+    await this.stopTrackedService();
     this.isStopping = false;
     await this.startOnDevice();
   }

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1256,7 +1256,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     this.processSupervisor.stop();
 
     const retiringController = this.runnerAbortController;
-    const retiringPid = this.xcTestProcessId;
 
     if (this.useRemoteRunner()) {
       try {
@@ -1286,25 +1285,33 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     // Stop iproxy tunnel if running
     await this.stopIproxyTunnel({ clearDevicePort: true });
 
+    const retiringPid =
+      this.runnerAbortController === retiringController ? this.xcTestProcessId : null;
+    const retiringChild = this.xcTestProcess;
     let runnerTerminationError: unknown;
-    if (this.xcTestProcessId) {
+    if (retiringPid) {
       try {
-        if (await this.isOwnRunnerProcessAlive()) {
-          await this.processClient.terminateProcessTree(retiringPid!, deadline);
+        if (await this.isOwnRunnerProcessAlive(retiringPid)) {
+          await this.processClient.terminateProcessTree(retiringPid, deadline);
         } else {
           logger.debug(
-            `[IOSCtrlProxy] Tracked runner PID ${this.xcTestProcessId} is not an owned CtrlProxy runner; ` +
+            `[IOSCtrlProxy] Tracked runner PID ${retiringPid} is not an owned CtrlProxy runner; ` +
               `clearing without terminating`,
           );
         }
       } catch (error) {
         runnerTerminationError = error;
         logger.warn(
-          `[IOSCtrlProxy] Failed to terminate tracked CtrlProxy runner ${this.xcTestProcessId}: ` +
+          `[IOSCtrlProxy] Failed to terminate tracked CtrlProxy runner ${retiringPid}: ` +
             `${errorMessage(error)}`,
         );
       }
-      if (runnerTerminationError === undefined) {
+      if (
+        runnerTerminationError === undefined &&
+        this.xcTestProcessId === retiringPid &&
+        this.xcTestProcess === retiringChild &&
+        this.runnerAbortController === retiringController
+      ) {
         this.xcTestProcessId = null;
         this.xcTestProcess = null;
       }
@@ -1997,25 +2004,23 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * this does NOT require a health response, so a runner still initializing counts
    * as alive — used to avoid killing+respawning our own still-starting runner (#2834).
    */
-  private async isOwnRunnerProcessAlive(): Promise<boolean> {
-    if (!this.xcTestProcessId) {
+  private async isOwnRunnerProcessAlive(
+    pid: number | null = this.xcTestProcessId,
+  ): Promise<boolean> {
+    if (!pid) {
       return false;
     }
     if (this.useRemoteRunner()) {
       try {
         const status = await this.remoteRunner.status({
           deviceId: this.device.deviceId,
-          pid: this.xcTestProcessId,
+          pid: pid,
         });
         // PID-strict: the remote daemon resolves status by deviceId BEFORE pid,
         // so running=true alone is not proof the TRACKED pid is alive — a newer runner
         // for the same device aliases it, and treating it as "ours" would make us wait
         // on (and eventually stop) that newer runner (#2834 review).
-        return (
-          status.success &&
-          (status.data?.running ?? false) &&
-          status.data?.pid === this.xcTestProcessId
-        );
+        return status.success && (status.data?.running ?? false) && status.data?.pid === pid;
       } catch (error) {
         // A failed remote status call (network/daemon error) is treated the same as
         // "not our tracked runner": returning false here is safe because the caller
@@ -2024,7 +2029,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         return false;
       }
     }
-    if (!(await this.isProcessRunning(this.xcTestProcessId))) {
+    if (!(await this.isProcessRunning(pid))) {
       return false;
     }
     // Guard against PID reuse (#2834 review): a bare `kill -0` only proves *some*
@@ -2032,7 +2037,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     // for THIS device before treating it as "still starting" — otherwise a recycled
     // PID (our runner exited, its PID reassigned to an unrelated process) would make
     // us defer to a health endpoint that never comes.
-    const info = await this.processClient.getProcessInfo(this.xcTestProcessId);
+    const info = await this.processClient.getProcessInfo(pid);
     if (!info) {
       return false;
     }
@@ -2044,7 +2049,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     // canonical isOwnedCtrlProxyRunnerProcess predicate (also used by the port-reclaim
     // path) distinguishes it.
     return this.isOwnedCtrlProxyRunnerProcess({
-      pid: this.xcTestProcessId,
+      pid: pid,
       port: this.servicePort,
       command: info.command,
       environment: info.environment,

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -255,6 +255,13 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   // XCUITest process state
   private xcTestProcessId: number | null = null;
   private xcTestProcess: ChildProcess | null = null;
+  // Owns the resident runner's process-lifecycle abort signal (issue #6410).
+  // Deliberately NOT the ambient per-request signal: this runner is shared
+  // across every session targeting the device and must outlive whichever
+  // request happened to start it. Only stop()/forceRestart() may abort it, so
+  // SharedCtrlProxyStart's teardown accounting stays the single authority
+  // deciding when the runner actually goes away.
+  private runnerAbortController: AbortController | null = null;
 
   // Process supervision
   private readonly processSupervisor: ProcessSupervisor;
@@ -1248,6 +1255,12 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     this.processSupervisor.stop();
 
+    // stop() is the ONLY place (besides forceRestart(), which calls stop())
+    // permitted to abort the resident runner's process-lifecycle signal —
+    // never an ambient per-request cancellation (issue #6410).
+    this.runnerAbortController?.abort(new Error("iOS CtrlProxy runner stopped"));
+    this.runnerAbortController = null;
+
     if (this.useRemoteRunner()) {
       try {
         if (this.xcTestProcessId) {
@@ -1671,10 +1684,16 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     // / isDaemonManagedSimulatorXcodebuildProcess).
     // `xcodebuild` itself becomes the detached process-group leader. This keeps
     // terminateProcessTree's group cleanup effective without a shell wrapper.
+    // The signal is THIS manager's own runnerAbortController, never the ambient
+    // per-request signal (issue #6410) — the runner is shared across every
+    // session targeting this device and must outlive whichever request started
+    // it; only stop()/forceRestart() abort this controller.
+    this.runnerAbortController = new AbortController();
     const child = await this.xcodebuild.startStreaming(args, {
       detached: true,
       env: { ...process.env, ...runnerEnv },
       stdio: ["ignore", "pipe", "pipe"],
+      signal: this.runnerAbortController.signal,
     });
 
     child.on("error", (error) => {
@@ -2825,10 +2844,14 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     // can later discover/own/recover this process by reading its env via `ps eww`.
     // xcodebuild itself is the detached process-group leader, so the manager's
     // existing terminateProcessTree() ownership semantics remain intact.
+    // The signal is THIS manager's own runnerAbortController, never the ambient
+    // per-request signal (issue #6410) — see the simulator call site for why.
+    this.runnerAbortController = new AbortController();
     const child = await this.xcodebuild.startStreaming(args, {
       detached: true,
       env: { ...process.env, ...runnerEnv },
       stdio: ["ignore", "pipe", "pipe"],
+      signal: this.runnerAbortController.signal,
     });
 
     child.on("error", (error) => {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1255,11 +1255,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     this.processSupervisor.stop();
 
-    // stop() is the ONLY place (besides forceRestart(), which calls stop())
-    // permitted to abort the resident runner's process-lifecycle signal —
-    // never an ambient per-request cancellation (issue #6410).
-    this.runnerAbortController?.abort(new Error("iOS CtrlProxy runner stopped"));
-    this.runnerAbortController = null;
+    const retiringController = this.runnerAbortController;
+    const retiringPid = this.xcTestProcessId;
 
     if (this.useRemoteRunner()) {
       try {
@@ -1293,7 +1290,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     if (this.xcTestProcessId) {
       try {
         if (await this.isOwnRunnerProcessAlive()) {
-          await this.processClient.terminateProcessTree(this.xcTestProcessId, deadline);
+          await this.processClient.terminateProcessTree(retiringPid!, deadline);
         } else {
           logger.debug(
             `[IOSCtrlProxy] Tracked runner PID ${this.xcTestProcessId} is not an owned CtrlProxy runner; ` +
@@ -1320,6 +1317,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         `Failed to stop iOS CtrlProxy runner ${this.xcTestProcessId}: ` +
           `${errorMessage(runnerTerminationError)}`,
       );
+    }
+    // Terminate descendants before abort can synchronously clear process tracking.
+    retiringController?.abort(new Error("iOS CtrlProxy runner stopped"));
+    if (this.runnerAbortController === retiringController) {
+      this.runnerAbortController = null;
     }
     PortManager.release(this.device.deviceId);
     logger.info("[IOSCtrlProxy] Service stopped");
@@ -1694,6 +1696,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       env: { ...process.env, ...runnerEnv },
       stdio: ["ignore", "pipe", "pipe"],
       signal: this.runnerAbortController.signal,
+      startupSignal: this.sharedStart?.controller.signal,
     });
 
     child.on("error", (error) => {
@@ -2852,6 +2855,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       env: { ...process.env, ...runnerEnv },
       stdio: ["ignore", "pipe", "pipe"],
       signal: this.runnerAbortController.signal,
+      startupSignal: this.sharedStart?.controller.signal,
     });
 
     child.on("error", (error) => {

--- a/src/utils/ios-cmdline-tools/XcodebuildClient.ts
+++ b/src/utils/ios-cmdline-tools/XcodebuildClient.ts
@@ -6,7 +6,7 @@ import { createExecResult } from "../execResult";
 import { defaultTimer, Timer } from "../SystemTimer";
 import { combineAbortSignals, getAbortSignal } from "../AbortContext";
 import { DEFAULT_RUNNER_READINESS_TIMEOUT_MS } from "../runnerReadinessConfig";
-import { waitForSpawn } from "../ChildProcessTracker";
+import { trackProcess, waitForExit, waitForSpawn } from "../ChildProcessTracker";
 
 export interface XcodebuildCommandOptions {
   timeoutMs?: number;
@@ -30,6 +30,8 @@ export type XcodebuildSpawner = (
   args: string[],
   options: SpawnOptions,
 ) => ChildProcess;
+
+export type XcodebuildProcessKiller = (pid: number, signal?: NodeJS.Signals | number) => boolean;
 
 export interface XcodebuildAvailabilityOptions {
   timeoutMs?: number;
@@ -89,6 +91,7 @@ export class XcodebuildClient implements Xcodebuild {
       | null = null,
     timer: Timer = defaultTimer,
     private readonly spawnProcess: XcodebuildSpawner = spawn,
+    private readonly killProcess: XcodebuildProcessKiller = process.kill,
   ) {
     this.execAsync = execAsyncFn || execAsync;
     this.timer = timer;
@@ -237,7 +240,7 @@ export class XcodebuildClient implements Xcodebuild {
     }
 
     if (startupSignal?.aborted) {
-      child.kill("SIGKILL");
+      await this.retireCancelledStartup(child, options.detached === true);
       startupSignal.throwIfAborted();
     }
 
@@ -247,6 +250,27 @@ export class XcodebuildClient implements Xcodebuild {
     }
 
     return child;
+  }
+
+  private async retireCancelledStartup(child: ChildProcess, detached: boolean): Promise<void> {
+    const tracker = trackProcess(child);
+    try {
+      if (detached && child.pid) {
+        this.killProcess(-child.pid, "SIGKILL");
+      } else {
+        child.kill("SIGKILL");
+      }
+    } catch (error) {
+      // Signal delivery may race a natural exit; the bounded tracker wait below is authoritative.
+      logger.debug(`[iOS] Cancelled xcodebuild runner signal raced process exit: ${error}`);
+    }
+
+    try {
+      await waitForExit(child, tracker.exitPromise, { timer: this.timer, signal: null });
+    } catch (error) {
+      // Startup cancellation remains the caller contract even when best-effort reaping is unconfirmed.
+      logger.debug(`[iOS] Cancelled xcodebuild runner exit was not confirmed: ${error}`);
+    }
   }
 
   private async isAvailableWithin(timeoutMs: number, callerSignal?: AbortSignal): Promise<boolean> {

--- a/src/utils/ios-cmdline-tools/XcodebuildClient.ts
+++ b/src/utils/ios-cmdline-tools/XcodebuildClient.ts
@@ -236,6 +236,11 @@ export class XcodebuildClient implements Xcodebuild {
       throw new ActionableError(`xcodebuild failed to start: ${String(error)}`);
     }
 
+    if (startupSignal?.aborted) {
+      child.kill("SIGKILL");
+      startupSignal.throwIfAborted();
+    }
+
     if (!child.pid) {
       child.kill();
       throw new ActionableError("xcodebuild failed to start: no process ID was assigned.");

--- a/src/utils/ios-cmdline-tools/XcodebuildClient.ts
+++ b/src/utils/ios-cmdline-tools/XcodebuildClient.ts
@@ -4,7 +4,7 @@ import { ActionableError, ExecResult } from "../../models";
 import { logger } from "../logger";
 import { createExecResult } from "../execResult";
 import { defaultTimer, Timer } from "../SystemTimer";
-import { getAbortSignal } from "../AbortContext";
+import { combineAbortSignals, getAbortSignal } from "../AbortContext";
 import { DEFAULT_RUNNER_READINESS_TIMEOUT_MS } from "../runnerReadinessConfig";
 import { waitForSpawn } from "../ChildProcessTracker";
 
@@ -19,15 +19,10 @@ export interface XcodebuildStreamingOptions {
   readonly detached?: boolean;
   readonly stdio?: SpawnOptions["stdio"];
   readonly timeoutMs?: number;
-  /**
-   * Used for BOTH the pre-spawn availability probe (defaulting to the ambient
-   * request signal, like short-lived reads) AND — ONLY if explicitly supplied
-   * here — the spawned child's OS-level kill wiring (issue #6410). Leave this
-   * unset for a resident/shared runner meant to outlive the caller's request;
-   * supply a caller-owned `AbortController.signal` here only when the spawned
-   * process's lifetime should genuinely be tied to that specific signal.
-   */
+  /** Explicit resident process lifetime; never defaults to request cancellation. */
   readonly signal?: AbortSignal;
+  /** Pre-spawn cancellation, defaulting to the ambient request signal. */
+  readonly startupSignal?: AbortSignal;
 }
 
 export type XcodebuildSpawner = (
@@ -191,7 +186,7 @@ export class XcodebuildClient implements Xcodebuild {
    * resolution, availability diagnostics, and argv-safe process creation.
    *
    * Two DIFFERENT signals are in play here, deliberately kept apart (issue
-   * #6410). The *startup* signal — `options.signal ?? getAbortSignal()` —
+   * #6410). The *startup* signal — `options.startupSignal ?? getAbortSignal()` —
    * bounds only the pre-spawn availability probe (`isAvailableWithin`); it is
    * correct for that probe to inherit the ambient per-request abort signal, the
    * same way short-lived reads do (see `AbortContext.ts`). The *process*
@@ -209,7 +204,11 @@ export class XcodebuildClient implements Xcodebuild {
     args: string[],
     options: XcodebuildStreamingOptions = {},
   ): Promise<ChildProcess> {
-    const startupSignal = options.signal ?? getAbortSignal();
+    const startupSignal = combineAbortSignals(
+      options.startupSignal ?? getAbortSignal(),
+      options.signal,
+    );
+    startupSignal?.throwIfAborted();
     if (
       !(await this.isAvailableWithin(
         options.timeoutMs ?? DEFAULT_RUNNER_READINESS_TIMEOUT_MS,
@@ -219,6 +218,7 @@ export class XcodebuildClient implements Xcodebuild {
       throw new ActionableError("xcodebuild is not available. Please install Xcode to continue.");
     }
 
+    startupSignal?.throwIfAborted();
     const child = this.spawnProcess("xcodebuild", args, {
       detached: options.detached,
       env: options.env,
@@ -249,6 +249,14 @@ export class XcodebuildClient implements Xcodebuild {
     const signal = callerSignal
       ? AbortSignal.any([callerSignal, controller.signal])
       : controller.signal;
+    callerSignal?.throwIfAborted();
+    let onAbort: (() => void) | undefined;
+    const cancelled = new Promise<never>((_resolve, reject) => {
+      if (callerSignal) {
+        onAbort = () => reject(callerSignal.reason);
+        callerSignal.addEventListener("abort", onAbort, { once: true });
+      }
+    });
     let timeoutId: NodeJS.Timeout;
     const timeout = new Promise<boolean>((_, reject) => {
       timeoutId = this.timer.setTimeout(() => {
@@ -257,9 +265,12 @@ export class XcodebuildClient implements Xcodebuild {
       }, timeoutMs);
     });
     try {
-      return await Promise.race([this.isLocalXcodebuildAvailable(signal), timeout]);
+      return await Promise.race([this.isLocalXcodebuildAvailable(signal), timeout, cancelled]);
     } finally {
       this.timer.clearTimeout(timeoutId!);
+      if (onAbort) {
+        callerSignal?.removeEventListener("abort", onAbort);
+      }
     }
   }
 

--- a/src/utils/ios-cmdline-tools/XcodebuildClient.ts
+++ b/src/utils/ios-cmdline-tools/XcodebuildClient.ts
@@ -19,6 +19,14 @@ export interface XcodebuildStreamingOptions {
   readonly detached?: boolean;
   readonly stdio?: SpawnOptions["stdio"];
   readonly timeoutMs?: number;
+  /**
+   * Used for BOTH the pre-spawn availability probe (defaulting to the ambient
+   * request signal, like short-lived reads) AND — ONLY if explicitly supplied
+   * here — the spawned child's OS-level kill wiring (issue #6410). Leave this
+   * unset for a resident/shared runner meant to outlive the caller's request;
+   * supply a caller-owned `AbortController.signal` here only when the spawned
+   * process's lifetime should genuinely be tied to that specific signal.
+   */
   readonly signal?: AbortSignal;
 }
 
@@ -181,16 +189,31 @@ export class XcodebuildClient implements Xcodebuild {
    * Launch a long-lived xcodebuild invocation without a shell. Callers retain
    * lifecycle ownership of the returned child, while this boundary owns binary
    * resolution, availability diagnostics, and argv-safe process creation.
+   *
+   * Two DIFFERENT signals are in play here, deliberately kept apart (issue
+   * #6410). The *startup* signal — `options.signal ?? getAbortSignal()` —
+   * bounds only the pre-spawn availability probe (`isAvailableWithin`); it is
+   * correct for that probe to inherit the ambient per-request abort signal, the
+   * same way short-lived reads do (see `AbortContext.ts`). The *process*
+   * signal handed to `spawnProcess` is different: this runner is meant to
+   * outlive the request that happened to start it (it is a shared, long-lived
+   * resident process — see the callers' `SharedCtrlProxyStart` ownership).
+   * Node's `signal` spawn option kills the child for the child's entire
+   * lifetime with no way to detach afterward, so it must NEVER default to the
+   * ambient request signal. Only a signal the caller explicitly supplies is
+   * forwarded to spawn; callers that want the runner's OS-level kill wired to
+   * a signal must own that AbortController themselves and abort it only from
+   * their own teardown path.
    */
   async startStreaming(
     args: string[],
     options: XcodebuildStreamingOptions = {},
   ): Promise<ChildProcess> {
-    const signal = options.signal ?? getAbortSignal();
+    const startupSignal = options.signal ?? getAbortSignal();
     if (
       !(await this.isAvailableWithin(
         options.timeoutMs ?? DEFAULT_RUNNER_READINESS_TIMEOUT_MS,
-        signal,
+        startupSignal,
       ))
     ) {
       throw new ActionableError("xcodebuild is not available. Please install Xcode to continue.");
@@ -201,7 +224,7 @@ export class XcodebuildClient implements Xcodebuild {
       env: options.env,
       stdio: options.stdio,
       shell: false,
-      signal,
+      signal: options.signal,
     });
 
     try {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -351,4 +351,27 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
       "src/utils/ios/IOSCtrlProxyProcessClient.ts",
     );
   });
+
+  test("both resident-runner startStreaming call sites pass an explicit process signal (issue #6410)", () => {
+    // XcodebuildClient.startStreaming only forwards a signal to spawn when the
+    // caller explicitly supplies one — it never defaults that wiring to the
+    // ambient per-request signal. Both IOSCtrlProxyManager call sites (simulator
+    // and physical device) MUST supply their own runner-owned signal rather than
+    // silently relying on that default, or the resident runner would have no
+    // lifecycle-abort wiring at all. A regression here (dropping the `signal:`
+    // line from either call) must fail loudly instead of just changing runtime
+    // behavior silently.
+    const manager = readFileSync(join(ROOT, "src/utils/IOSCtrlProxyManager.ts"), "utf8");
+    const callSitePattern = /this\.xcodebuild\.startStreaming\(args,\s*\{/g;
+    const callSiteStarts = [...manager.matchAll(callSitePattern)].map((match) => match.index);
+    expect(callSiteStarts).toHaveLength(2);
+    for (const start of callSiteStarts) {
+      // The options object closes well within 300 characters at both call
+      // sites; slicing a fixed window (rather than brace-matching through the
+      // nested `env: { ...process.env, ...runnerEnv }`) keeps this a plain
+      // source-text assertion, consistent with the rest of this file.
+      const window = manager.slice(start, start + 300);
+      expect(window).toMatch(/signal:\s*this\.runnerAbortController\.signal/);
+    }
+  });
 });

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -11,11 +11,60 @@ const ROOT = join(import.meta.dir, "..", "..");
 const OWNER = join(ROOT, "src/utils/ios/IOSCtrlProxyProcessClient.ts");
 const CHECK = join(ROOT, "scripts/check-ios-ctrl-proxy-process-boundary.ts");
 
+// Raw-source regex guards below match against the whole file, so commented-out
+// code would otherwise satisfy (or falsely trip) them (issue #6410 review). Use
+// the TypeScript scanner rather than a comment-stripping regex: the scanner
+// tokenizes strings correctly, so `"http://x"` is never mistaken for a comment.
+function stripComments(source: string): string {
+  const scanner = ts.createScanner(
+    ts.ScriptTarget.Latest,
+    /* skipTrivia */ false,
+    ts.LanguageVariant.Standard,
+    source,
+  );
+  let result = "";
+  for (let token = scanner.scan(); token !== ts.SyntaxKind.EndOfFileToken; token = scanner.scan()) {
+    if (
+      token === ts.SyntaxKind.SingleLineCommentTrivia ||
+      token === ts.SyntaxKind.MultiLineCommentTrivia
+    ) {
+      continue;
+    }
+    result += scanner.getTokenText();
+  }
+  return result;
+}
+
 describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
   test("keeps ps, pgrep, and kill ownership in the lifecycle client", () => {
-    const manager = readFileSync(join(ROOT, "src/utils/IOSCtrlProxyManager.ts"), "utf8");
+    const manager = stripComments(
+      readFileSync(join(ROOT, "src/utils/IOSCtrlProxyManager.ts"), "utf8"),
+    );
     expect(manager).not.toMatch(/processExecutor\.exec\(\s*["'`](?:ps|pgrep|kill)/);
-    expect(readFileSync(OWNER, "utf8")).toMatch(/executeCommand\(\s*"pgrep"/);
+    expect(stripComments(readFileSync(OWNER, "utf8"))).toMatch(/executeCommand\(\s*"pgrep"/);
+  });
+
+  test("ownership guard ignores commented-out process tooling (issue #6410 review)", () => {
+    // A raw-source regex over the whole file fires on commented-out code even
+    // though it is not a real call site; stripping comments first must silence
+    // the false positive while still catching a genuine (uncommented) call.
+    const lineComment = '// processExecutor.exec("kill", ["-9", "42"]);\nconst x = 1;';
+    const blockComment = '/* processExecutor.exec("ps", ["-p", "42"]); */\nconst y = 2;';
+    const realCall = 'processExecutor.exec("kill", ["-9", "42"]);';
+    expect(stripComments(lineComment)).not.toMatch(
+      /processExecutor\.exec\(\s*["'`](?:ps|pgrep|kill)/,
+    );
+    expect(stripComments(blockComment)).not.toMatch(
+      /processExecutor\.exec\(\s*["'`](?:ps|pgrep|kill)/,
+    );
+    expect(stripComments(realCall)).toMatch(/processExecutor\.exec\(\s*["'`](?:ps|pgrep|kill)/);
+    // A comment mentioning the owner API must not satisfy the positive presence
+    // check that pins pgrep ownership inside the lifecycle client.
+    expect(stripComments('/* executeCommand("pgrep") */')).not.toMatch(
+      /executeCommand\(\s*"pgrep"/,
+    );
+    // A `//` inside a string literal is not a comment and must survive.
+    expect(stripComments('const url = "http://example.com";')).toMatch(/http:\/\/example\.com/);
   });
 
   test("rejects direct and wrapped process APIs for lifecycle tools", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -1,3 +1,4 @@
+import ts from "typescript";
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -362,16 +363,32 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
     // line from either call) must fail loudly instead of just changing runtime
     // behavior silently.
     const manager = readFileSync(join(ROOT, "src/utils/IOSCtrlProxyManager.ts"), "utf8");
-    const callSitePattern = /this\.xcodebuild\.startStreaming\(args,\s*\{/g;
-    const callSiteStarts = [...manager.matchAll(callSitePattern)].map((match) => match.index);
-    expect(callSiteStarts).toHaveLength(2);
-    for (const start of callSiteStarts) {
-      // The options object closes well within 300 characters at both call
-      // sites; slicing a fixed window (rather than brace-matching through the
-      // nested `env: { ...process.env, ...runnerEnv }`) keeps this a plain
-      // source-text assertion, consistent with the rest of this file.
-      const window = manager.slice(start, start + 300);
-      expect(window).toMatch(/signal:\s*this\.runnerAbortController\.signal/);
+    const source = ts.createSourceFile("manager.ts", manager, ts.ScriptTarget.Latest, true);
+    const calls: ts.CallExpression[] = [];
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        node.expression.getText(source) === "this.xcodebuild.startStreaming"
+      ) {
+        calls.push(node);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+    expect(calls).toHaveLength(2);
+    for (const call of calls) {
+      const options = call.arguments[1];
+      expect(ts.isObjectLiteralExpression(options)).toBe(true);
+      if (!ts.isObjectLiteralExpression(options)) {
+        continue;
+      }
+      const signal = options.properties.find(
+        (property) =>
+          ts.isPropertyAssignment(property) && property.name.getText(source) === "signal",
+      );
+      expect(signal && ts.isPropertyAssignment(signal) && signal.initializer.getText(source)).toBe(
+        "this.runnerAbortController.signal",
+      );
     }
   });
 });

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1615,7 +1615,15 @@ describe("IOSCtrlProxyManager", function () {
         undefined,
         fakeExecutor,
       );
-      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 912345;
+      // Startup may publish its PID while tunnel shutdown yields.
+      const internal = manager as unknown as {
+        xcTestProcessId: number | null;
+        stopIproxyTunnel: () => Promise<void>;
+      };
+      internal.stopIproxyTunnel = async () => {
+        await Promise.resolve();
+        internal.xcTestProcessId = 912345;
+      };
 
       const ownedRunner = ownRunnerProcess(912345);
       const otherDeviceRunner: FakeListeningProcess = {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1699,6 +1699,87 @@ describe("IOSCtrlProxyManager", function () {
       expect(recycledProcess.alive).toBe(true);
     });
 
+    test("stop() cancels and awaits a local startup before retiring its published runner", async function () {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        physicalDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor,
+      );
+      const startupEntered = deferred();
+      const releaseStartup = deferred();
+      const tunnelStopEntered = deferred();
+      const releaseTunnelStop = deferred();
+      const runner = new FakeChildProcess(fakeTimer);
+      runner.pid = 912349;
+      const runnerController = new AbortController();
+      const terminatedPids: number[] = [];
+      let sharedStartupSignal: AbortSignal | undefined;
+      const internal = manager as unknown as {
+        sharedStart: { controller: AbortController } | null;
+        runnerAbortController: AbortController | null;
+        xcTestProcessId: number | null;
+        xcTestProcess: FakeChildProcess | null;
+        processClient: IOSCtrlProxyProcessClient;
+        awaitStartupOrphanRunnerReap: () => Promise<void>;
+        isCtrlProxyProcessAlive: () => Promise<boolean>;
+        isRunning: () => Promise<boolean>;
+        startOnDevice: () => Promise<void>;
+        waitForHealthEndpoint: (start: { controller: AbortController }) => Promise<boolean>;
+        completeHealthStartup: () => Promise<void>;
+        stopIproxyTunnel: () => Promise<void>;
+        isOwnRunnerProcessAlive: () => Promise<boolean>;
+      };
+      internal.awaitStartupOrphanRunnerReap = async () => {};
+      internal.isCtrlProxyProcessAlive = async () => false;
+      internal.isRunning = async () => false;
+      internal.startOnDevice = async () => {
+        sharedStartupSignal = internal.sharedStart?.controller.signal;
+        startupEntered.resolve();
+        await releaseStartup.promise;
+        internal.runnerAbortController = runnerController;
+        internal.xcTestProcessId = runner.pid!;
+        internal.xcTestProcess = runner;
+      };
+      internal.waitForHealthEndpoint = async (start) => {
+        start.controller.signal.throwIfAborted();
+        return true;
+      };
+      internal.completeHealthStartup = async () => {};
+      internal.stopIproxyTunnel = async () => {
+        tunnelStopEntered.resolve();
+        await releaseTunnelStop.promise;
+      };
+      internal.isOwnRunnerProcessAlive = async () => true;
+      internal.processClient.terminateProcessTree = async (pid) => {
+        terminatedPids.push(pid);
+      };
+
+      const startOutcome = manager.start().then(
+        () => "resolved" as const,
+        (error: unknown) => error,
+      );
+      await startupEntered.promise;
+
+      const stopOutcome = manager.stop().then(
+        () => "resolved" as const,
+        (error: unknown) => error,
+      );
+      const startupWasCancelledBeforePublication = sharedStartupSignal?.aborted;
+      releaseStartup.resolve();
+      await tunnelStopEntered.promise;
+      releaseTunnelStop.resolve();
+      const [startResult, stopResult] = await Promise.all([startOutcome, stopOutcome]);
+
+      expect(startupWasCancelledBeforePublication).toBe(true);
+      expect(startResult).toBeInstanceOf(Error);
+      expect(stopResult).toBe("resolved");
+      expect(terminatedPids).toEqual([runner.pid]);
+      expect(runnerController.signal.aborted).toBe(true);
+      expect(internal.xcTestProcessId).toBeNull();
+      expect(internal.xcTestProcess).toBeNull();
+    });
+
     test("start() waits for an own runner then terminates it if it never becomes healthy (#2834)", async function () {
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice, // simulator UUID

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -3143,8 +3143,26 @@ describe("IOSCtrlProxyManager", function () {
         ambientRequestController.abort();
         expect(spawn.options?.signal?.aborted).toBe(false);
 
-        // Only stop() (or forceRestart(), which calls stop()) may abort it.
+        const tracked = manager as unknown as {
+          xcTestProcessId: number | null;
+          processClient: IOSCtrlProxyProcessClient;
+        };
+        const pid = tracked.xcTestProcessId!;
+        (
+          manager as unknown as { isOwnRunnerProcessAlive: () => Promise<boolean> }
+        ).isOwnRunnerProcessAlive = async () => true;
+        let terminated = false;
+        tracked.processClient.terminateProcessTree = async (target) => {
+          expect(target).toBe(pid);
+          expect(spawn.options?.signal?.aborted).toBe(false);
+          terminated = true;
+        };
+        spawn.options?.signal?.addEventListener("abort", () => {
+          expect(terminated).toBe(true);
+          tracked.xcTestProcessId = null;
+        });
         await manager.stop();
+        expect(terminated).toBe(true);
         expect(spawn.options?.signal?.aborted).toBe(true);
       } finally {
         PortManager.setPortAvailabilityCheckerForTesting(null);

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -15,6 +15,7 @@ import { PortManager } from "../../src/utils/PortManager";
 import { IOSCtrlProxyBuilder } from "../../src/utils/IOSCtrlProxyBuilder";
 import { IOSCtrlProxyProcessClient } from "../../src/utils/ios/IOSCtrlProxyProcessClient";
 import { logger } from "../../src/utils/logger";
+import { runWithAbortSignal } from "../../src/utils/AbortContext";
 import type { Xcodebuild } from "../../src/utils/ios-cmdline-tools/XcodebuildClient";
 import type { DeviceAppManager } from "../../src/utils/ios-cmdline-tools/DeviceAppManager";
 import { parsePlist } from "../../src/utils/ios-cmdline-tools/XctestrunPlist";
@@ -3101,6 +3102,50 @@ describe("IOSCtrlProxyManager", function () {
         expect(
           Object.keys(spawn.options?.env ?? {}).some((key) => key.startsWith("SIMCTL_CHILD_")),
         ).toBe(false);
+      } finally {
+        PortManager.setPortAvailabilityCheckerForTesting(null);
+      }
+    });
+
+    test("startOnSimulator() gives the resident runner its own process signal, not the ambient request signal (issue #6410)", async function () {
+      // The runner is a shared, long-lived resident process serving every session
+      // targeting this device. Binding its OS-level kill to whichever MCP
+      // request happened to start it would let an unrelated request cancellation
+      // SIGTERM a runner that is already healthy and serving other work.
+      PortManager.setPortAvailabilityCheckerForTesting({
+        isPortAvailable: (port: number) => port !== 8765,
+      });
+      try {
+        const fakeBuilder = {
+          getXctestrunPath: async () => "/tmp/test.xctestrun",
+          getRunnerBinaryPath: async () => null,
+          verifyRunnerBinaryBeforeLaunch: async () => {},
+          writeRunnerEnvironment: fakeWriteRunnerEnvironment,
+        } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          testDevice,
+          fakeTimer,
+          fakeBuilder,
+          fakeExecutor,
+        );
+
+        const ambientRequestController = new AbortController();
+        await runWithAbortSignal(ambientRequestController.signal, () =>
+          (manager as unknown as { startOnSimulator: () => Promise<void> }).startOnSimulator(),
+        );
+
+        const spawn = fakeExecutor.getSpawnedProcesses()[0];
+        expect(spawn.options?.signal).toBeDefined();
+        expect(spawn.options?.signal).not.toBe(ambientRequestController.signal);
+
+        // Cancelling the ambient request that started the runner must not reach
+        // the runner's own lifecycle controller.
+        ambientRequestController.abort();
+        expect(spawn.options?.signal?.aborted).toBe(false);
+
+        // Only stop() (or forceRestart(), which calls stop()) may abort it.
+        await manager.stop();
+        expect(spawn.options?.signal?.aborted).toBe(true);
       } finally {
         PortManager.setPortAvailabilityCheckerForTesting(null);
       }

--- a/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
@@ -3,6 +3,7 @@ import { XcodebuildClient } from "../../../src/utils/ios-cmdline-tools/Xcodebuil
 import type { ExecResult } from "../../../src/models";
 import { createExecResult } from "../../../src/utils/execResult";
 import { DEFAULT_RUNNER_READINESS_TIMEOUT_MS } from "../../../src/utils/runnerReadinessConfig";
+import { runWithAbortSignal } from "../../../src/utils/AbortContext";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeChildProcess } from "../../fakes/FakeChildProcess";
 
@@ -243,5 +244,90 @@ describe("XcodebuildClient streaming runner", () => {
     await expect(
       timer.resolvePromise(client.startStreaming(["test-without-building"])),
     ).rejects.toThrow("xcodebuild failed to start: Error: posix_spawn: executable missing");
+  });
+
+  test("does not hand the ambient request signal to the resident spawn (issue #6410)", async () => {
+    // A resident runner started inside runWithAbortSignal(requestSignal, ...) must
+    // NOT bind spawn's `signal` option to that ambient request signal — a later
+    // cancellation of the STARTING request would otherwise SIGTERM the shared,
+    // long-lived runner. The startup availability probe may still inherit the
+    // ambient signal (bounding how long the probe waits); only the spawn wiring
+    // must not.
+    const child = new FakeChildProcess();
+    let capturedSpawnOptions: import("node:child_process").SpawnOptions | undefined;
+    const client = new XcodebuildClient(
+      async () => createExecResult("Xcode 26.5", ""),
+      new FakeTimer(),
+      (_command, _args, options) => {
+        capturedSpawnOptions = options;
+        child.simulateSpawn();
+        return child as never;
+      },
+    );
+
+    const requestController = new AbortController();
+    const result = await runWithAbortSignal(requestController.signal, () =>
+      client.startStreaming(["test-without-building"], {
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    );
+
+    expect(result).toBe(child);
+    expect(capturedSpawnOptions?.signal).toBeUndefined();
+  });
+
+  test("forwards an explicitly supplied process signal to the resident spawn", async () => {
+    // A caller that explicitly opts in to a process-lifecycle signal (rather than
+    // relying on the ambient request signal) must still have it reach spawn.
+    const child = new FakeChildProcess();
+    let capturedSpawnOptions: import("node:child_process").SpawnOptions | undefined;
+    const client = new XcodebuildClient(
+      async () => createExecResult("Xcode 26.5", ""),
+      new FakeTimer(),
+      (_command, _args, options) => {
+        capturedSpawnOptions = options;
+        child.simulateSpawn();
+        return child as never;
+      },
+    );
+
+    const ownedController = new AbortController();
+    await client.startStreaming(["test-without-building"], {
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      signal: ownedController.signal,
+    });
+
+    expect(capturedSpawnOptions?.signal).toBe(ownedController.signal);
+  });
+
+  test("aborting the ambient request signal after startStreaming resolves does not kill the child", async () => {
+    const child = new FakeChildProcess();
+    const client = new XcodebuildClient(
+      async () => createExecResult("Xcode 26.5", ""),
+      new FakeTimer(),
+      (_command, _args, _options) => {
+        child.simulateSpawn();
+        return child as never;
+      },
+    );
+
+    const requestController = new AbortController();
+    let killed = false;
+    (child as unknown as { kill: () => void }).kill = () => {
+      killed = true;
+    };
+
+    await runWithAbortSignal(requestController.signal, () =>
+      client.startStreaming(["test-without-building"], {
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    );
+
+    requestController.abort();
+
+    expect(killed).toBe(false);
   });
 });

--- a/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
@@ -277,6 +277,23 @@ describe("XcodebuildClient streaming runner", () => {
     expect(capturedSpawnOptions?.signal).toBeUndefined();
   });
 
+  test("kills a child if startup cancellation wins while spawn settles", async () => {
+    const child = new FakeChildProcess();
+    const startup = new AbortController();
+    const reason = new Error("startup canceled while spawning");
+    const client = new XcodebuildClient(
+      async () => createExecResult("Xcode 26.5", ""),
+      new FakeTimer(),
+      () => {
+        startup.abort(reason);
+        child.simulateSpawn();
+        return child as never;
+      },
+    );
+    await expect(client.startStreaming([], { startupSignal: startup.signal })).rejects.toBe(reason);
+    expect(child.killed).toBe(true);
+  });
+
   test("forwards an explicitly supplied process signal to the resident spawn", async () => {
     // A caller that explicitly opts in to a process-lifecycle signal (rather than
     // relying on the ambient request signal) must still have it reach spawn.

--- a/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
@@ -307,7 +307,8 @@ describe("XcodebuildClient streaming runner", () => {
     const client = new XcodebuildClient(
       async () => createExecResult("Xcode 26.5", ""),
       new FakeTimer(),
-      (_command, _args, _options) => {
+      (_command, _args, options) => {
+        options.signal?.addEventListener("abort", () => child.kill());
         child.simulateSpawn();
         return child as never;
       },
@@ -329,5 +330,56 @@ describe("XcodebuildClient streaming runner", () => {
     requestController.abort();
 
     expect(killed).toBe(false);
+  });
+  test("startup cancellation rejects a pending probe without spawning the resident", async () => {
+    const timer = new FakeTimer();
+    const startup = new AbortController();
+    const owner = new AbortController();
+    let release!: (result: ExecResult) => void;
+    let spawns = 0;
+    const client = new XcodebuildClient(
+      async () =>
+        new Promise<ExecResult>((resolve) => {
+          release = resolve;
+        }),
+      timer,
+      () => {
+        spawns++;
+        throw new Error("must not spawn");
+      },
+    );
+    const reason = new Error("startup cancelled");
+    const outcome = client
+      .startStreaming([], { signal: owner.signal, startupSignal: startup.signal })
+      .catch((error: unknown) => error);
+    startup.abort(reason);
+    expect(await outcome).toBe(reason);
+    release(createExecResult("Xcode 26.5", ""));
+    await Promise.resolve();
+    expect(spawns).toBe(0);
+    expect(owner.signal.aborted).toBe(false);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("cancellation at probe completion prevents spawn", async () => {
+    const startup = new AbortController();
+    const owner = new AbortController();
+    let spawns = 0;
+    const reason = new Error("cancelled at probe completion");
+    const client = new XcodebuildClient(
+      async () => {
+        startup.abort(reason);
+        return createExecResult("Xcode 26.5", "");
+      },
+      new FakeTimer(),
+      () => {
+        spawns++;
+        throw new Error("must not spawn");
+      },
+    );
+    await expect(
+      client.startStreaming([], { signal: owner.signal, startupSignal: startup.signal }),
+    ).rejects.toBe(reason);
+    expect(spawns).toBe(0);
   });
 });

--- a/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
@@ -278,20 +278,119 @@ describe("XcodebuildClient streaming runner", () => {
   });
 
   test("kills a child if startup cancellation wins while spawn settles", async () => {
-    const child = new FakeChildProcess();
+    const timer = new FakeTimer();
+    const child = new FakeChildProcess(timer);
     const startup = new AbortController();
     const reason = new Error("startup canceled while spawning");
+    const groupKills: number[] = [];
     const client = new XcodebuildClient(
       async () => createExecResult("Xcode 26.5", ""),
-      new FakeTimer(),
+      timer,
       () => {
         startup.abort(reason);
         child.simulateSpawn();
         return child as never;
       },
+      (pid) => {
+        groupKills.push(pid);
+        return true;
+      },
     );
-    await expect(client.startStreaming([], { startupSignal: startup.signal })).rejects.toBe(reason);
+    await expect(
+      timer.resolvePromise(client.startStreaming([], { startupSignal: startup.signal })),
+    ).rejects.toBe(reason);
     expect(child.killed).toBe(true);
+    expect(groupKills).toEqual([]);
+  });
+
+  test("kills a cancelled detached runner group and awaits exit before rejecting", async () => {
+    const timer = new FakeTimer();
+    const child = new FakeChildProcess(timer);
+    const startup = new AbortController();
+    const reason = new Error("startup cancelled after descendants spawned");
+    const groupKills: Array<{ pid: number; signal?: NodeJS.Signals | number }> = [];
+    const client = new XcodebuildClient(
+      async () => createExecResult("Xcode 26.5", ""),
+      timer,
+      () => {
+        startup.abort(reason);
+        child.simulateSpawn();
+        return child as never;
+      },
+      (pid, signal) => {
+        groupKills.push({ pid, signal });
+        return true;
+      },
+    );
+    let settled = false;
+    const outcome = client
+      .startStreaming([], { detached: true, startupSignal: startup.signal })
+      .then(
+        () => "resolved" as const,
+        (error: unknown) => error,
+      );
+    void outcome.then(() => {
+      settled = true;
+    });
+
+    for (let turn = 0; turn < 5 && groupKills.length === 0; turn++) {
+      timer.advanceTime(0);
+      await Promise.resolve();
+    }
+    const settledBeforeExit = settled;
+    child.simulateExit(0, "SIGKILL");
+    timer.advanceTime(0);
+
+    expect(await outcome).toBe(reason);
+    expect(groupKills).toEqual([{ pid: -child.pid!, signal: "SIGKILL" }]);
+    expect(settledBeforeExit).toBe(false);
+    expect(child.killed).toBe(false);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("preserves cancellation after the bounded detached-runner exit wait", async () => {
+    const timer = new FakeTimer();
+    const child = new FakeChildProcess(timer);
+    const directKillSignals: Array<NodeJS.Signals | number | undefined> = [];
+    child.kill = (signal?: NodeJS.Signals | number) => {
+      directKillSignals.push(signal);
+      return true;
+    };
+    const startup = new AbortController();
+    const reason = new Error("startup cancellation remains authoritative");
+    const groupKills: Array<{ pid: number; signal?: NodeJS.Signals | number }> = [];
+    const client = new XcodebuildClient(
+      async () => createExecResult("Xcode 26.5", ""),
+      timer,
+      () => {
+        startup.abort(reason);
+        child.simulateSpawn();
+        return child as never;
+      },
+      (pid, signal) => {
+        groupKills.push({ pid, signal });
+        return true;
+      },
+    );
+    const outcome = client.startStreaming([], {
+      detached: true,
+      startupSignal: startup.signal,
+    });
+
+    for (let turn = 0; turn < 5 && groupKills.length === 0; turn++) {
+      timer.advanceTime(0);
+      await Promise.resolve();
+    }
+    timer.advanceTime(5000);
+    for (let turn = 0; turn < 5 && directKillSignals.length === 0; turn++) {
+      await Promise.resolve();
+    }
+    timer.advanceTime(5000);
+
+    await expect(outcome).rejects.toBe(reason);
+    expect(groupKills).toEqual([{ pid: -child.pid!, signal: "SIGKILL" }]);
+    expect(directKillSignals).toEqual(["SIGKILL"]);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
   });
 
   test("forwards an explicitly supplied process signal to the resident spawn", async () => {


### PR DESCRIPTION
## Summary

XcodebuildClient.startStreaming previously defaulted spawn's signal option to the ambient per-request AbortSignal, so the resident, hours-long xcodebuild test-without-building CtrlProxy runner was SIGTERMed whenever the MCP request that started it was later cancelled or timed out — even though the runner was healthy and serving other sessions on that device. The fix splits the startup-probe signal (still options.signal ?? getAbortSignal(), correct for bounding isAvailableWithin) from the spawn/process-lifecycle signal, which now only forwards a signal the caller explicitly supplies rather than falling back to the ambient one. IOSCtrlProxyManager now owns a per-runner AbortController at both the simulator and physical-device call sites, passing its signal explicitly to startStreaming, and aborts it only from stop() (which forceRestart() also goes through), keeping SharedCtrlProxyStart's teardown accounting the sole authority over the runner's lifecycle.

Part of epic #6372.

Stacked on `work/issue-6416-ios-availability-cache-reopen`; GitHub retargets to `main` once it merges.

## Linked Issue

Closes #6410

## Validation

New tests: XcodebuildClient.test.ts pins that the ambient request signal is never forwarded to spawn, an explicitly-supplied signal is, and aborting the ambient signal post-resolve never kills the child; a manager-level test proves the resident runner gets its own AbortController (only stop() aborts it); a source-level regression asserts both startStreaming call sites pass an explicit signal. Red-then-green verified. 166 targeted tests plus the full test/utils suite (3109) pass; the only full-suite failures are pre-existing sandbox/socket-path artifacts unrelated to this diff.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
