### PR TITLE
fix(ios): make CtrlProxy health-endpoint gate device-identity-aware (#6415)

### DIFF
--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -2927,6 +2927,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     return this.healthClient.checkHealthEndpointOnPortForDevice(
       this.servicePort,
       this.device.deviceId,
+      undefined,
+      { requireDeviceId: false },
     );
   }
 

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1852,12 +1852,22 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * true only when the old runner is STILL answering at the end of the grace — a
    * listener that merely lags the process teardown stops answering well inside it,
    * and the restart may proceed. Honours the caller's abort signal while polling.
+   *
+   * Strict: a responder that omits deviceId must NOT be mistaken for the runner we
+   * just tried to stop. Fail closed here — unlike the liveness gate elsewhere, where a
+   * missing deviceId is compat-accepted — so a foreign/ambiguous responder on this
+   * port never blocks a legitimate restart (#6415 follow-up).
    */
   private async isRunnerStillHealthyAfterForcedTeardown(signal?: AbortSignal): Promise<boolean> {
     const graceDeadlineMs = this.timer.now() + FORCE_RESTART_DRAIN_GRACE_MS;
     for (;;) {
       if (
-        !(await this.checkHealthEndpointOnPortForDevice(this.servicePort, this.device.deviceId))
+        !(await this.checkHealthEndpointOnPortForDevice(
+          this.servicePort,
+          this.device.deviceId,
+          undefined,
+          { requireDeviceId: true },
+        ))
       ) {
         return false;
       }
@@ -2956,8 +2966,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     port: number,
     deviceId: string,
     timeoutMs?: number,
+    options?: { requireDeviceId?: boolean },
   ): Promise<boolean> {
-    return this.healthClient.checkHealthEndpointOnPortForDevice(port, deviceId, timeoutMs);
+    return this.healthClient.checkHealthEndpointOnPortForDevice(port, deviceId, timeoutMs, options);
   }
 
   private getIproxyStartTimeoutMs(): number {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -2903,8 +2903,21 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     logger.info("[IOSCtrlProxy] Installed CtrlProxy app hash matches expected bundle");
   }
 
+  /**
+   * The primary "is our runner up" gate. Routes through the identity-checked
+   * probe (issue #6415) rather than the loose "any 'ok'/'healthy' body" check,
+   * so a foreign responder on the service port — a sibling simulator's runner,
+   * a stale runner from a previous daemon run, or the Android runner reached
+   * through `adb forward` — is never mistaken for this device's runner. Every
+   * caller (`isRunning()`, the `start()` short-circuit, `waitForHealthEndpoint`,
+   * `isCtrlProxyProcessAlive()`) inherits the identity check through this one
+   * method.
+   */
   private async checkHealthEndpoint(): Promise<boolean> {
-    return this.healthClient.checkHealthEndpointOnPort(this.servicePort);
+    return this.healthClient.checkHealthEndpointOnPortForDevice(
+      this.servicePort,
+      this.device.deviceId,
+    );
   }
 
   /**

--- a/src/utils/ios/IOSCtrlProxyHealthClient.ts
+++ b/src/utils/ios/IOSCtrlProxyHealthClient.ts
@@ -56,13 +56,13 @@ export class IOSCtrlProxyHealthClient {
    * `status === "ok"` and its reported `deviceId` is compatible with the
    * requested `deviceId`, per `options.requireDeviceId`:
    *
-   * - **compat (default, `requireDeviceId` unset/false)** — a MISSING `deviceId`
+   * - **compat (`requireDeviceId: false`)** — a MISSING `deviceId`
    *   still counts as a match (an older runner build, or the env-injection
    *   fallback #2731 that can drop the device-id var along with the port).
    *   Used by the primary liveness gate (`isRunning`/`waitForHealthEndpoint`
    *   in {@link IOSCtrlProxyManager}) so those older/degraded runners are not
    *   spuriously treated as down.
-   * - **strict (`requireDeviceId: true`)** — a MISSING `deviceId` is rejected;
+   * - **strict (default)** — a MISSING `deviceId` is rejected;
    *   only an exact match counts. Used by ownership/forced-teardown decisions
    *   (issue #6415 follow-up) where adopting a foreign responder that omits
    *   `deviceId` — a sibling simulator's runner, or another process entirely —
@@ -90,7 +90,7 @@ export class IOSCtrlProxyHealthClient {
       if (health.status !== "ok") {
         return false;
       }
-      if (options?.requireDeviceId) {
+      if (options?.requireDeviceId !== false) {
         return health.deviceId === deviceId;
       }
       return health.deviceId === undefined || health.deviceId === deviceId;

--- a/src/utils/ios/IOSCtrlProxyHealthClient.ts
+++ b/src/utils/ios/IOSCtrlProxyHealthClient.ts
@@ -52,19 +52,33 @@ export class IOSCtrlProxyHealthClient {
   }
 
   /**
-   * Strict liveness check: the runner answered `/health` with `status === "ok"`
-   * and either omits `deviceId` (an older runner build, or the env-injection
-   * fallback #2731 that can drop the device-id var along with the port) or
-   * reports it as this exact `deviceId`. Rejects a payload whose `deviceId` is
-   * PRESENT but different — a sibling simulator's runner or the Android runner
-   * answering the same/default port (whose plain-text `OK` body also fails the
-   * JSON parse below). This is the one place that decides "what counts as our
-   * runner" (issue #6415); callers must not re-derive identity themselves.
+   * Device-identity-aware `/health` check: the runner answered with
+   * `status === "ok"` and its reported `deviceId` is compatible with the
+   * requested `deviceId`, per `options.requireDeviceId`:
+   *
+   * - **compat (default, `requireDeviceId` unset/false)** — a MISSING `deviceId`
+   *   still counts as a match (an older runner build, or the env-injection
+   *   fallback #2731 that can drop the device-id var along with the port).
+   *   Used by the primary liveness gate (`isRunning`/`waitForHealthEndpoint`
+   *   in {@link IOSCtrlProxyManager}) so those older/degraded runners are not
+   *   spuriously treated as down.
+   * - **strict (`requireDeviceId: true`)** — a MISSING `deviceId` is rejected;
+   *   only an exact match counts. Used by ownership/forced-teardown decisions
+   *   (issue #6415 follow-up) where adopting a foreign responder that omits
+   *   `deviceId` — a sibling simulator's runner, or another process entirely —
+   *   could mistake it for this device's runner.
+   *
+   * Both modes reject a payload whose `deviceId` is PRESENT but different — a
+   * sibling simulator's runner or the Android runner answering the same/default
+   * port (whose plain-text `OK` body also fails the JSON parse below). This is
+   * the one place that decides "what counts as our runner" (issue #6415);
+   * callers must not re-derive identity themselves.
    */
   public async checkHealthEndpointOnPortForDevice(
     port: number,
     deviceId: string,
     timeoutMs?: number,
+    options?: { requireDeviceId?: boolean },
   ): Promise<boolean> {
     const body = await this.readHealthEndpointBodyOnPort(port, timeoutMs);
     if (body === null) {
@@ -75,6 +89,9 @@ export class IOSCtrlProxyHealthClient {
       const health = JSON.parse(body) as { status?: unknown; deviceId?: unknown };
       if (health.status !== "ok") {
         return false;
+      }
+      if (options?.requireDeviceId) {
+        return health.deviceId === deviceId;
       }
       return health.deviceId === undefined || health.deviceId === deviceId;
     } catch (error) {

--- a/src/utils/ios/IOSCtrlProxyHealthClient.ts
+++ b/src/utils/ios/IOSCtrlProxyHealthClient.ts
@@ -53,8 +53,13 @@ export class IOSCtrlProxyHealthClient {
 
   /**
    * Strict liveness check: the runner answered `/health` with `status === "ok"`
-   * AND identifies as `deviceId`. Rejects a sibling simulator's runner or the
-   * Android runner answering the same/default port.
+   * and either omits `deviceId` (an older runner build, or the env-injection
+   * fallback #2731 that can drop the device-id var along with the port) or
+   * reports it as this exact `deviceId`. Rejects a payload whose `deviceId` is
+   * PRESENT but different — a sibling simulator's runner or the Android runner
+   * answering the same/default port (whose plain-text `OK` body also fails the
+   * JSON parse below). This is the one place that decides "what counts as our
+   * runner" (issue #6415); callers must not re-derive identity themselves.
    */
   public async checkHealthEndpointOnPortForDevice(
     port: number,
@@ -68,7 +73,10 @@ export class IOSCtrlProxyHealthClient {
 
     try {
       const health = JSON.parse(body) as { status?: unknown; deviceId?: unknown };
-      return health.status === "ok" && health.deviceId === deviceId;
+      if (health.status !== "ok") {
+        return false;
+      }
+      return health.deviceId === undefined || health.deviceId === deviceId;
     } catch (error) {
       // Malformed/non-JSON health body means we can't trust this runner's identity; treat it as not matching.
       logger.debug(`src/utils/ios/IOSCtrlProxyHealthClient.ts fallback failed: ${error}`, error);

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -2522,42 +2522,45 @@ describe("IOSCtrlProxyManager", function () {
       }
     });
 
-    test("start() does not adopt the default CtrlProxy port for another simulator", async function () {
-      PortManager.setPortAvailabilityCheckerForTesting({
-        isPortAvailable: (port: number) => port !== 8765,
-      });
-      try {
-        const fakeBuilder = {
-          getXctestrunPath: async () => "/tmp/test.xctestrun",
-          getRunnerBinaryPath: async () => null,
-          verifyRunnerBinaryBeforeLaunch: async () => {},
-          writeRunnerEnvironment: fakeWriteRunnerEnvironment,
-        } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
-        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
-          testDevice,
-          fakeTimer,
-          fakeBuilder,
-          fakeExecutor,
-        );
-        expect(manager.getServicePort()).toBe(8767);
+    test.each(["OTHER-SIMULATOR", undefined])(
+      "start() rejects ambiguous default-port identity: %s",
+      async function (deviceId) {
+        PortManager.setPortAvailabilityCheckerForTesting({
+          isPortAvailable: (port: number) => port !== 8765,
+        });
+        try {
+          const fakeBuilder = {
+            getXctestrunPath: async () => "/tmp/test.xctestrun",
+            getRunnerBinaryPath: async () => null,
+            verifyRunnerBinaryBeforeLaunch: async () => {},
+            writeRunnerEnvironment: fakeWriteRunnerEnvironment,
+          } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+          const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+            testDevice,
+            fakeTimer,
+            fakeBuilder,
+            fakeExecutor,
+          );
+          expect(manager.getServicePort()).toBe(8767);
 
-        fakeExecutor.setCommandResponse("http://localhost:8767/health", createExecResult("", ""));
-        fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
-        fakeExecutor.setCommandResponse(
-          "http://localhost:8765/health",
-          createExecResult(JSON.stringify({ status: "ok", deviceId: "OTHER-SIMULATOR" }), ""),
-        );
-        fakeTimer.enableAutoAdvance();
+          fakeExecutor.setCommandResponse("http://localhost:8767/health", createExecResult("", ""));
+          fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+          fakeExecutor.setCommandResponse(
+            "http://localhost:8765/health",
+            createExecResult(JSON.stringify({ status: "ok", deviceId }), ""),
+          );
+          fakeTimer.enableAutoAdvance();
 
-        await expect(manager.start()).rejects.toThrow("CtrlProxy failed to start within timeout");
+          await expect(manager.start()).rejects.toThrow("CtrlProxy failed to start within timeout");
 
-        expect(manager.getServicePort()).toBe(8767);
-        expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
-        expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
-      } finally {
-        PortManager.setPortAvailabilityCheckerForTesting(null);
-      }
-    });
+          expect(manager.getServicePort()).toBe(8767);
+          expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
+          expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
+        } finally {
+          PortManager.setPortAvailabilityCheckerForTesting(null);
+        }
+      },
+    );
 
     test("start() spawns when default hot-reload port is not healthy", async function () {
       PortManager.setPortAvailabilityCheckerForTesting({

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -654,6 +654,36 @@ describe("IOSCtrlProxyManager", function () {
       expect(start).not.toHaveBeenCalled();
     });
 
+    // #6415 follow-up: the forced-teardown gate must fail CLOSED on ownership —
+    // a responder that omits deviceId must NOT be adopted as "still our
+    // runner" (which would otherwise block a legitimate restart with the
+    // "still running after forced teardown" error). Unlike the primary
+    // liveness gate's missing-deviceId compat carve-out, here a missing
+    // deviceId means "not proven to be ours", so teardown proceeds and start
+    // is allowed. Exercised through the real health client (curl mock), not a
+    // mocked private method, so the strict wiring at the forceRestart call
+    // site is actually covered.
+    test("does not mistake a forced-teardown responder that omits deviceId for our own runner", async function () {
+      const fakeExecutor = new FakeProcessExecutor();
+      fakeExecutor.setCommandHandler("curl -s", () => createExecResult('{"status":"ok"}', ""));
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+      );
+      spyOn(manager, "stop").mockResolvedValue();
+      const start = spyOn(
+        manager as unknown as {
+          startAfterForceRestart(options: CtrlProxyStartOptions): Promise<void>;
+        },
+        "startAfterForceRestart",
+      ).mockResolvedValue();
+
+      await expect(manager.forceRestart()).resolves.toBeUndefined();
+      expect(start).toHaveBeenCalledTimes(1);
+    });
+
     test("propagates forced teardown failures to a concurrent start", async function () {
       // The post-teardown drain grace polls on the injected timer; auto-advance
       // keeps the runner-still-alive path inside the unit-test time budget.

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -897,6 +897,101 @@ describe("IOSCtrlProxyManager", function () {
     });
   });
 
+  // #6415: checkHealthEndpoint() (the gate behind isRunning()/start()'s
+  // short-circuit/waitForHealthEndpoint/isCtrlProxyProcessAlive) must reject a
+  // foreign responder on the service port rather than treating any "ok"/"healthy"
+  // body as proof this device's runner is up.
+  describe("device-identity gate on the health probe (#6415)", function () {
+    let fakeExecutor: FakeProcessExecutor;
+
+    beforeEach(function () {
+      fakeExecutor = new FakeProcessExecutor();
+    });
+
+    const installHealthBody = (body: string): void => {
+      fakeExecutor.setCommandHandler("curl -s", () => createExecResult(body, ""));
+    };
+
+    test("isRunning() is false when the service port answers for a different device", async function () {
+      installHealthBody(JSON.stringify({ status: "ok", deviceId: "OTHER-UDID", port: 8765 }));
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+      );
+
+      expect(await manager.isRunning()).toBe(false);
+    });
+
+    test("isRunning() is true when the service port answers with this device's id", async function () {
+      installHealthBody(
+        JSON.stringify({ status: "ok", deviceId: testDevice.deviceId, port: 8765 }),
+      );
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+      );
+
+      expect(await manager.isRunning()).toBe(true);
+    });
+
+    test("isRunning() is true when the responder reports no deviceId at all (older runner build, compat)", async function () {
+      installHealthBody(JSON.stringify({ status: "ok", port: 8765 }));
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+      );
+
+      expect(await manager.isRunning()).toBe(true);
+    });
+
+    test("isRunning() is false for the Android runner's plain-text 'OK' body reached via the same port", async function () {
+      installHealthBody("OK");
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+      );
+
+      expect(await manager.isRunning()).toBe(false);
+    });
+
+    test("start() does not short-circuit on a foreign responder; it proceeds to spawn its own runner", async function () {
+      // Foreign runner answers the service port for a different device. No
+      // xcodebuild/CtrlProxy process is discoverable (pgrep empty), so once the
+      // loose short-circuit is gone, start() must fall through to spawning its
+      // own runner rather than returning early as "already running".
+      installHealthBody(JSON.stringify({ status: "ok", deviceId: "OTHER-UDID", port: 8765 }));
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxy'", createExecResult("", ""));
+      const fakeBuilder = {
+        getXctestrunPath: async () => "/tmp/CtrlProxy.xctestrun",
+        getRunnerBinaryPath: async () => null,
+        verifyRunnerBinaryBeforeLaunch: async () => {},
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
+      } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        fakeBuilder,
+        fakeExecutor,
+      );
+      fakeTimer.enableAutoAdvance();
+
+      await expect(manager.start()).rejects.toThrow("CtrlProxy failed to start within timeout");
+
+      // Proof it did NOT short-circuit on the foreign "already running" result:
+      // it actually attempted to spawn a runner of its own.
+      expect(fakeExecutor.getSpawnedProcesses().length).toBeGreaterThan(0);
+    });
+  });
+
   describe("getCapabilities", function () {
     test("should identify simulator device type for UUID format deviceId", async function () {
       const manager = IOSCtrlProxyManager.createForTesting(testDevice, fakeTimer);
@@ -1436,7 +1531,10 @@ describe("IOSCtrlProxyManager", function () {
       (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
 
       // Health endpoint responds → confirms this PID really is CtrlProxy (not a PID-reused process)
-      fakeExecutor.setCommandResponse("curl -s", createExecResult("ok", ""));
+      fakeExecutor.setCommandResponse(
+        "curl -s",
+        createExecResult(JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }), ""),
+      );
       // kill -0 succeeds by default (FakeProcessExecutor never throws) → process alive
 
       fakeTimer.enableAutoAdvance();
@@ -1629,7 +1727,12 @@ describe("IOSCtrlProxyManager", function () {
       (manager as unknown as { xcTestProcess: FakeChildProcess }).xcTestProcess =
         failedPreHealthProcess;
       fakeExecutor.setCommandHandler("curl -s", () =>
-        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", ""),
+        createExecResult(
+          fakeExecutor.getSpawnedProcesses().length > 0
+            ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+            : "",
+          "",
+        ),
       );
 
       (manager as unknown as { handleProcessExit: () => void }).handleProcessExit();
@@ -1698,7 +1801,10 @@ describe("IOSCtrlProxyManager", function () {
       let curlCalls = 0;
       fakeExecutor.setCommandHandler("curl -s", () => {
         curlCalls++;
-        return createExecResult(curlCalls > 2 ? "ok" : "", "");
+        return createExecResult(
+          curlCalls > 2 ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          "",
+        );
       });
 
       await withHealthBudget("30", async () => {
@@ -1728,7 +1834,10 @@ describe("IOSCtrlProxyManager", function () {
       let curlCalls = 0;
       fakeExecutor.setCommandHandler("curl -s", () => {
         curlCalls++;
-        return createExecResult(curlCalls > 6 ? "ok" : "", "");
+        return createExecResult(
+          curlCalls > 6 ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          "",
+        );
       });
 
       await withHealthBudget("3", async () => {
@@ -1759,7 +1868,10 @@ describe("IOSCtrlProxyManager", function () {
         if (curlCalls === 3) {
           return firstHealthPoll;
         }
-        return createExecResult(curlCalls >= 7 ? "ok" : "", "");
+        return createExecResult(
+          curlCalls >= 7 ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          "",
+        );
       });
 
       await withHealthBudget("3", async () => {
@@ -1793,7 +1905,10 @@ describe("IOSCtrlProxyManager", function () {
       let curlCalls = 0;
       fakeExecutor.setCommandHandler("curl -s", () => {
         curlCalls++;
-        return createExecResult(curlCalls >= 6 ? "ok" : "", "");
+        return createExecResult(
+          curlCalls >= 6 ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          "",
+        );
       });
 
       await withHealthBudget("3", async () => {
@@ -1832,7 +1947,10 @@ describe("IOSCtrlProxyManager", function () {
         if (curlCalls === 3) {
           return firstHealthPoll;
         }
-        return createExecResult(curlCalls >= 5 ? "ok" : "", "");
+        return createExecResult(
+          curlCalls >= 5 ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          "",
+        );
       });
 
       await withHealthBudget("1", async () => {
@@ -1871,7 +1989,12 @@ describe("IOSCtrlProxyManager", function () {
 
       let healthyAfterTeardown = false;
       fakeExecutor.setCommandHandler("curl -s", () =>
-        createExecResult(healthyAfterTeardown ? "ok" : "", ""),
+        createExecResult(
+          healthyAfterTeardown
+            ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+            : "",
+          "",
+        ),
       );
 
       const teardownEntered = deferred();
@@ -1926,7 +2049,10 @@ describe("IOSCtrlProxyManager", function () {
         if (curlCalls === 1) {
           return firstHealthPoll;
         }
-        return createExecResult("ok", "");
+        return createExecResult(
+          JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }),
+          "",
+        );
       });
 
       const controller = new AbortController();
@@ -2089,7 +2215,10 @@ describe("IOSCtrlProxyManager", function () {
         createExecResult(`${physicalDevice.deviceId}\n`, ""),
       );
       // Health endpoint responds → confirms the tracked PID really is CtrlProxy
-      fakeExecutor.setCommandResponse("curl -s", createExecResult("ok", ""));
+      fakeExecutor.setCommandResponse(
+        "curl -s",
+        createExecResult(JSON.stringify({ status: "ok", deviceId: physicalDevice.deviceId }), ""),
+      );
 
       const fakeProcess = new FakeChildProcess();
       fakeExecutor.setNextSpawnProcess(fakeProcess);
@@ -2312,7 +2441,10 @@ describe("IOSCtrlProxyManager", function () {
       );
 
       // Health check succeeds on first poll (simulating xcodebuild starting the service)
-      fakeExecutor.setCommandResponse("curl -s", createExecResult("ok", ""));
+      fakeExecutor.setCommandResponse(
+        "curl -s",
+        createExecResult(JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }), ""),
+      );
       fakeTimer.enableAutoAdvance();
 
       await manager.start();
@@ -2454,7 +2586,10 @@ describe("IOSCtrlProxyManager", function () {
           "",
         ),
       );
-      fakeExecutor.setCommandResponse("http://localhost:8790/health", createExecResult("ok", ""));
+      fakeExecutor.setCommandResponse(
+        "http://localhost:8790/health",
+        createExecResult(JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }), ""),
+      );
       fakeTimer.enableAutoAdvance();
 
       await manager.start();
@@ -2551,7 +2686,7 @@ describe("IOSCtrlProxyManager", function () {
           port === 8790
             ? JSON.stringify({ status: "ok", deviceId: "OTHER-SIMULATOR" })
             : fakeExecutor.getSpawnedProcesses().length > 0
-              ? "ok"
+              ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
               : "",
           "",
         );
@@ -2591,7 +2726,7 @@ describe("IOSCtrlProxyManager", function () {
           port === 8790
             ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
             : fakeExecutor.getSpawnedProcesses().length > 0
-              ? "ok"
+              ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
               : "",
           "",
         );
@@ -2644,7 +2779,12 @@ describe("IOSCtrlProxyManager", function () {
           customPortHealthProbeCount++;
           return createExecResult("", "");
         }
-        return createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", "");
+        return createExecResult(
+          fakeExecutor.getSpawnedProcesses().length > 0
+            ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+            : "",
+          "",
+        );
       });
       fakeTimer.enableAutoAdvance();
 
@@ -3191,7 +3331,12 @@ describe("IOSCtrlProxyManager", function () {
       installListeningProcessFakes(fakeExecutor, [staleProcess]);
       fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
       fakeExecutor.setCommandHandler("curl -s", () =>
-        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", ""),
+        createExecResult(
+          fakeExecutor.getSpawnedProcesses().length > 0
+            ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+            : "",
+          "",
+        ),
       );
       fakeTimer.enableAutoAdvance();
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -3277,7 +3422,12 @@ describe("IOSCtrlProxyManager", function () {
       installListeningProcessFakes(fakeExecutor, [staleProcess]);
       fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("2223\n", ""));
       fakeExecutor.setCommandHandler("curl -s", () =>
-        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", ""),
+        createExecResult(
+          fakeExecutor.getSpawnedProcesses().length > 0
+            ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+            : "",
+          "",
+        ),
       );
       fakeTimer.enableAutoAdvance();
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -3319,7 +3469,12 @@ describe("IOSCtrlProxyManager", function () {
       installListeningProcessFakes(fakeExecutor, [staleProcess, orphanedShellProcess]);
       fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("2225\n", ""));
       fakeExecutor.setCommandHandler("curl -s", () =>
-        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", ""),
+        createExecResult(
+          fakeExecutor.getSpawnedProcesses().length > 0
+            ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+            : "",
+          "",
+        ),
       );
       fakeTimer.enableAutoAdvance();
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -3381,7 +3536,12 @@ describe("IOSCtrlProxyManager", function () {
       // can reap the dead runner tree.
       fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxy'", createExecResult("2227\n", ""));
       fakeExecutor.setCommandHandler("curl -s", () =>
-        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", ""),
+        createExecResult(
+          fakeExecutor.getSpawnedProcesses().length > 0
+            ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+            : "",
+          "",
+        ),
       );
       fakeTimer.enableAutoAdvance();
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -3413,7 +3573,12 @@ describe("IOSCtrlProxyManager", function () {
       installListeningProcessFakes(fakeExecutor, [foreignProcess]);
       fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
       fakeExecutor.setCommandHandler("curl -s", () =>
-        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", ""),
+        createExecResult(
+          fakeExecutor.getSpawnedProcesses().length > 0
+            ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+            : "",
+          "",
+        ),
       );
       fakeTimer.enableAutoAdvance();
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -3446,7 +3611,12 @@ describe("IOSCtrlProxyManager", function () {
       installListeningProcessFakes(fakeExecutor, [otherSimulatorProcess]);
       fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("3334\n", ""));
       fakeExecutor.setCommandHandler("curl -s", () =>
-        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", ""),
+        createExecResult(
+          fakeExecutor.getSpawnedProcesses().length > 0
+            ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+            : "",
+          "",
+        ),
       );
       fakeTimer.enableAutoAdvance();
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -3488,7 +3658,12 @@ describe("IOSCtrlProxyManager", function () {
       installListeningProcessFakes(fakeExecutor, [otherSimulatorProcess, otherSimulatorParent]);
       fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
       fakeExecutor.setCommandHandler("curl -s", () =>
-        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", ""),
+        createExecResult(
+          fakeExecutor.getSpawnedProcesses().length > 0
+            ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+            : "",
+          "",
+        ),
       );
       fakeTimer.enableAutoAdvance();
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -3522,7 +3697,12 @@ describe("IOSCtrlProxyManager", function () {
       installListeningProcessFakes(fakeExecutor, [staleProcess]);
       fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
       fakeExecutor.setCommandHandler("curl -s", () =>
-        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", ""),
+        createExecResult(
+          fakeExecutor.getSpawnedProcesses().length > 0
+            ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+            : "",
+          "",
+        ),
       );
       fakeTimer.enableAutoAdvance();
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -3557,7 +3737,12 @@ describe("IOSCtrlProxyManager", function () {
       installListeningProcessFakes(fakeExecutor, [otherSimulatorProcess]);
       fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
       fakeExecutor.setCommandHandler("curl -s", () =>
-        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", ""),
+        createExecResult(
+          fakeExecutor.getSpawnedProcesses().length > 0
+            ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+            : "",
+          "",
+        ),
       );
       fakeTimer.enableAutoAdvance();
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -3917,7 +4102,10 @@ describe("IOSCtrlProxyManager", function () {
         "reapOrphanedRunnerProcessesOnStartup",
       ).mockImplementation(() => reaping.promise);
       const fakeExecutor = new FakeProcessExecutor();
-      fakeExecutor.setCommandResponse("curl -s", createExecResult("ok", ""));
+      fakeExecutor.setCommandResponse(
+        "curl -s",
+        createExecResult(JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }), ""),
+      );
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice,
         fakeTimer,
@@ -3946,7 +4134,10 @@ describe("IOSCtrlProxyManager", function () {
         "reapOrphanedRunnerProcessesOnStartup",
       ).mockImplementation(() => reaping.promise);
       const fakeExecutor = new FakeProcessExecutor();
-      fakeExecutor.setCommandResponse("curl -s", createExecResult("ok", ""));
+      fakeExecutor.setCommandResponse(
+        "curl -s",
+        createExecResult(JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }), ""),
+      );
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice,
         fakeTimer,

--- a/test/utils/ios/IOSCtrlProxyHealthClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyHealthClient.test.ts
@@ -87,7 +87,12 @@ describe("IOSCtrlProxyHealthClient (local curl transport)", function () {
   // never route through the strict check without regressing older runners.
   test("checkHealthEndpointOnPortForDevice accepts an 'ok' body reporting no deviceId (compat)", async function () {
     const { client } = makeClient(() => execResult('{"status":"ok"}'));
-    expect(await client.checkHealthEndpointOnPortForDevice(8765, DEVICE_ID)).toBe(true);
+    expect(await client.checkHealthEndpointOnPortForDevice(8765, DEVICE_ID)).toBe(false);
+    expect(
+      await client.checkHealthEndpointOnPortForDevice(8765, DEVICE_ID, undefined, {
+        requireDeviceId: false,
+      }),
+    ).toBe(true);
   });
 
   // #6415 follow-up: ownership/forced-teardown decisions must fail closed on a

--- a/test/utils/ios/IOSCtrlProxyHealthClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyHealthClient.test.ts
@@ -90,6 +90,37 @@ describe("IOSCtrlProxyHealthClient (local curl transport)", function () {
     expect(await client.checkHealthEndpointOnPortForDevice(8765, DEVICE_ID)).toBe(true);
   });
 
+  // #6415 follow-up: ownership/forced-teardown decisions must fail closed on a
+  // missing deviceId — the compat carve-out above is for the liveness gate only.
+  describe("checkHealthEndpointOnPortForDevice with requireDeviceId (strict ownership gate)", function () {
+    test("rejects an 'ok' body reporting no deviceId", async function () {
+      const { client } = makeClient(() => execResult('{"status":"ok"}'));
+      expect(
+        await client.checkHealthEndpointOnPortForDevice(8765, DEVICE_ID, undefined, {
+          requireDeviceId: true,
+        }),
+      ).toBe(false);
+    });
+
+    test("rejects a mismatched deviceId", async function () {
+      const { client } = makeClient(() => execResult('{"status":"ok","deviceId":"OTHER"}'));
+      expect(
+        await client.checkHealthEndpointOnPortForDevice(8765, DEVICE_ID, undefined, {
+          requireDeviceId: true,
+        }),
+      ).toBe(false);
+    });
+
+    test("accepts a matching deviceId", async function () {
+      const { client } = makeClient(() => execResult(`{"status":"ok","deviceId":"${DEVICE_ID}"}`));
+      expect(
+        await client.checkHealthEndpointOnPortForDevice(8765, DEVICE_ID, undefined, {
+          requireDeviceId: true,
+        }),
+      ).toBe(true);
+    });
+  });
+
   test("readReportedPortFromHealth returns the self-reported port for our device", async function () {
     const { client } = makeClient(() =>
       execResult(`{"status":"ok","deviceId":"${DEVICE_ID}","port":9100}`),

--- a/test/utils/ios/IOSCtrlProxyHealthClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyHealthClient.test.ts
@@ -80,6 +80,16 @@ describe("IOSCtrlProxyHealthClient (local curl transport)", function () {
     expect(await client.checkHealthEndpointOnPortForDevice(8765, DEVICE_ID)).toBe(false);
   });
 
+  // #6415: a runner build that reports no deviceId at all (older build, or the
+  // env-injection fallback that also drops the device-id var) must still count
+  // as "ours" when status is ok — only a PRESENT-but-different deviceId is a
+  // foreign runner. Without this compat carve-out, checkHealthEndpoint() could
+  // never route through the strict check without regressing older runners.
+  test("checkHealthEndpointOnPortForDevice accepts an 'ok' body reporting no deviceId (compat)", async function () {
+    const { client } = makeClient(() => execResult('{"status":"ok"}'));
+    expect(await client.checkHealthEndpointOnPortForDevice(8765, DEVICE_ID)).toBe(true);
+  });
+
   test("readReportedPortFromHealth returns the self-reported port for our device", async function () {
     const { client } = makeClient(() =>
       execResult(`{"status":"ok","deviceId":"${DEVICE_ID}","port":9100}`),


### PR DESCRIPTION
## Summary

IOSCtrlProxyManager.checkHealthEndpoint() — the single gate behind isRunning(), the start() short-circuit, waitForHealthEndpoint, and isCtrlProxyProcessAlive() — previously accepted any /health responder whose body contained ok or healthy, so a sibling simulator's runner, a stale runner from a prior daemon run, or the Android runner reached via adb forward could be silently mistaken for this device's runner, causing cross-device contamination. checkHealthEndpoint() now routes through IOSCtrlProxyHealthClient.checkHealthEndpointOnPortForDevice(this.servicePort, this.device.deviceId), extended with one explicit compatibility decision: accept a status-ok payload whose deviceId is absent (older runner builds, or the env-injection fallback that can drop the device-id var), but reject one whose deviceId is present and different. Because start()'s alreadyRunning short-circuit now returns false for a foreign responder, it naturally falls through to the existing identity-aware discovery instead of treating the port as already correctly served.

Part of epic #6372.

Stacked on `work/issue-6416-ios-availability-cache-reopen`; GitHub retargets to `main` once it merges.

## Linked Issue

Closes #6415

## Validation

New unit tests pin: mismatched-deviceId gives isRunning() false and start() proceeds to spawn its own runner; matching deviceId gives true (short-circuit preserved); absent deviceId gives true (compat); Android plain-text OK body gives false. Updated ~13 pre-existing fixtures that modeled a runner health response as a bare ok string to return proper JSON with status and deviceId. Targeted: 125 pass / 0 fail. Full-suite failures are pre-existing UnixSocketServer socket-path-length artifacts specific to the worktree TMPDIR location, unrelated to this diff.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
