### PR TITLE
fix(ios): unify simctl booted-device availability convention across boot paths (#6412)

### DIFF
--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -453,6 +453,19 @@ function pickHighestRuntime(
     .pop();
 }
 
+/**
+ * Shared simctl availability convention (issue #6412): a device record whose
+ * `isAvailable` field is explicitly `false` is unavailable; missing/undefined
+ * (an unvalidated `JSON.parse` cast can drop the field) is treated as
+ * available. Matches the runtime convention already used for
+ * `AppleDeviceRuntime.isAvailable` above. Every booted-device lookup in this
+ * file must route through this predicate so a boot's post-condition cannot
+ * drift between listings again.
+ */
+function isDeviceAvailable(device: { isAvailable?: boolean }): boolean {
+  return device.isAvailable !== false;
+}
+
 function isAlreadyBootedCoreSimulator405(error: unknown, udid: string): boolean {
   if (!isIosSimulatorUdid(udid) || !(error instanceof Error)) {
     return false;
@@ -1440,6 +1453,44 @@ export class SimCtlClient implements SimCtl {
   }
 
   /**
+   * Find a device by UDID whose `state` is `Booted`, directly from `simctl
+   * list devices --json`. This is the single lookup both boot-completion
+   * paths share — {@link resolveRegisteredBootSimulator} and
+   * {@link resolveReadySimulator} — so a finished boot's post-condition
+   * cannot drift between them again (issue #6412). Availability is reported
+   * rather than filtered here: callers apply {@link isDeviceAvailable} so
+   * each can produce its own not-found vs. unavailable error.
+   */
+  private async findBootedSimulator(
+    udid: string,
+    timeoutMs?: number,
+    signal?: AbortSignal,
+  ): Promise<AppleDevice | undefined> {
+    const simulatorList = await this.listSimulators(timeoutMs, signal);
+    for (const [runtimeId, runtimeDevices] of Object.entries(simulatorList.devices)) {
+      const device = runtimeDevices.find(
+        (candidate) => candidate.udid === udid && candidate.state === "Booted",
+      );
+      if (device) {
+        return { ...device, runtime: runtimeId };
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Build the ActionableError for a booted device rejected on availability,
+   * naming the actual `availabilityError` (issue #6412) instead of a generic
+   * boot-failure message that hides the cause.
+   */
+  private unavailableBootError(udid: string, device: AppleDevice): ActionableError {
+    return new ActionableError(
+      `Simulator with UDID ${udid} booted but is unavailable` +
+        (device.availabilityError ? `: ${device.availabilityError}` : ""),
+    );
+  }
+
+  /**
    * Look up full device metadata for an already-booted simulator and return it
    * as a BootedDevice. Shared by the cold-boot (assumeBooted) and already-running
    * branches of {@link waitForSimulatorReady}.
@@ -1447,19 +1498,20 @@ export class SimCtlClient implements SimCtl {
   private async resolveReadySimulator(udid: string, timeoutMs?: number): Promise<BootedDevice> {
     const perf = createGlobalPerformanceTracker();
     perf.startOperation("deviceLookup");
-    const simulator = (await this.listSimulatorImages(timeoutMs)).find(
-      (device) => device.deviceId === udid,
-    );
+    const simulator = await this.findBootedSimulator(udid, timeoutMs);
     perf.endOperation("deviceLookup");
 
     if (!simulator) {
       throw new ActionableError(`Simulator with UDID ${udid} not found after boot`);
     }
+    if (!isDeviceAvailable(simulator)) {
+      throw this.unavailableBootError(udid, simulator);
+    }
 
     return {
       name: simulator.name,
-      platform: simulator.platform,
-      deviceId: simulator.deviceId,
+      platform: "ios",
+      deviceId: simulator.udid,
       observedAt: this.observationSequence.next(),
     } as BootedDevice;
   }
@@ -1567,7 +1619,7 @@ export class SimCtlClient implements SimCtl {
     // Extract booted devices from all runtime versions
     for (const [runtimeId, runtimeDevices] of Object.entries(simulatorList.devices)) {
       for (const device of runtimeDevices) {
-        if (device.isAvailable && device.state === "Booted") {
+        if (isDeviceAvailable(device) && device.state === "Booted") {
           const iosVersion = normalizeIosVersion(runtimeId, device.os_version);
           bootedDevices.push({
             name: device.name,
@@ -1652,15 +1704,30 @@ export class SimCtlClient implements SimCtl {
     perf: ReturnType<typeof createGlobalPerformanceTracker>,
   ): Promise<BootedDevice> {
     perf.startOperation("bootRegistration");
-    const bootedSimulators = await this.getBootedSimulatorsChecked(
+    // Shares findBootedSimulator with resolveReadySimulator (issue #6412) so
+    // this session auto-start path and the explicit startSimulator +
+    // waitForSimulatorReady path agree on the same booted device.
+    const device = await this.findBootedSimulator(
+      udid,
       this.remainingBootTimeoutMs(udid, deadlineMs),
     );
-    const bootedSimulator = bootedSimulators.find((device) => device.deviceId === udid);
     perf.endOperation("bootRegistration");
-    if (!bootedSimulator) {
+    if (!device) {
       throw new ActionableError(`Failed to boot iOS simulator ${udid}`);
     }
-    return bootedSimulator;
+    if (!isDeviceAvailable(device)) {
+      throw this.unavailableBootError(udid, device);
+    }
+    const iosVersion = normalizeIosVersion(device.runtime, device.os_version);
+    return {
+      name: device.name,
+      platform: "ios",
+      deviceId: device.udid,
+      observedAt: this.observationSequence.next(),
+      iosVersion,
+      osVersion: iosVersion,
+      formFactor: inferIosFormFactor(device.deviceTypeIdentifier),
+    } as BootedDevice;
   }
 
   /**

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -1199,4 +1199,96 @@ describe("SimCtlClient boot self-verification", () => {
     await expect(readiness).rejects.toBeInstanceOf(ActionableError);
     await expect(readiness).rejects.toThrow(new RegExp(UDID));
   });
+
+  // #6412: bootSimulator (-> resolveRegisteredBootSimulator ->
+  // getBootedSimulatorsChecked) and waitForSimulatorReady (->
+  // resolveReadySimulator -> listSimulatorImages) resolve a finished boot
+  // through two independent listings. Both must agree on whether a `Booted`
+  // record with missing/false `isAvailable` counts as booted.
+  function bootedDeviceListResult(isAvailable: boolean | undefined, availabilityError?: string) {
+    const device: Record<string, unknown> = {
+      udid: UDID,
+      name: "iPhone 17",
+      state: "Booted",
+    };
+    if (isAvailable !== undefined) {
+      device.isAvailable = isAvailable;
+    }
+    if (availabilityError !== undefined) {
+      device.availabilityError = availabilityError;
+    }
+    return createExecResult(
+      JSON.stringify({
+        devices: {
+          "com.apple.CoreSimulator.SimRuntime.iOS-26-0": [device],
+        },
+      }),
+      "",
+    );
+  }
+
+  test("bootSimulator and waitForSimulatorReady agree when isAvailable is absent", async () => {
+    const bootHarness = createConcurrentStartHarness(
+      () => createExecResult("", ""),
+      () => bootedDeviceListResult(undefined),
+    );
+    const readyHarness = createConcurrentStartHarness(
+      () => createExecResult("", ""),
+      () => bootedDeviceListResult(undefined),
+    );
+
+    const bootDevice = await bootHarness
+      .createClient()
+      .bootSimulator(UDID)
+      .then(
+        (device) => ({ ok: true as const, device }),
+        (error: unknown) => ({ ok: false as const, error }),
+      );
+    const readyDevice = await readyHarness
+      .createClient()
+      .waitForSimulatorReady(UDID, 5_000)
+      .then(
+        (device) => ({ ok: true as const, device }),
+        (error: unknown) => ({ ok: false as const, error }),
+      );
+
+    expect(bootDevice.ok).toBe(true);
+    expect(readyDevice.ok).toBe(true);
+    if (bootDevice.ok && readyDevice.ok) {
+      expect(bootDevice.device.deviceId).toBe(UDID);
+      expect(readyDevice.device.deviceId).toBe(UDID);
+    }
+  });
+
+  test("bootSimulator and waitForSimulatorReady agree when isAvailable is false", async () => {
+    const availabilityError = "the requested device runtime is unavailable";
+    const bootHarness = createConcurrentStartHarness(
+      () => createExecResult("", ""),
+      () => bootedDeviceListResult(false, availabilityError),
+    );
+    const readyHarness = createConcurrentStartHarness(
+      () => createExecResult("", ""),
+      () => bootedDeviceListResult(false, availabilityError),
+    );
+
+    const bootError = await bootHarness
+      .createClient()
+      .bootSimulator(UDID)
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+    const readyError = await readyHarness
+      .createClient()
+      .waitForSimulatorReady(UDID, 5_000)
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+    expect(bootError).toBeInstanceOf(ActionableError);
+    expect(readyError).toBeInstanceOf(ActionableError);
+    expect((bootError as Error).message).toContain(availabilityError);
+    expect((readyError as Error).message).toContain(availabilityError);
+  });
 });


### PR DESCRIPTION
## Summary

bootSimulator (via resolveRegisteredBootSimulator/getBootedSimulatorsChecked) and waitForSimulatorReady (via resolveReadySimulator/listSimulatorImages) applied two different availability checks to the same simctl device record, so a Booted device whose isAvailable was missing or false could succeed on one path and be rejected on the other. This introduces a single isDeviceAvailable(device) predicate (isAvailable !== false, matching the existing runtime convention) plus a shared findBootedSimulator(udid) lookup that both paths now call, so they can no longer drift. A Booted-but-unavailable device now throws an ActionableError naming the actual availabilityError on both paths instead of the generic boot-failure message on only one.

Part of epic #6372.

## Linked Issue

Closes #6412

## Validation

Two new FakeTimer-backed regression tests in simctl-client.bootVerification.test.ts assert bootSimulator and waitForSimulatorReady return matching verdicts for isAvailable-absent (both resolve) and isAvailable:false (both reject with the same availabilityError); both were red before the fix. Targeted 39/39, test/utils/ios-cmdline-tools 443/443, full test/utils 3103/3103 pass.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
