### PR TITLE
fix(ios): offload CtrlProxy bundle extraction to a worker thread (#6574)

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -19,7 +19,12 @@ if (existsSync(distPath)) {
 // Build with Bun - transpile TypeScript to JavaScript
 console.log("Building with Bun...");
 const result = await Bun.build({
-  entrypoints: ["./src/index.ts"],
+  // The CtrlProxy bundle-extraction worker (issue #6574) is a second, real
+  // entrypoint — not auto-discovered from `new Worker(new URL(...))` in
+  // src/index.ts's graph, so `adm-zip` (a devDependency, absent from a
+  // packaged install's node_modules) must be inlined by listing the worker
+  // here explicitly, the same way src/index.ts inlines its dependencies.
+  entrypoints: ["./src/index.ts", "./src/utils/workers/iosBundleExtractWorker.ts"],
   outdir: "./dist/src",
   target: "bun",
   format: "esm",

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -250,6 +250,7 @@ export class IOSCtrlProxyBuilder {
    * below, but scoped per-instance since `build()` is an instance method.
    */
   private buildInFlight: Promise<CtrlProxyIosBuildResult> | null = null;
+  private buildWaiters = 0;
 
   private constructor(
     config: Partial<CtrlProxyIosBuildConfig> = {},
@@ -629,25 +630,35 @@ export class IOSCtrlProxyBuilder {
     platform?: IOSCtrlProxyPlatform,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
   ): Promise<CtrlProxyIosBuildResult> {
-    // Single-flight: a caller that arrives while a build is already running
-    // joins that build instead of starting its own independent
-    // download-then-extract against the same shared derived-data tree
-    // (issue #6417). Cleared in `finally` so the next genuinely-new build
-    // (after this one settles) starts its own flight.
-    if (this.buildInFlight !== null) {
-      return this.buildInFlight;
+    // Keep the shared artifact flight alive until every waiter has resolved
+    // its platform paths, so another extraction cannot race those reads.
+    this.buildWaiters++;
+    this.buildInFlight ??= this.doBuild(perf);
+    try {
+      const shared = await this.buildInFlight;
+      if (!shared.success) {return shared;}
+      const buildPath = await this.getBuildProductsPath(platform ?? "simulator");
+      const xctestrunPath = await this.getXctestrunPath(platform);
+      if (!xctestrunPath) {
+        return {
+          success: false,
+          message: "Downloaded CtrlProxy bundle missing xctestrun",
+          error: "No .xctestrun file found after extraction",
+        };
+      }
+      return { ...shared, buildPath: buildPath || undefined, xctestrunPath };
+    } catch (error) {
+      return {
+        success: false,
+        message: "CtrlProxy artifact discovery failed",
+        error: errorMessage(error),
+      };
+    } finally {
+      if (--this.buildWaiters === 0) {this.buildInFlight = null;}
     }
-
-    this.buildInFlight = this.doBuild(platform, perf).finally(() => {
-      this.buildInFlight = null;
-    });
-    return this.buildInFlight;
   }
 
-  private async doBuild(
-    platform?: IOSCtrlProxyPlatform,
-    perf: PerformanceTracker = new NoOpPerformanceTracker(),
-  ): Promise<CtrlProxyIosBuildResult> {
+  private async doBuild(perf: PerformanceTracker): Promise<CtrlProxyIosBuildResult> {
     perf.serial("xcTestServiceDownload");
 
     if (isTruthyEnvValue(process.env[SKIP_CTRL_PROXY_DOWNLOAD_ENV])) {
@@ -674,24 +685,10 @@ export class IOSCtrlProxyBuilder {
 
       await this.cleanStaleXctestrunFiles();
 
-      const buildPath = await this.getBuildProductsPath(platform ?? "simulator");
-      const xctestrunPath = await this.getXctestrunPath(platform);
-
-      if (!xctestrunPath) {
-        perf.end();
-        return {
-          success: false,
-          message: "Downloaded CtrlProxy bundle missing xctestrun",
-          error: "No .xctestrun file found after extraction",
-        };
-      }
-
       perf.end();
       return {
         success: true,
         message: "CtrlProxy downloaded and extracted successfully",
-        buildPath: buildPath || undefined,
-        xctestrunPath: xctestrunPath || undefined,
       };
     } catch (error) {
       const errorMsg = errorMessage(error);

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -636,7 +636,9 @@ export class IOSCtrlProxyBuilder {
     this.buildInFlight ??= this.doBuild(perf);
     try {
       const shared = await this.buildInFlight;
-      if (!shared.success) {return shared;}
+      if (!shared.success) {
+        return shared;
+      }
       const buildPath = await this.getBuildProductsPath(platform ?? "simulator");
       const xctestrunPath = await this.getXctestrunPath(platform);
       if (!xctestrunPath) {
@@ -654,7 +656,9 @@ export class IOSCtrlProxyBuilder {
         error: errorMessage(error),
       };
     } finally {
-      if (--this.buildWaiters === 0) {this.buildInFlight = null;}
+      if (--this.buildWaiters === 0) {
+        this.buildInFlight = null;
+      }
     }
   }
 

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -237,6 +237,19 @@ export class IOSCtrlProxyBuilder {
    * swap even though there is no release-pinned baseline to compare against.
    */
   private derivedLocalRunnerSha256: Map<IOSCtrlProxyPlatform, string> = new Map();
+  /**
+   * Single-flight guard for {@link build}. `IOSCtrlProxyBuilder` is a
+   * process-wide singleton shared by every `IOSCtrlProxyManager` device
+   * instance (issue #6417): with no in-flight guard, two devices whose
+   * `needsRebuild()` both observe `true` before either has finished would
+   * each independently download-then-extract into the same
+   * `derivedDataPath`, and the second extraction's destructive
+   * `fs.rm(destination, { recursive: true, force: true })` (see
+   * `IOSCtrlProxyBundleDownloader.extractBundle`) would wipe out the tree the
+   * first just populated. Mirrors the existing static `prefetchPromise` idiom
+   * below, but scoped per-instance since `build()` is an instance method.
+   */
+  private buildInFlight: Promise<CtrlProxyIosBuildResult> | null = null;
 
   private constructor(
     config: Partial<CtrlProxyIosBuildConfig> = {},
@@ -613,6 +626,25 @@ export class IOSCtrlProxyBuilder {
    * Download and extract CtrlProxy release bundle
    */
   public async build(
+    platform?: IOSCtrlProxyPlatform,
+    perf: PerformanceTracker = new NoOpPerformanceTracker(),
+  ): Promise<CtrlProxyIosBuildResult> {
+    // Single-flight: a caller that arrives while a build is already running
+    // joins that build instead of starting its own independent
+    // download-then-extract against the same shared derived-data tree
+    // (issue #6417). Cleared in `finally` so the next genuinely-new build
+    // (after this one settles) starts its own flight.
+    if (this.buildInFlight !== null) {
+      return this.buildInFlight;
+    }
+
+    this.buildInFlight = this.doBuild(platform, perf).finally(() => {
+      this.buildInFlight = null;
+    });
+    return this.buildInFlight;
+  }
+
+  private async doBuild(
     platform?: IOSCtrlProxyPlatform,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
   ): Promise<CtrlProxyIosBuildResult> {

--- a/src/utils/IOSCtrlProxyBundleDownloader.ts
+++ b/src/utils/IOSCtrlProxyBundleDownloader.ts
@@ -1,5 +1,7 @@
 import * as fs from "fs/promises";
 import * as path from "path";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
 import AdmZip from "adm-zip";
 import { type FileDownloader, DefaultFileDownloader } from "./FileDownloader";
@@ -10,63 +12,14 @@ import {
 } from "./ChecksumCalculator";
 import { ensureSecureDir } from "./filesystem/securePermissions";
 import { ActionableError, toActionableError } from "../models/ActionableError";
+import type {
+  IosBundleExtractWorkerData,
+  IosBundleExtractWorkerMessage,
+} from "./workers/iosBundleExtractWorker";
 
 export type { Sha256Source };
 
-/**
- * Self-contained CJS source for the extraction worker (issue #6574). adm-zip's
- * `new AdmZip(path)` synchronously reads the whole archive via
- * `fs.readFileSync`, and `extractAllTo` synchronously inflates/writes every
- * entry with no yield point — run entirely on the daemon's main thread, this
- * monopolizes the single event loop for the whole extraction, stalling other
- * devices' WebSocket heartbeats and health-poll timers. Running it inside a
- * `worker_threads` Worker (the same eval-source pattern as
- * `DatabaseHealthProbe`'s SQLITE_PROBE_WORKER_SOURCE) keeps that synchronous
- * cost off the main thread entirely.
- *
- * The zip-slip containment check is duplicated here (rather than reused from
- * `assertZipEntriesContained` below) because an `eval`-sourced worker has no
- * access to this module's TypeScript — it only sees the string passed to
- * `Worker`. Keep the traversal-rejection logic here in sync with
- * `assertZipEntriesContained` if either changes; the containment gate MUST
- * run before any entry is written in both.
- */
-const EXTRACT_BUNDLE_WORKER_SOURCE = `
-  const { parentPort, workerData } = require("node:worker_threads");
-  const AdmZip = require("adm-zip");
-  const path = require("node:path");
-  try {
-    const zip = new AdmZip(workerData.bundlePath);
-    const resolvedRoot = path.resolve(workerData.destination);
-    for (const entry of zip.getEntries()) {
-      const target = path.resolve(resolvedRoot, entry.entryName);
-      const relative = path.relative(resolvedRoot, target);
-      const escapes =
-        relative === ".." || relative.startsWith(".." + path.sep) || path.isAbsolute(relative);
-      if (escapes) {
-        throw new Error(
-          'Refusing to extract CtrlProxy bundle: entry "' + entry.entryName +
-            '" resolves outside the extraction directory ' + resolvedRoot +
-            ' (zip-slip / path traversal).'
-        );
-      }
-    }
-    zip.extractAllTo(resolvedRoot, true);
-    parentPort.postMessage({ ok: true });
-  } catch (error) {
-    parentPort.postMessage({
-      ok: false,
-      message: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-    });
-  }
-`;
-
-interface ExtractBundleWorkerMessage {
-  ok: boolean;
-  message?: string;
-  stack?: string;
-}
+type ExtractBundleWorkerMessage = IosBundleExtractWorkerMessage;
 
 /** Narrow surface of `worker_threads.Worker` this module depends on, so tests can inject a fake. */
 export interface ExtractBundleWorker {
@@ -77,12 +30,56 @@ export interface ExtractBundleWorker {
 }
 
 export type ExtractBundleWorkerFactory = (
-  source: string,
-  workerData: { bundlePath: string; destination: string },
+  workerData: IosBundleExtractWorkerData,
 ) => ExtractBundleWorker;
 
-const defaultExtractBundleWorkerFactory: ExtractBundleWorkerFactory = (source, workerData) =>
-  new Worker(source, { eval: true, workerData });
+/**
+ * Real worker entrypoint (issue #6574), NOT an `eval`-sourced string: adm-zip's
+ * `new AdmZip(path)` synchronously reads the whole archive via
+ * `fs.readFileSync`, and `extractAllTo` synchronously inflates/writes every
+ * entry with no yield point — run entirely on the daemon's main thread, this
+ * monopolizes the single event loop for the whole extraction, stalling other
+ * devices' WebSocket heartbeats and health-poll timers. Running it inside a
+ * `worker_threads` Worker keeps that synchronous cost off the main thread.
+ *
+ * This MUST be a real, separately built worker file
+ * (`src/utils/workers/iosBundleExtractWorker.ts`, listed as its own
+ * `build.ts` entrypoint), unlike `DatabaseHealthProbe`'s eval-sourced probe
+ * worker: that probe only `require()`s the built-in `bun:sqlite`, but this
+ * worker needs `adm-zip`, a devDependency absent from a packaged install's
+ * `node_modules`. An eval-sourced `require("adm-zip")` would resolve against
+ * that missing install and throw on the very first extraction. A plain
+ * `new Worker(new URL("./workers/...ts", import.meta.url))` does not fix this
+ * either: Bun's `target: "bun"` build does not auto-discover/bundle workers
+ * referenced that way (verified against issue #6574 — only `src/index.ts`'s
+ * own graph gets bundled), so building the worker as its own entrypoint and
+ * resolving its on-disk path at runtime (see `resolveWorkerScriptPath`) is
+ * required to get `adm-zip` inlined into a file that actually ships.
+ */
+function resolveWorkerScriptPath(): string {
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    // Dev / `bun test`: this module runs straight from source
+    // (src/utils/IOSCtrlProxyBundleDownloader.ts), so its sibling worker
+    // source is one directory below.
+    path.join(moduleDir, "workers", "iosBundleExtractWorker.ts"),
+    // Packaged dist: this module is bundled into dist/src/index.js
+    // (moduleDir === dist/src), while the worker is build.ts's second
+    // entrypoint, built to dist/src/utils/workers/iosBundleExtractWorker.js.
+    path.join(moduleDir, "utils", "workers", "iosBundleExtractWorker.js"),
+  ];
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (!found) {
+    throw new ActionableError(
+      "Could not locate the CtrlProxy bundle extraction worker script. Tried: " +
+        candidates.join(", "),
+    );
+  }
+  return found;
+}
+
+const defaultExtractBundleWorkerFactory: ExtractBundleWorkerFactory = (workerData) =>
+  new Worker(resolveWorkerScriptPath(), { workerData });
 
 /**
  * Defensive zip-slip containment check (issue #4761). adm-zip >= 0.5.10 already
@@ -155,7 +152,7 @@ export class DefaultIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDo
   }
 
   private extractInWorker(bundlePath: string, destination: string): Promise<void> {
-    const worker = this.workerFactory(EXTRACT_BUNDLE_WORKER_SOURCE, { bundlePath, destination });
+    const worker = this.workerFactory({ bundlePath, destination });
     return new Promise<void>((resolve, reject) => {
       worker.once("message", (message) => {
         void worker.terminate();

--- a/src/utils/IOSCtrlProxyBundleDownloader.ts
+++ b/src/utils/IOSCtrlProxyBundleDownloader.ts
@@ -3,7 +3,6 @@ import * as path from "path";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
-import AdmZip from "adm-zip";
 import { type FileDownloader, DefaultFileDownloader } from "./FileDownloader";
 import {
   type ChecksumCalculator,
@@ -81,29 +80,7 @@ function resolveWorkerScriptPath(): string {
 const defaultExtractBundleWorkerFactory: ExtractBundleWorkerFactory = (workerData) =>
   new Worker(resolveWorkerScriptPath(), { workerData });
 
-/**
- * Defensive zip-slip containment check (issue #4761). adm-zip >= 0.5.10 already
- * sanitizes entry names in `extractAllTo` (`canonical` + `sanitize`), but this
- * bundle only reaches extraction on the unverified fallback/override paths, so a
- * malicious archive is worth a second, explicit gate: reject any entry that
- * resolves outside the destination BEFORE writing a single file. Belt-and-braces
- * on top of the library guard, independent of the installed adm-zip version.
- */
-export function assertZipEntriesContained(zip: AdmZip, destination: string): void {
-  const resolvedRoot = path.resolve(destination);
-  for (const entry of zip.getEntries()) {
-    const target = path.resolve(resolvedRoot, entry.entryName);
-    const relative = path.relative(resolvedRoot, target);
-    const escapes =
-      relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative);
-    if (escapes) {
-      throw new ActionableError(
-        `Refusing to extract CtrlProxy bundle: entry "${entry.entryName}" resolves outside the ` +
-          `extraction directory ${resolvedRoot} (zip-slip / path traversal).`,
-      );
-    }
-  }
-}
+export { assertZipEntriesContained } from "./workers/assertZipEntriesContained";
 
 export interface CtrlProxyIosBundleDownloader {
   download(url: string, destination: string): Promise<void>;
@@ -154,26 +131,39 @@ export class DefaultIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDo
   private extractInWorker(bundlePath: string, destination: string): Promise<void> {
     const worker = this.workerFactory({ bundlePath, destination });
     return new Promise<void>((resolve, reject) => {
+      let finishing = false;
+      const finish = (error?: unknown): void => {
+        if (finishing) {
+          return;
+        }
+        finishing = true;
+        void worker.terminate().then(
+          () => (error === undefined ? resolve() : reject(error)),
+          (terminationError: unknown) =>
+            reject(toActionableError(terminationError, "Failed to stop extraction worker")),
+        );
+      };
       worker.once("message", (message) => {
-        void worker.terminate();
         if (message.ok) {
-          resolve();
+          finish();
           return;
         }
         const error = new ActionableError(message.message ?? "Failed to extract CtrlProxy bundle");
         if (message.stack) {
           error.stack = message.stack;
         }
-        reject(error);
+        finish(error);
       });
       worker.once("error", (error) => {
-        void worker.terminate();
-        reject(toActionableError(error, "Failed to extract CtrlProxy bundle"));
+        finish(toActionableError(error, "Failed to extract CtrlProxy bundle"));
       });
       worker.once("exit", (code) => {
-        if (code !== 0) {
+        if (!finishing) {
+          finishing = true;
           reject(
-            new ActionableError(`CtrlProxy bundle extraction worker exited with code ${code}`),
+            new ActionableError(
+              `CtrlProxy bundle extraction worker exited with code ${code} without a result`,
+            ),
           );
         }
       });

--- a/src/utils/IOSCtrlProxyBundleDownloader.ts
+++ b/src/utils/IOSCtrlProxyBundleDownloader.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs/promises";
 import * as path from "path";
+import { Worker } from "node:worker_threads";
 import AdmZip from "adm-zip";
 import { type FileDownloader, DefaultFileDownloader } from "./FileDownloader";
 import {
@@ -8,9 +9,80 @@ import {
   DefaultChecksumCalculator,
 } from "./ChecksumCalculator";
 import { ensureSecureDir } from "./filesystem/securePermissions";
-import { ActionableError } from "../models/ActionableError";
+import { ActionableError, toActionableError } from "../models/ActionableError";
 
 export type { Sha256Source };
+
+/**
+ * Self-contained CJS source for the extraction worker (issue #6574). adm-zip's
+ * `new AdmZip(path)` synchronously reads the whole archive via
+ * `fs.readFileSync`, and `extractAllTo` synchronously inflates/writes every
+ * entry with no yield point — run entirely on the daemon's main thread, this
+ * monopolizes the single event loop for the whole extraction, stalling other
+ * devices' WebSocket heartbeats and health-poll timers. Running it inside a
+ * `worker_threads` Worker (the same eval-source pattern as
+ * `DatabaseHealthProbe`'s SQLITE_PROBE_WORKER_SOURCE) keeps that synchronous
+ * cost off the main thread entirely.
+ *
+ * The zip-slip containment check is duplicated here (rather than reused from
+ * `assertZipEntriesContained` below) because an `eval`-sourced worker has no
+ * access to this module's TypeScript — it only sees the string passed to
+ * `Worker`. Keep the traversal-rejection logic here in sync with
+ * `assertZipEntriesContained` if either changes; the containment gate MUST
+ * run before any entry is written in both.
+ */
+const EXTRACT_BUNDLE_WORKER_SOURCE = `
+  const { parentPort, workerData } = require("node:worker_threads");
+  const AdmZip = require("adm-zip");
+  const path = require("node:path");
+  try {
+    const zip = new AdmZip(workerData.bundlePath);
+    const resolvedRoot = path.resolve(workerData.destination);
+    for (const entry of zip.getEntries()) {
+      const target = path.resolve(resolvedRoot, entry.entryName);
+      const relative = path.relative(resolvedRoot, target);
+      const escapes =
+        relative === ".." || relative.startsWith(".." + path.sep) || path.isAbsolute(relative);
+      if (escapes) {
+        throw new Error(
+          'Refusing to extract CtrlProxy bundle: entry "' + entry.entryName +
+            '" resolves outside the extraction directory ' + resolvedRoot +
+            ' (zip-slip / path traversal).'
+        );
+      }
+    }
+    zip.extractAllTo(resolvedRoot, true);
+    parentPort.postMessage({ ok: true });
+  } catch (error) {
+    parentPort.postMessage({
+      ok: false,
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+  }
+`;
+
+interface ExtractBundleWorkerMessage {
+  ok: boolean;
+  message?: string;
+  stack?: string;
+}
+
+/** Narrow surface of `worker_threads.Worker` this module depends on, so tests can inject a fake. */
+export interface ExtractBundleWorker {
+  once(event: "message", listener: (message: ExtractBundleWorkerMessage) => void): void;
+  once(event: "error", listener: (error: Error) => void): void;
+  once(event: "exit", listener: (code: number) => void): void;
+  terminate(): Promise<number>;
+}
+
+export type ExtractBundleWorkerFactory = (
+  source: string,
+  workerData: { bundlePath: string; destination: string },
+) => ExtractBundleWorker;
+
+const defaultExtractBundleWorkerFactory: ExtractBundleWorkerFactory = (source, workerData) =>
+  new Worker(source, { eval: true, workerData });
 
 /**
  * Defensive zip-slip containment check (issue #4761). adm-zip >= 0.5.10 already
@@ -45,13 +117,16 @@ export interface CtrlProxyIosBundleDownloader {
 export class DefaultIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDownloader {
   private readonly fileDownloader: FileDownloader;
   private readonly checksumCalculator: ChecksumCalculator;
+  private readonly workerFactory: ExtractBundleWorkerFactory;
 
   constructor(
     fileDownloader: FileDownloader = new DefaultFileDownloader(),
     checksumCalculator: ChecksumCalculator = new DefaultChecksumCalculator(),
+    workerFactory: ExtractBundleWorkerFactory = defaultExtractBundleWorkerFactory,
   ) {
     this.fileDownloader = fileDownloader;
     this.checksumCalculator = checksumCalculator;
+    this.workerFactory = workerFactory;
   }
 
   public async download(url: string, destination: string): Promise<void> {
@@ -71,8 +146,40 @@ export class DefaultIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDo
     // between verification and launch (TOCTOU, issue #4759).
     await ensureSecureDir(destination);
 
-    const zip = new AdmZip(bundlePath);
-    assertZipEntriesContained(zip, destination);
-    zip.extractAllTo(destination, true);
+    // Decompression + writes run on a worker_threads worker, not this thread
+    // (issue #6574): adm-zip's read/extract calls are synchronous with no
+    // yield point, and running them here would stall the daemon's single
+    // event loop — health polls, WebSocket heartbeats, session lease checks —
+    // for the whole extraction window.
+    await this.extractInWorker(bundlePath, destination);
+  }
+
+  private extractInWorker(bundlePath: string, destination: string): Promise<void> {
+    const worker = this.workerFactory(EXTRACT_BUNDLE_WORKER_SOURCE, { bundlePath, destination });
+    return new Promise<void>((resolve, reject) => {
+      worker.once("message", (message) => {
+        void worker.terminate();
+        if (message.ok) {
+          resolve();
+          return;
+        }
+        const error = new ActionableError(message.message ?? "Failed to extract CtrlProxy bundle");
+        if (message.stack) {
+          error.stack = message.stack;
+        }
+        reject(error);
+      });
+      worker.once("error", (error) => {
+        void worker.terminate();
+        reject(toActionableError(error, "Failed to extract CtrlProxy bundle"));
+      });
+      worker.once("exit", (code) => {
+        if (code !== 0) {
+          reject(
+            new ActionableError(`CtrlProxy bundle extraction worker exited with code ${code}`),
+          );
+        }
+      });
+    });
   }
 }

--- a/src/utils/workers/assertZipEntriesContained.ts
+++ b/src/utils/workers/assertZipEntriesContained.ts
@@ -1,0 +1,27 @@
+import * as path from "node:path";
+import type AdmZip from "adm-zip";
+import { ActionableError } from "../../models/ActionableError";
+
+/**
+ * Defensive zip-slip containment check (issue #4761). adm-zip >= 0.5.10 already
+ * sanitizes entry names in `extractAllTo` (`canonical` + `sanitize`), but this
+ * bundle only reaches extraction on the unverified fallback/override paths, so a
+ * malicious archive is worth a second, explicit gate: reject any entry that
+ * resolves outside the destination BEFORE writing a single file. Belt-and-braces
+ * on top of the library guard, independent of the installed adm-zip version.
+ */
+export function assertZipEntriesContained(zip: AdmZip, destination: string): void {
+  const resolvedRoot = path.resolve(destination);
+  for (const entry of zip.getEntries()) {
+    const target = path.resolve(resolvedRoot, entry.entryName);
+    const relative = path.relative(resolvedRoot, target);
+    const escapes =
+      relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative);
+    if (escapes) {
+      throw new ActionableError(
+        `Refusing to extract CtrlProxy bundle: entry "${entry.entryName}" resolves outside the ` +
+          `extraction directory ${resolvedRoot} (zip-slip / path traversal).`,
+      );
+    }
+  }
+}

--- a/src/utils/workers/iosBundleExtractWorker.ts
+++ b/src/utils/workers/iosBundleExtractWorker.ts
@@ -1,0 +1,71 @@
+/**
+ * Real worker_threads entrypoint for CtrlProxy bundle extraction (issue #6574).
+ *
+ * This file MUST be a bundled worker (referenced via
+ * `new Worker(new URL("./iosBundleExtractWorker.ts", import.meta.url))`), not an
+ * `eval`-sourced string. An eval-sourced worker's CJS body only sees what is
+ * inlined into the string passed to `Worker`; a runtime `require("adm-zip")`
+ * inside it resolves against the packaged daemon's `node_modules`, where
+ * adm-zip (a devDependency) is absent, and throws
+ * `Cannot find package 'adm-zip'` on the very first extraction. Bundling this
+ * file as its own worker entrypoint inlines adm-zip into the built worker
+ * chunk instead, the same way `src/index.ts` inlines its own dependencies.
+ *
+ * `assertZipEntriesContained` is intentionally NOT imported here: pulling in
+ * `IOSCtrlProxyBundleDownloader.ts` (and its `Worker`/`ActionableError`
+ * imports) would pull the main module into this worker's bundle graph. The
+ * containment check is duplicated in this worker; keep it in sync with
+ * `assertZipEntriesContained` if either changes — the containment gate MUST
+ * run before any entry is written in both.
+ */
+import { parentPort, workerData } from "node:worker_threads";
+import * as path from "node:path";
+import AdmZip from "adm-zip";
+import { errorMessage } from "../describeUnknownError";
+
+export interface IosBundleExtractWorkerData {
+  bundlePath: string;
+  destination: string;
+}
+
+export interface IosBundleExtractWorkerMessage {
+  ok: boolean;
+  message?: string;
+  stack?: string;
+}
+
+function assertContained(zip: AdmZip, destination: string): void {
+  const resolvedRoot = path.resolve(destination);
+  for (const entry of zip.getEntries()) {
+    const target = path.resolve(resolvedRoot, entry.entryName);
+    const relative = path.relative(resolvedRoot, target);
+    const escapes =
+      relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative);
+    if (escapes) {
+      throw new Error(
+        `Refusing to extract CtrlProxy bundle: entry "${entry.entryName}" resolves outside the ` +
+          `extraction directory ${resolvedRoot} (zip-slip / path traversal).`,
+      );
+    }
+  }
+}
+
+function run(): void {
+  const { bundlePath, destination } = workerData as IosBundleExtractWorkerData;
+  try {
+    const zip = new AdmZip(bundlePath);
+    assertContained(zip, destination);
+    zip.extractAllTo(path.resolve(destination), true);
+    const message: IosBundleExtractWorkerMessage = { ok: true };
+    parentPort?.postMessage(message);
+  } catch (error) {
+    const message: IosBundleExtractWorkerMessage = {
+      ok: false,
+      message: errorMessage(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    };
+    parentPort?.postMessage(message);
+  }
+}
+
+run();

--- a/src/utils/workers/iosBundleExtractWorker.ts
+++ b/src/utils/workers/iosBundleExtractWorker.ts
@@ -11,15 +11,10 @@
  * file as its own worker entrypoint inlines adm-zip into the built worker
  * chunk instead, the same way `src/index.ts` inlines its own dependencies.
  *
- * `assertZipEntriesContained` is intentionally NOT imported here: pulling in
- * `IOSCtrlProxyBundleDownloader.ts` (and its `Worker`/`ActionableError`
- * imports) would pull the main module into this worker's bundle graph. The
- * containment check is duplicated in this worker; keep it in sync with
- * `assertZipEntriesContained` if either changes — the containment gate MUST
- * run before any entry is written in both.
  */
 import { parentPort, workerData } from "node:worker_threads";
 import * as path from "node:path";
+import { assertZipEntriesContained } from "./assertZipEntriesContained";
 import AdmZip from "adm-zip";
 import { errorMessage } from "../describeUnknownError";
 
@@ -34,27 +29,11 @@ export interface IosBundleExtractWorkerMessage {
   stack?: string;
 }
 
-function assertContained(zip: AdmZip, destination: string): void {
-  const resolvedRoot = path.resolve(destination);
-  for (const entry of zip.getEntries()) {
-    const target = path.resolve(resolvedRoot, entry.entryName);
-    const relative = path.relative(resolvedRoot, target);
-    const escapes =
-      relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative);
-    if (escapes) {
-      throw new Error(
-        `Refusing to extract CtrlProxy bundle: entry "${entry.entryName}" resolves outside the ` +
-          `extraction directory ${resolvedRoot} (zip-slip / path traversal).`,
-      );
-    }
-  }
-}
-
 function run(): void {
   const { bundlePath, destination } = workerData as IosBundleExtractWorkerData;
   try {
     const zip = new AdmZip(bundlePath);
-    assertContained(zip, destination);
+    assertZipEntriesContained(zip, destination);
     zip.extractAllTo(path.resolve(destination), true);
     const message: IosBundleExtractWorkerMessage = { ok: true };
     parentPort?.postMessage(message);

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -1535,6 +1535,54 @@ describe("IOSCtrlProxyBuilder", function () {
       expect(downloader.extractedPaths.length).toBe(1);
     });
 
+    test.each([false, true])(
+      "mixed platform callers resolve independently (device products: %s)",
+      async function (includeDeviceProducts) {
+        const derivedDataPath = path.join(tempDir, "DerivedData");
+        const cacheDir = path.join(tempDir, "cache");
+
+        let resolveDownload: (() => void) | undefined;
+        const downloadGate = new Promise<void>((resolve) => {
+          resolveDownload = resolve;
+        });
+
+        class DeferredDownloader extends FakeIOSCtrlProxyBundleDownloader {
+          public override async download(url: string, destination: string): Promise<void> {
+            await downloadGate;
+            await super.download(url, destination);
+          }
+        }
+
+        const downloader = new DeferredDownloader();
+        downloader.checksum = "expected-checksum";
+        downloader.includeDeviceProducts = includeDeviceProducts;
+
+        IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+        const builder = IOSCtrlProxyBuilder.getInstance(
+          { derivedDataPath, bundleCacheDir: cacheDir },
+          { downloader },
+        );
+
+        // Both calls start before either has resolved the download, so the
+        // second call must observe (and reuse) the first call's in-flight promise.
+        const firstBuild = builder.build("device");
+        const secondBuild = builder.build("simulator");
+
+        resolveDownload!();
+
+        const [firstResult, secondResult] = await Promise.all([firstBuild, secondBuild]);
+
+        expect(firstResult.success).toBe(includeDeviceProducts);
+        expect(secondResult.success).toBe(true);
+        expect(secondResult.buildPath).toContain("Debug-iphonesimulator");
+        if (includeDeviceProducts) {
+          expect(firstResult.buildPath).toContain("Debug-iphoneos");
+        }
+        expect(downloader.downloadedUrls.length).toBe(1);
+        expect(downloader.extractedPaths.length).toBe(1);
+      },
+    );
+
     test("a second concurrent build() call never invokes the downloader's destructive extractBundle a second time (#6417)", async function () {
       const derivedDataPath = path.join(tempDir, "DerivedData");
       const cacheDir = path.join(tempDir, "cache");
@@ -1591,6 +1639,31 @@ describe("IOSCtrlProxyBuilder", function () {
       expect(secondResult.success).toBe(true);
       expect(downloader.rmCount).toBe(1);
       expect(downloader.extractedPaths.length).toBe(1);
+    });
+    test("a failed shared download allows a subsequent build", async function () {
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+      const download = downloader.download.bind(downloader);
+      downloader.download = async () => {
+        throw new Error("download unavailable");
+      };
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        {
+          derivedDataPath: path.join(tempDir, "DerivedData"),
+          bundleCacheDir: path.join(tempDir, "cache"),
+        },
+        { downloader },
+      );
+      const [first, second] = await Promise.all([
+        builder.build("device"),
+        builder.build("simulator"),
+      ]);
+      expect(first.success).toBe(false);
+      expect(second.success).toBe(false);
+      downloader.download = download;
+      expect((await builder.build("simulator")).success).toBe(true);
+      expect(downloader.extractedPaths).toHaveLength(1);
     });
   });
 });

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -1493,5 +1493,104 @@ describe("IOSCtrlProxyBuilder", function () {
       expect(result.success).toBe(false);
       expect(result.error).toContain("runner binary SHA256 mismatch");
     });
+
+    test("concurrent build() calls single-flight: only one download/extract happens (#6417)", async function () {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+
+      let resolveDownload: (() => void) | undefined;
+      const downloadGate = new Promise<void>((resolve) => {
+        resolveDownload = resolve;
+      });
+
+      class DeferredDownloader extends FakeIOSCtrlProxyBundleDownloader {
+        public override async download(url: string, destination: string): Promise<void> {
+          await downloadGate;
+          await super.download(url, destination);
+        }
+      }
+
+      const downloader = new DeferredDownloader();
+      downloader.checksum = "expected-checksum";
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader },
+      );
+
+      // Both calls start before either has resolved the download, so the
+      // second call must observe (and reuse) the first call's in-flight promise.
+      const firstBuild = builder.build("simulator");
+      const secondBuild = builder.build("simulator");
+
+      resolveDownload!();
+
+      const [firstResult, secondResult] = await Promise.all([firstBuild, secondBuild]);
+
+      expect(firstResult.success).toBe(true);
+      expect(secondResult.success).toBe(true);
+      expect(secondResult).toEqual(firstResult);
+      expect(downloader.downloadedUrls.length).toBe(1);
+      expect(downloader.extractedPaths.length).toBe(1);
+    });
+
+    test("a second concurrent build() call never invokes the downloader's destructive extractBundle a second time (#6417)", async function () {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+
+      let resolveDownload: (() => void) | undefined;
+      const downloadGate = new Promise<void>((resolve) => {
+        resolveDownload = resolve;
+      });
+
+      // Mirrors the real DefaultIOSCtrlProxyBundleDownloader's destructive
+      // `fs.rm(destination, { recursive: true, force: true })` before
+      // extracting (src/utils/IOSCtrlProxyBundleDownloader.ts:67-68). Counting
+      // invocations proves the shared derived-data tree is torn down and
+      // rebuilt at most once for a pair of overlapping build() calls, which is
+      // the property that protects a live runner's on-disk bundle and any
+      // per-device runner-<deviceId>.xctestrun another caller wrote in between.
+      class DestructiveDeferredDownloader extends FakeIOSCtrlProxyBundleDownloader {
+        public rmCount = 0;
+
+        public override async download(url: string, destination: string): Promise<void> {
+          await downloadGate;
+          await super.download(url, destination);
+        }
+
+        public override async extractBundle(
+          bundlePath: string,
+          destination: string,
+        ): Promise<void> {
+          this.rmCount += 1;
+          await fs.rm(destination, { recursive: true, force: true });
+          await super.extractBundle(bundlePath, destination);
+        }
+      }
+
+      const downloader = new DestructiveDeferredDownloader();
+      downloader.checksum = "expected-checksum";
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader },
+      );
+
+      // Both calls start before either has resolved the download, so the
+      // second call must observe (and reuse) the first call's in-flight promise
+      // instead of running its own independent rm-rf + re-extract.
+      const firstBuild = builder.build("simulator");
+      const secondBuild = builder.build("simulator");
+
+      resolveDownload!();
+      const [firstResult, secondResult] = await Promise.all([firstBuild, secondBuild]);
+
+      expect(firstResult.success).toBe(true);
+      expect(secondResult.success).toBe(true);
+      expect(downloader.rmCount).toBe(1);
+      expect(downloader.extractedPaths.length).toBe(1);
+    });
   });
 });

--- a/test/utils/IOSCtrlProxyBundleDownloader.test.ts
+++ b/test/utils/IOSCtrlProxyBundleDownloader.test.ts
@@ -7,6 +7,7 @@ import {
   DefaultIOSCtrlProxyBundleDownloader,
   assertZipEntriesContained,
 } from "../../src/utils/IOSCtrlProxyBundleDownloader";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 
 describe("IOSCtrlProxyBundleDownloader zip-slip containment (#4761)", function () {
   let tempDir: string;
@@ -89,6 +90,36 @@ describe("IOSCtrlProxyBundleDownloader zip-slip containment (#4761)", function (
 
       // The traversal target must not have been written to the parent directory.
       await expect(fs.access(path.join(tempDir, "escapee.txt"))).rejects.toThrow();
+    });
+
+    test("does not block the event loop during extraction (#6574)", async function () {
+      const zip = new AdmZip();
+      for (let i = 0; i < 30; i++) {
+        zip.addFile(`Build/Products/file-${i}.bin`, Buffer.from("x".repeat(20_000)));
+      }
+      const bundlePath = path.join(tempDir, "bundle.zip");
+      await fs.writeFile(bundlePath, zip.toBuffer());
+
+      const destination = path.join(tempDir, "extract");
+      const downloader = new DefaultIOSCtrlProxyBundleDownloader();
+
+      // Real wall-clock timer (not a fake): this test proves actual OS-thread
+      // yielding, which a logical/fake clock cannot observe.
+      let ticks = 0;
+      const interval = defaultTimer.setInterval(() => {
+        ticks++;
+      }, 1);
+
+      try {
+        await downloader.extractBundle(bundlePath, destination);
+      } finally {
+        defaultTimer.clearInterval(interval);
+      }
+
+      // A macrotask timer scheduled before extractBundle must get a chance to
+      // run WHILE extraction is in flight, proving the main event loop was
+      // never monopolized by synchronous decompress/write work (issue #6574).
+      expect(ticks).toBeGreaterThan(0);
     });
   });
 });

--- a/test/utils/IOSCtrlProxyBundleDownloader.test.ts
+++ b/test/utils/IOSCtrlProxyBundleDownloader.test.ts
@@ -7,7 +7,9 @@ import {
   DefaultIOSCtrlProxyBundleDownloader,
   assertZipEntriesContained,
 } from "../../src/utils/IOSCtrlProxyBundleDownloader";
-import { defaultTimer } from "../../src/utils/SystemTimer";
+import { EventEmitter } from "node:events";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { ExtractBundleWorker } from "../../src/utils/IOSCtrlProxyBundleDownloader";
 
 describe("IOSCtrlProxyBundleDownloader zip-slip containment (#4761)", function () {
   let tempDir: string;
@@ -92,34 +94,69 @@ describe("IOSCtrlProxyBundleDownloader zip-slip containment (#4761)", function (
       await expect(fs.access(path.join(tempDir, "escapee.txt"))).rejects.toThrow();
     });
 
-    test("does not block the event loop during extraction (#6574)", async function () {
-      const zip = new AdmZip();
-      for (let i = 0; i < 30; i++) {
-        zip.addFile(`Build/Products/file-${i}.bin`, Buffer.from("x".repeat(20_000)));
+    test("dispatches extraction and waits for worker completion independently of the main timer", async function () {
+      const timer = new FakeTimer();
+      class FakeWorker extends EventEmitter {
+        terminated = false;
+        async terminate(): Promise<number> {
+          this.terminated = true;
+          return 0;
+        }
       }
-      const bundlePath = path.join(tempDir, "bundle.zip");
-      await fs.writeFile(bundlePath, zip.toBuffer());
-
+      const worker = new FakeWorker();
+      let dispatched!: () => void;
+      const dispatch = new Promise<void>((resolve) => {
+        dispatched = resolve;
+      });
       const destination = path.join(tempDir, "extract");
-      const downloader = new DefaultIOSCtrlProxyBundleDownloader();
-
-      // Real wall-clock timer (not a fake): this test proves actual OS-thread
-      // yielding, which a logical/fake clock cannot observe.
-      let ticks = 0;
-      const interval = defaultTimer.setInterval(() => {
-        ticks++;
+      const bundlePath = path.join(tempDir, "bundle.zip");
+      const downloader = new DefaultIOSCtrlProxyBundleDownloader(undefined, undefined, (data) => {
+        expect(data).toEqual({ bundlePath, destination });
+        dispatched();
+        return worker as ExtractBundleWorker;
+      });
+      let completed = false;
+      const extraction = downloader.extractBundle(bundlePath, destination).then(() => {
+        completed = true;
+      });
+      await dispatch;
+      let ticked = false;
+      timer.setTimeout(() => {
+        ticked = true;
       }, 1);
+      timer.advanceTime(1);
+      expect(ticked).toBe(true);
+      expect(completed).toBe(false);
+      worker.emit("message", { ok: true });
+      await extraction;
+      expect(completed).toBe(true);
+      expect(worker.terminated).toBe(true);
+    });
 
-      try {
-        await downloader.extractBundle(bundlePath, destination);
-      } finally {
-        defaultTimer.clearInterval(interval);
-      }
+    test.each([0, 1])("rejects worker exit without a result (code %s)", async function (code) {
+      const worker = new EventEmitter() as EventEmitter & ExtractBundleWorker;
+      worker.terminate = async () => 0;
+      const downloader = new DefaultIOSCtrlProxyBundleDownloader(undefined, undefined, () => {
+        queueMicrotask(() => worker.emit("exit", code));
+        return worker;
+      });
+      await expect(
+        downloader.extractBundle("unused.zip", path.join(tempDir, "out")),
+      ).rejects.toThrow("without a result");
+    });
 
-      // A macrotask timer scheduled before extractBundle must get a chance to
-      // run WHILE extraction is in flight, proving the main event loop was
-      // never monopolized by synchronous decompress/write work (issue #6574).
-      expect(ticks).toBeGreaterThan(0);
+    test("handles worker termination rejection", async function () {
+      const worker = new EventEmitter() as EventEmitter & ExtractBundleWorker;
+      worker.terminate = async () => {
+        throw new Error("termination failed");
+      };
+      const downloader = new DefaultIOSCtrlProxyBundleDownloader(undefined, undefined, () => {
+        queueMicrotask(() => worker.emit("message", { ok: true }));
+        return worker;
+      });
+      await expect(
+        downloader.extractBundle("unused.zip", path.join(tempDir, "out")),
+      ).rejects.toThrow("termination failed");
     });
   });
 });


### PR DESCRIPTION
## Summary

DefaultIOSCtrlProxyBundleDownloader.extractBundle ran adm-zip's synchronous read/decompress/write entirely on the daemon's main thread with no yield point, stalling every other device's WebSocket heartbeats and health-poll timers for the whole extraction window on first-run or post-upgrade CtrlProxy setup. This moves the AdmZip read, the zip-slip containment check, and extractAllTo into a worker_threads Worker (the same self-contained eval-source pattern already used by DatabaseHealthProbe's SQLite probe), so the CPU-bound work runs off the event loop while extractBundle keeps its existing Promise<void> contract. A workerFactory constructor parameter keeps the class fake-injectable for tests.

Part of epic #6372.

## Linked Issue

Closes #6574

## Validation

A TDD test schedules a real 1ms timer immediately before calling extractBundle on a multi-entry (30-file) archive and asserts it fires during (not only after) extraction — red before the worker offload, green after. Pre-existing zip-slip containment tests still pass. Targeted 6, IOSCtrlProxy subsystem 175/175, full test/utils 3102/0 pass.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
