### PR TITLE
fix(ios): recognize FormatVersion 2 xctestrun layout in runner env injection (#6418)

### DIFF
--- a/scripts/local-dev/lib/ctrl-proxy-ios.sh
+++ b/scripts/local-dev/lib/ctrl-proxy-ios.sh
@@ -199,17 +199,34 @@ start_ctrl_proxy_ios() {
 
   runner_xctestrun_path="$(dirname "${xctestrun_path}")/automobile-runner-${simulator_id}.xctestrun"
   cp "${xctestrun_path}" "${runner_xctestrun_path}"
-  plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_PORT" \
-    -string "${port}" "${runner_xctestrun_path}"
-  plutil -replace "CtrlProxyUITests.EnvironmentVariables.AUTOMOBILE_DEVICE_ID" \
-    -string "${simulator_id}" "${runner_xctestrun_path}"
+  # plutil fails when the xctestrun does not carry the top-level
+  # CtrlProxyUITests key it expects (e.g. a FormatVersion 2 layout produced by
+  # a scheme with a test plan) — an unpatched xctestrun would silently launch
+  # the runner on the wrong port (issue #2731), so a patch failure must be a
+  # hard failure rather than a swallowed one.
+  if ! plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_PORT" \
+      -string "${port}" "${runner_xctestrun_path}"; then
+    log_error "Failed to patch CTRL_PROXY_IOS_PORT into runner xctestrun (CtrlProxyUITests.EnvironmentVariables keypath not found — is this a FormatVersion 1 xctestrun?)."
+    return 1
+  fi
+  if ! plutil -replace "CtrlProxyUITests.EnvironmentVariables.AUTOMOBILE_DEVICE_ID" \
+      -string "${simulator_id}" "${runner_xctestrun_path}"; then
+    log_error "Failed to patch AUTOMOBILE_DEVICE_ID into runner xctestrun."
+    return 1
+  fi
   if [[ -n "${CTRL_PROXY_IOS_BUNDLE_ID:-}" ]]; then
-    plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_BUNDLE_ID" \
-      -string "${CTRL_PROXY_IOS_BUNDLE_ID}" "${runner_xctestrun_path}"
+    if ! plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_BUNDLE_ID" \
+        -string "${CTRL_PROXY_IOS_BUNDLE_ID}" "${runner_xctestrun_path}"; then
+      log_error "Failed to patch CTRL_PROXY_IOS_BUNDLE_ID into runner xctestrun."
+      return 1
+    fi
   fi
   if [[ -n "${CTRL_PROXY_IOS_TIMEOUT:-}" ]]; then
-    plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_TIMEOUT" \
-      -string "${CTRL_PROXY_IOS_TIMEOUT}" "${runner_xctestrun_path}"
+    if ! plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_TIMEOUT" \
+        -string "${CTRL_PROXY_IOS_TIMEOUT}" "${runner_xctestrun_path}"; then
+      log_error "Failed to patch CTRL_PROXY_IOS_TIMEOUT into runner xctestrun."
+      return 1
+    fi
   fi
 
   local cmd=(

--- a/scripts/test-ctrl-proxy-ios.sh
+++ b/scripts/test-ctrl-proxy-ios.sh
@@ -177,8 +177,16 @@ if [ "$HEALTH_RESPONSE" == "FAILED" ]; then
                 else
                     RUNNER_XCTESTRUN_FILE="$(dirname "${XCTESTRUN_FILE}")/automobile-runner-${BOOTED_SIMULATOR}.xctestrun"
                     cp "${XCTESTRUN_FILE}" "${RUNNER_XCTESTRUN_FILE}"
-                    plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_PORT" -string "${PORT}" "${RUNNER_XCTESTRUN_FILE}"
-                    plutil -replace "CtrlProxyUITests.EnvironmentVariables.AUTOMOBILE_DEVICE_ID" -string "${BOOTED_SIMULATOR}" "${RUNNER_XCTESTRUN_FILE}"
+                    if ! plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_PORT" -string "${PORT}" "${RUNNER_XCTESTRUN_FILE}" \
+                        || ! plutil -replace "CtrlProxyUITests.EnvironmentVariables.AUTOMOBILE_DEVICE_ID" -string "${BOOTED_SIMULATOR}" "${RUNNER_XCTESTRUN_FILE}"; then
+                        # plutil fails when the xctestrun does not carry the
+                        # top-level CtrlProxyUITests key it expects (e.g. a
+                        # FormatVersion 2 layout) — an unpatched xctestrun
+                        # silently launches the runner on the wrong port
+                        # (issue #2731), so this must be a hard failure.
+                        print_status 1 "Failed to patch runner xctestrun (CtrlProxyUITests.EnvironmentVariables keypath not found — is this a FormatVersion 1 xctestrun?)"
+                        exit 1
+                    fi
 
                     print_info "Starting patched CtrlProxy iOS in background..."
 

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -478,8 +478,12 @@ export class IOSCtrlProxyBuilder {
 
       const injected = injectUITestEnvironment(root as Map<string, PlistValue>, env);
       if (injected === 0) {
+        const metadata = (root as Map<string, PlistValue>).get("__xctestrun_metadata__");
+        const formatVersion = metadata instanceof Map ? metadata.get("FormatVersion") : undefined;
+        const observedFormat = formatVersion === undefined ? "unknown" : String(formatVersion);
         throw new Error(
-          "xctestrun contains no UI-test bundle (IsUITestBundle) to receive the runner environment",
+          `xctestrun contains no UI-test bundle (IsUITestBundle) to receive the runner ` +
+            `environment (observed __xctestrun_metadata__.FormatVersion: ${observedFormat})`,
         );
       }
 

--- a/src/utils/ios-cmdline-tools/XctestrunPlist.ts
+++ b/src/utils/ios-cmdline-tools/XctestrunPlist.ts
@@ -149,8 +149,40 @@ export const buildPlist = (value: PlistValue): string => {
 };
 
 /**
+ * Recursively collect every `Map` in `value` (walking into arrays and nested
+ * dicts) whose `IsUITestBundle` key is exactly `true`.
+ *
+ * This makes the walk layout-agnostic: it finds UI-test targets whether they
+ * sit at the plist top level (FormatVersion 1, `{ <TargetName>: { ... } }`)
+ * or nested under a test-plan configuration array (FormatVersion 2,
+ * `TestConfigurations[].TestTargets[]`), without needing to branch on
+ * `__xctestrun_metadata__.FormatVersion`.
+ */
+const collectUITestTargets = (value: PlistValue): Map<string, PlistValue>[] => {
+  if (Array.isArray(value)) {
+    return value.flatMap((child) => collectUITestTargets(child));
+  }
+
+  if (!(value instanceof Map)) {
+    return [];
+  }
+
+  const targets: Map<string, PlistValue>[] = [];
+  if (value.get("IsUITestBundle") === true) {
+    targets.push(value);
+  }
+  for (const child of value.values()) {
+    targets.push(...collectUITestTargets(child));
+  }
+  return targets;
+};
+
+/**
  * Merge `env` (string key/value pairs) into the `EnvironmentVariables` dict of
- * every test target in `root` that is a UI-test bundle (`IsUITestBundle` true).
+ * every test target in `root` that is a UI-test bundle (`IsUITestBundle` true),
+ * regardless of whether it sits at the plist top level (FormatVersion 1) or
+ * nested under `TestConfigurations[].TestTargets[]` (FormatVersion 2 — the
+ * layout `xcodebuild` emits when the scheme resolves a test plan).
  *
  * Existing keys are overwritten, missing `EnvironmentVariables` dicts are
  * created, and non-UI targets are left untouched.
@@ -161,24 +193,19 @@ export const injectUITestEnvironment = (
   root: Map<string, PlistValue>,
   env: Record<string, string>,
 ): number => {
-  let injected = 0;
+  const targets = collectUITestTargets(root);
 
-  for (const value of root.values()) {
-    if (!(value instanceof Map) || value.get("IsUITestBundle") !== true) {
-      continue;
-    }
-
-    let envDict = value.get("EnvironmentVariables");
+  for (const target of targets) {
+    let envDict = target.get("EnvironmentVariables");
     if (!(envDict instanceof Map)) {
       envDict = new Map<string, PlistValue>();
-      value.set("EnvironmentVariables", envDict);
+      target.set("EnvironmentVariables", envDict);
     }
 
     for (const [key, val] of Object.entries(env)) {
       (envDict as Map<string, PlistValue>).set(key, val);
     }
-    injected += 1;
   }
 
-  return injected;
+  return targets.length;
 };

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -598,7 +598,7 @@ describe("IOSCtrlProxyBuilder", function () {
       expect(path.basename(outputPath)).toBe("automobile-runner-00008030-001E_28C1_1E.xctestrun");
     });
 
-    test("throws an actionable error when the xctestrun has no UI-test bundle (EC4)", async function () {
+    test("throws an actionable error naming the observed FormatVersion when the xctestrun has no UI-test bundle (EC4)", async function () {
       const productsDir = path.join(tempDir, "Build", "Products");
       await fs.mkdir(productsDir, { recursive: true });
       const sourcePath = path.join(productsDir, "CtrlProxyApp_iphonesimulator.xctestrun");
@@ -610,6 +610,8 @@ describe("IOSCtrlProxyBuilder", function () {
           "<dict>",
           "\t<key>CtrlProxyTests</key>",
           "\t<dict><key>IsUITestBundle</key><false/></dict>",
+          "\t<key>__xctestrun_metadata__</key>",
+          "\t<dict><key>FormatVersion</key><integer>1</integer></dict>",
           "</dict>",
           "</plist>",
         ].join("\n"),
@@ -619,6 +621,61 @@ describe("IOSCtrlProxyBuilder", function () {
       await expect(
         builder.writeRunnerEnvironment(sourcePath, { CTRL_PROXY_IOS_PORT: "8767" }, "SIM"),
       ).rejects.toThrow("no UI-test bundle");
+      await expect(
+        builder.writeRunnerEnvironment(sourcePath, { CTRL_PROXY_IOS_PORT: "8767" }, "SIM"),
+      ).rejects.toThrow("FormatVersion: 1");
+    });
+
+    test("injects into a FormatVersion 2 (TestConfigurations[].TestTargets[]) xctestrun", async function () {
+      const productsDir = path.join(tempDir, "Build", "Products");
+      await fs.mkdir(productsDir, { recursive: true });
+      const sourcePath = path.join(
+        productsDir,
+        "CtrlProxyApp_iphonesimulator26.2-arm64-x86_64.xctestrun",
+      );
+      const V2_XCTESTRUN = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<plist version="1.0">',
+        "<dict>",
+        "\t<key>TestConfigurations</key>",
+        "\t<array>",
+        "\t\t<dict>",
+        "\t\t\t<key>TestTargets</key>",
+        "\t\t\t<array>",
+        "\t\t\t\t<dict>",
+        "\t\t\t\t\t<key>BlueprintName</key>",
+        "\t\t\t\t\t<string>CtrlProxyUITests</string>",
+        "\t\t\t\t\t<key>IsUITestBundle</key>",
+        "\t\t\t\t\t<true/>",
+        "\t\t\t\t\t<key>EnvironmentVariables</key>",
+        "\t\t\t\t\t<dict><key>TERM</key><string>dumb</string></dict>",
+        "\t\t\t\t</dict>",
+        "\t\t\t</array>",
+        "\t\t</dict>",
+        "\t</array>",
+        "\t<key>__xctestrun_metadata__</key>",
+        "\t<dict><key>FormatVersion</key><integer>2</integer></dict>",
+        "</dict>",
+        "</plist>",
+      ].join("\n");
+      await fs.writeFile(sourcePath, V2_XCTESTRUN);
+
+      const builder = IOSCtrlProxyBuilder.getInstance({ derivedDataPath: tempDir });
+      const outputPath = await builder.writeRunnerEnvironment(
+        sourcePath,
+        { CTRL_PROXY_IOS_PORT: "8767" },
+        "SIM-UUID",
+      );
+
+      const xml = await fs.readFile(outputPath, "utf-8");
+      const root = (await parsePlist(xml)) as Map<string, unknown>;
+      const configurations = root.get("TestConfigurations") as unknown[];
+      const configuration = configurations[0] as Map<string, unknown>;
+      const testTargets = configuration.get("TestTargets") as unknown[];
+      const uiTarget = testTargets[0] as Map<string, unknown>;
+      const env = uiTarget.get("EnvironmentVariables") as Map<string, unknown>;
+      expect(env.get("CTRL_PROXY_IOS_PORT")).toBe("8767");
+      expect(env.get("TERM")).toBe("dumb");
     });
   });
 

--- a/test/utils/ios-cmdline-tools/XctestrunPlist.test.ts
+++ b/test/utils/ios-cmdline-tools/XctestrunPlist.test.ts
@@ -52,6 +52,44 @@ const SAMPLE_XCTESTRUN = `<?xml version="1.0" encoding="UTF-8"?>
 </dict>
 </plist>`;
 
+/**
+ * A minimal format-version-2 xctestrun: the layout `xcodebuild` emits when
+ * the scheme resolves a test plan. The UI-test target lives nested under
+ * `TestConfigurations[].TestTargets[]` instead of at the top level.
+ */
+const SAMPLE_XCTESTRUN_V2 = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+\t<key>TestConfigurations</key>
+\t<array>
+\t\t<dict>
+\t\t\t<key>Name</key>
+\t\t\t<string>Configuration 1</string>
+\t\t\t<key>TestTargets</key>
+\t\t\t<array>
+\t\t\t\t<dict>
+\t\t\t\t\t<key>BlueprintName</key>
+\t\t\t\t\t<string>CtrlProxyUITests</string>
+\t\t\t\t\t<key>IsUITestBundle</key>
+\t\t\t\t\t<true/>
+\t\t\t\t\t<key>EnvironmentVariables</key>
+\t\t\t\t\t<dict>
+\t\t\t\t\t\t<key>TERM</key>
+\t\t\t\t\t\t<string>dumb</string>
+\t\t\t\t\t</dict>
+\t\t\t\t</dict>
+\t\t\t</array>
+\t\t</dict>
+\t</array>
+\t<key>__xctestrun_metadata__</key>
+\t<dict>
+\t\t<key>FormatVersion</key>
+\t\t<integer>2</integer>
+\t</dict>
+</dict>
+</plist>`;
+
 function expectDict(value: unknown): Map<string, unknown> {
   expect(value).toBeInstanceOf(Map);
   return value as Map<string, unknown>;
@@ -155,6 +193,68 @@ describe("XctestrunPlist", function () {
       const root = new Map<string, unknown>([
         ["UnitTarget", new Map<string, unknown>([["IsUITestBundle", false]])],
       ]);
+      expect(injectUITestEnvironment(root, { X: "1" })).toBe(0);
+    });
+
+    test("injects into a FormatVersion 2 (TestConfigurations[].TestTargets[]) UI-test target", async function () {
+      const root = expectDict(await parsePlist(SAMPLE_XCTESTRUN_V2));
+      const count = injectUITestEnvironment(root, {
+        CTRL_PROXY_IOS_PORT: "8767",
+        AUTOMOBILE_DEVICE_ID: "SIM-UUID",
+      });
+
+      expect(count).toBe(1);
+
+      const configurations = root.get("TestConfigurations") as unknown[];
+      const configuration = expectDict(configurations[0]);
+      const testTargets = configuration.get("TestTargets") as unknown[];
+      const uiTarget = expectDict(testTargets[0]);
+      const uiEnv = expectDict(uiTarget.get("EnvironmentVariables"));
+
+      // Existing entry preserved.
+      expect(uiEnv.get("TERM")).toBe("dumb");
+      // New entries injected.
+      expect(uiEnv.get("CTRL_PROXY_IOS_PORT")).toBe("8767");
+      expect(uiEnv.get("AUTOMOBILE_DEVICE_ID")).toBe("SIM-UUID");
+    });
+
+    test("injected environment survives a buildPlist -> parsePlist round-trip at the nested v2 location", async function () {
+      const root = expectDict(await parsePlist(SAMPLE_XCTESTRUN_V2));
+      injectUITestEnvironment(root, { CTRL_PROXY_IOS_PORT: "8767" });
+      const rebuilt = buildPlist(root);
+
+      const reparsed = expectDict(await parsePlist(rebuilt));
+      const configurations = reparsed.get("TestConfigurations") as unknown[];
+      const configuration = expectDict(configurations[0]);
+      const testTargets = configuration.get("TestTargets") as unknown[];
+      const uiTarget = expectDict(testTargets[0]);
+      const uiEnv = expectDict(uiTarget.get("EnvironmentVariables"));
+
+      expect(uiEnv.get("CTRL_PROXY_IOS_PORT")).toBe("8767");
+      expect(uiEnv.get("TERM")).toBe("dumb");
+    });
+
+    test("returns 0 for a v2-shaped file with no UI-test target in either layout", async function () {
+      const root = expectDict(
+        await parsePlist(
+          [
+            '<?xml version="1.0" encoding="UTF-8"?>',
+            '<plist version="1.0">',
+            "<dict>",
+            "\t<key>TestConfigurations</key>",
+            "\t<array>",
+            "\t\t<dict>",
+            "\t\t\t<key>TestTargets</key>",
+            "\t\t\t<array>",
+            "\t\t\t\t<dict><key>IsUITestBundle</key><false/></dict>",
+            "\t\t\t</array>",
+            "\t\t</dict>",
+            "\t</array>",
+            "</dict>",
+            "</plist>",
+          ].join("\n"),
+        ),
+      );
       expect(injectUITestEnvironment(root, { X: "1" })).toBe(0);
     });
   });


### PR DESCRIPTION
## Summary

injectUITestEnvironment only understood the FormatVersion 1 xctestrun layout, so runner-environment injection silently found zero UI-test bundles (and failed closed) on the FormatVersion 2 TestConfigurations[].TestTargets[] shape produced by newer Xcode. It now recurses through arrays/dicts collecting every Map with IsUITestBundle===true regardless of layout, keeping the returned count as the zero-check contract, and writeRunnerEnvironment now includes the observed __xctestrun_metadata__.FormatVersion in its ActionableError when the count is zero. Also added exit-status checks around the plutil -replace calls in the ctrl-proxy-ios shell scripts so a failed plist edit no longer passes silently.

Part of epic #6372.

Stacked on `work/issue-6416-ios-availability-cache-reopen`; GitHub retargets to `main` once it merges.

## Linked Issue

Closes #6418

## Validation

Added a FormatVersion 2 fixture to XctestrunPlist.test.ts (TestConfigurations[].TestTargets[] shape) and extended IOSCtrlProxyBuilder.test.ts around the no-UI-test-bundle-throws case; red before the recursion fix, green after. Targeted iOS-cmdline-tools + Builder suites pass.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
