### PR TITLE
fix(ios): probe legacy CtrlProxy uninstall at most once per manager (#6575)

### DIFF
--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -238,6 +238,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
   // Setup state tracking
   private attemptedSetup: boolean = false;
+  // #6575: the legacy-app uninstall probe is a one-time cleanup for a
+  // long-renamed bundle ID; gate it to at most once per manager instance so
+  // repeat setup() calls (including the attemptedSetup fast path) don't pay
+  // for a redundant external-process round trip.
+  private legacyCheckDone: boolean = false;
 
   // XCUITest process state
   private xcTestProcessId: number | null = null;
@@ -744,6 +749,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    */
   public resetSetupState(): void {
     this.attemptedSetup = false;
+    this.legacyCheckDone = false;
     this.clearCaches();
     logger.info("[IOSCtrlProxy] Reset setup state");
   }
@@ -1294,6 +1300,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * This cleans up the old bundle ID left over from before the rename to CtrlProxy.
    */
   private async uninstallLegacyAppIfPresent(): Promise<void> {
+    if (this.legacyCheckDone) {
+      return;
+    }
+    this.legacyCheckDone = true;
     try {
       const simulator = this.isSimulator();
       const isInstalled = await this.deviceAppManager.getInstalledAppBundleHash(

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -948,6 +948,108 @@ describe("IOSCtrlProxyManager", function () {
     });
   });
 
+  // #6575: the legacy-app uninstall probe used to run on every setup() call,
+  // including the attemptedSetup fast path that exists to make repeat calls
+  // cheap. It should fire at most once per manager instance.
+  describe("legacy-app uninstall probe runs at most once per manager (#6575)", function () {
+    test("does not re-probe on a setup() call that hits the attemptedSetup fast path", async function () {
+      const fakeExecutor = new FakeProcessExecutor();
+      let healthy = false;
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(
+          healthy ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          "",
+        ),
+      );
+      let legacyProbeCount = 0;
+      const fakeDeviceAppManager = {
+        getInstalledAppBundleHash: async () => {
+          legacyProbeCount++;
+          return null;
+        },
+      } as unknown as DeviceAppManager;
+      const xcodebuild: Xcodebuild = {
+        executeCommand: async () => createExecResult("", ""),
+        isAvailable: async () => true,
+        startStreaming: async () => {
+          healthy = true;
+          return new FakeChildProcess() as unknown as ChildProcess;
+        },
+      };
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor,
+        undefined,
+        fakeDeviceAppManager,
+        undefined,
+        undefined,
+        xcodebuild,
+      );
+      fakeTimer.enableAutoAdvance();
+
+      const first = await manager.setup();
+      expect(first.success).toBe(true);
+      expect(legacyProbeCount).toBe(1);
+
+      // Second call hits the `attemptedSetup && !force` fast path.
+      const second = await manager.setup();
+      expect(second.success).toBe(true);
+      expect(legacyProbeCount).toBe(1);
+    });
+
+    test("re-arms after resetSetupState so a fresh device/session probes again", async function () {
+      const fakeExecutor = new FakeProcessExecutor();
+      let healthy = false;
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(
+          healthy ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          "",
+        ),
+      );
+      fakeExecutor.setCommandHandler("kill -0", () => {
+        throw new Error("runner is no longer running");
+      });
+      let legacyProbeCount = 0;
+      const fakeDeviceAppManager = {
+        getInstalledAppBundleHash: async () => {
+          legacyProbeCount++;
+          return null;
+        },
+      } as unknown as DeviceAppManager;
+      const xcodebuild: Xcodebuild = {
+        executeCommand: async () => createExecResult("", ""),
+        isAvailable: async () => true,
+        startStreaming: async () => {
+          healthy = true;
+          return new FakeChildProcess() as unknown as ChildProcess;
+        },
+      };
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor,
+        undefined,
+        fakeDeviceAppManager,
+        undefined,
+        undefined,
+        xcodebuild,
+      );
+      fakeTimer.enableAutoAdvance();
+
+      expect((await manager.setup()).success).toBe(true);
+      expect(legacyProbeCount).toBe(1);
+
+      healthy = false;
+      manager.resetSetupState();
+
+      expect((await manager.setup()).success).toBe(true);
+      expect(legacyProbeCount).toBe(2);
+    });
+  });
+
   // #6416: `isAvailable()` used to serve a positive answer from a 1-hour
   // `cachedAvailability` layer that `setup()`'s already-attempted gate
   // consults. A runner that dies without a local child-exit event (killed


### PR DESCRIPTION
## Summary

uninstallLegacyAppIfPresent() ran its getInstalledAppBundleHash probe for the legacy bundle id on every setup() call, before the attemptedSetup fast-path short-circuit, paying a redundant simctl probe on every ensure-ready. This adds a legacyCheckDone guard so the probe runs at most once per manager instance (set after the first attempt completes, success or failure), reset alongside attemptedSetup where setup state is reset so a fresh device/session re-arms it.

Part of epic #6372.

Stacked on `work/issue-6416-ios-availability-cache-reopen`; GitHub retargets to `main` once it merges.

## Linked Issue

Closes #6575

## Validation

A unit test with a fake DeviceAppManager spy asserts getInstalledAppBundleHash for the legacy bundle id is called at most once across two setup() calls, including one hitting the attemptedSetup fast path; red before the guard. Targeted IOSCtrlProxyManager tests green.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
