### PR TITLE
fix(ios): coalesce simctl device listing and retain last-good snapshot (#6576)

### DIFF
--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -24,7 +24,7 @@ import {
 import { PlistClient, type PlistReader } from "./PlistClient";
 import { inferIosFormFactor, isIosSimulatorUdid } from "./iosDeviceType";
 import { iosVersionStringFromRuntimeId } from "./iosVersion";
-import { getAbortSignal } from "../AbortContext";
+import { getAbortSignal, runWithAbortSignal } from "../AbortContext";
 import { Mutex } from "async-mutex";
 import { iosSimulatorCapabilityInventory } from "../../features/device-control/virtualDeviceCapabilities";
 
@@ -906,7 +906,11 @@ export class SimCtlClient implements SimCtl {
       }
       if (lease.state.lastBootSucceeded) {
         const simulatorStillBooted = (
-          await this.getBootedSimulatorsChecked(this.remainingBootTimeoutMs(udid, deadlineMs))
+          await this.getBootedSimulatorsChecked(
+            this.remainingBootTimeoutMs(udid, deadlineMs),
+            undefined,
+            { bypassCache: true },
+          )
         ).some((simulator) => simulator.deviceId === udid);
         if (simulatorStillBooted) {
           throw new ActionableError(`iOS simulator ${udid} is already running`);
@@ -1071,7 +1075,11 @@ export class SimCtlClient implements SimCtl {
       }
       if (priorBootSucceeded && adoptPriorSuccess) {
         const simulatorStillBooted = (
-          await this.getBootedSimulatorsChecked(this.remainingBootTimeoutMs(udid, deadlineMs))
+          await this.getBootedSimulatorsChecked(
+            this.remainingBootTimeoutMs(udid, deadlineMs),
+            undefined,
+            { bypassCache: true },
+          )
         ).some((simulator) => simulator.deviceId === udid);
         if (simulatorStillBooted) {
           return await adoptPriorSuccess();
@@ -1678,6 +1686,11 @@ export class SimCtlClient implements SimCtl {
   private async resolveReadySimulator(udid: string, timeoutMs?: number): Promise<BootedDevice> {
     const perf = createGlobalPerformanceTracker();
     perf.startOperation("deviceLookup");
+    // findBootedSimulator always issues its own unshared `simctl list
+    // devices` read (never listSimulatorImages()'s TTL cache), and is shared
+    // with resolveRegisteredBootSimulator (issue #6412) so both boot-
+    // completion paths agree on the same booted device and neither trusts a
+    // stale cached snapshot (issue #6576).
     const simulator = await this.findBootedSimulator(udid, timeoutMs);
     perf.endOperation("deviceLookup");
 
@@ -1707,7 +1720,8 @@ export class SimCtlClient implements SimCtl {
     // An already-aborted caller must fail even on a cache hit below -- a cached
     // "success" for a request the caller has already given up on is silently
     // wrong (issue #6576).
-    options.signal?.throwIfAborted();
+    const signal = options.signal ?? getAbortSignal();
+    signal?.throwIfAborted();
 
     // Check cache first
     if (!options.bypassCache && SimCtlClient.deviceListCache) {
@@ -1724,7 +1738,9 @@ export class SimCtlClient implements SimCtl {
     // — that request's failure-fallback behavior is not this caller's to
     // inherit. Run it standalone instead of sharing the coalescing slot below.
     if (options.bypassCache) {
-      return this.runListSimulatorImages(timeoutMs, { bypassCache: true });
+      SimCtlClient.deviceListGeneration++;
+      SimCtlClient.inFlightDeviceList = null;
+      return this.runListSimulatorImages(timeoutMs, { bypassCache: true, signal });
     }
 
     // Concurrent callers racing a cold/expired cache share one `simctl list
@@ -1735,15 +1751,22 @@ export class SimCtlClient implements SimCtl {
     // waiter below races the shared result against its own deadline/signal
     // instead, so aborting/bounding one waiter can never fail or truncate the
     // read for a sibling waiter.
-    const generation = SimCtlClient.deviceListGeneration;
-    SimCtlClient.inFlightDeviceList ??= this.runListSimulatorImages(
-      SimCtlClient.SHARED_DEVICE_LIST_TIMEOUT_MS,
-      { bypassCache: false },
-      generation,
-    ).finally(() => {
-      SimCtlClient.inFlightDeviceList = null;
-    });
-    return this.raceOwnDeadline(SimCtlClient.inFlightDeviceList, timeoutMs, options.signal);
+    if (!SimCtlClient.inFlightDeviceList) {
+      const generation = SimCtlClient.deviceListGeneration;
+      const flight = runWithAbortSignal(undefined, () =>
+        this.runListSimulatorImages(
+          SimCtlClient.SHARED_DEVICE_LIST_TIMEOUT_MS,
+          { bypassCache: false },
+          generation,
+        ),
+      ).finally(() => {
+        if (SimCtlClient.inFlightDeviceList === flight) {
+          SimCtlClient.inFlightDeviceList = null;
+        }
+      });
+      SimCtlClient.inFlightDeviceList = flight;
+    }
+    return this.raceOwnDeadline(SimCtlClient.inFlightDeviceList, timeoutMs, signal);
   }
 
   /**
@@ -1758,6 +1781,7 @@ export class SimCtlClient implements SimCtl {
     timeoutMs: number | undefined,
     signal: AbortSignal | undefined,
   ): Promise<DeviceInfo[]> {
+    signal?.throwIfAborted();
     if (timeoutMs === undefined && !signal) {
       return shared;
     }
@@ -1832,13 +1856,13 @@ export class SimCtlClient implements SimCtl {
 
   private async runListSimulatorImages(
     timeoutMs: number | undefined,
-    options: { bypassCache?: boolean },
+    options: { bypassCache?: boolean; signal?: AbortSignal },
     generation: number = SimCtlClient.deviceListGeneration,
   ): Promise<DeviceInfo[]> {
     logger.debug("Getting list of iOS simulators");
 
     try {
-      const simulatorList = await this.listSimulators(timeoutMs);
+      const simulatorList = await this.listSimulators(timeoutMs, options.signal);
       const devices = SimCtlClient.mapSimulatorListToDeviceInfos(simulatorList);
       // A create/delete (or explicit invalidation) that landed while this fetch
       // was in flight bumps the generation; a snapshot captured under the OLD
@@ -1847,29 +1871,15 @@ export class SimCtlClient implements SimCtl {
       // (issue #6576) -- otherwise it would resurrect pre-mutation data right
       // after the mutation invalidated it.
       const stillCurrent = SimCtlClient.deviceListGeneration === generation;
-      if (devices.length > 0) {
+      if (stillCurrent) {
         const timestamp = this.timer.now();
-        // A bypassCache read is a deliberately un-shared, provably-fresh read
-        // (e.g. boot verification via readSimulatorState); populating the TTL
-        // cache from it would let an unrelated cache-eligible caller silently
-        // consume that read instead of making its own, which the boot
-        // verification tests pin as a fixed invocation count.
-        if (!options.bypassCache && stillCurrent) {
-          SimCtlClient.deviceListCache = { devices, timestamp };
-          SimCtlClient.lastGoodDeviceList = { devices, timestamp };
-        }
-      } else if (!options.bypassCache && stillCurrent) {
-        SimCtlClient.deviceListCache = null;
-        // An authoritative empty listing means no simulators exist right now.
-        // Replace (not merely clear) the last-good snapshot with that same
-        // empty result, so a later failed discovery within the retention
-        // window reports "none" instead of resurrecting devices this read
-        // just proved absent (issue #6576).
-        SimCtlClient.lastGoodDeviceList = { devices: [], timestamp: this.timer.now() };
+        SimCtlClient.deviceListCache = devices.length ? { devices, timestamp } : null;
+        SimCtlClient.lastGoodDeviceList = { devices, timestamp };
       }
       return devices;
     } catch (error) {
-      if (!options.bypassCache) {
+      options.signal?.throwIfAborted();
+      if (!options.bypassCache && SimCtlClient.deviceListGeneration === generation) {
         SimCtlClient.deviceListCache = null;
       }
       const detail = errorMessage(error);
@@ -1932,6 +1942,7 @@ export class SimCtlClient implements SimCtl {
     // An already-aborted caller must fail even on a cache hit below -- a cached
     // "success" for a request the caller has already given up on is silently
     // wrong (issue #6576).
+    signal ??= getAbortSignal();
     signal?.throwIfAborted();
     const cached = SimCtlClient.deviceListCache;
     const devices =
@@ -2180,6 +2191,7 @@ export class SimCtlClient implements SimCtl {
   static invalidateDeviceListCache(): void {
     SimCtlClient.deviceListCache = null;
     SimCtlClient.lastGoodDeviceList = null;
+    SimCtlClient.inFlightDeviceList = null;
     SimCtlClient.deviceListGeneration++;
   }
 

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -573,6 +573,14 @@ export class SimCtlClient implements SimCtl {
   // Static cache for device list
   private static deviceListCache: { devices: DeviceInfo[]; timestamp: number } | null = null;
   private static readonly DEVICE_LIST_CACHE_TTL = 5000; // 5 seconds
+  // Last-known-good device list, retained past a failed listing so a transient
+  // `simctl` error degrades to a stale-but-usable snapshot instead of throwing
+  // (issue #6576), mirroring DevicectlDeviceLister.lastGood.
+  private static lastGoodDeviceList: { devices: DeviceInfo[]; timestamp: number } | null = null;
+  private static readonly LAST_GOOD_DEVICE_LIST_RETENTION_MS = 60_000;
+  // Concurrent cold/expired-cache callers share one `simctl list devices`
+  // invocation rather than each spawning their own process (issue #6576).
+  private static inFlightDeviceList: Promise<DeviceInfo[]> | null = null;
   private static readonly simulatorBoots = new Map<string, SimulatorBootState>();
 
   /**
@@ -1569,14 +1577,20 @@ export class SimCtlClient implements SimCtl {
    *         directly.
    */
   private async readSimulatorState(udid: string, timeoutMs: number): Promise<string | undefined> {
-    const simulatorList = await this.listSimulators(timeoutMs);
-    for (const runtimeDevices of Object.values(simulatorList.devices)) {
-      const match = runtimeDevices.find((device) => device.udid === udid);
-      if (match) {
-        return match.state;
-      }
+    try {
+      // `bypassCache: true` because a failed verification always falls through
+      // to a stale last-good snapshot instead of throwing (issue #6576), which
+      // would defeat the "never trust a stale snapshot" contract this method
+      // promises boot verification.
+      const devices = await this.listSimulatorImages(timeoutMs, { bypassCache: true });
+      return devices.find((device) => device.deviceId === udid)?.state;
+    } catch (error) {
+      logger.warn(
+        `[iOS] Could not read simulator state for ${udid}: ${errorMessage(error)}`,
+        error,
+      );
+      return undefined;
     }
-    return undefined;
   }
 
   /**
@@ -1686,56 +1700,107 @@ export class SimCtlClient implements SimCtl {
       }
     }
 
+    // A caller that explicitly bypassed the cache wants a read that is
+    // provably fresh (e.g. boot verification via readSimulatorState), so it
+    // must not join an in-flight request some other caller's options started
+    // — that request's failure-fallback behavior is not this caller's to
+    // inherit. Run it standalone instead of sharing the coalescing slot below.
+    if (options.bypassCache) {
+      return this.runListSimulatorImages(timeoutMs, options);
+    }
+
+    // Concurrent callers racing a cold/expired cache share one `simctl list
+    // devices` invocation rather than each spawning their own process
+    // (issue #6576), mirroring DevicectlDeviceLister.listConnectedDevices().
+    SimCtlClient.inFlightDeviceList ??= this.runListSimulatorImages(timeoutMs, options).finally(
+      () => {
+        SimCtlClient.inFlightDeviceList = null;
+      },
+    );
+    return SimCtlClient.inFlightDeviceList;
+  }
+
+  /** Map a raw `simctl list devices --json` payload into sorted {@link DeviceInfo} records. */
+  private static mapSimulatorListToDeviceInfos(simulatorList: SimulatorList): DeviceInfo[] {
+    const devices: DeviceInfo[] = [];
+    for (const [runtimeId, runtimeDevices] of Object.entries(simulatorList.devices)) {
+      for (const device of runtimeDevices) {
+        logger.debug(`Found iOS simulator: ${device.name} (${device.udid}) state=${device.state}`);
+        const iosVersion = normalizeIosVersion(runtimeId, device.os_version);
+        devices.push({
+          name: device.name,
+          platform: "ios",
+          deviceId: device.udid,
+          isRunning: device.state === "Booted",
+          state: device.state,
+          isAvailable: device.isAvailable,
+          availabilityError: device.availabilityError,
+          iosVersion,
+          osVersion: iosVersion,
+          formFactor: inferIosFormFactor(device.deviceTypeIdentifier),
+          deviceType: device.deviceTypeIdentifier,
+          runtime: runtimeId,
+          model: device.model,
+          architecture: device.architecture,
+          capabilityInventory: iosSimulatorCapabilityInventory({
+            isAvailable: device.isAvailable,
+            availabilityError: device.availabilityError,
+            runtime: runtimeId,
+          }),
+        } as DeviceInfo);
+      }
+    }
+    devices.sort((a, b) => (a.deviceId || "").localeCompare(b.deviceId || ""));
+    return devices;
+  }
+
+  private async runListSimulatorImages(
+    timeoutMs: number | undefined,
+    options: { bypassCache?: boolean },
+  ): Promise<DeviceInfo[]> {
     logger.debug("Getting list of iOS simulators");
 
     try {
       const simulatorList = await this.listSimulators(timeoutMs);
-      const devices: DeviceInfo[] = [];
-
-      // Extract all devices from all runtime versions
-      for (const [runtimeId, runtimeDevices] of Object.entries(simulatorList.devices)) {
-        for (const device of runtimeDevices) {
-          logger.debug(
-            `Found iOS simulator: ${device.name} (${device.udid}) state=${device.state}`,
-          );
-          const iosVersion = normalizeIosVersion(runtimeId, device.os_version);
-          devices.push({
-            name: device.name,
-            platform: "ios",
-            deviceId: device.udid,
-            isRunning: device.state === "Booted",
-            state: device.state,
-            isAvailable: device.isAvailable,
-            availabilityError: device.availabilityError,
-            iosVersion,
-            osVersion: iosVersion,
-            formFactor: inferIosFormFactor(device.deviceTypeIdentifier),
-            deviceType: device.deviceTypeIdentifier,
-            runtime: runtimeId,
-            model: device.model,
-            architecture: device.architecture,
-            capabilityInventory: iosSimulatorCapabilityInventory({
-              isAvailable: device.isAvailable,
-              availabilityError: device.availabilityError,
-              runtime: runtimeId,
-            }),
-          } as DeviceInfo);
-        }
-      }
-
-      devices.sort((a, b) => (a.deviceId || "").localeCompare(b.deviceId || ""));
+      const devices = SimCtlClient.mapSimulatorListToDeviceInfos(simulatorList);
       if (devices.length > 0) {
-        SimCtlClient.deviceListCache = {
-          devices,
-          timestamp: this.timer.now(),
-        };
-      } else {
+        const timestamp = this.timer.now();
+        // A bypassCache read is a deliberately un-shared, provably-fresh read
+        // (e.g. boot verification via readSimulatorState); populating the TTL
+        // cache from it would let an unrelated cache-eligible caller silently
+        // consume that read instead of making its own, which the boot
+        // verification tests pin as a fixed invocation count.
+        if (!options.bypassCache) {
+          SimCtlClient.deviceListCache = { devices, timestamp };
+          SimCtlClient.lastGoodDeviceList = { devices, timestamp };
+        }
+      } else if (!options.bypassCache) {
         SimCtlClient.deviceListCache = null;
       }
       return devices;
     } catch (error) {
-      SimCtlClient.deviceListCache = null;
+      if (!options.bypassCache) {
+        SimCtlClient.deviceListCache = null;
+      }
       const detail = errorMessage(error);
+
+      // A caller that explicitly requested a fresh read (e.g. boot
+      // verification via readSimulatorState) must never be handed a stale
+      // snapshot in place of the failure it asked to observe. Everyone else
+      // gets the last-good snapshot within its retention window, mirroring
+      // DevicectlDeviceLister.lastGood (issue #6576).
+      const lastGood = SimCtlClient.lastGoodDeviceList;
+      if (
+        !options.bypassCache &&
+        lastGood &&
+        this.timer.now() - lastGood.timestamp < SimCtlClient.LAST_GOOD_DEVICE_LIST_RETENTION_MS
+      ) {
+        logger.warn(
+          `Failed to get iOS devices: ${detail}. Falling back to last-good simulator list (age: ${this.timer.now() - lastGood.timestamp}ms).`,
+        );
+        return lastGood.devices;
+      }
+
       logger.warn(`Failed to get iOS devices: ${detail}`);
       throw new ActionableError(`Failed to list iOS simulator devices: ${detail}`);
     }
@@ -1759,36 +1824,51 @@ export class SimCtlClient implements SimCtl {
    * Like {@link getBootedSimulators} but rethrows discovery failures instead of
    * swallowing them into an empty list. Callers that must distinguish "no
    * simulators are booted" from "simctl discovery failed" should use this.
+   *
+   * Reuses a fresh {@link listSimulatorImages} cache entry instead of spawning
+   * a redundant `simctl list devices` process (issue #6576). On a cold/expired
+   * cache this falls back to calling {@link listSimulators} directly rather
+   * than through `listSimulatorImages`, preserving two contracts existing
+   * callers rely on that the shared listing path does not offer: the raw
+   * discovery error propagates unwrapped (not `listSimulatorImages`'s
+   * `ActionableError`), and `signal` bounds this specific invocation rather
+   * than a request potentially shared with unrelated callers.
    */
   async getBootedSimulatorsChecked(
     timeoutMs?: number,
     signal?: AbortSignal,
   ): Promise<BootedDevice[]> {
-    const simulatorList = await this.listSimulators(timeoutMs, signal);
-    logger.debug(`Found simulator list: ${simulatorList}`);
+    const cached = SimCtlClient.deviceListCache;
+    const devices =
+      cached && this.timer.now() - cached.timestamp < SimCtlClient.DEVICE_LIST_CACHE_TTL
+        ? cached.devices
+        : await this.listDevicesForBootedCheck(timeoutMs, signal);
     const observedAt = this.observationSequence.next();
-    const bootedDevices: BootedDevice[] = [];
 
-    // Extract booted devices from all runtime versions
-    for (const [runtimeId, runtimeDevices] of Object.entries(simulatorList.devices)) {
-      for (const device of runtimeDevices) {
-        if (isDeviceAvailable(device) && device.state === "Booted") {
-          const iosVersion = normalizeIosVersion(runtimeId, device.os_version);
-          bootedDevices.push({
+    return devices
+      .filter((device) => device.isAvailable && device.state === "Booted" && device.deviceId)
+      .map(
+        (device) =>
+          ({
             name: device.name,
             platform: "ios",
-            deviceId: device.udid,
+            deviceId: device.deviceId,
             observedAt,
-            iosVersion,
-            osVersion: iosVersion,
-            formFactor: inferIosFormFactor(device.deviceTypeIdentifier),
-          } as BootedDevice);
-        }
-      }
-    }
+            iosVersion: device.iosVersion,
+            osVersion: device.osVersion,
+            formFactor: device.formFactor,
+          }) as BootedDevice,
+      )
+      .sort((a, b) => a.deviceId.localeCompare(b.deviceId));
+  }
 
-    bootedDevices.sort((a, b) => a.deviceId.localeCompare(b.deviceId));
-    return bootedDevices;
+  /** Cold-cache path for {@link getBootedSimulatorsChecked}: a direct, unshared discovery read. */
+  private async listDevicesForBootedCheck(
+    timeoutMs: number | undefined,
+    signal: AbortSignal | undefined,
+  ): Promise<DeviceInfo[]> {
+    const simulatorList = await this.listSimulators(timeoutMs, signal);
+    return SimCtlClient.mapSimulatorListToDeviceInfos(simulatorList);
   }
 
   /**
@@ -1798,14 +1878,22 @@ export class SimCtlClient implements SimCtl {
    */
   async getDeviceInfo(udid: string): Promise<AppleDevice | null> {
     try {
-      const simulatorList = await this.listSimulators();
-
-      // Search for the device in all runtime versions
-      for (const [runtimeId, runtimeDevices] of Object.entries(simulatorList.devices)) {
-        const device = runtimeDevices.find((d) => d.udid === udid);
-        if (device) {
-          return { ...device, runtime: runtimeId };
-        }
+      // Routes through listSimulatorImages so this shares the cached/coalesced
+      // listing instead of always spawning a fresh `simctl` process (issue #6576).
+      const device = (await this.listSimulatorImages()).find((d) => d.deviceId === udid);
+      if (device) {
+        return {
+          udid: device.deviceId ?? udid,
+          name: device.name,
+          state: device.state ?? "",
+          isAvailable: device.isAvailable ?? false,
+          availabilityError: device.availabilityError,
+          deviceTypeIdentifier: device.deviceType,
+          runtime: device.runtime,
+          model: device.model,
+          os_version: device.osVersion,
+          architecture: device.architecture,
+        };
       }
 
       return null;
@@ -1975,9 +2063,16 @@ export class SimCtlClient implements SimCtl {
     return simulatorUdid;
   }
 
-  /** Drop the shared device-list snapshot so the next list re-reads simctl. */
+  /**
+   * Drop the shared device-list snapshot so the next list re-reads simctl.
+   * Also drops the last-good fallback: a caller invalidating the cache knows
+   * something changed (a device was created/deleted, or a test is resetting
+   * state), so a subsequent transient failure must not resurrect the
+   * pre-invalidation snapshot as if it were still trustworthy (issue #6576).
+   */
   static invalidateDeviceListCache(): void {
     SimCtlClient.deviceListCache = null;
+    SimCtlClient.lastGoodDeviceList = null;
   }
 
   /**

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1193,6 +1193,7 @@ export class SimCtlClient implements SimCtl {
       // Cleanup must not inherit the already-aborted request signal.
       const cleanupSignal = new AbortController().signal;
       await this.executeCommandArgs(["shutdown", udid], 10_000, cleanupSignal);
+      SimCtlClient.invalidateDeviceListCache();
     } catch (error) {
       logger.warn(`[iOS] Failed to shut down simulator ${udid} after unsuccessful start: ${error}`);
     }

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1226,6 +1226,7 @@ export class SimCtlClient implements SimCtl {
         signal,
         true,
       );
+      SimCtlClient.invalidateDeviceListCache();
       lease.state.lastBootSucceeded = false;
       lease.state.ownerToken = undefined;
     } finally {
@@ -1743,30 +1744,31 @@ export class SimCtlClient implements SimCtl {
       return this.runListSimulatorImages(timeoutMs, { bypassCache: true, signal });
     }
 
-    // Concurrent callers racing a cold/expired cache share one `simctl list
-    // devices` invocation rather than each spawning their own process
-    // (issue #6576), mirroring DevicectlDeviceLister.listConnectedDevices().
-    // The shared fetch runs under its OWN ceiling, independent of any single
-    // caller's timeoutMs/signal (see SHARED_DEVICE_LIST_TIMEOUT_MS); each
-    // waiter below races the shared result against its own deadline/signal
-    // instead, so aborting/bounding one waiter can never fail or truncate the
-    // read for a sibling waiter.
+    return this.raceOwnDeadline(this.runListSimulatorImages(undefined, {}), timeoutMs, signal);
+  }
+
+  private sharedDeviceList(): Promise<DeviceInfo[]> {
     if (!SimCtlClient.inFlightDeviceList) {
       const generation = SimCtlClient.deviceListGeneration;
       const flight = runWithAbortSignal(undefined, () =>
-        this.runListSimulatorImages(
-          SimCtlClient.SHARED_DEVICE_LIST_TIMEOUT_MS,
-          { bypassCache: false },
-          generation,
-        ),
-      ).finally(() => {
-        if (SimCtlClient.inFlightDeviceList === flight) {
-          SimCtlClient.inFlightDeviceList = null;
-        }
-      });
+        this.listDevicesForBootedCheck(SimCtlClient.SHARED_DEVICE_LIST_TIMEOUT_MS, undefined),
+      )
+        .then((devices) => {
+          if (SimCtlClient.deviceListGeneration === generation) {
+            const timestamp = this.timer.now();
+            SimCtlClient.deviceListCache = devices.length ? { devices, timestamp } : null;
+            SimCtlClient.lastGoodDeviceList = { devices, timestamp };
+          }
+          return devices;
+        })
+        .finally(() => {
+          if (SimCtlClient.inFlightDeviceList === flight) {
+            SimCtlClient.inFlightDeviceList = null;
+          }
+        });
       SimCtlClient.inFlightDeviceList = flight;
     }
-    return this.raceOwnDeadline(SimCtlClient.inFlightDeviceList, timeoutMs, signal);
+    return SimCtlClient.inFlightDeviceList;
   }
 
   /**
@@ -1862,8 +1864,9 @@ export class SimCtlClient implements SimCtl {
     logger.debug("Getting list of iOS simulators");
 
     try {
-      const simulatorList = await this.listSimulators(timeoutMs, options.signal);
-      const devices = SimCtlClient.mapSimulatorListToDeviceInfos(simulatorList);
+      const devices = options.bypassCache
+        ? await this.listDevicesForBootedCheck(timeoutMs, options.signal)
+        : await this.sharedDeviceList();
       // A create/delete (or explicit invalidation) that landed while this fetch
       // was in flight bumps the generation; a snapshot captured under the OLD
       // generation may already be obsolete, so only a fetch that started under
@@ -1925,14 +1928,9 @@ export class SimCtlClient implements SimCtl {
    * swallowing them into an empty list. Callers that must distinguish "no
    * simulators are booted" from "simctl discovery failed" should use this.
    *
-   * Reuses a fresh {@link listSimulatorImages} cache entry instead of spawning
-   * a redundant `simctl list devices` process (issue #6576). On a cold/expired
-   * cache this falls back to calling {@link listSimulators} directly rather
-   * than through `listSimulatorImages`, preserving two contracts existing
-   * callers rely on that the shared listing path does not offer: the raw
-   * discovery error propagates unwrapped (not `listSimulatorImages`'s
-   * `ActionableError`), and `signal` bounds this specific invocation rather
-   * than a request potentially shared with unrelated callers.
+   * Reuses fresh cached discovery or the shared raw listing. Each waiter retains
+   * its own cancellation/deadline, and checked discovery propagates raw errors
+   * instead of returning the UI listing's last-good fallback.
    */
   async getBootedSimulatorsChecked(
     timeoutMs?: number,
@@ -1950,7 +1948,9 @@ export class SimCtlClient implements SimCtl {
       cached &&
       this.timer.now() - cached.timestamp < SimCtlClient.DEVICE_LIST_CACHE_TTL
         ? cached.devices
-        : await this.listDevicesForBootedCheck(timeoutMs, signal);
+        : options.bypassCache
+          ? await this.listDevicesForBootedCheck(timeoutMs, signal)
+          : await this.raceOwnDeadline(this.sharedDeviceList(), timeoutMs, signal);
     const observedAt = this.observationSequence.next();
 
     return devices
@@ -1970,7 +1970,7 @@ export class SimCtlClient implements SimCtl {
       .sort((a, b) => a.deviceId.localeCompare(b.deviceId));
   }
 
-  /** Cold-cache path for {@link getBootedSimulatorsChecked}: a direct, unshared discovery read. */
+  /** Cold-cache path for {@link getBootedSimulatorsChecked}: the raw discovery primitive. */
   private async listDevicesForBootedCheck(
     timeoutMs: number | undefined,
     signal: AbortSignal | undefined,

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1600,20 +1600,14 @@ export class SimCtlClient implements SimCtl {
    *         directly.
    */
   private async readSimulatorState(udid: string, timeoutMs: number): Promise<string | undefined> {
-    try {
-      // `bypassCache: true` because a failed verification always falls through
-      // to a stale last-good snapshot instead of throwing (issue #6576), which
-      // would defeat the "never trust a stale snapshot" contract this method
-      // promises boot verification.
-      const devices = await this.listSimulatorImages(timeoutMs, { bypassCache: true });
-      return devices.find((device) => device.deviceId === udid)?.state;
-    } catch (error) {
-      logger.warn(
-        `[iOS] Could not read simulator state for ${udid}: ${errorMessage(error)}`,
-        error,
-      );
-      return undefined;
-    }
+    // `bypassCache: true` because a stale cached/last-good snapshot would defeat
+    // the "never trust a stale snapshot" contract this method promises boot
+    // verification (issue #6576); a bypassCache read always throws on discovery
+    // failure rather than falling back, so that failure propagates to
+    // {@link readSimulatorStateRetrying} for its own retry-vs-surface decision
+    // (issue #6411) instead of being swallowed here.
+    const devices = await this.listSimulatorImages(timeoutMs, { bypassCache: true });
+    return devices.find((device) => device.deviceId === udid)?.state;
   }
 
   /**

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1734,7 +1734,16 @@ export class SimCtlClient implements SimCtl {
     // — that request's failure-fallback behavior is not this caller's to
     // inherit. Run it standalone instead of sharing the coalescing slot below.
     if (options.bypassCache) {
-      SimCtlClient.deviceListGeneration++;
+      // Do NOT bump the generation here, before the bypass read has produced
+      // an authoritative result: a shared flight that started earlier and
+      // resolves successfully WHILE this bypass is still in flight must still
+      // be allowed to populate the cache/last-good snapshot. Bumping eagerly
+      // would discard that genuinely successful data solely because an
+      // unrelated, as-yet-unproven bypass happened to overlap it -- including
+      // when the bypass itself goes on to fail (issue #6576 follow-up). Only a
+      // bypass read that ITSELF succeeds is authoritative enough to supersede
+      // a concurrent shared flight, so the generation bump moves to
+      // runListSimulatorImages's success path below.
       SimCtlClient.inFlightDeviceList = null;
       return this.runListSimulatorImages(timeoutMs, { bypassCache: true, signal });
     }
@@ -1851,6 +1860,39 @@ export class SimCtlClient implements SimCtl {
     return devices;
   }
 
+  /**
+   * Write a successful listing to the cache/last-good snapshot. A bypass read
+   * always writes -- it is always the freshest, most authoritative result
+   * available, so there is no earlier-generation snapshot to defer to -- and
+   * bumps the generation AFTER writing (not before starting the read, see
+   * listSimulatorImages) so a concurrent shared flight that resolves
+   * successfully can still populate the cache while the bypass is in flight;
+   * only once this bypass itself succeeds does it supersede that shared
+   * flight for any later resolution (issue #6576 follow-up). A bypass that
+   * throws never reaches this write, so a sibling shared flight's success is
+   * preserved rather than discarded when the bypass fails. A shared (non-
+   * bypass) read only writes if its captured generation is still current: a
+   * create/delete (or explicit invalidation) that landed while it was in
+   * flight bumps the generation, and a snapshot captured under the OLD
+   * generation may already be obsolete, so writing it would resurrect
+   * pre-mutation data right after the mutation invalidated it.
+   */
+  private recordDeviceListSnapshot(
+    devices: DeviceInfo[],
+    options: { bypassCache?: boolean },
+    generation: number,
+  ): void {
+    if (!options.bypassCache && SimCtlClient.deviceListGeneration !== generation) {
+      return;
+    }
+    const timestamp = this.timer.now();
+    SimCtlClient.deviceListCache = devices.length ? { devices, timestamp } : null;
+    SimCtlClient.lastGoodDeviceList = { devices, timestamp };
+    if (options.bypassCache) {
+      SimCtlClient.deviceListGeneration++;
+    }
+  }
+
   private async runListSimulatorImages(
     timeoutMs: number | undefined,
     options: { bypassCache?: boolean; signal?: AbortSignal },
@@ -1862,18 +1904,7 @@ export class SimCtlClient implements SimCtl {
       const devices = options.bypassCache
         ? await this.listDevicesForBootedCheck(timeoutMs, options.signal)
         : await this.sharedDeviceList();
-      // A create/delete (or explicit invalidation) that landed while this fetch
-      // was in flight bumps the generation; a snapshot captured under the OLD
-      // generation may already be obsolete, so only a fetch that started under
-      // the CURRENT generation may populate the cache/last-good snapshot below
-      // (issue #6576) -- otherwise it would resurrect pre-mutation data right
-      // after the mutation invalidated it.
-      const stillCurrent = SimCtlClient.deviceListGeneration === generation;
-      if (stillCurrent) {
-        const timestamp = this.timer.now();
-        SimCtlClient.deviceListCache = devices.length ? { devices, timestamp } : null;
-        SimCtlClient.lastGoodDeviceList = { devices, timestamp };
-      }
+      this.recordDeviceListSnapshot(devices, options, generation);
       return devices;
     } catch (error) {
       options.signal?.throwIfAborted();

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -175,7 +175,7 @@ export interface SimCtl {
    */
   listSimulatorImages(
     timeoutMs?: number,
-    options?: { bypassCache?: boolean },
+    options?: { bypassCache?: boolean; signal?: AbortSignal },
   ): Promise<DeviceInfo[]>;
 
   /**
@@ -581,6 +581,19 @@ export class SimCtlClient implements SimCtl {
   // Concurrent cold/expired-cache callers share one `simctl list devices`
   // invocation rather than each spawning their own process (issue #6576).
   private static inFlightDeviceList: Promise<DeviceInfo[]> | null = null;
+  // Ceiling on the SHARED `simctl list devices` invocation behind
+  // inFlightDeviceList. Deliberately NOT any individual caller's timeoutMs --
+  // that would let one bounded/aborted caller cut the read short (or, before
+  // this fix, extend it) for every other waiter sharing the same promise.
+  // Mirrors DevicectlDeviceLister.DEVICE_LIST_TIMEOUT_MS; each waiter instead
+  // races the shared result against its OWN deadline/signal (issue #6576).
+  private static readonly SHARED_DEVICE_LIST_TIMEOUT_MS = 15_000;
+  // Bumped by invalidateDeviceListCache() (create/delete a simulator, or an
+  // explicit cache reset). A listing started before the bump must not
+  // repopulate the cache/last-good snapshot after it resolves -- that would
+  // resurrect a pre-mutation snapshot the invalidation was meant to discard
+  // (issue #6576).
+  private static deviceListGeneration = 0;
   private static readonly simulatorBoots = new Map<string, SimulatorBootState>();
 
   /**
@@ -1689,8 +1702,13 @@ export class SimCtlClient implements SimCtl {
    */
   async listSimulatorImages(
     timeoutMs?: number,
-    options: { bypassCache?: boolean } = {},
+    options: { bypassCache?: boolean; signal?: AbortSignal } = {},
   ): Promise<DeviceInfo[]> {
+    // An already-aborted caller must fail even on a cache hit below -- a cached
+    // "success" for a request the caller has already given up on is silently
+    // wrong (issue #6576).
+    options.signal?.throwIfAborted();
+
     // Check cache first
     if (!options.bypassCache && SimCtlClient.deviceListCache) {
       const cacheAge = this.timer.now() - SimCtlClient.deviceListCache.timestamp;
@@ -1706,18 +1724,76 @@ export class SimCtlClient implements SimCtl {
     // — that request's failure-fallback behavior is not this caller's to
     // inherit. Run it standalone instead of sharing the coalescing slot below.
     if (options.bypassCache) {
-      return this.runListSimulatorImages(timeoutMs, options);
+      return this.runListSimulatorImages(timeoutMs, { bypassCache: true });
     }
 
     // Concurrent callers racing a cold/expired cache share one `simctl list
     // devices` invocation rather than each spawning their own process
     // (issue #6576), mirroring DevicectlDeviceLister.listConnectedDevices().
-    SimCtlClient.inFlightDeviceList ??= this.runListSimulatorImages(timeoutMs, options).finally(
-      () => {
-        SimCtlClient.inFlightDeviceList = null;
-      },
-    );
-    return SimCtlClient.inFlightDeviceList;
+    // The shared fetch runs under its OWN ceiling, independent of any single
+    // caller's timeoutMs/signal (see SHARED_DEVICE_LIST_TIMEOUT_MS); each
+    // waiter below races the shared result against its own deadline/signal
+    // instead, so aborting/bounding one waiter can never fail or truncate the
+    // read for a sibling waiter.
+    const generation = SimCtlClient.deviceListGeneration;
+    SimCtlClient.inFlightDeviceList ??= this.runListSimulatorImages(
+      SimCtlClient.SHARED_DEVICE_LIST_TIMEOUT_MS,
+      { bypassCache: false },
+      generation,
+    ).finally(() => {
+      SimCtlClient.inFlightDeviceList = null;
+    });
+    return this.raceOwnDeadline(SimCtlClient.inFlightDeviceList, timeoutMs, options.signal);
+  }
+
+  /**
+   * Await a listing shared with other callers (`SimCtlClient.inFlightDeviceList`)
+   * but bound ONLY by THIS caller's own timeout/signal. Losing that race must
+   * not cancel the shared fetch or affect any other waiter racing the same
+   * promise (issue #6576) -- unlike `executeCommandArgv`'s timeout, this never
+   * aborts the underlying process, since other callers may still need it.
+   */
+  private async raceOwnDeadline(
+    shared: Promise<DeviceInfo[]>,
+    timeoutMs: number | undefined,
+    signal: AbortSignal | undefined,
+  ): Promise<DeviceInfo[]> {
+    if (timeoutMs === undefined && !signal) {
+      return shared;
+    }
+
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    let abortListener: (() => void) | undefined;
+    const contenders: Array<Promise<DeviceInfo[]>> = [shared];
+    if (timeoutMs !== undefined) {
+      contenders.push(
+        new Promise<never>((_resolve, reject) => {
+          timeoutHandle = this.timer.setTimeout(() => {
+            reject(new Error(`Timed out waiting for iOS simulator listing after ${timeoutMs}ms`));
+          }, timeoutMs);
+        }),
+      );
+    }
+    if (signal) {
+      contenders.push(
+        new Promise<never>((_resolve, reject) => {
+          abortListener = () =>
+            reject(signal.reason ?? new ActionableError("iOS simulator listing aborted"));
+          signal.addEventListener("abort", abortListener, { once: true });
+        }),
+      );
+    }
+
+    try {
+      return await Promise.race(contenders);
+    } finally {
+      if (timeoutHandle) {
+        this.timer.clearTimeout(timeoutHandle);
+      }
+      if (signal && abortListener) {
+        signal.removeEventListener("abort", abortListener);
+      }
+    }
   }
 
   /** Map a raw `simctl list devices --json` payload into sorted {@link DeviceInfo} records. */
@@ -1757,12 +1833,20 @@ export class SimCtlClient implements SimCtl {
   private async runListSimulatorImages(
     timeoutMs: number | undefined,
     options: { bypassCache?: boolean },
+    generation: number = SimCtlClient.deviceListGeneration,
   ): Promise<DeviceInfo[]> {
     logger.debug("Getting list of iOS simulators");
 
     try {
       const simulatorList = await this.listSimulators(timeoutMs);
       const devices = SimCtlClient.mapSimulatorListToDeviceInfos(simulatorList);
+      // A create/delete (or explicit invalidation) that landed while this fetch
+      // was in flight bumps the generation; a snapshot captured under the OLD
+      // generation may already be obsolete, so only a fetch that started under
+      // the CURRENT generation may populate the cache/last-good snapshot below
+      // (issue #6576) -- otherwise it would resurrect pre-mutation data right
+      // after the mutation invalidated it.
+      const stillCurrent = SimCtlClient.deviceListGeneration === generation;
       if (devices.length > 0) {
         const timestamp = this.timer.now();
         // A bypassCache read is a deliberately un-shared, provably-fresh read
@@ -1770,12 +1854,18 @@ export class SimCtlClient implements SimCtl {
         // cache from it would let an unrelated cache-eligible caller silently
         // consume that read instead of making its own, which the boot
         // verification tests pin as a fixed invocation count.
-        if (!options.bypassCache) {
+        if (!options.bypassCache && stillCurrent) {
           SimCtlClient.deviceListCache = { devices, timestamp };
           SimCtlClient.lastGoodDeviceList = { devices, timestamp };
         }
-      } else if (!options.bypassCache) {
+      } else if (!options.bypassCache && stillCurrent) {
         SimCtlClient.deviceListCache = null;
+        // An authoritative empty listing means no simulators exist right now.
+        // Replace (not merely clear) the last-good snapshot with that same
+        // empty result, so a later failed discovery within the retention
+        // window reports "none" instead of resurrecting devices this read
+        // just proved absent (issue #6576).
+        SimCtlClient.lastGoodDeviceList = { devices: [], timestamp: this.timer.now() };
       }
       return devices;
     } catch (error) {
@@ -1837,10 +1927,17 @@ export class SimCtlClient implements SimCtl {
   async getBootedSimulatorsChecked(
     timeoutMs?: number,
     signal?: AbortSignal,
+    options: { bypassCache?: boolean } = {},
   ): Promise<BootedDevice[]> {
+    // An already-aborted caller must fail even on a cache hit below -- a cached
+    // "success" for a request the caller has already given up on is silently
+    // wrong (issue #6576).
+    signal?.throwIfAborted();
     const cached = SimCtlClient.deviceListCache;
     const devices =
-      cached && this.timer.now() - cached.timestamp < SimCtlClient.DEVICE_LIST_CACHE_TTL
+      !options.bypassCache &&
+      cached &&
+      this.timer.now() - cached.timestamp < SimCtlClient.DEVICE_LIST_CACHE_TTL
         ? cached.devices
         : await this.listDevicesForBootedCheck(timeoutMs, signal);
     const observedAt = this.observationSequence.next();
@@ -1948,6 +2045,12 @@ export class SimCtlClient implements SimCtl {
     // Shares findBootedSimulator with resolveReadySimulator (issue #6412) so
     // this session auto-start path and the explicit startSimulator +
     // waitForSimulatorReady path agree on the same booted device.
+    //
+    // findBootedSimulator always issues its own unshared `simctl list
+    // devices` read (it calls listSimulators() directly, never
+    // listSimulatorImages()'s TTL cache), so it is already immune to the
+    // stale-cache risk bypassCache guards against elsewhere (issue #6576):
+    // there is no cached snapshot here to trust in the first place.
     const device = await this.findBootedSimulator(
       udid,
       this.remainingBootTimeoutMs(udid, deadlineMs),
@@ -2069,10 +2172,15 @@ export class SimCtlClient implements SimCtl {
    * something changed (a device was created/deleted, or a test is resetting
    * state), so a subsequent transient failure must not resurrect the
    * pre-invalidation snapshot as if it were still trustworthy (issue #6576).
+   *
+   * Also bumps `deviceListGeneration` so an in-flight listing that was already
+   * running when this invalidation fires cannot repopulate the cache with the
+   * obsolete snapshot it captured before the mutation (issue #6576).
    */
   static invalidateDeviceListCache(): void {
     SimCtlClient.deviceListCache = null;
     SimCtlClient.lastGoodDeviceList = null;
+    SimCtlClient.deviceListGeneration++;
   }
 
   /**

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -588,12 +588,16 @@ export class SimCtlClient implements SimCtl {
   // Mirrors DevicectlDeviceLister.DEVICE_LIST_TIMEOUT_MS; each waiter instead
   // races the shared result against its OWN deadline/signal (issue #6576).
   private static readonly SHARED_DEVICE_LIST_TIMEOUT_MS = 15_000;
-  // Bumped by invalidateDeviceListCache() (create/delete a simulator, or an
-  // explicit cache reset). A listing started before the bump must not
-  // repopulate the cache/last-good snapshot after it resolves -- that would
-  // resurrect a pre-mutation snapshot the invalidation was meant to discard
-  // (issue #6576).
+  // Invalidation epoch. A listing started in an older epoch must not
+  // repopulate the cache/last-good snapshot after a create/delete/reset.
   private static deviceListGeneration = 0;
+  // Physical listing order is distinct from invalidation. Only successful
+  // reads advance the recorded sequence, so a failed newer refresh does not
+  // discard an older flight's usable result; once a newer read succeeds, an
+  // older completion cannot overwrite it.
+  private static deviceListRequestSequence = 0;
+  private static recordedDeviceListRequestSequence = 0;
+  private static inFlightDeviceListRequestSequence: number | null = null;
   private static readonly simulatorBoots = new Map<string, SimulatorBootState>();
 
   /**
@@ -1734,17 +1738,6 @@ export class SimCtlClient implements SimCtl {
     // — that request's failure-fallback behavior is not this caller's to
     // inherit. Run it standalone instead of sharing the coalescing slot below.
     if (options.bypassCache) {
-      // Do NOT bump the generation here, before the bypass read has produced
-      // an authoritative result: a shared flight that started earlier and
-      // resolves successfully WHILE this bypass is still in flight must still
-      // be allowed to populate the cache/last-good snapshot. Bumping eagerly
-      // would discard that genuinely successful data solely because an
-      // unrelated, as-yet-unproven bypass happened to overlap it -- including
-      // when the bypass itself goes on to fail (issue #6576 follow-up). Only a
-      // bypass read that ITSELF succeeds is authoritative enough to supersede
-      // a concurrent shared flight, so the generation bump moves to
-      // runListSimulatorImages's success path below.
-      SimCtlClient.inFlightDeviceList = null;
       return this.runListSimulatorImages(timeoutMs, { bypassCache: true, signal });
     }
 
@@ -1754,23 +1747,22 @@ export class SimCtlClient implements SimCtl {
   private sharedDeviceList(): Promise<DeviceInfo[]> {
     if (!SimCtlClient.inFlightDeviceList) {
       const generation = SimCtlClient.deviceListGeneration;
+      const requestSequence = ++SimCtlClient.deviceListRequestSequence;
       const flight = runWithAbortSignal(undefined, () =>
         this.listDevicesForBootedCheck(SimCtlClient.SHARED_DEVICE_LIST_TIMEOUT_MS, undefined),
       )
         .then((devices) => {
-          if (SimCtlClient.deviceListGeneration === generation) {
-            const timestamp = this.timer.now();
-            SimCtlClient.deviceListCache = devices.length ? { devices, timestamp } : null;
-            SimCtlClient.lastGoodDeviceList = { devices, timestamp };
-          }
+          this.recordDeviceListSnapshot(devices, generation, requestSequence);
           return devices;
         })
         .finally(() => {
           if (SimCtlClient.inFlightDeviceList === flight) {
             SimCtlClient.inFlightDeviceList = null;
+            SimCtlClient.inFlightDeviceListRequestSequence = null;
           }
         });
       SimCtlClient.inFlightDeviceList = flight;
+      SimCtlClient.inFlightDeviceListRequestSequence = requestSequence;
     }
     return SimCtlClient.inFlightDeviceList;
   }
@@ -1860,57 +1852,51 @@ export class SimCtlClient implements SimCtl {
     return devices;
   }
 
-  /**
-   * Write a successful listing to the cache/last-good snapshot. A bypass read
-   * always writes -- it is always the freshest, most authoritative result
-   * available, so there is no earlier-generation snapshot to defer to -- and
-   * bumps the generation AFTER writing (not before starting the read, see
-   * listSimulatorImages) so a concurrent shared flight that resolves
-   * successfully can still populate the cache while the bypass is in flight;
-   * only once this bypass itself succeeds does it supersede that shared
-   * flight for any later resolution (issue #6576 follow-up). A bypass that
-   * throws never reaches this write, so a sibling shared flight's success is
-   * preserved rather than discarded when the bypass fails. A shared (non-
-   * bypass) read only writes if its captured generation is still current: a
-   * create/delete (or explicit invalidation) that landed while it was in
-   * flight bumps the generation, and a snapshot captured under the OLD
-   * generation may already be obsolete, so writing it would resurrect
-   * pre-mutation data right after the mutation invalidated it.
-   */
+  /** Write a successful physical listing unless invalidation or a newer success superseded it. */
   private recordDeviceListSnapshot(
     devices: DeviceInfo[],
-    options: { bypassCache?: boolean },
     generation: number,
-  ): void {
-    if (!options.bypassCache && SimCtlClient.deviceListGeneration !== generation) {
-      return;
+    requestSequence: number,
+  ): boolean {
+    if (
+      SimCtlClient.deviceListGeneration !== generation ||
+      requestSequence < SimCtlClient.recordedDeviceListRequestSequence
+    ) {
+      return false;
     }
     const timestamp = this.timer.now();
     SimCtlClient.deviceListCache = devices.length ? { devices, timestamp } : null;
     SimCtlClient.lastGoodDeviceList = { devices, timestamp };
-    if (options.bypassCache) {
-      SimCtlClient.deviceListGeneration++;
-    }
+    SimCtlClient.recordedDeviceListRequestSequence = requestSequence;
+    return true;
   }
 
   private async runListSimulatorImages(
     timeoutMs: number | undefined,
     options: { bypassCache?: boolean; signal?: AbortSignal },
-    generation: number = SimCtlClient.deviceListGeneration,
   ): Promise<DeviceInfo[]> {
     logger.debug("Getting list of iOS simulators");
+    const generation = SimCtlClient.deviceListGeneration;
+    const requestSequence = options.bypassCache
+      ? ++SimCtlClient.deviceListRequestSequence
+      : undefined;
 
     try {
       const devices = options.bypassCache
         ? await this.listDevicesForBootedCheck(timeoutMs, options.signal)
         : await this.sharedDeviceList();
-      this.recordDeviceListSnapshot(devices, options, generation);
+      if (
+        requestSequence !== undefined &&
+        this.recordDeviceListSnapshot(devices, generation, requestSequence) &&
+        SimCtlClient.inFlightDeviceListRequestSequence !== null &&
+        SimCtlClient.inFlightDeviceListRequestSequence < requestSequence
+      ) {
+        SimCtlClient.inFlightDeviceList = null;
+        SimCtlClient.inFlightDeviceListRequestSequence = null;
+      }
       return devices;
     } catch (error) {
       options.signal?.throwIfAborted();
-      if (!options.bypassCache && SimCtlClient.deviceListGeneration === generation) {
-        SimCtlClient.deviceListCache = null;
-      }
       const detail = errorMessage(error);
 
       // A caller that explicitly requested a fresh read (e.g. boot
@@ -2218,6 +2204,7 @@ export class SimCtlClient implements SimCtl {
     SimCtlClient.deviceListCache = null;
     SimCtlClient.lastGoodDeviceList = null;
     SimCtlClient.inFlightDeviceList = null;
+    SimCtlClient.inFlightDeviceListRequestSequence = null;
     SimCtlClient.deviceListGeneration++;
   }
 

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -15,8 +15,15 @@ const OTHER_UDID = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
 function resetSimctlState(): void {
   const simctlClass = SimCtlClient as unknown as {
     simulatorBoots: Map<string, unknown>;
+    inFlightDeviceList: Promise<unknown[]> | null;
   };
   simctlClass.simulatorBoots.clear();
+  // Drop any still-pending shared listing a previous test left behind (e.g. one
+  // whose mock only settles on an abort that never fired within that test's own
+  // FakeTimer). Without this a later test's caller-independent coalesced read
+  // (see SimCtlClient.listSimulatorImages, issue #6576) would silently join that
+  // orphaned promise and hang forever awaiting a timer no one is driving.
+  simctlClass.inFlightDeviceList = null;
   SimCtlClient.invalidateDeviceListCache();
 }
 
@@ -900,10 +907,15 @@ describe("SimCtlClient boot self-verification", () => {
 
     harness.timer.advanceTime(100);
 
+    // This caller's own 100ms deadline elapses; it must reject regardless of
+    // the shared `simctl list devices` invocation's own state (issue #6576 --
+    // the shared fetch is intentionally caller-independent, so it is neither
+    // driven nor aborted by any single waiter's deadline; see the coalescing
+    // tests in simctl.test.ts for that contract).
     await expect(readiness).rejects.toThrow(
-      "Command timed out after 100ms: xcrun simctl list devices --json",
+      "Timed out waiting for iOS simulator listing after 100ms",
     );
-    expect(metadataSignal?.aborted).toBe(true);
+    expect(metadataSignal?.aborted).toBe(false);
     await expect(harness.createClient().startSimulator(UDID, 5_000)).resolves.toBeDefined();
     expect(harness.shutdownInvocations()).toBe(0);
   });
@@ -1273,6 +1285,40 @@ describe("SimCtlClient boot self-verification", () => {
       true,
       true,
     ]);
+  });
+
+  test("bootSimulator registration does not trust a stale pre-boot cache entry", async () => {
+    const harness = createHarness({ maxAttempts: 1, retryBackoffMs: 10 });
+
+    // Seed a fresh (within-TTL) cache entry as if an earlier, unrelated caller
+    // listed devices moments before this boot began, while the device was
+    // still Shutdown.
+    (
+      SimCtlClient as unknown as {
+        deviceListCache: { devices: unknown[]; timestamp: number } | null;
+      }
+    ).deviceListCache = {
+      devices: [
+        {
+          name: "iPhone 17",
+          platform: "ios",
+          deviceId: UDID,
+          isRunning: false,
+          state: "Shutdown",
+          isAvailable: true,
+        },
+      ],
+      timestamp: harness.timer.now(),
+    };
+    harness.setStates(["Booted"]);
+
+    // Without the fix, resolveRegisteredBootSimulator's getBootedSimulatorsChecked
+    // would still see the stale "Shutdown" cache entry (well within its TTL) and
+    // falsely report the boot as failed even though bootAndVerify's bypassCache
+    // read just observed "Booted".
+    const device = await harness.timer.resolvePromise(harness.simctl.bootSimulator(UDID));
+
+    expect(device.deviceId).toBe(UDID);
   });
 
   test("waitForSimulatorReady rejects a wedged boot instead of returning a device", async () => {

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -555,9 +555,11 @@ describe("SimCtlClient boot self-verification", () => {
           : createExecResult(JSON.stringify({ devices: {} }), ""),
     );
 
-    await expect(harness.createClient().bootSimulator(UDID)).rejects.toThrow(
+    const client = harness.createClient();
+    await expect(client.bootSimulator(UDID)).rejects.toThrow(
       `Failed to boot iOS simulator ${UDID}`,
     );
+    expect(await client.getBootedSimulatorsChecked()).toEqual([]);
     expect(harness.lifecycleCalls).toEqual(["bootstatus-1", "shutdown"]);
   });
 

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -907,15 +907,10 @@ describe("SimCtlClient boot self-verification", () => {
 
     harness.timer.advanceTime(100);
 
-    // This caller's own 100ms deadline elapses; it must reject regardless of
-    // the shared `simctl list devices` invocation's own state (issue #6576 --
-    // the shared fetch is intentionally caller-independent, so it is neither
-    // driven nor aborted by any single waiter's deadline; see the coalescing
-    // tests in simctl.test.ts for that contract).
-    await expect(readiness).rejects.toThrow(
-      "Timed out waiting for iOS simulator listing after 100ms",
-    );
-    expect(metadataSignal?.aborted).toBe(false);
+    // Authoritative readiness metadata uses a fresh, owned read, so the
+    // caller deadline must stop its discovery process and release the lease.
+    await expect(readiness).rejects.toThrow("Command timed out after 100ms");
+    expect(metadataSignal?.aborted).toBe(true);
     await expect(harness.createClient().startSimulator(UDID, 5_000)).resolves.toBeDefined();
     expect(harness.shutdownInvocations()).toBe(0);
   });

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -3,6 +3,7 @@ import { Simctl } from "../../../src/utils/ios-cmdline-tools/SimCtlClient";
 import { BootedDevice, ExecResult } from "../../../src/models";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { createExecResult } from "../../../src/utils/execResult";
+import { runWithAbortSignal } from "../../../src/utils/AbortContext";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../../../src/utils/deviceTimeouts";
 
@@ -1112,10 +1113,16 @@ describe("Simctl", function () {
       let resolveList!: (payload: string) => void;
       const payload = bootedListPayload("test-ios-device-id");
 
-      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+      mockExecAsync = async (
+        file: string,
+        args: string[],
+        _maxBuffer?: number,
+        signal?: AbortSignal,
+      ): Promise<ExecResult> => {
         if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
           listCalls++;
-          return await new Promise<ExecResult>((resolve) => {
+          return await new Promise<ExecResult>((resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
             resolveList = (stdout: string) => resolve(createExecResult(stdout, ""));
           });
         }
@@ -1125,9 +1132,9 @@ describe("Simctl", function () {
       simctl = new Simctl(null, mockExecAsync);
 
       const controllerA = new AbortController();
-      const callerA = simctl
-        .listSimulatorImages(undefined, { signal: controllerA.signal })
-        .catch((error: unknown) => error);
+      const callerA = runWithAbortSignal(controllerA.signal, () =>
+        simctl.listSimulatorImages(),
+      ).catch((error: unknown) => error);
       const callerB = simctl.listSimulatorImages();
       await waitForCondition(() => resolveList !== undefined, "shared simctl invocation");
       expect(listCalls).toBe(1);
@@ -1143,6 +1150,103 @@ describe("Simctl", function () {
       const callerBDevices = await callerB;
       expect(callerBDevices.map((device) => device.deviceId)).toEqual(["test-ios-device-id"]);
       expect(listCalls).toBe(1);
+    });
+
+    test.each([false, true])(
+      "invalidated flights cannot disturb replacement (old failure: %s)",
+      async function (failOld) {
+        const requests: Array<{
+          resolve: (value: ExecResult) => void;
+          reject: (error: Error) => void;
+        }> = [];
+        mockExecAsync = async (_file, args) => {
+          if (args.join(" ") !== "simctl list devices --json") {
+            return createExecResult("", "");
+          }
+          return new Promise<ExecResult>((resolve, reject) => {
+            requests.push({ resolve, reject });
+          });
+        };
+        simctl = new Simctl(null, mockExecAsync, new FakeTimer());
+        const old = simctl.listSimulatorImages().catch(() => []);
+        await waitForCondition(() => requests.length === 1, "old listing");
+        Simctl.invalidateDeviceListCache();
+        const fresh = simctl.listSimulatorImages();
+        await waitForCondition(() => requests.length === 2, "new listing");
+        if (failOld) {
+          requests[1].resolve(createExecResult(bootedListPayload("new"), ""));
+          await fresh;
+          requests[0].reject(new Error("obsolete failure"));
+          await old;
+        } else {
+          requests[0].resolve(createExecResult(bootedListPayload("old"), ""));
+          await old;
+          const joined = simctl.listSimulatorImages();
+          requests[1].resolve(createExecResult(bootedListPayload("new"), ""));
+          await joined;
+        }
+        expect((await simctl.listSimulatorImages())[0].deviceId).toBe("new");
+        expect(requests).toHaveLength(2);
+      },
+    );
+
+    test.each([false, true])(
+      "bypass refresh supersedes older snapshots (empty: %s)",
+      async function (empty) {
+        const timer = new FakeTimer();
+        let calls = 0;
+        let oldResolve!: (value: ExecResult) => void;
+        mockExecAsync = async (_file, args) => {
+          if (args.join(" ") !== "simctl list devices --json") {
+            return createExecResult("", "");
+          }
+          calls++;
+          if (calls === 1) {
+            return new Promise<ExecResult>((resolve) => {
+              oldResolve = resolve;
+            });
+          }
+          if (calls === 2) {
+            return createExecResult(
+              empty ? simulatorListPayload([]) : bootedListPayload("new"),
+              "",
+            );
+          }
+          throw new Error("transient failure");
+        };
+        simctl = new Simctl(null, mockExecAsync, timer);
+        const old = simctl.listSimulatorImages();
+        await waitForCondition(() => oldResolve !== undefined, "old listing");
+        const fresh = await simctl.listSimulatorImages(undefined, { bypassCache: true });
+        oldResolve(createExecResult(bootedListPayload("old"), ""));
+        await old;
+        timer.advanceTime(6000);
+        expect(await simctl.listSimulatorImages()).toEqual(fresh);
+        expect(fresh.map((device) => device.deviceId)).toEqual(empty ? [] : ["new"]);
+      },
+    );
+
+    test("an explicit bypass signal cancels the underlying discovery", async function () {
+      let captured: AbortSignal | undefined;
+      mockExecAsync = async (_file, args, _maxBuffer, signal) => {
+        if (args.join(" ") !== "simctl list devices --json") {
+          return createExecResult("", "");
+        }
+        captured = signal;
+        return new Promise<ExecResult>((_resolve, reject) =>
+          signal?.addEventListener("abort", () => reject(signal.reason), { once: true }),
+        );
+      };
+      simctl = new Simctl(null, mockExecAsync, new FakeTimer());
+      const controller = new AbortController();
+      const result = simctl
+        .listSimulatorImages(undefined, { bypassCache: true, signal: controller.signal })
+        .catch((error: unknown) => error);
+      await waitForCondition(() => captured !== undefined, "bypass discovery");
+      const reason = new Error("bypass cancelled");
+      controller.abort(reason);
+      expect(await result).toBe(reason);
+      expect(captured?.aborted).toBe(true);
     });
 
     test("getBootedSimulatorsChecked throws on an already-aborted signal even on a fresh cache hit", async function () {

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -906,15 +906,52 @@ describe("Simctl", function () {
       simctl = new Simctl(null, mockExecAsync);
 
       const first = simctl.listSimulatorImages();
-      const second = simctl.listSimulatorImages();
+      const second = simctl.getBootedSimulatorsChecked();
+      const third = simctl.getBootedSimulatorsChecked();
 
       await waitForCondition(() => resolveList !== undefined, "simctl list invocation");
       resolveList(payload);
 
-      const [firstDevices, secondDevices] = await Promise.all([first, second]);
+      const [firstDevices, secondDevices] = await Promise.all([first, second, third]);
       expect(listCalls).toBe(1);
       expect(firstDevices.map((device) => device.deviceId)).toEqual(["test-ios-device-id"]);
       expect(secondDevices.map((device) => device.deviceId)).toEqual(["test-ios-device-id"]);
+    });
+
+    test("successful shutdown invalidates the cached boot state", async function () {
+      const timer = new FakeTimer();
+      let running = true;
+      let reads = 0;
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          reads++;
+          return createExecResult(
+            simulatorListPayload([
+              {
+                udid: "test-ios-device-id",
+                name: "iPhone 17",
+                state: running ? "Booted" : "Shutdown",
+                isAvailable: true,
+              },
+            ]),
+            "",
+          );
+        }
+        if (args.includes("shutdown")) {
+          running = false;
+        }
+        return createExecResult("", "");
+      };
+      simctl = new Simctl(null, mockExecAsync, timer);
+      expect(await simctl.getBootedSimulatorsChecked()).toHaveLength(1);
+      await simctl.killSimulator({
+        deviceId: "test-ios-device-id",
+        platform: "ios",
+        name: "iPhone 17",
+      });
+      expect(await simctl.getBootedSimulatorsChecked()).toEqual([]);
+      expect(reads).toBe(2);
+      expect(timer.now()).toBe(0);
     });
 
     test("getBootedSimulatorsChecked reuses a fresh listSimulatorImages cache within the TTL", async function () {

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -12,11 +12,13 @@ function resetSimctlCaches(): void {
     deviceListCache: { devices: unknown[]; timestamp: number } | null;
     lastGoodDeviceList: { devices: unknown[]; timestamp: number } | null;
     inFlightDeviceList: Promise<unknown[]> | null;
+    inFlightDeviceListRequestSequence: number | null;
     simulatorBoots: Map<string, unknown>;
   };
   simctlClass.deviceListCache = null;
   simctlClass.lastGoodDeviceList = null;
   simctlClass.inFlightDeviceList = null;
+  simctlClass.inFlightDeviceListRequestSequence = null;
   simctlClass.simulatorBoots.clear();
 }
 
@@ -1262,6 +1264,100 @@ describe("Simctl", function () {
         expect(fresh.map((device) => device.deviceId)).toEqual(empty ? [] : ["new"]);
       },
     );
+
+    test.each([
+      ["bypass", { bypassCache: true }],
+      ["shared", {}],
+    ] as const)(
+      "an earlier bypass cannot overwrite a later %s listing",
+      async function (_laterKind, laterOptions) {
+        const timer = new FakeTimer();
+        const requests: Array<{
+          resolve: (value: ExecResult) => void;
+        }> = [];
+        let calls = 0;
+        mockExecAsync = async (_file, args) => {
+          if (args.join(" ") !== "simctl list devices --json") {
+            return createExecResult("", "");
+          }
+          calls++;
+          if (calls <= 2) {
+            return new Promise<ExecResult>((resolve) => {
+              requests.push({ resolve });
+            });
+          }
+          throw new Error("simctl list devices exploded");
+        };
+        simctl = new Simctl(null, mockExecAsync, timer);
+
+        const older = simctl.listSimulatorImages(undefined, { bypassCache: true });
+        await waitForCondition(() => requests.length === 1, "older bypass listing");
+        const newer = simctl.listSimulatorImages(undefined, laterOptions);
+        await waitForCondition(() => requests.length === 2, "newer listing");
+
+        requests[1].resolve(createExecResult(bootedListPayload("newer"), ""));
+        await expect(newer).resolves.toHaveLength(1);
+        requests[0].resolve(createExecResult(bootedListPayload("older"), ""));
+        await expect(older).resolves.toHaveLength(1);
+
+        timer.advanceTime(6000);
+        const fallback = await simctl.listSimulatorImages();
+        expect(calls).toBe(3);
+        expect(fallback.map((device) => device.deviceId)).toEqual(["newer"]);
+      },
+    );
+
+    test("a bypass does not evict the shared coalescing slot", async function () {
+      const requests: Array<{ resolve: (value: ExecResult) => void }> = [];
+      mockExecAsync = async (_file, args) => {
+        if (args.join(" ") !== "simctl list devices --json") {
+          return createExecResult("", "");
+        }
+        return new Promise<ExecResult>((resolve) => {
+          requests.push({ resolve });
+        });
+      };
+      simctl = new Simctl(null, mockExecAsync, new FakeTimer());
+
+      const firstShared = simctl.listSimulatorImages();
+      const bypass = simctl.listSimulatorImages(undefined, { bypassCache: true });
+      const secondShared = simctl.listSimulatorImages();
+      const requestCount = requests.length;
+      for (const [index, request] of requests.entries()) {
+        request.resolve(createExecResult(bootedListPayload(`device-${index}`), ""));
+      }
+      await Promise.all([firstShared, bypass, secondShared]);
+
+      expect(requestCount).toBe(2);
+    });
+
+    test("a bypass started before invalidation cannot repopulate the cache", async function () {
+      let calls = 0;
+      let resolveBypass!: (value: ExecResult) => void;
+      mockExecAsync = async (_file, args) => {
+        if (args.join(" ") !== "simctl list devices --json") {
+          return createExecResult("", "");
+        }
+        calls++;
+        if (calls === 1) {
+          return new Promise<ExecResult>((resolve) => {
+            resolveBypass = resolve;
+          });
+        }
+        return createExecResult(bootedListPayload("post-invalidation"), "");
+      };
+      simctl = new Simctl(null, mockExecAsync, new FakeTimer());
+
+      const stale = simctl.listSimulatorImages(undefined, { bypassCache: true });
+      await waitForCondition(() => resolveBypass !== undefined, "pre-invalidation bypass listing");
+      Simctl.invalidateDeviceListCache();
+      resolveBypass(createExecResult(bootedListPayload("pre-invalidation"), ""));
+      await expect(stale).resolves.toHaveLength(1);
+
+      const current = await simctl.listSimulatorImages();
+      expect(calls).toBe(2);
+      expect(current.map((device) => device.deviceId)).toEqual(["post-invalidation"]);
+    });
 
     test("a failed bypass refresh must not discard a shared flight that succeeded with newer data", async function () {
       const timer = new FakeTimer();

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -1263,6 +1263,61 @@ describe("Simctl", function () {
       },
     );
 
+    test("a failed bypass refresh must not discard a shared flight that succeeded with newer data", async function () {
+      const timer = new FakeTimer();
+      let calls = 0;
+      let sharedResolve!: (value: ExecResult) => void;
+      let bypassReject!: (error: Error) => void;
+      mockExecAsync = async (_file, args) => {
+        if (args.join(" ") !== "simctl list devices --json") {
+          return createExecResult("", "");
+        }
+        calls++;
+        if (calls === 1) {
+          // The ordinary shared flight -- left pending so the bypass below can
+          // start concurrently.
+          return new Promise<ExecResult>((resolve) => {
+            sharedResolve = resolve;
+          });
+        }
+        if (calls === 2) {
+          // The bypass refresh -- also left pending so it can be failed AFTER
+          // the shared flight above has already resolved successfully.
+          return new Promise<ExecResult>((_resolve, reject) => {
+            bypassReject = reject;
+          });
+        }
+        throw new Error("simctl list devices exploded");
+      };
+      simctl = new Simctl(null, mockExecAsync, timer);
+
+      const shared = simctl.listSimulatorImages();
+      await waitForCondition(() => sharedResolve !== undefined, "shared listing");
+      const bypass = simctl
+        .listSimulatorImages(undefined, { bypassCache: true })
+        .catch((error: unknown) => error);
+      await waitForCondition(() => bypassReject !== undefined, "bypass listing");
+
+      // The shared flight succeeds with genuinely newer data while the bypass
+      // is still in flight.
+      sharedResolve(createExecResult(bootedListPayload("newer"), ""));
+      await expect(shared).resolves.toHaveLength(1);
+
+      // The bypass then fails -- it never produced an authoritative result, so
+      // it must not have superseded the shared flight's successful snapshot.
+      bypassReject(new Error("bypass discovery failed"));
+      expect(await bypass).toBeInstanceOf(Error);
+
+      // Expire the TTL cache so the next call re-invokes simctl and fails,
+      // forcing a fallback to the last-good snapshot -- which must be the
+      // shared flight's successful "newer" data, not stale/missing data
+      // discarded because of the bypass's failed attempt.
+      timer.advanceTime(6000);
+      const fallback = await simctl.listSimulatorImages();
+      expect(calls).toBe(3);
+      expect(fallback.map((device) => device.deviceId)).toEqual(["newer"]);
+    });
+
     test("an explicit bypass signal cancels the underlying discovery", async function () {
       let captured: AbortSignal | undefined;
       mockExecAsync = async (_file, args, _maxBuffer, signal) => {

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -9,9 +9,13 @@ import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../../../src/utils/deviceTimeou
 function resetSimctlCaches(): void {
   const simctlClass = Simctl as unknown as {
     deviceListCache: { devices: unknown[]; timestamp: number } | null;
+    lastGoodDeviceList: { devices: unknown[]; timestamp: number } | null;
+    inFlightDeviceList: Promise<unknown[]> | null;
     simulatorBoots: Map<string, unknown>;
   };
   simctlClass.deviceListCache = null;
+  simctlClass.lastGoodDeviceList = null;
+  simctlClass.inFlightDeviceList = null;
   simctlClass.simulatorBoots.clear();
 }
 
@@ -879,6 +883,93 @@ describe("Simctl", function () {
       expect(unavailable?.availabilityError).toBe("runtime missing");
       expect(unavailable?.runtime).toBe("com.apple.CoreSimulator.SimRuntime.iOS-17-4");
       expect(unavailable?.iosVersion).toBe("17.4");
+    });
+
+    test("coalesces concurrent calls with a cold cache onto one simctl invocation", async function () {
+      let listCalls = 0;
+      let resolveList!: (payload: string) => void;
+      const payload = simulatorListPayload([
+        { udid: "test-ios-device-id", name: "iPhone 17", state: "Booted", isAvailable: true },
+      ]);
+
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          listCalls++;
+          return await new Promise<ExecResult>((resolve) => {
+            resolveList = (stdout: string) => resolve(createExecResult(stdout, ""));
+          });
+        }
+        return createExecResult("", "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync);
+
+      const first = simctl.listSimulatorImages();
+      const second = simctl.listSimulatorImages();
+
+      await waitForCondition(() => resolveList !== undefined, "simctl list invocation");
+      resolveList(payload);
+
+      const [firstDevices, secondDevices] = await Promise.all([first, second]);
+      expect(listCalls).toBe(1);
+      expect(firstDevices.map((device) => device.deviceId)).toEqual(["test-ios-device-id"]);
+      expect(secondDevices.map((device) => device.deviceId)).toEqual(["test-ios-device-id"]);
+    });
+
+    test("getBootedSimulatorsChecked reuses a fresh listSimulatorImages cache within the TTL", async function () {
+      const timer = new FakeTimer();
+      let listCalls = 0;
+      const payload = simulatorListPayload([
+        { udid: "test-ios-device-id", name: "iPhone 17", state: "Booted", isAvailable: true },
+      ]);
+
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          listCalls++;
+          return createExecResult(payload, "");
+        }
+        return createExecResult("", "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync, timer);
+
+      await simctl.listSimulatorImages();
+      expect(listCalls).toBe(1);
+
+      const booted = await simctl.getBootedSimulatorsChecked();
+      expect(listCalls).toBe(1);
+      expect(booted.map((device) => device.deviceId)).toEqual(["test-ios-device-id"]);
+    });
+
+    test("returns the last-good device list instead of throwing on a transient discovery failure", async function () {
+      const timer = new FakeTimer();
+      let listCalls = 0;
+      const payload = simulatorListPayload([
+        { udid: "test-ios-device-id", name: "iPhone 17", state: "Booted", isAvailable: true },
+      ]);
+
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          listCalls++;
+          if (listCalls === 2) {
+            throw new Error("simctl list devices exploded");
+          }
+          return createExecResult(payload, "");
+        }
+        return createExecResult("", "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync, timer);
+
+      const firstDevices = await simctl.listSimulatorImages();
+      expect(firstDevices.map((device) => device.deviceId)).toEqual(["test-ios-device-id"]);
+
+      // Expire the TTL cache so the next call re-invokes simctl, which fails.
+      timer.advanceTime(6_000);
+
+      const fallbackDevices = await simctl.listSimulatorImages();
+      expect(listCalls).toBe(2);
+      expect(fallbackDevices.map((device) => device.deviceId)).toEqual(["test-ios-device-id"]);
     });
   });
 

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -971,6 +971,201 @@ describe("Simctl", function () {
       expect(listCalls).toBe(2);
       expect(fallbackDevices.map((device) => device.deviceId)).toEqual(["test-ios-device-id"]);
     });
+
+    test("an authoritative empty listing also clears the last-good snapshot", async function () {
+      const timer = new FakeTimer();
+      let listCalls = 0;
+      const withDevice = simulatorListPayload([
+        { udid: "test-ios-device-id", name: "iPhone 17", state: "Booted", isAvailable: true },
+      ]);
+      const empty = simulatorListPayload([]);
+
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          listCalls++;
+          if (listCalls === 1) {
+            return createExecResult(withDevice, "");
+          }
+          if (listCalls === 2) {
+            return createExecResult(empty, "");
+          }
+          throw new Error("simctl list devices exploded");
+        }
+        return createExecResult("", "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync, timer);
+
+      expect(await simctl.listSimulatorImages()).toHaveLength(1);
+
+      // Expire the TTL cache so the next call re-invokes simctl with an
+      // authoritative empty result.
+      timer.advanceTime(6_000);
+      expect(await simctl.listSimulatorImages()).toEqual([]);
+
+      // Expire the TTL cache again so the third call fails and falls back to
+      // the last-good snapshot -- which must now be empty, not the stale
+      // one-device snapshot from before the authoritative empty listing.
+      timer.advanceTime(6_000);
+      const fallbackDevices = await simctl.listSimulatorImages();
+      expect(listCalls).toBe(3);
+      expect(fallbackDevices).toEqual([]);
+    });
+
+    test("an in-flight listing started before an invalidation must not repopulate the cache", async function () {
+      let listCalls = 0;
+      let resolveList!: (payload: string) => void;
+      const payload = bootedListPayload("test-ios-device-id");
+
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          listCalls++;
+          return await new Promise<ExecResult>((resolve) => {
+            resolveList = (stdout: string) => resolve(createExecResult(stdout, ""));
+          });
+        }
+        return createExecResult("", "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync);
+
+      const inFlight = simctl.listSimulatorImages();
+      await waitForCondition(() => resolveList !== undefined, "in-flight simctl listing");
+
+      // A create/delete (or an explicit reset) invalidates the cache while the
+      // above listing -- captured under the OLD generation -- is still pending.
+      Simctl.invalidateDeviceListCache();
+      resolveList(payload);
+
+      await expect(inFlight).resolves.toHaveLength(1);
+      expect(listCalls).toBe(1);
+
+      const simctlClass = Simctl as unknown as {
+        deviceListCache: { devices: unknown[]; timestamp: number } | null;
+        lastGoodDeviceList: { devices: unknown[]; timestamp: number } | null;
+      };
+      expect(simctlClass.deviceListCache).toBeNull();
+      expect(simctlClass.lastGoodDeviceList).toBeNull();
+
+      // The stale-generation resolution must not have satisfied the cache: the
+      // next call re-invokes simctl instead of trusting a phantom cache entry.
+      let resolveNext!: (payload: string) => void;
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          listCalls++;
+          return await new Promise<ExecResult>((resolve) => {
+            resolveNext = (stdout: string) => resolve(createExecResult(stdout, ""));
+          });
+        }
+        return createExecResult("", "");
+      };
+      simctl = new Simctl(null, mockExecAsync);
+      const next = simctl.listSimulatorImages();
+      await waitForCondition(() => resolveNext !== undefined, "post-invalidation simctl listing");
+      resolveNext(payload);
+      await expect(next).resolves.toHaveLength(1);
+      expect(listCalls).toBe(2);
+    });
+
+    test("coalesces concurrent callers but bounds each to its own deadline", async function () {
+      let listCalls = 0;
+      let resolveList!: (payload: string) => void;
+      const payload = bootedListPayload("test-ios-device-id");
+
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          listCalls++;
+          return await new Promise<ExecResult>((resolve) => {
+            resolveList = (stdout: string) => resolve(createExecResult(stdout, ""));
+          });
+        }
+        return createExecResult("", "");
+      };
+
+      const timer = new FakeTimer();
+      simctl = new Simctl(null, mockExecAsync, timer);
+
+      // Caller A is unbounded; caller B bounds itself to 100ms. Both must
+      // collapse onto the same shared `simctl list devices` invocation.
+      const callerA = simctl.listSimulatorImages();
+      const callerB = simctl.listSimulatorImages(100).catch((error: unknown) => error);
+      await waitForCondition(() => resolveList !== undefined, "shared simctl invocation");
+      expect(listCalls).toBe(1);
+
+      // Caller B's own deadline elapses while the shared fetch is still
+      // pending; this must reject ONLY caller B, not the shared fetch.
+      timer.advanceTime(100);
+      const callerBOutcome = await callerB;
+      expect(callerBOutcome).toBeInstanceOf(Error);
+      expect((callerBOutcome as Error).message).toContain("Timed out waiting for iOS simulator");
+
+      // The shared fetch is unaffected by caller B's timeout: resolving it now
+      // still satisfies caller A.
+      resolveList(payload);
+      const callerADevices = await callerA;
+      expect(callerADevices.map((device) => device.deviceId)).toEqual(["test-ios-device-id"]);
+      expect(listCalls).toBe(1);
+    });
+
+    test("aborting one coalesced caller does not reject the others", async function () {
+      let listCalls = 0;
+      let resolveList!: (payload: string) => void;
+      const payload = bootedListPayload("test-ios-device-id");
+
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          listCalls++;
+          return await new Promise<ExecResult>((resolve) => {
+            resolveList = (stdout: string) => resolve(createExecResult(stdout, ""));
+          });
+        }
+        return createExecResult("", "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync);
+
+      const controllerA = new AbortController();
+      const callerA = simctl
+        .listSimulatorImages(undefined, { signal: controllerA.signal })
+        .catch((error: unknown) => error);
+      const callerB = simctl.listSimulatorImages();
+      await waitForCondition(() => resolveList !== undefined, "shared simctl invocation");
+      expect(listCalls).toBe(1);
+
+      controllerA.abort(new Error("caller A cancelled"));
+      const callerAOutcome = await callerA;
+      expect(callerAOutcome).toBeInstanceOf(Error);
+      expect((callerAOutcome as Error).message).toBe("caller A cancelled");
+
+      // Caller B must still resolve from the shared fetch, unaffected by A's
+      // abort.
+      resolveList(payload);
+      const callerBDevices = await callerB;
+      expect(callerBDevices.map((device) => device.deviceId)).toEqual(["test-ios-device-id"]);
+      expect(listCalls).toBe(1);
+    });
+
+    test("getBootedSimulatorsChecked throws on an already-aborted signal even on a fresh cache hit", async function () {
+      const payload = bootedListPayload("test-ios-device-id");
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          return createExecResult(payload, "");
+        }
+        return createExecResult("", "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync);
+
+      // Populate a fresh (within-TTL) cache entry.
+      expect(await simctl.listSimulatorImages()).toHaveLength(1);
+
+      const controller = new AbortController();
+      controller.abort(new Error("caller aborted"));
+
+      await expect(simctl.getBootedSimulatorsChecked(undefined, controller.signal)).rejects.toThrow(
+        "caller aborted",
+      );
+    });
   });
 
   describe("getRuntimes uses dedicated simctl command", function () {


### PR DESCRIPTION
## Summary

listSimulatorImages now shares one in-flight simctl list-devices invocation across concurrent cold/expired-cache callers, and readSimulatorState/getBootedSimulatorsChecked/getDeviceInfo route through the cached/coalesced listing rather than each spawning a fresh process (mirroring DevicectlDeviceLister). On a transient discovery failure it falls back to a 60s last-known-good snapshot instead of nulling the cache and throwing, except the deliberately-fresh bypassCache boot-verification path which still fails closed. invalidateDeviceListCache now also clears the last-good snapshot so a create/delete simulator cannot resurrect stale data on a later failure.

Part of epic #6372.

## Linked Issue

Closes #6576

## Validation

3 new tests in simctl.test.ts: two concurrent cold-cache listSimulatorImages calls collapse to one simctl list-devices; a fresh getBootedSimulatorsChecked reuses the TTL cache with no second invocation; a transient failure after a prior success returns the last-good list instead of throwing. All red pre-fix, green after. Targeted iOS suites 668/668 pass; full-suite failures are the pre-existing worktree unix-socket artifacts, unrelated.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
