### PR TITLE
fix(ios): bound shutdownSimulatorCoordinated's boot-lease wait with its own deadline (#6577)

### DIFF
--- a/src/utils/deviceTimeouts.ts
+++ b/src/utils/deviceTimeouts.ts
@@ -18,3 +18,9 @@ export const MAX_DEVICE_READY_TIMEOUT_MS =
 // budget so a failed newly-created device can report verified rollback status.
 export const MAX_PROVISION_DEVICE_TIMEOUT_MS =
   MAX_DEVICE_READY_TIMEOUT_MS - DEFAULT_DEVICE_TEARDOWN_TIMEOUT_MS;
+// A coordinated shutdown must queue behind an in-flight boot without consuming
+// the shutdown command's own timeout budget (see SimCtlClient.shutdownSimulatorCoordinated),
+// but the queue wait still needs its own ceiling so a caller with no ambient
+// abort signal (CI boot recovery, boot-handle cleanup) can't block forever on a
+// wedged boot. Bound it by the same allowance a boot itself is granted.
+export const SIMULATOR_SHUTDOWN_LEASE_WAIT_TIMEOUT_MS = DEFAULT_DEVICE_READY_TIMEOUT_MS;

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1098,7 +1098,7 @@ export class SimCtlClient implements SimCtl {
       };
     } finally {
       abandoned = !acquired;
-      if (abandoned && acquiredRelease) {
+      if (acquiredRelease) {
         const release = acquiredRelease;
         acquiredRelease = undefined;
         this.releaseSimulatorBoot(udid, state, release);

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -17,7 +17,10 @@ import {
   type DiscoveryObservationSequence,
 } from "../DiscoveryObservationSequence";
 import { createGlobalPerformanceTracker } from "../PerformanceTracker";
-import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../deviceTimeouts";
+import {
+  DEFAULT_DEVICE_READY_TIMEOUT_MS,
+  SIMULATOR_SHUTDOWN_LEASE_WAIT_TIMEOUT_MS,
+} from "../deviceTimeouts";
 import { PlistClient, type PlistReader } from "./PlistClient";
 import { inferIosFormFactor, isIosSimulatorUdid } from "./iosDeviceType";
 import { getAbortSignal } from "../AbortContext";
@@ -1133,9 +1136,13 @@ export class SimCtlClient implements SimCtl {
     expectedOwnerToken?: object,
   ): Promise<void> {
     // Waiting for an active boot must not consume the shutdown command's own
-    // timeout. The caller's abort signal bounds the queue wait; once acquired,
-    // simctl shutdown receives the complete timeout budget.
-    const lease = await this.acquireSimulatorBoot(udid, undefined, signal);
+    // timeout, so the queue wait gets its own dedicated deadline instead of
+    // `timeoutMs`. That deadline is still a hard ceiling, independent of
+    // `signal`: callers with no ambient abort signal (CI boot recovery, a boot
+    // handle's cleanup) must not queue forever behind a wedged boot (issue #6577).
+    // Once the lease is acquired, simctl shutdown receives the complete timeoutMs budget.
+    const leaseDeadlineMs = this.timer.now() + SIMULATOR_SHUTDOWN_LEASE_WAIT_TIMEOUT_MS;
+    const lease = await this.acquireSimulatorBoot(udid, leaseDeadlineMs, signal);
     try {
       if (
         expectedOwnerToken !== undefined &&

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1037,9 +1037,10 @@ export class SimCtlClient implements SimCtl {
     udid: string,
     deadlineMs: number | undefined,
     signal: AbortSignal | undefined,
+    operation: "start" | "shut down" = "start",
   ): Promise<SimulatorBootLease> {
     if (signal?.aborted) {
-      throw signal.reason ?? new ActionableError(`iOS simulator start aborted for ${udid}`);
+      throw signal.reason ?? new ActionableError(`iOS simulator ${operation} aborted for ${udid}`);
     }
 
     let state = SimCtlClient.simulatorBoots.get(udid);
@@ -1067,7 +1068,7 @@ export class SimCtlClient implements SimCtl {
       contenders.push(
         new Promise<never>((_resolve, reject) => {
           timeoutHandle = this.timer.setTimeout(
-            () => reject(new Error(`Timed out waiting to start iOS simulator ${udid}`)),
+            () => reject(new Error(`Timed out waiting to ${operation} iOS simulator ${udid}`)),
             remainingMs,
           );
         }),
@@ -1077,7 +1078,10 @@ export class SimCtlClient implements SimCtl {
       contenders.push(
         new Promise<never>((_resolve, reject) => {
           abortListener = () =>
-            reject(signal.reason ?? new ActionableError(`iOS simulator start aborted for ${udid}`));
+            reject(
+              signal.reason ??
+                new ActionableError(`iOS simulator ${operation} aborted for ${udid}`),
+            );
           signal.addEventListener("abort", abortListener, { once: true });
         }),
       );
@@ -1142,7 +1146,7 @@ export class SimCtlClient implements SimCtl {
     // handle's cleanup) must not queue forever behind a wedged boot (issue #6577).
     // Once the lease is acquired, simctl shutdown receives the complete timeoutMs budget.
     const leaseDeadlineMs = this.timer.now() + SIMULATOR_SHUTDOWN_LEASE_WAIT_TIMEOUT_MS;
-    const lease = await this.acquireSimulatorBoot(udid, leaseDeadlineMs, signal);
+    const lease = await this.acquireSimulatorBoot(udid, leaseDeadlineMs, signal, "shut down");
     try {
       if (
         expectedOwnerToken !== undefined &&

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -884,7 +884,13 @@ describe("SimCtlClient boot self-verification", () => {
     // Simulate a wedged boot: readiness never resolves, so the boot lease is
     // held indefinitely. killSimulator (via deviceBootRecovery / handle.kill())
     // is called with no ambient abort signal (no getAbortSignal() in scope).
-    const harness = createConcurrentStartHarness(() => new Promise(() => undefined));
+    let releaseBoot!: () => void;
+    const harness = createConcurrentStartHarness(
+      () =>
+        new Promise((resolve) => {
+          releaseBoot = () => resolve(createExecResult("", ""));
+        }),
+    );
     // A huge readiness timeout keeps the boot's own internal bootstatus exec
     // timeout from firing within this test's assertion window, isolating the
     // boot-lease wait's own deadline as the only thing that can settle `kill`.
@@ -901,9 +907,20 @@ describe("SimCtlClient boot self-verification", () => {
 
     const killResult = await kill;
     expect(killResult).toBeInstanceOf(Error);
+    expect((killResult as Error).message).toBe(
+      `Timed out waiting to shut down iOS simulator ${UDID}`,
+    );
     expect(harness.shutdownInvocations()).toBe(0);
 
-    void readiness.catch(() => undefined);
+    releaseBoot();
+    await readiness;
+    await drainMicrotasks();
+    expect(harness.shutdownInvocations()).toBe(0);
+    await harness
+      .createClient()
+      .killSimulator({ name: "iPhone 17", platform: "ios", deviceId: UDID });
+    expect(harness.shutdownInvocations()).toBe(1);
+    expect(harness.timer.getPendingTimeoutCount()).toBe(0);
   });
 
   test("preserves successful boot state when coordinated shutdown fails", async () => {

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -880,6 +880,32 @@ describe("SimCtlClient boot self-verification", () => {
     expect(harness.lifecycleCalls).toEqual(["bootstatus-1", "shutdown"]);
   });
 
+  test("bounds killSimulator's boot-lease wait when no signal ever aborts it", async () => {
+    // Simulate a wedged boot: readiness never resolves, so the boot lease is
+    // held indefinitely. killSimulator (via deviceBootRecovery / handle.kill())
+    // is called with no ambient abort signal (no getAbortSignal() in scope).
+    const harness = createConcurrentStartHarness(() => new Promise(() => undefined));
+    // A huge readiness timeout keeps the boot's own internal bootstatus exec
+    // timeout from firing within this test's assertion window, isolating the
+    // boot-lease wait's own deadline as the only thing that can settle `kill`.
+    const readiness = harness.createClient().waitForSimulatorReady(UDID, 10_000_000);
+    await drainMicrotasks();
+
+    const kill = harness
+      .createClient()
+      .killSimulator({ name: "iPhone 17", platform: "ios", deviceId: UDID })
+      .catch((error: unknown) => error);
+
+    harness.timer.advanceTime(DEFAULT_DEVICE_READY_TIMEOUT_MS);
+    await drainMicrotasks();
+
+    const killResult = await kill;
+    expect(killResult).toBeInstanceOf(Error);
+    expect(harness.shutdownInvocations()).toBe(0);
+
+    void readiness.catch(() => undefined);
+  });
+
   test("preserves successful boot state when coordinated shutdown fails", async () => {
     let completeOwnerBootstatus: (() => void) | undefined;
     const shutdownError = new Error("shutdown failed");


### PR DESCRIPTION
## Summary

shutdownSimulatorCoordinated passed undefined as the lease-queue deadline into acquireSimulatorBoot, so the wait was bounded only by the caller's AbortSignal — which is undefined for CI boot-recovery (runs outside any MCP request) and structurally never fires for the boot handle's kill() cleanup, letting a shutdown/cleanup call queue forever behind a wedged boot. This adds a dedicated SIMULATOR_SHUTDOWN_LEASE_WAIT_TIMEOUT_MS deadline (deviceTimeouts.ts) computed from timer.now() and passes it into acquireSimulatorBoot, independent of the caller signal and separate from the simctl shutdown command's own timeoutMs budget. Both previously-unbounded call sites funnel through this path, so no changes were needed in deviceBootRecovery or the handle's kill().

Part of epic #6372.

## Linked Issue

Closes #6577

## Validation

A FakeTimer unit test holds a never-resolving boot lease and calls killSimulator with no ambient signal; it hung indefinitely before the fix and now settles once the fake clock advances past the new deadline. Targeted test/utils/ios-cmdline-tools + deviceBootRecovery 445/445 pass, all sub-100ms.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
