### PR TITLE
fix(ios): escalate straight to SIGKILL on shutdown-time force-stop (#6578)

### DIFF
--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -462,7 +462,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     // Threaded into stop()'s own terminateProcessTree call so its sleeps/execs
     // degrade predictably against this stage's budget instead of running
     // unbounded (#6578).
-    const stopDeadline = timer.now() + SHUTDOWN_STOP_TIMEOUT_MS;
+    const stopDeadline = instance.timer.now() + SHUTDOWN_STOP_TIMEOUT_MS;
     const settled = instance.stop(stopDeadline).then(
       () => null,
       (error) => error,
@@ -498,7 +498,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     let timeout: NodeJS.Timeout | undefined;
     // Computed here (not at the start of the overall shutdown stage) since
     // this stage's budget only starts once stop()'s own attempt has timed out.
-    const forceStopDeadline = timer.now() + SHUTDOWN_FORCE_STOP_TIMEOUT_MS;
+    const forceStopDeadline = instance.timer.now() + SHUTDOWN_FORCE_STOP_TIMEOUT_MS;
     const deadline = new Promise<void>((resolve) => {
       timeout = timer.setTimeout(resolve, SHUTDOWN_FORCE_STOP_TIMEOUT_MS);
     });

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -304,7 +304,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     this.builder = builder || IOSCtrlProxyBuilder.getInstance();
     this.processExecutor = processExecutor;
     this.xcodebuild = xcodebuild;
-    this.processClient = processClient ?? new IOSCtrlProxyProcessClient();
+    this.processClient = processClient ?? new IOSCtrlProxyProcessClient(processExecutor, timer);
     this.signingManager = signingManager;
     this.deviceAppManager = deviceAppManager;
     this.hostPortAvailabilityChecker = hostPortAvailabilityChecker;

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -458,7 +458,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     timer: Timer,
   ): Promise<unknown | null> {
     let timeout: NodeJS.Timeout | undefined;
-    let forceStopStarted = false;
+    let forceStop: Promise<void> | undefined;
     // Threaded into stop()'s own terminateProcessTree call so its sleeps/execs
     // degrade predictably against this stage's budget instead of running
     // unbounded (#6578).
@@ -471,17 +471,18 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       timeout = timer.setTimeout(() => {
         // stop() may be blocked on a remote runner call. Reserve a bounded
         // window to await direct termination before clearing the registry.
-        forceStopStarted = true;
-        void IOSCtrlProxyManager.forceStopWithinShutdownDeadline(instance, timer).then(() =>
+        forceStop = IOSCtrlProxyManager.forceStopWithinShutdownDeadline(instance, timer);
+        void forceStop.then(() =>
           resolve(new Error(`timed out after ${SHUTDOWN_STOP_TIMEOUT_MS}ms`)),
         );
       }, SHUTDOWN_STOP_TIMEOUT_MS);
     });
     try {
       const result = await Promise.race([settled, timedOut]);
-      if (result !== null && !forceStopStarted) {
-        await IOSCtrlProxyManager.forceStopWithinShutdownDeadline(instance, timer);
+      if (result !== null) {
+        forceStop ??= IOSCtrlProxyManager.forceStopWithinShutdownDeadline(instance, timer);
       }
+      await forceStop;
       return result;
     } finally {
       if (timeout) {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -471,7 +471,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       timeout = timer.setTimeout(() => {
         // stop() may be blocked on a remote runner call. Reserve a bounded
         // window to await direct termination before clearing the registry.
-        forceStop = IOSCtrlProxyManager.forceStopWithinShutdownDeadline(instance, timer);
+        forceStop ??= IOSCtrlProxyManager.forceStopWithinShutdownDeadline(instance, timer);
         void forceStop.then(() =>
           resolve(new Error(`timed out after ${SHUTDOWN_STOP_TIMEOUT_MS}ms`)),
         );

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -459,7 +459,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   ): Promise<unknown | null> {
     let timeout: NodeJS.Timeout | undefined;
     let forceStopStarted = false;
-    const settled = instance.stop().then(
+    // Threaded into stop()'s own terminateProcessTree call so its sleeps/execs
+    // degrade predictably against this stage's budget instead of running
+    // unbounded (#6578).
+    const stopDeadline = timer.now() + SHUTDOWN_STOP_TIMEOUT_MS;
+    const settled = instance.stop(stopDeadline).then(
       () => null,
       (error) => error,
     );
@@ -491,11 +495,14 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     timer: Timer,
   ): Promise<void> {
     let timeout: NodeJS.Timeout | undefined;
+    // Computed here (not at the start of the overall shutdown stage) since
+    // this stage's budget only starts once stop()'s own attempt has timed out.
+    const forceStopDeadline = timer.now() + SHUTDOWN_FORCE_STOP_TIMEOUT_MS;
     const deadline = new Promise<void>((resolve) => {
       timeout = timer.setTimeout(resolve, SHUTDOWN_FORCE_STOP_TIMEOUT_MS);
     });
     try {
-      await Promise.race([instance.forceStopForShutdown(), deadline]);
+      await Promise.race([instance.forceStopForShutdown(forceStopDeadline), deadline]);
     } finally {
       if (timeout) {
         timer.clearTimeout(timeout);
@@ -503,7 +510,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
   }
 
-  private async forceStopForShutdown(): Promise<void> {
+  private async forceStopForShutdown(deadline?: number): Promise<void> {
     this.isStopping = true;
     this.processSupervisor.stop();
     this.iproxySupervisor.stop();
@@ -540,9 +547,15 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       logger.debug(`[IOSCtrlProxy] Forced iproxy termination was already complete: ${error}`);
     }
     if (runnerPid) {
-      await this.processClient.terminateProcessTree(runnerPid).catch((error) => {
-        logger.warn(`[IOSCtrlProxy] Forced CtrlProxy runner termination failed: ${error}`);
-      });
+      // This only runs after stop()'s own graceful attempt has already timed
+      // out, so replaying a fresh SIGTERM grace ladder here would just burn
+      // the (much smaller) force-stop budget without ever reaching SIGKILL --
+      // go straight to it (#6578).
+      await this.processClient
+        .terminateProcessTree(runnerPid, deadline, { skipGraceful: true })
+        .catch((error) => {
+          logger.warn(`[IOSCtrlProxy] Forced CtrlProxy runner termination failed: ${error}`);
+        });
     }
   }
 
@@ -1215,7 +1228,13 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   /**
    * Stop CtrlProxy
    */
-  public async stop(): Promise<void> {
+  /**
+   * @param deadline Absolute timer.now() bound past which the runner-tree
+   * termination's own sleeps/execs must clamp rather than run unbounded.
+   * Threaded through by shutdownAll's stopWithinShutdownDeadline (#6578);
+   * omitted by every other caller.
+   */
+  public async stop(deadline?: number): Promise<void> {
     logger.info("[IOSCtrlProxy] Stopping CtrlProxy");
     this.isStopping = true;
 
@@ -1253,7 +1272,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     if (this.xcTestProcessId) {
       try {
         if (await this.isOwnRunnerProcessAlive()) {
-          await this.processClient.terminateProcessTree(this.xcTestProcessId);
+          await this.processClient.terminateProcessTree(this.xcTestProcessId, deadline);
         } else {
           logger.debug(
             `[IOSCtrlProxy] Tracked runner PID ${this.xcTestProcessId} is not an owned CtrlProxy runner; ` +

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -205,14 +205,28 @@ export class IOSCtrlProxyProcessClient {
     deadline?: number,
     options?: { skipGraceful?: boolean },
   ): Promise<void> {
+    if (options?.skipGraceful) {
+      // SIGKILL the known root/process group FIRST, before the best-effort
+      // descendant enumeration below. `ps` enumeration is not bounded tightly
+      // enough to guarantee it finishes inside a short force-stop deadline;
+      // if it were awaited first and ate the whole deadline, the root would
+      // never be signaled and forceStopForShutdown would clear tracking with
+      // an orphaned runner still alive (issue #6578).
+      await this.signalGroup(pid, "KILL", deadline);
+      await this.signalPids([pid], "KILL", deadline);
+      const descendants = await this.findDescendantProcessIds(pid, deadline);
+      await this.signalPids([...descendants].reverse(), "KILL", deadline);
+      if (!(await this.waitForExit([pid, ...descendants], deadline))) {
+        throw new Error(`CtrlProxy process tree rooted at PID ${pid} remained alive after SIGKILL`);
+      }
+      return;
+    }
     const descendants = await this.findDescendantProcessIds(pid, deadline);
     const targets = [...descendants].reverse().concat(pid);
-    if (!options?.skipGraceful) {
-      await this.signalGroup(pid, "TERM", deadline);
-      await this.signalPids(targets, "TERM", deadline);
-      if (await this.waitForExit([pid, ...descendants], deadline)) {
-        return;
-      }
+    await this.signalGroup(pid, "TERM", deadline);
+    await this.signalPids(targets, "TERM", deadline);
+    if (await this.waitForExit([pid, ...descendants], deadline)) {
+      return;
     }
     await this.signalGroup(pid, "KILL", deadline);
     await this.signalPids(targets, "KILL", deadline);

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -206,15 +206,12 @@ export class IOSCtrlProxyProcessClient {
     options?: { skipGraceful?: boolean },
   ): Promise<void> {
     if (options?.skipGraceful) {
-      // SIGKILL the known root/process group FIRST, before the best-effort
-      // descendant enumeration below. `ps` enumeration is not bounded tightly
-      // enough to guarantee it finishes inside a short force-stop deadline;
-      // if it were awaited first and ate the whole deadline, the root would
-      // never be signaled and forceStopForShutdown would clear tracking with
-      // an orphaned runner still alive (issue #6578).
+      // Begin the snapshot while parent relationships still exist, but do
+      // not wait for ps before sending the deadline-critical root/group kill.
+      const snapshot = this.findDescendantProcessIds(pid, deadline);
       await this.signalGroup(pid, "KILL", deadline);
       await this.signalPids([pid], "KILL", deadline);
-      const descendants = await this.findDescendantProcessIds(pid, deadline);
+      const descendants = await snapshot;
       await this.signalPids([...descendants].reverse(), "KILL", deadline);
       if (!(await this.waitForExit([pid, ...descendants], deadline))) {
         throw new Error(`CtrlProxy process tree rooted at PID ${pid} remained alive after SIGKILL`);

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -209,8 +209,10 @@ export class IOSCtrlProxyProcessClient {
       // Begin the snapshot while parent relationships still exist, but do
       // not wait for ps before sending the deadline-critical root/group kill.
       const snapshot = this.findDescendantProcessIds(pid, deadline);
-      await this.signalGroup(pid, "KILL", deadline);
-      await this.signalPids([pid], "KILL", deadline);
+      await Promise.all([
+        this.signalGroup(pid, "KILL", deadline),
+        this.signalPids([pid], "KILL", deadline),
+      ]);
       const descendants = await snapshot;
       await this.signalPids([...descendants].reverse(), "KILL", deadline);
       if (!(await this.waitForExit([pid, ...descendants], deadline))) {

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -212,9 +212,11 @@ export class IOSCtrlProxyProcessClient {
       await Promise.all([
         this.signalGroup(pid, "KILL", deadline),
         this.signalPids([pid], "KILL", deadline),
+        snapshot.then((descendants) =>
+          this.signalPids([...descendants].reverse(), "KILL", deadline),
+        ),
       ]);
       const descendants = await snapshot;
-      await this.signalPids([...descendants].reverse(), "KILL", deadline);
       if (!(await this.waitForExit([pid, ...descendants], deadline))) {
         throw new Error(`CtrlProxy process tree rooted at PID ${pid} remained alive after SIGKILL`);
       }

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -193,13 +193,26 @@ export class IOSCtrlProxyProcessClient {
     }
   }
 
-  async terminateProcessTree(pid: number, deadline?: number): Promise<void> {
+  /**
+   * @param options.skipGraceful Skip the SIGTERM ladder entirely and signal
+   * SIGKILL immediately. For callers (e.g. a shutdown-time force-stop) that
+   * only run after a prior graceful attempt has already timed out -- a fresh
+   * TERM grace period there would just spend an already-exhausted deadline
+   * without ever reaching SIGKILL (issue #6578).
+   */
+  async terminateProcessTree(
+    pid: number,
+    deadline?: number,
+    options?: { skipGraceful?: boolean },
+  ): Promise<void> {
     const descendants = await this.findDescendantProcessIds(pid, deadline);
     const targets = [...descendants].reverse().concat(pid);
-    await this.signalGroup(pid, "TERM", deadline);
-    await this.signalPids(targets, "TERM", deadline);
-    if (await this.waitForExit([pid, ...descendants], deadline)) {
-      return;
+    if (!options?.skipGraceful) {
+      await this.signalGroup(pid, "TERM", deadline);
+      await this.signalPids(targets, "TERM", deadline);
+      if (await this.waitForExit([pid, ...descendants], deadline)) {
+        return;
+      }
     }
     await this.signalGroup(pid, "KILL", deadline);
     await this.signalPids(targets, "KILL", deadline);

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -332,6 +332,37 @@ describe("IOSCtrlProxyManager", function () {
       expect(IOSCtrlProxyManager.getInstance(testDevice)).not.toBe(first);
     });
 
+    test("retains the force stage when graceful stop expires at the same deadline", async function () {
+      const timer = new FakeTimer();
+      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+      spyOn(manager, "stop").mockImplementation(async (deadline) => {
+        await new Promise<void>((_resolve, reject) =>
+          timer.setTimeout(() => reject(new Error("stop expired")), deadline! - timer.now()),
+        );
+      });
+      let releaseForce!: () => void;
+      const force = spyOn(
+        manager as unknown as { forceStopForShutdown: () => Promise<void> },
+        "forceStopForShutdown",
+      ).mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseForce = resolve;
+          }),
+      );
+      let completed = false;
+      const shutdown = IOSCtrlProxyManager.shutdownAll(timer).then(() => {
+        completed = true;
+      });
+      timer.advanceTime(1200);
+      for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+      expect(force).toHaveBeenCalledTimes(1);
+      expect(completed).toBe(false);
+      releaseForce();
+      await shutdown;
+      expect(completed).toBe(true);
+      expect(timer.getPendingTimeoutCount()).toBe(0);
+    });
     // Models the runner command shape that isOwnRunnerProcessAlive/
     // isCtrlProxyRunnerCommand recognize as this daemon's own launch, mirroring
     // the "restart prevention" describe block's helper of the same name.
@@ -1050,8 +1081,14 @@ describe("IOSCtrlProxyManager", function () {
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice,
         fakeTimer,
-        undefined,
+        {
+          ...createFakeBuilder(),
+          needsRebuild: async () => true,
+          build: async () => ({ success: false, message: "fake rebuild unavailable" }),
+        } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder,
         fakeExecutor,
+        undefined,
+        { getInstalledAppBundleHash: async () => null } as unknown as DeviceAppManager,
       );
 
       // First pass through the gate: attemptedSetup becomes true and the
@@ -1088,8 +1125,14 @@ describe("IOSCtrlProxyManager", function () {
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice,
         fakeTimer,
-        undefined,
+        {
+          ...createFakeBuilder(),
+          needsRebuild: async () => true,
+          build: async () => ({ success: false, message: "fake rebuild unavailable" }),
+        } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder,
         fakeExecutor,
+        undefined,
+        { getInstalledAppBundleHash: async () => null } as unknown as DeviceAppManager,
       );
 
       expect((await manager.setup()).success).toBe(true);
@@ -1115,8 +1158,14 @@ describe("IOSCtrlProxyManager", function () {
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice,
         fakeTimer,
-        undefined,
+        {
+          ...createFakeBuilder(),
+          needsRebuild: async () => true,
+          build: async () => ({ success: false, message: "fake rebuild unavailable" }),
+        } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder,
         fakeExecutor,
+        undefined,
+        { getInstalledAppBundleHash: async () => null } as unknown as DeviceAppManager,
       );
 
       expect((await manager.setup()).success).toBe(true);

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -336,7 +336,7 @@ describe("IOSCtrlProxyManager", function () {
       "retains one force stage when graceful stop expires (early by %sms)",
       async function (earlyBy) {
         const timer = new FakeTimer();
-        const manager = IOSCtrlProxyManager.getInstance(testDevice);
+        const manager = IOSCtrlProxyManager.getInstance(testDevice, timer);
         spyOn(manager, "stop").mockImplementation(async (deadline) => {
           await new Promise<void>((_resolve, reject) =>
             timer.setTimeout(

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -332,37 +332,45 @@ describe("IOSCtrlProxyManager", function () {
       expect(IOSCtrlProxyManager.getInstance(testDevice)).not.toBe(first);
     });
 
-    test("retains the force stage when graceful stop expires at the same deadline", async function () {
-      const timer = new FakeTimer();
-      const manager = IOSCtrlProxyManager.getInstance(testDevice);
-      spyOn(manager, "stop").mockImplementation(async (deadline) => {
-        await new Promise<void>((_resolve, reject) =>
-          timer.setTimeout(() => reject(new Error("stop expired")), deadline! - timer.now()),
+    test.each([0, 100])(
+      "retains one force stage when graceful stop expires (early by %sms)",
+      async function (earlyBy) {
+        const timer = new FakeTimer();
+        const manager = IOSCtrlProxyManager.getInstance(testDevice);
+        spyOn(manager, "stop").mockImplementation(async (deadline) => {
+          await new Promise<void>((_resolve, reject) =>
+            timer.setTimeout(
+              () => reject(new Error("stop expired")),
+              deadline! - timer.now() - earlyBy,
+            ),
+          );
+        });
+        let releaseForce!: () => void;
+        const force = spyOn(
+          manager as unknown as { forceStopForShutdown: () => Promise<void> },
+          "forceStopForShutdown",
+        ).mockImplementation(
+          () =>
+            new Promise<void>((resolve) => {
+              releaseForce = resolve;
+            }),
         );
-      });
-      let releaseForce!: () => void;
-      const force = spyOn(
-        manager as unknown as { forceStopForShutdown: () => Promise<void> },
-        "forceStopForShutdown",
-      ).mockImplementation(
-        () =>
-          new Promise<void>((resolve) => {
-            releaseForce = resolve;
-          }),
-      );
-      let completed = false;
-      const shutdown = IOSCtrlProxyManager.shutdownAll(timer).then(() => {
-        completed = true;
-      });
-      timer.advanceTime(1200);
-      for (let turn = 0; turn < 20; turn++) await Promise.resolve();
-      expect(force).toHaveBeenCalledTimes(1);
-      expect(completed).toBe(false);
-      releaseForce();
-      await shutdown;
-      expect(completed).toBe(true);
-      expect(timer.getPendingTimeoutCount()).toBe(0);
-    });
+        let completed = false;
+        const shutdown = IOSCtrlProxyManager.shutdownAll(timer).then(() => {
+          completed = true;
+        });
+        timer.advanceTime(1200 - earlyBy);
+        for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+        timer.advanceTime(earlyBy);
+        for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+        expect(force).toHaveBeenCalledTimes(1);
+        expect(completed).toBe(false);
+        releaseForce();
+        await shutdown;
+        expect(completed).toBe(true);
+        expect(timer.getPendingTimeoutCount()).toBe(0);
+      },
+    );
     // Models the runner command shape that isOwnRunnerProcessAlive/
     // isCtrlProxyRunnerCommand recognize as this daemon's own launch, mirroring
     // the "restart prevention" describe block's helper of the same name.

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -331,6 +331,88 @@ describe("IOSCtrlProxyManager", function () {
       expect(secondStop).toHaveBeenCalledTimes(1);
       expect(IOSCtrlProxyManager.getInstance(testDevice)).not.toBe(first);
     });
+
+    // Models the runner command shape that isOwnRunnerProcessAlive/
+    // isCtrlProxyRunnerCommand recognize as this daemon's own launch, mirroring
+    // the "restart prevention" describe block's helper of the same name.
+    function ownRunnerProcess(pid: number): FakeListeningProcess {
+      return {
+        pid,
+        port: 8765,
+        command:
+          `xcodebuild test-without-building ` +
+          `-xctestrun /tmp/automobile-ctrl-proxy/automobile-runner-${testDevice.deviceId}.xctestrun ` +
+          `-destination "platform=iOS Simulator,id=${testDevice.deviceId}" ` +
+          `-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        environment: `CTRL_PROXY_IOS_PORT=8765 AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        alive: true,
+      };
+    }
+
+    function registerAsShutdownInstance(manager: IOSCtrlProxyManager): void {
+      (
+        IOSCtrlProxyManager as unknown as {
+          instances: Map<string, IOSCtrlProxyManager>;
+        }
+      ).instances.set(testDevice.deviceId, manager);
+    }
+
+    // Pins #6578: forceStopForShutdown only ever runs after stop()'s own
+    // TERM+KILL ladder has already timed out, so replaying a fresh TERM grace
+    // period there just burns the tiny 250ms force-stop budget without ever
+    // reaching SIGKILL. The fix must escalate straight to SIGKILL.
+    test("escalates straight to SIGKILL within the shutdown stage when the runner ignores SIGTERM (#6578)", async function () {
+      const fakeExecutor = new FakeProcessExecutor();
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 912345;
+      const wedgedRunner: FakeListeningProcess = {
+        ...ownRunnerProcess(912345),
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [wedgedRunner]);
+      registerAsShutdownInstance(manager);
+      // stop() itself never settles -- the wedged runner ignores both signals
+      // in its own ladder too, so only the force-stop stage is exercised here.
+      spyOn(manager, "stop").mockImplementation(async () => {
+        await new Promise<void>(() => {});
+      });
+
+      fakeTimer.enableAutoAdvance();
+      await IOSCtrlProxyManager.shutdownAll(fakeTimer);
+
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL -- -912345")).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL 912345")).toBe(true);
+    });
+
+    // Companion case from the issue: a tree that exits promptly on SIGTERM
+    // must still resolve without ever reaching forceStopForShutdown/SIGKILL --
+    // the fix must not turn every shutdown into a hard kill.
+    test("resolves via a plain SIGTERM without forcing SIGKILL when the runner exits promptly", async function () {
+      const fakeExecutor = new FakeProcessExecutor();
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 912345;
+      installListeningProcessFakes(fakeExecutor, [ownRunnerProcess(912345)]);
+      registerAsShutdownInstance(manager);
+      const forceStop = spyOn(manager as any, "forceStopForShutdown");
+
+      fakeTimer.enableAutoAdvance();
+      await IOSCtrlProxyManager.shutdownAll(fakeTimer);
+
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -912345")).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL -- -912345")).toBe(false);
+      expect(forceStop).not.toHaveBeenCalled();
+    });
   });
 
   describe("getServicePort", function () {

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -97,6 +97,11 @@ describe("IOSCtrlProxyProcessClient", () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
     const commandOrder: string[] = [];
+    let rootAlive = true;
+    let rootKilled!: () => void;
+    const rootKill = new Promise<void>((resolve) => {
+      rootKilled = resolve;
+    });
     let releaseEnumeration: (() => void) | undefined;
     let psCalled: ((commandsBeforePs: string[]) => void) | undefined;
     const psCalledPromise = new Promise<string[]>((resolve) => {
@@ -108,14 +113,22 @@ describe("IOSCtrlProxyProcessClient", () => {
         if (file === "ps") {
           // Simulate slow descendant enumeration that would otherwise eat a
           // tight force-stop deadline if it were awaited before signaling.
+          const snapshot = rootAlive ? "42 1\n43 42\n" : "43 1\n";
           psCalled?.([...commandOrder]);
           commandOrder.push(command);
           await new Promise<void>((resolve) => {
             releaseEnumeration = resolve;
           });
-          return result("42 1\n43 42\n");
+          return result(snapshot);
         }
         commandOrder.push(command);
+        if (command === "kill -KILL -- -42") {
+          throw new Error("group unavailable");
+        }
+        if (command === "kill -KILL 42") {
+          rootAlive = false;
+          rootKilled();
+        }
         if (file === "kill" && args[0] === "-0") {
           throw new Error("not running");
         }
@@ -130,7 +143,10 @@ describe("IOSCtrlProxyProcessClient", () => {
     const pending = client.terminateProcessTree(42, undefined, { skipGraceful: true });
     const commandsBeforePs = await psCalledPromise;
 
-    expect(commandsBeforePs).toEqual(["kill -KILL -- -42", "kill -KILL 42"]);
+    expect(commandsBeforePs).toEqual([]);
+    await rootKill;
+    expect(commandOrder).toContain("kill -KILL -- -42");
+    expect(commandOrder).toContain("kill -KILL 42");
 
     releaseEnumeration?.();
     await expect(pending).resolves.toBeUndefined();

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -97,6 +97,10 @@ describe("IOSCtrlProxyProcessClient", () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
     const commandOrder: string[] = [];
+    let releaseGroup!: () => void;
+    const groupWait = new Promise<void>((resolve) => {
+      releaseGroup = resolve;
+    });
     let rootAlive = true;
     let rootKilled!: () => void;
     const rootKill = new Promise<void>((resolve) => {
@@ -123,6 +127,7 @@ describe("IOSCtrlProxyProcessClient", () => {
         }
         commandOrder.push(command);
         if (command === "kill -KILL -- -42") {
+          await groupWait;
           throw new Error("group unavailable");
         }
         if (command === "kill -KILL 42") {
@@ -148,6 +153,7 @@ describe("IOSCtrlProxyProcessClient", () => {
     expect(commandOrder).toContain("kill -KILL -- -42");
     expect(commandOrder).toContain("kill -KILL 42");
 
+    releaseGroup();
     releaseEnumeration?.();
     await expect(pending).resolves.toBeUndefined();
     expect(commandOrder).toContain("kill -KILL 43");

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -93,6 +93,50 @@ describe("IOSCtrlProxyProcessClient", () => {
     );
   });
 
+  test("SIGKILLs the tracked root/group before descendant enumeration completes on skipGraceful (#6578)", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const commandOrder: string[] = [];
+    let releaseEnumeration: (() => void) | undefined;
+    let psCalled: ((commandsBeforePs: string[]) => void) | undefined;
+    const psCalledPromise = new Promise<string[]>((resolve) => {
+      psCalled = resolve;
+    });
+    const host: HostCommandExecutor = {
+      async executeCommand(file, args) {
+        const command = `${file} ${args.join(" ")}`;
+        if (file === "ps") {
+          // Simulate slow descendant enumeration that would otherwise eat a
+          // tight force-stop deadline if it were awaited before signaling.
+          psCalled?.([...commandOrder]);
+          commandOrder.push(command);
+          await new Promise<void>((resolve) => {
+            releaseEnumeration = resolve;
+          });
+          return result("42 1\n43 42\n");
+        }
+        commandOrder.push(command);
+        if (file === "kill" && args[0] === "-0") {
+          throw new Error("not running");
+        }
+        return result();
+      },
+    };
+    const client = new IOSCtrlProxyProcessClient(host, timer, {
+      releaseAttempts: 1,
+      releaseGraceMs: 1,
+    });
+
+    const pending = client.terminateProcessTree(42, undefined, { skipGraceful: true });
+    const commandsBeforePs = await psCalledPromise;
+
+    expect(commandsBeforePs).toEqual(["kill -KILL -- -42", "kill -KILL 42"]);
+
+    releaseEnumeration?.();
+    await expect(pending).resolves.toBeUndefined();
+    expect(commandOrder).toContain("kill -KILL 43");
+  });
+
   test("resolves process-tree termination once SIGKILL removes every target", async () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -101,6 +101,10 @@ describe("IOSCtrlProxyProcessClient", () => {
     const groupWait = new Promise<void>((resolve) => {
       releaseGroup = resolve;
     });
+    let descendantKilled!: () => void;
+    const descendantKill = new Promise<void>((resolve) => {
+      descendantKilled = resolve;
+    });
     let rootAlive = true;
     let rootKilled!: () => void;
     const rootKill = new Promise<void>((resolve) => {
@@ -134,6 +138,7 @@ describe("IOSCtrlProxyProcessClient", () => {
           rootAlive = false;
           rootKilled();
         }
+        if (command === "kill -KILL 43") descendantKilled();
         if (file === "kill" && args[0] === "-0") {
           throw new Error("not running");
         }
@@ -153,8 +158,9 @@ describe("IOSCtrlProxyProcessClient", () => {
     expect(commandOrder).toContain("kill -KILL -- -42");
     expect(commandOrder).toContain("kill -KILL 42");
 
-    releaseGroup();
     releaseEnumeration?.();
+    await descendantKill;
+    releaseGroup();
     await expect(pending).resolves.toBeUndefined();
     expect(commandOrder).toContain("kill -KILL 43");
   });


### PR DESCRIPTION
## Summary

The force-stop path that runs after stop()'s graceful attempt times out replayed a fresh, unbounded SIGTERM ladder before ever reaching SIGKILL, so a wedged runner tree could outlive the daemon's bounded shutdown stage entirely and be orphaned. terminateProcessTree in IOSCtrlProxyProcessClient now accepts a skipGraceful option that jumps straight to SIGKILL, and forceStopForShutdown uses it since it only runs after a prior timeout. Deadlines are threaded through both stop() and forceStopForShutdown from the shared shutdown Timer (computed at each stage's start) so terminateProcessTree's sleeps and execs clamp to the remaining budget instead of running unbounded.

Part of epic #6372.

Stacked on `work/issue-6416-ios-availability-cache-reopen`; GitHub retargets to `main` once it merges.

## Linked Issue

Closes #6578

## Validation

Two FakeTimer tests in the shutdownAll block: a SIGTERM-ignoring runner now receives SIGKILL within the shutdown stage (red before — only SIGTERM was seen); a promptly-exiting runner still resolves without ever reaching force-stop/SIGKILL. Targeted IOSCtrlProxyManager 111 + IOSCtrlProxyProcessClient 10 + broader test/utils 3107 pass.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
