### PR TITLE
fix(ios): re-verify runner ownership before forceStopForShutdown tree kill (#6579)

### DIFF
--- a/src/utils/CommandError.ts
+++ b/src/utils/CommandError.ts
@@ -65,7 +65,7 @@ export function formatCommandError(error: unknown, options: CommandErrorFormatOp
 }
 
 export function wrapCommandError(error: unknown, options: CommandErrorFormatOptions): Error {
-  const wrapped = new Error(formatCommandError(error, options));
+  const wrapped = new Error(formatCommandError(error, options), { cause: error });
   if (error instanceof Error) {
     wrapped.name = error.name;
   }

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -26,7 +26,7 @@ import {
   type HostPortAvailabilityChecker,
 } from "./ios/IOSHostPortAvailabilityChecker";
 import { IOSCtrlProxyHealthClient, isValidCtrlProxyPort } from "./ios/IOSCtrlProxyHealthClient";
-import { IOSCtrlProxyProcessClient } from "./ios/IOSCtrlProxyProcessClient";
+import { IOSCtrlProxyProcessClient, type RunnerOwnership } from "./ios/IOSCtrlProxyProcessClient";
 import type { ProxyManager, ProxySetupResult } from "./interfaces/ProxyManager";
 
 export const MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES = 20;
@@ -668,8 +668,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       logger.debug(`[IOSCtrlProxy] Forced iproxy termination was already complete: ${error}`);
     }
     if (runnerPid) {
-      const stillOwned = await this.isRunnerStillOwnedWithinShutdownDeadline(runnerPid);
-      if (stillOwned) {
+      const mayTerminate = await this.isRunnerStillOwnedWithinShutdownDeadline(runnerPid);
+      if (mayTerminate) {
         await this.processClient
           .terminateProcessTree(runnerPid, deadline, {
             skipGraceful: true,
@@ -680,8 +680,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           });
       } else {
         logger.warn(
-          `[IOSCtrlProxy] Tracked runner PID ${runnerPid} is no longer verifiably ours ` +
-            `(exited/PID-reused); skipping forced termination`,
+          `[IOSCtrlProxy] Tracked runner PID ${runnerPid} is confirmed foreign ` +
+            `(PID-reused); skipping forced termination`,
         );
       }
     }
@@ -694,22 +694,27 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * by a short timeout, separate from the caller's terminateProcessTree budget, so a
    * slow `ps`/`kill -0` round trip cannot itself consume the 250 ms force-stop
    * deadline — on timeout we fail OPEN (treat as still owned) to preserve today's
-   * shutdown behavior rather than silently skip a genuinely hung runner.
+   * shutdown behavior rather than silently skip a genuinely hung runner. An absent
+   * root also proceeds because its original process group may still have live members.
    */
   private async isRunnerStillOwnedWithinShutdownDeadline(runnerPid: number): Promise<boolean> {
     let timeout: NodeJS.Timeout | undefined;
-    const fallbackToOwned = new Promise<boolean>((resolve) => {
-      timeout = this.timer.setTimeout(() => resolve(true), FORCE_STOP_OWNERSHIP_CHECK_TIMEOUT_MS);
+    const fallbackToOwned = new Promise<RunnerOwnership>((resolve) => {
+      timeout = this.timer.setTimeout(
+        () => resolve("owned"),
+        FORCE_STOP_OWNERSHIP_CHECK_TIMEOUT_MS,
+      );
     });
     try {
-      return await Promise.race([
-        this.processClient.isOwnedRunnerAlive(
+      const ownership = await Promise.race([
+        this.processClient.checkRunnerOwnership(
           runnerPid,
           this.device.deviceId,
           this.timer.now() + FORCE_STOP_OWNERSHIP_CHECK_TIMEOUT_MS,
         ),
         fallbackToOwned,
       ]);
+      return ownership !== "foreign";
     } catch (error) {
       // A failed ownership check (exec error) is treated the same as "cannot
       // disprove ownership": fail open so a genuinely hung runner still gets

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -37,6 +37,9 @@ export const STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS = 5_000;
 // consume it all before the remaining owners receive their stop attempt.
 const SHUTDOWN_STOP_TIMEOUT_MS = 1_200;
 const SHUTDOWN_FORCE_STOP_TIMEOUT_MS = 250;
+// A fraction of SHUTDOWN_FORCE_STOP_TIMEOUT_MS: the ownership re-verify in
+// forceStopForShutdown must not itself consume the budget the tree kill needs.
+const FORCE_STOP_OWNERSHIP_CHECK_TIMEOUT_MS = 100;
 const IPROXY_GRACEFUL_STOP_TIMEOUT_MS = 1_000;
 // `stop()` tears the runner's process tree down, but its HTTP listener can keep
 // answering /health for a moment while the process drains. A single probe fired
@@ -665,11 +668,61 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       logger.debug(`[IOSCtrlProxy] Forced iproxy termination was already complete: ${error}`);
     }
     if (runnerPid) {
-      await this.processClient
-        .terminateProcessTree(runnerPid, deadline, { skipGraceful: true })
-        .catch((error) => {
-          logger.warn(`[IOSCtrlProxy] Forced CtrlProxy runner termination failed: ${error}`);
-        });
+      const stillOwned = await this.isRunnerStillOwnedWithinShutdownDeadline(runnerPid);
+      if (stillOwned) {
+        await this.processClient
+          .terminateProcessTree(runnerPid, deadline, {
+            skipGraceful: true,
+            expectedDeviceId: this.device.deviceId,
+          })
+          .catch((error) => {
+            logger.warn(`[IOSCtrlProxy] Forced CtrlProxy runner termination failed: ${error}`);
+          });
+      } else {
+        logger.warn(
+          `[IOSCtrlProxy] Tracked runner PID ${runnerPid} is no longer verifiably ours ` +
+            `(exited/PID-reused); skipping forced termination`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Re-verifies ownership of `runnerPid` right before `forceStopForShutdown`'s tree
+   * kill, mirroring the re-checks in `stop()` and the hung-runner path (#6579). The
+   * field is already nulled by this point, so the pid is passed explicitly. Bounded
+   * by a short timeout, separate from the caller's terminateProcessTree budget, so a
+   * slow `ps`/`kill -0` round trip cannot itself consume the 250 ms force-stop
+   * deadline — on timeout we fail OPEN (treat as still owned) to preserve today's
+   * shutdown behavior rather than silently skip a genuinely hung runner.
+   */
+  private async isRunnerStillOwnedWithinShutdownDeadline(runnerPid: number): Promise<boolean> {
+    let timeout: NodeJS.Timeout | undefined;
+    const fallbackToOwned = new Promise<boolean>((resolve) => {
+      timeout = this.timer.setTimeout(() => resolve(true), FORCE_STOP_OWNERSHIP_CHECK_TIMEOUT_MS);
+    });
+    try {
+      return await Promise.race([
+        this.processClient.isOwnedRunnerAlive(
+          runnerPid,
+          this.device.deviceId,
+          this.timer.now() + FORCE_STOP_OWNERSHIP_CHECK_TIMEOUT_MS,
+        ),
+        fallbackToOwned,
+      ]);
+    } catch (error) {
+      // A failed ownership check (exec error) is treated the same as "cannot
+      // disprove ownership": fail open so a genuinely hung runner still gets
+      // torn down during shutdown, matching the timeout fallback above.
+      logger.debug(
+        `[IOSCtrlProxy] Ownership re-verification for runner ${runnerPid} failed; ` +
+          `assuming owned: ${errorMessage(error)}`,
+      );
+      return true;
+    } finally {
+      if (timeout) {
+        this.timer.clearTimeout(timeout);
+      }
     }
   }
 

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -21,6 +21,8 @@ export interface CtrlProxyExternalProcess {
   readonly port: number;
 }
 
+export type RunnerOwnership = "owned" | "foreign" | "absent";
+
 interface ProcessClientOptions {
   readonly releaseAttempts?: number;
   readonly releaseGraceMs?: number;
@@ -189,20 +191,31 @@ export class IOSCtrlProxyProcessClient {
     }
   }
 
-  /** Strict shutdown ownership proof; failed inspection remains inconclusive to its caller. */
-  async isOwnedRunnerAlive(pid: number, deviceId: string, deadline?: number): Promise<boolean> {
+  /** Strict shutdown ownership classification; failed inspection remains inconclusive. */
+  async checkRunnerOwnership(
+    pid: number,
+    deviceId: string,
+    deadline?: number,
+  ): Promise<RunnerOwnership> {
     // Both launch paths spawn xcodebuild directly. Parent PID plus the device
     // argument distinguishes another daemon's otherwise identical runner.
     const process = await this.getProcessInfo(pid, deadline, {
       strict: true,
       includeEnvironment: false,
     });
-    return (
-      !!process &&
-      process.ppid === this.ownerPid &&
+    if (!process) {
+      return "absent";
+    }
+    return process.ppid === this.ownerPid &&
       this.isCtrlProxyRunnerCommand(process.command) &&
       this.hasDeviceIdentity(process.command, deviceId)
-    );
+      ? "owned"
+      : "foreign";
+  }
+
+  /** Preserves the existing boolean alive-and-owned contract for other callers. */
+  async isOwnedRunnerAlive(pid: number, deviceId: string, deadline?: number): Promise<boolean> {
+    return (await this.checkRunnerOwnership(pid, deviceId, deadline)) === "owned";
   }
 
   async findDescendantProcessIds(
@@ -316,7 +329,7 @@ export class IOSCtrlProxyProcessClient {
       return false;
     }
     try {
-      return !(await this.isOwnedRunnerAlive(pid, expectedDeviceId, deadline));
+      return (await this.checkRunnerOwnership(pid, expectedDeviceId, deadline)) === "foreign";
     } catch (error) {
       this.remainingTimeoutMs(deadline);
       logger.debug(`[IOSCtrlProxy] Runner ownership remains inconclusive: ${error}`);

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -24,6 +24,7 @@ export interface CtrlProxyExternalProcess {
 interface ProcessClientOptions {
   readonly releaseAttempts?: number;
   readonly releaseGraceMs?: number;
+  readonly ownerPid?: number;
 }
 
 /**
@@ -36,6 +37,7 @@ export class IOSCtrlProxyProcessClient {
   private static readonly DEFAULT_PORT = 8765;
   private readonly releaseAttempts: number;
   private readonly releaseGraceMs: number;
+  private readonly ownerPid: number;
 
   constructor(
     private readonly host: HostCommandExecutor = new DefaultHostCommandExecutor(),
@@ -44,6 +46,7 @@ export class IOSCtrlProxyProcessClient {
   ) {
     this.releaseAttempts = options.releaseAttempts ?? 4;
     this.releaseGraceMs = options.releaseGraceMs ?? 250;
+    this.ownerPid = options.ownerPid ?? process.pid;
   }
 
   async findExternalXcodebuildCtrlProxyProcess(
@@ -109,26 +112,63 @@ export class IOSCtrlProxyProcessClient {
     }
   }
 
-  async getProcessInfo(pid: number, deadline?: number): Promise<CtrlProxyProcessInfo | null> {
+  async getProcessInfo(
+    pid: number,
+    deadline?: number,
+    options: { strict?: boolean; includeEnvironment?: boolean } = {},
+  ): Promise<CtrlProxyProcessInfo | null> {
     try {
       const { stdout } = await this.executeCommand(
         "ps",
-        ["-p", String(pid), "-o", "ppid=", "-o", "args="],
+        ["-p", String(pid), "-o", "ppid=", "-o", "args=", "-ww"],
         deadline,
       );
       const output = stdout.trim();
       if (!output) {
         return null;
       }
-      const environment = await this.getProcessEnvironment(pid, deadline);
+      const environment =
+        options.includeEnvironment === false
+          ? undefined
+          : await this.getProcessEnvironment(pid, deadline);
       const match = output.match(/^(\d+)\s+([\s\S]+)$/);
+      if (!match && options.strict) {
+        throw new Error("Could not parse runner process identity");
+      }
       return match
         ? { ppid: Number.parseInt(match[1], 10), command: match[2], environment }
         : { command: output, environment };
     } catch (error) {
+      if (this.isMissingProcessError(error)) {
+        return null;
+      }
+      if (options.strict) {
+        throw error;
+      }
       logger.debug(`[IOSCtrlProxy] Failed to inspect PID ${pid}: ${error}`);
       return null;
     }
+  }
+
+  private isMissingProcessError(error: unknown): boolean {
+    const cause = error instanceof Error ? (error.cause ?? error) : error;
+    if (typeof cause !== "object" || cause === null) {
+      return false;
+    }
+    const failure = cause as {
+      code?: unknown;
+      stdout?: unknown;
+      stderr?: unknown;
+      signal?: unknown;
+    };
+    return (
+      failure.code === 1 &&
+      !failure.signal &&
+      typeof failure.stdout === "string" &&
+      failure.stdout.trim() === "" &&
+      typeof failure.stderr === "string" &&
+      failure.stderr.trim() === ""
+    );
   }
 
   async isRunning(pid: number, deadline?: number): Promise<boolean> {
@@ -149,15 +189,19 @@ export class IOSCtrlProxyProcessClient {
     }
   }
 
-  async isOwnedRunnerAlive(pid: number, deviceId: string): Promise<boolean> {
-    if (!(await this.isRunning(pid))) {
-      return false;
-    }
-    const process = await this.getProcessInfo(pid);
+  /** Strict shutdown ownership proof; failed inspection remains inconclusive to its caller. */
+  async isOwnedRunnerAlive(pid: number, deviceId: string, deadline?: number): Promise<boolean> {
+    // Both launch paths spawn xcodebuild directly. Parent PID plus the device
+    // argument distinguishes another daemon's otherwise identical runner.
+    const process = await this.getProcessInfo(pid, deadline, {
+      strict: true,
+      includeEnvironment: false,
+    });
     return (
       !!process &&
+      process.ppid === this.ownerPid &&
       this.isCtrlProxyRunnerCommand(process.command) &&
-      this.hasDeviceIdentity(`${process.command} ${process.environment ?? ""}`, deviceId)
+      this.hasDeviceIdentity(process.command, deviceId)
     );
   }
 
@@ -203,8 +247,14 @@ export class IOSCtrlProxyProcessClient {
   async terminateProcessTree(
     pid: number,
     deadline?: number,
-    options: { skipGraceful?: boolean } = {},
+    options: { skipGraceful?: boolean; expectedDeviceId?: string } = {},
   ): Promise<void> {
+    // Re-verify ownership immediately before signaling: a captured runner PID
+    // can be recycled between capture and shutdown, so killing it blind could
+    // tear down an unrelated process (#6579).
+    if (await this.isTerminationTargetForeign(pid, options.expectedDeviceId, deadline)) {
+      return;
+    }
     let descendants: number[];
     if (options.skipGraceful) {
       // Snapshot before root exit can reparent children, but reserve at least
@@ -247,6 +297,30 @@ export class IOSCtrlProxyProcessClient {
     }
     if (!(await this.waitForExit([pid, ...descendants], deadline))) {
       throw new Error(`CtrlProxy process tree rooted at PID ${pid} remained alive after SIGKILL`);
+    }
+  }
+
+  /**
+   * When a caller names the device it believes owns `pid`, prove the PID is
+   * still that owned runner before signaling. Returns true only when ownership
+   * is AFFIRMATIVELY disconfirmed (skip the kill). An inconclusive probe
+   * (exec/parse failure) returns false so termination falls through to our own
+   * possibly-hung runner rather than leaving it alive (#6579).
+   */
+  private async isTerminationTargetForeign(
+    pid: number,
+    expectedDeviceId: string | undefined,
+    deadline?: number,
+  ): Promise<boolean> {
+    if (expectedDeviceId === undefined) {
+      return false;
+    }
+    try {
+      return !(await this.isOwnedRunnerAlive(pid, expectedDeviceId, deadline));
+    } catch (error) {
+      this.remainingTimeoutMs(deadline);
+      logger.debug(`[IOSCtrlProxy] Runner ownership remains inconclusive: ${error}`);
+      return false;
     }
   }
 

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -313,7 +313,10 @@ describe("IOSCtrlProxyManager", function () {
         const executor = new FakeProcessExecutor();
         const processes: FakeListeningProcess[] = [42, 43].map((pid) => ({
           pid,
-          ppid: pid === 42 ? 1 : 42,
+          // The tracked runner (42) is parented by this daemon so the #6579
+          // ownership re-verification in forceStopForShutdown recognizes it as
+          // ours; 43 is its child.
+          ppid: pid === 42 ? process.pid : 42,
           port: 8765,
           command: `xcodebuild CtrlProxy -destination id=${testDevice.deviceId}`,
           alive: true,
@@ -1911,6 +1914,116 @@ describe("IOSCtrlProxyManager", function () {
       expect(runnerController.signal.aborted).toBe(true);
       expect(internal.xcTestProcessId).toBeNull();
       expect(internal.xcTestProcess).toBeNull();
+    });
+
+    test("forceStopForShutdown does not signal a recycled tracked PID that is no longer our runner (#6579)", async function () {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 912349;
+      const foreignProcess: FakeListeningProcess = {
+        pid: 912349,
+        port: 8998,
+        command: "/usr/sbin/some-other-daemons-runner --serve",
+        alive: true,
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [foreignProcess]);
+
+      // Only relevant if the fix regresses: an unfixed forceStopForShutdown would
+      // attempt terminateProcessTree against this never-dying foreign process,
+      // whose waitForExit retry loop sleeps via the timer.
+      fakeTimer.enableAutoAdvance();
+      await (
+        manager as unknown as { forceStopForShutdown(deadline: number): Promise<void> }
+      ).forceStopForShutdown(fakeTimer.now() + 5000);
+
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -912349")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 912349")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL -- -912349")).toBe(false);
+      expect(foreignProcess.alive).toBe(true);
+    });
+
+    test("forceStopForShutdown does not signal another daemon runner for the same device", async function () {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 912349;
+      const foreignProcess: FakeListeningProcess = {
+        pid: 912349,
+        port: 8998,
+        command: ownRunnerProcess(912349).command,
+        ppid: process.pid + 1,
+        alive: true,
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [foreignProcess]);
+
+      // Only relevant if the fix regresses: an unfixed forceStopForShutdown would
+      // attempt terminateProcessTree against this never-dying foreign process,
+      // whose waitForExit retry loop sleeps via the timer.
+      fakeTimer.enableAutoAdvance();
+      await (
+        manager as unknown as { forceStopForShutdown(deadline: number): Promise<void> }
+      ).forceStopForShutdown(fakeTimer.now() + 5000);
+
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -912349")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 912349")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL -- -912349")).toBe(false);
+      expect(foreignProcess.alive).toBe(true);
+    });
+
+    test.each(["error", "timeout"])(
+      "keeps an inconclusive ownership %s separate from mismatch",
+      async function (mode) {
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          testDevice,
+          fakeTimer,
+          undefined,
+          fakeExecutor,
+        );
+        fakeExecutor.setCommandHandler("ps -p", async () => {
+          if (mode === "error") {
+            throw new Error("temporary ps failure");
+          }
+          return new Promise<ReturnType<typeof createExecResult>>(() => {});
+        });
+        const result = (
+          manager as unknown as {
+            isRunnerStillOwnedWithinShutdownDeadline: (pid: number) => Promise<boolean>;
+          }
+        ).isRunnerStillOwnedWithinShutdownDeadline(912350);
+        expect(await fakeTimer.resolvePromise(result)).toBe(true);
+        expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+      },
+    );
+    test("forceStopForShutdown still tree-kills a re-verified owned runner (#6579)", async function () {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 912350;
+      const ownedRunner = { ...ownRunnerProcess(912350), ppid: process.pid };
+      installListeningProcessFakes(fakeExecutor, [ownedRunner]);
+
+      await (
+        manager as unknown as { forceStopForShutdown(deadline: number): Promise<void> }
+      ).forceStopForShutdown(fakeTimer.now() + 5000);
+
+      // forceStopForShutdown drives terminateProcessTree with skipGraceful, so a
+      // re-verified owned runner is signaled straight with SIGKILL (no SIGTERM).
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL -- -912350")).toBe(true);
+      expect(ownedRunner.alive).toBe(false);
     });
 
     test("start() waits for an own runner then terminates it if it never becomes healthy (#2834)", async function () {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -2026,6 +2026,34 @@ describe("IOSCtrlProxyManager", function () {
       expect(ownedRunner.alive).toBe(false);
     });
 
+    test("forceStopForShutdown kills a surviving owned process group after its root exits (#6579)", async function () {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+      );
+      const runnerPid = 912351;
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = runnerPid;
+      const exitedRunner = { ...ownRunnerProcess(runnerPid), alive: false };
+      const survivingChild: FakeListeningProcess = {
+        pid: 912352,
+        port: 8765,
+        command: "CtrlProxyUITests-Runner",
+        alive: true,
+        ppid: 1,
+        pgid: runnerPid,
+      };
+      installListeningProcessFakes(fakeExecutor, [exitedRunner, survivingChild]);
+
+      await (
+        manager as unknown as { forceStopForShutdown(deadline: number): Promise<void> }
+      ).forceStopForShutdown(250);
+
+      expect(fakeExecutor.wasCommandExecuted(`kill -KILL -- -${runnerPid}`)).toBe(true);
+      expect(survivingChild.alive).toBe(false);
+    });
+
     test("start() waits for an own runner then terminates it if it never becomes healthy (#2834)", async function () {
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice, // simulator UUID

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -141,7 +141,7 @@ describe("IOSCtrlProxyProcessClient", () => {
 
     expect(process).toEqual({ pid: 42, port: 8765 });
     expect(host.getExecutedCommands()).toContain("pgrep -x xcodebuild");
-    expect(host.getExecutedCommands()).toContain("ps -p 42 -o ppid= -o args=");
+    expect(host.getExecutedCommands()).toContain("ps -p 42 -o ppid= -o args= -ww");
   });
 
   test("does not report a daemon-managed runner behind an orphaned shell as external, even when its own environment carries a device identity marker (#6372 predicate-divergence regression)", async () => {
@@ -183,6 +183,62 @@ describe("IOSCtrlProxyProcessClient", () => {
     await expect(client.isOwnedRunnerAlive(42, "DEVICE-1")).resolves.toBe(false);
   });
 
+  test.each([100, 101])(
+    "checks untruncated arguments and daemon parent PID (%s)",
+    async (parentPid) => {
+      const command = `${parentPid} xcodebuild test-without-building -xctestrun /tmp/${"long-path/".repeat(40)}CtrlProxy.xctestrun -destination id=DEVICE-1`;
+      const host: HostCommandExecutor = {
+        async executeCommand(file, args) {
+          expect(file).toBe("ps");
+          return result(args.includes("-ww") ? command : command.slice(0, 256));
+        },
+      };
+      const client = new IOSCtrlProxyProcessClient(host, new FakeTimer(), { ownerPid: 100 });
+      expect(await client.isOwnedRunnerAlive(42, "DEVICE-1")).toBe(parentPid === 100);
+    },
+  );
+
+  test("recognizes the wrapped no-match ps exit without assuming ownership", async () => {
+    const failure = Object.assign(new Error("no matching process"), {
+      code: 1,
+      stdout: "",
+      stderr: "",
+    });
+    const host: HostCommandExecutor = {
+      async executeCommand() {
+        throw new Error("wrapped command failure", { cause: failure });
+      },
+    };
+    const client = new IOSCtrlProxyProcessClient(host, new FakeTimer());
+    expect(await client.isOwnedRunnerAlive(42, "DEVICE-1")).toBe(false);
+  });
+
+  test("does not signal a PID recycled while descendants are enumerated", async () => {
+    const commands: string[] = [];
+    const host: HostCommandExecutor = {
+      async executeCommand(file, args) {
+        commands.push(`${file} ${args.join(" ")}`);
+        if (args.includes("-axo")) {
+          return result("42 100\n43 42");
+        }
+        return result("101 unrelated-process");
+      },
+    };
+    const client = new IOSCtrlProxyProcessClient(host, new FakeTimer(), { ownerPid: 100 });
+    await client.terminateProcessTree(42, 250, { expectedDeviceId: "DEVICE-1" });
+    expect(commands.some((command) => command.startsWith("kill "))).toBe(false);
+  });
+
+  test("preserves a transient ownership inspection failure", async () => {
+    const failure = new Error("ps temporarily unavailable");
+    const host: HostCommandExecutor = {
+      executeCommand: async () => {
+        throw failure;
+      },
+    };
+    const client = new IOSCtrlProxyProcessClient(host, new FakeTimer());
+    await expect(client.isOwnedRunnerAlive(42, "DEVICE-1")).rejects.toBe(failure);
+  });
   test("signals the owned process group, then descendants, and escalates after the bounded wait", async () => {
     const host = new FakeHostCommandExecutor();
     const timer = new FakeTimer();

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -213,6 +213,47 @@ describe("IOSCtrlProxyProcessClient", () => {
     expect(await client.isOwnedRunnerAlive(42, "DEVICE-1")).toBe(false);
   });
 
+  test("distinguishes owned, absent, and foreign runners", async () => {
+    const host = new FakeHostCommandExecutor();
+    host.setCommandResponse("ps -p 42", result());
+    host.setCommandResponse("ps -p 43", result("101 unrelated-process"));
+    host.setCommandResponse(
+      "ps -p 44",
+      result(
+        "100 xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun -destination id=DEVICE-1",
+      ),
+    );
+    const client = new IOSCtrlProxyProcessClient(host, new FakeTimer(), { ownerPid: 100 });
+
+    await expect(client.checkRunnerOwnership(44, "DEVICE-1")).resolves.toBe("owned");
+    await expect(client.checkRunnerOwnership(42, "DEVICE-1")).resolves.toBe("absent");
+    await expect(client.checkRunnerOwnership(43, "DEVICE-1")).resolves.toBe("foreign");
+  });
+
+  test("force termination signals the tracked process group when its root is absent", async () => {
+    const commands: string[] = [];
+    const host: HostCommandExecutor = {
+      async executeCommand(file, args) {
+        commands.push(`${file} ${args.join(" ")}`);
+        if (file === "ps") {
+          return result();
+        }
+        if (file === "kill" && args[0] === "-0") {
+          throw new Error("No such process");
+        }
+        return result();
+      },
+    };
+    const client = new IOSCtrlProxyProcessClient(host, new FakeTimer());
+
+    await client.terminateProcessTree(42, 250, {
+      skipGraceful: true,
+      expectedDeviceId: "DEVICE-1",
+    });
+
+    expect(commands).toContain("kill -KILL -- -42");
+  });
+
   test("does not signal a PID recycled while descendants are enumerated", async () => {
     const commands: string[] = [];
     const host: HostCommandExecutor = {


### PR DESCRIPTION
## Summary

forceStopForShutdown was the only kill site in IOSCtrlProxyManager that tree-killed the tracked runner PID without re-verifying ownership first (unlike stop() and the hung-runner path), so a PID recycled between the last liveness check and daemon shutdown could get SIGTERM/SIGKILL sent to an unrelated process group — most plausibly another AutoMobile daemon's runner. This adds isRunnerStillOwnedWithinShutdownDeadline, which calls the existing processClient.isOwnedRunnerAlive(pid, deviceId) and races it against a 100ms timeout nested inside the 250ms force-stop budget so the check cannot starve the kill; on timeout or exec error it fails open (treats the PID as still owned) to preserve today's behavior for a genuinely hung runner. terminateProcessTree is skipped, with a warn log, when ownership cannot be confirmed.

Part of epic #6372.

Stacked on `work/issue-6416-ios-availability-cache-reopen`; GitHub retargets to `main` once it merges.

## Linked Issue

Closes #6579

## Validation

Two deterministic tests next to the existing stop() ownership-recheck tests: a foreign/recycled-PID case asserts no TERM/KILL is ever sent (red before — it issued kill -TERM), and its converse asserts a re-verified owned runner is still tree-killed. Targeted 2; IOSCtrlProxyManager+ProcessClient 121/0; test/utils/ios+Manager 627/0 pass.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
