### PR TITLE
fix(ios): evict CtrlProxy manager instance and port reservation on device teardown (#6580)

### DIFF
--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -40,6 +40,7 @@ import { syncInstalledAppResources } from "./appResources";
 import { listActiveVideoRecordings, stopVideoRecording } from "./videoRecordingManager";
 import { stopSegmentedVideoRecordingsForDevice } from "./videoRecordingTools";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
+import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { AndroidCtrlProxyClient } from "../features/observe/android/AndroidCtrlProxyClient";
 import { logger } from "../utils/logger";
 import { createPerformanceTracker } from "../utils/PerformanceTracker";
@@ -7000,6 +7001,16 @@ export function registerDeviceTools() {
                 ? target.device.name
                 : (target.device.deviceId ?? args.target.stableId),
             );
+            // Evict the CtrlProxy manager instance and (iOS) its PortManager
+            // reservation for this device id regardless of whether it was
+            // booted, so a deleted device never permanently retains either
+            // (issue #6580).
+            const evictedDeviceId = target.device.deviceId ?? args.target.stableId;
+            if (target.device.platform === "ios") {
+              await IOSCtrlProxyManager.evict(evictedDeviceId);
+            } else {
+              AndroidCtrlProxyManager.evict(evictedDeviceId);
+            }
           },
           verify: async (state, stop) => {
             if (state.earlyResponse) {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2649,7 +2649,12 @@ async function readTeardownInventory(
 async function evictTeardownManagers(context: TeardownContext, runtimeId?: string): Promise<void> {
   const { platform, stableId } = context.args.target;
   if (platform === "ios") {
-    await IOSCtrlProxyManager.evict(runtimeId ?? stableId, context.dependencies.timer);
+    if (runtimeId) {
+      await IOSCtrlProxyManager.evict(runtimeId, context.dependencies.timer);
+    } else {
+      await IOSCtrlProxyManager.evict(stableId, context.dependencies.timer);
+      await IOSCtrlProxyManager.evictSimulatorByName(stableId, context.dependencies.timer);
+    }
   } else {
     AndroidCtrlProxyManager.evict(runtimeId ?? stableId, stableId);
   }
@@ -6939,6 +6944,7 @@ export function registerDeviceTools() {
     type TeardownState = {
       context: TeardownContext;
       target: TeardownResolvedTarget;
+      androidManager?: AndroidCtrlProxyManager;
       earlyResponse?: TeardownToolResponse;
     };
     try {
@@ -6971,7 +6977,14 @@ export function registerDeviceTools() {
             if ("response" in resolution) {
               return { response: resolution.response };
             }
-            return { target: { context, target: resolution.target } };
+            const runtime = resolution.target.wasBooted
+              ? resolution.target.bootedDevice
+              : undefined;
+            const androidManager =
+              runtime?.platform === "android"
+                ? AndroidCtrlProxyManager.getExistingInstance(runtime.deviceId)
+                : undefined;
+            return { target: { context, target: resolution.target, androidManager } };
           },
           stop: async (state, requestAbortSignal, retainLeaseUntil) => {
             const { context, target } = state;
@@ -7011,7 +7024,11 @@ export function registerDeviceTools() {
                 ? target.device.name
                 : (target.device.deviceId ?? args.target.stableId),
             );
-            await evictTeardownManagers(context, target.device.deviceId);
+            if (state.androidManager) {
+              AndroidCtrlProxyManager.evictInstance(state.androidManager);
+            } else {
+              await evictTeardownManagers(context, target.device.deviceId);
+            }
           },
           verify: async (state, stop) => {
             if (state.earlyResponse) {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2646,6 +2646,15 @@ async function readTeardownInventory(
   );
 }
 
+async function evictTeardownManagers(context: TeardownContext, runtimeId?: string): Promise<void> {
+  const { platform, stableId } = context.args.target;
+  if (platform === "ios") {
+    await IOSCtrlProxyManager.evict(runtimeId ?? stableId, context.dependencies.timer);
+  } else {
+    AndroidCtrlProxyManager.evict(runtimeId ?? stableId, stableId);
+  }
+}
+
 async function resolveAbsentTeardownTarget(
   context: TeardownContext,
   booted: BootedDeviceDiscovery,
@@ -2664,6 +2673,7 @@ async function resolveAbsentTeardownTarget(
     };
   }
   await retireAbsentTeardownOwnership(context);
+  await evictTeardownManagers(context);
   unregisterDirectSessionsForStableIdentity(
     context.args.target.platform,
     context.args.target.stableId,
@@ -7001,16 +7011,7 @@ export function registerDeviceTools() {
                 ? target.device.name
                 : (target.device.deviceId ?? args.target.stableId),
             );
-            // Evict the CtrlProxy manager instance and (iOS) its PortManager
-            // reservation for this device id regardless of whether it was
-            // booted, so a deleted device never permanently retains either
-            // (issue #6580).
-            const evictedDeviceId = target.device.deviceId ?? args.target.stableId;
-            if (target.device.platform === "ios") {
-              await IOSCtrlProxyManager.evict(evictedDeviceId);
-            } else {
-              AndroidCtrlProxyManager.evict(evictedDeviceId);
-            }
+            await evictTeardownManagers(context, target.device.deviceId);
           },
           verify: async (state, stop) => {
             if (state.earlyResponse) {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2650,13 +2650,35 @@ async function evictTeardownManagers(context: TeardownContext, runtimeId?: strin
   const { platform, stableId } = context.args.target;
   if (platform === "ios") {
     if (runtimeId) {
-      await IOSCtrlProxyManager.evict(runtimeId, context.dependencies.timer);
+      await IOSCtrlProxyManager.evict(runtimeId, context.dependencies.timer, context.deadlineMs);
     } else {
-      await IOSCtrlProxyManager.evict(stableId, context.dependencies.timer);
-      await IOSCtrlProxyManager.evictSimulatorByName(stableId, context.dependencies.timer);
+      await IOSCtrlProxyManager.evict(stableId, context.dependencies.timer, context.deadlineMs);
+      await IOSCtrlProxyManager.evictSimulatorByName(
+        stableId,
+        context.dependencies.timer,
+        context.deadlineMs,
+      );
     }
   } else {
     AndroidCtrlProxyManager.evict(runtimeId ?? stableId, stableId);
+  }
+}
+
+async function finalizeTeardownEviction(
+  context: TeardownContext,
+  target: TeardownResolvedTarget,
+  androidManager: AndroidCtrlProxyManager | undefined,
+): Promise<void> {
+  unregisterDirectSessionsForStableIdentity(
+    target.device.platform,
+    target.device.platform === "android"
+      ? target.device.name
+      : (target.device.deviceId ?? context.args.target.stableId),
+  );
+  if (androidManager) {
+    AndroidCtrlProxyManager.evictInstance(androidManager);
+  } else {
+    await evictTeardownManagers(context, target.device.deviceId);
   }
 }
 
@@ -2677,8 +2699,20 @@ async function resolveAbsentTeardownTarget(
       ),
     };
   }
+  const daemonState = DaemonState.getInstance();
+  const runtimeId = daemonState.isInitialized()
+    ? findAbsentTeardownPooledDevices(daemonState.getDevicePool(), context.args.target)[0]?.id
+    : undefined;
+  const androidManager =
+    context.args.target.platform === "android" && runtimeId
+      ? AndroidCtrlProxyManager.getExistingInstance(runtimeId)
+      : undefined;
   await retireAbsentTeardownOwnership(context);
-  await evictTeardownManagers(context);
+  if (androidManager) {
+    AndroidCtrlProxyManager.evictInstance(androidManager);
+  } else {
+    await evictTeardownManagers(context, runtimeId);
+  }
   unregisterDirectSessionsForStableIdentity(
     context.args.target.platform,
     context.args.target.stableId,
@@ -3007,6 +3041,7 @@ async function destroyTeardownTarget(
   target: TeardownResolvedTarget,
   retainStableLifecycleUntil: (operation: Promise<unknown>) => void,
   markDestructionStarted: () => void,
+  onLateSuccess: () => void,
 ): Promise<void> {
   const deadlineTarget: BootedDevice = {
     name: target.device.name,
@@ -3035,6 +3070,13 @@ async function destroyTeardownTarget(
   } catch (error) {
     if (destroy) {
       retainStableLifecycleUntil(destroy);
+      void destroy.then(
+        () => onLateSuccess(),
+        () => {
+          // A rejected late destroy did not remove the platform device, so no eviction is safe.
+          logger.debug("[DeviceTools] Late platform deletion rejected; retaining teardown state");
+        },
+      );
     }
     throw error;
   }
@@ -7017,18 +7059,16 @@ export function registerDeviceTools() {
               return;
             }
             const { context, target } = state;
-            await destroyTeardownTarget(context, target, retainLeaseUntil, markDestructionStarted);
-            unregisterDirectSessionsForStableIdentity(
-              target.device.platform,
-              target.device.platform === "android"
-                ? target.device.name
-                : (target.device.deviceId ?? args.target.stableId),
+            await destroyTeardownTarget(
+              context,
+              target,
+              retainLeaseUntil,
+              markDestructionStarted,
+              () => {
+                void finalizeTeardownEviction(context, target, state.androidManager);
+              },
             );
-            if (state.androidManager) {
-              AndroidCtrlProxyManager.evictInstance(state.androidManager);
-            } else {
-              await evictTeardownManagers(context, target.device.deviceId);
-            }
+            await finalizeTeardownEviction(context, target, state.androidManager);
           },
           verify: async (state, stop) => {
             if (state.earlyResponse) {

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -230,6 +230,18 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
   }
 
   /**
+   * Evict a single device's manager instance. Mirrors
+   * `IOSCtrlProxyManager.evict` so both platforms share the same per-device
+   * teardown seam (issue #6580) — call this from device teardown/destroy so a
+   * deleted device does not retain a manager for the daemon's lifetime.
+   * `AndroidCtrlProxyManager` holds no `PortManager` reservation, so deleting
+   * the map entry is the entire eviction.
+   */
+  public static evict(deviceId: string): void {
+    AndroidCtrlProxyManager.instances.delete(deviceId);
+  }
+
+  /**
    * Prefetch the accessibility service APK asynchronously.
    * Call this at server startup to warm the cache before first device connection.
    * This is a no-op if prefetch is already in progress or completed.

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -237,6 +237,16 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
    * `AndroidCtrlProxyManager` holds no `PortManager` reservation, so deleting
    * the map entry is the entire eviction.
    */
+  public static getExistingInstance(deviceId: string): AndroidCtrlProxyManager | undefined {
+    return AndroidCtrlProxyManager.instances.get(deviceId);
+  }
+
+  public static evictInstance(instance: AndroidCtrlProxyManager): void {
+    if (AndroidCtrlProxyManager.instances.get(instance.device.deviceId) === instance) {
+      AndroidCtrlProxyManager.instances.delete(instance.device.deviceId);
+    }
+  }
+
   public static evict(deviceId: string, avdName?: string): void {
     if (!avdName) AndroidCtrlProxyManager.instances.delete(deviceId);
     if (avdName) {

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -237,8 +237,17 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
    * `AndroidCtrlProxyManager` holds no `PortManager` reservation, so deleting
    * the map entry is the entire eviction.
    */
-  public static evict(deviceId: string): void {
-    AndroidCtrlProxyManager.instances.delete(deviceId);
+  public static evict(deviceId: string, avdName?: string): void {
+    if (!avdName) AndroidCtrlProxyManager.instances.delete(deviceId);
+    if (avdName) {
+      // The stopped AVD inventory lacks an ADB serial. The manager retains
+      // the booted incarnation's name and runtime ID, including direct sessions.
+      for (const [runtimeId, manager] of AndroidCtrlProxyManager.instances) {
+        if (runtimeId.startsWith("emulator-") && manager.device.name === avdName) {
+          AndroidCtrlProxyManager.instances.delete(runtimeId);
+        }
+      }
+    }
   }
 
   /**

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -463,6 +463,23 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * Safe to call for a device that was never constructed via `getInstance` —
    * `PortManager.release` is a no-op when nothing is allocated for the id.
    */
+  public static async evictSimulatorByName(
+    name: string,
+    timer: Timer = defaultTimer,
+  ): Promise<void> {
+    const matching = [...IOSCtrlProxyManager.instances.entries()].filter(
+      ([, instance]) => instance.device.name === name && instance.isSimulator(),
+    );
+    await Promise.all(
+      matching.map(([deviceId, instance]) => {
+        if (IOSCtrlProxyManager.instances.get(deviceId) === instance) {
+          return IOSCtrlProxyManager.evict(deviceId, timer);
+        }
+        return Promise.resolve();
+      }),
+    );
+  }
+
   public static async evict(deviceId: string, timer: Timer = defaultTimer): Promise<void> {
     const instance = IOSCtrlProxyManager.instances.get(deviceId);
     if (instance) {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -456,6 +456,29 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   /**
+   * Evict a single device's manager instance and its `PortManager` reservation.
+   * Call this from device teardown/destroy so a deleted-or-evicted device does
+   * not permanently retain a manager (and its two process supervisors) or a
+   * port reservation for the remainder of the daemon's lifetime (issue #6580).
+   * Safe to call for a device that was never constructed via `getInstance` —
+   * `PortManager.release` is a no-op when nothing is allocated for the id.
+   */
+  public static async evict(deviceId: string): Promise<void> {
+    const instance = IOSCtrlProxyManager.instances.get(deviceId);
+    if (instance) {
+      IOSCtrlProxyManager.instances.delete(deviceId);
+      try {
+        await instance.forceStopForShutdown();
+      } catch (error) {
+        logger.warn(
+          `[IOSCtrlProxy] Failed to stop instance ${deviceId} during eviction: ${errorMessage(error)}`,
+        );
+      }
+    }
+    PortManager.release(deviceId);
+  }
+
+  /**
    * Stop all active instances (for shutdown)
    */
   public static async shutdownAll(timer: Timer = defaultTimer): Promise<void> {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -463,12 +463,16 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * Safe to call for a device that was never constructed via `getInstance` —
    * `PortManager.release` is a no-op when nothing is allocated for the id.
    */
-  public static async evict(deviceId: string): Promise<void> {
+  public static async evict(deviceId: string, timer: Timer = defaultTimer): Promise<void> {
     const instance = IOSCtrlProxyManager.instances.get(deviceId);
     if (instance) {
       IOSCtrlProxyManager.instances.delete(deviceId);
       try {
-        await instance.forceStopForShutdown();
+        // Bound the force-stop the same way shutdownAll() does: a hung
+        // runner cleanup must not block the port release / map deletion
+        // below, which the caller's deleteDevice verification depends on
+        // (issue #6580).
+        await IOSCtrlProxyManager.forceStopWithinShutdownDeadline(instance, timer);
       } catch (error) {
         logger.warn(
           `[IOSCtrlProxy] Failed to stop instance ${deviceId} during eviction: ${errorMessage(error)}`,

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -466,6 +466,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   public static async evictSimulatorByName(
     name: string,
     timer: Timer = defaultTimer,
+    deadlineMs?: number,
   ): Promise<void> {
     const matching = [...IOSCtrlProxyManager.instances.entries()].filter(
       ([, instance]) => instance.device.name === name && instance.isSimulator(),
@@ -473,14 +474,18 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     await Promise.all(
       matching.map(([deviceId, instance]) => {
         if (IOSCtrlProxyManager.instances.get(deviceId) === instance) {
-          return IOSCtrlProxyManager.evict(deviceId, timer);
+          return IOSCtrlProxyManager.evict(deviceId, timer, deadlineMs);
         }
         return Promise.resolve();
       }),
     );
   }
 
-  public static async evict(deviceId: string, timer: Timer = defaultTimer): Promise<void> {
+  public static async evict(
+    deviceId: string,
+    timer: Timer = defaultTimer,
+    deadlineMs?: number,
+  ): Promise<void> {
     const instance = IOSCtrlProxyManager.instances.get(deviceId);
     if (instance) {
       IOSCtrlProxyManager.instances.delete(deviceId);
@@ -489,7 +494,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         // runner cleanup must not block the port release / map deletion
         // below, which the caller's deleteDevice verification depends on
         // (issue #6580).
-        await IOSCtrlProxyManager.forceStopWithinShutdownDeadline(instance, timer);
+        await IOSCtrlProxyManager.forceStopWithinEvictionDeadline(instance, timer, deadlineMs);
       } catch (error) {
         logger.warn(
           `[IOSCtrlProxy] Failed to stop instance ${deviceId} during eviction: ${errorMessage(error)}`,
@@ -566,6 +571,48 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       await Promise.race([
         instance.forceStopForShutdown(instance.timer.now() + SHUTDOWN_FORCE_STOP_TIMEOUT_MS),
         deadline,
+      ]);
+    } finally {
+      if (timeout) {
+        timer.clearTimeout(timeout);
+      }
+    }
+  }
+
+  private static async forceStopWithinEvictionDeadline(
+    instance: IOSCtrlProxyManager,
+    timer: Timer,
+    deadlineMs?: number,
+  ): Promise<void> {
+    if (deadlineMs === undefined) {
+      await IOSCtrlProxyManager.forceStopWithinShutdownDeadline(instance, timer);
+      return;
+    }
+
+    const now = timer.now();
+    const remainingMs = deadlineMs - now;
+    if (remainingMs <= 0) {
+      logger.debug(
+        `[IOSCtrlProxy] Eviction deadline already expired for ${instance.device.deviceId}; ` +
+          "starting force-stop without waiting",
+      );
+      void Promise.resolve(instance.forceStopForShutdown(deadlineMs)).catch((error) => {
+        logger.debug(
+          `[IOSCtrlProxy] Force-stop after an expired eviction deadline failed: ${error}`,
+        );
+      });
+      return;
+    }
+
+    const waitMs = Math.min(remainingMs, SHUTDOWN_FORCE_STOP_TIMEOUT_MS);
+    let timeout: NodeJS.Timeout | undefined;
+    const waitForDeadline = new Promise<void>((resolve) => {
+      timeout = timer.setTimeout(resolve, waitMs);
+    });
+    try {
+      await Promise.race([
+        instance.forceStopForShutdown(Math.min(deadlineMs, now + SHUTDOWN_FORCE_STOP_TIMEOUT_MS)),
+        waitForDeadline,
       ]);
     } finally {
       if (timeout) {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -479,7 +479,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         );
       }
     }
-    PortManager.release(deviceId);
+    if (!IOSCtrlProxyManager.instances.has(deviceId)) {
+      PortManager.release(deviceId);
+    }
   }
 
   /**

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -905,6 +905,47 @@ describe("deleteDevice handler", () => {
     expect(pool.getDevice(second.deviceId)).toBeNull();
   });
 
+  test("evicts an absent Android manager by its pooled runtime identity", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionRepository());
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    const image: DeviceInfo = {
+      platform: "android",
+      name: "Pixel_8",
+      isRunning: false,
+    };
+    const pooledRuntime: BootedDevice = {
+      platform: "android",
+      name: "Unknown (emulator-5556)",
+      deviceId: "emulator-5556",
+    };
+    await pool.addDevice(pooledRuntime, image);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    const staleManager = AndroidCtrlProxyManager.getInstance(pooledRuntime);
+    manager.setBootedDevices("android", []);
+    manager.setDeviceImages("android", []);
+
+    try {
+      expect(pool.getDevice(pooledRuntime.deviceId)?.avdName).toBe(image.name);
+      expect(AndroidCtrlProxyManager.getExistingInstance(pooledRuntime.deviceId)).toBe(
+        staleManager,
+      );
+      const response = await teardownTool().handler(request("android", image.name, image.name));
+
+      expect(responseBody(response).state).toBe("already_absent");
+      expect(AndroidCtrlProxyManager.getExistingInstance(pooledRuntime.deviceId)).toBeUndefined();
+    } finally {
+      AndroidCtrlProxyManager.resetInstances();
+    }
+  });
+
   test("retires every stale pooled Android incarnation before deleting a stopped AVD", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionRepository());
@@ -1416,6 +1457,113 @@ describe("deleteDevice handler", () => {
 
     releaseDestroy();
     await expect(start).rejects.toThrow(/not found/);
+  });
+
+  test("evicts the CtrlProxy manager after a timed-out destroy later succeeds", async () => {
+    const timer = new FakeTimer();
+    const device: DeviceInfo = {
+      platform: "ios",
+      name: "iPhone 16",
+      deviceId: "IOS-DEVICE-1",
+      isRunning: false,
+    };
+    const proxy = IOSCtrlProxyManager.getInstance(device);
+    const forceStop = spyOn(
+      proxy as unknown as { forceStopForShutdown: () => Promise<void> },
+      "forceStopForShutdown",
+    ).mockResolvedValue();
+    let releaseDestroy!: () => void;
+    const destroyStarted = new Promise<void>((resolve) => {
+      manager.destroyStarted = resolve;
+    });
+    manager.destroyGate = new Promise<void>((resolve) => {
+      releaseDestroy = resolve;
+    });
+    manager.setDeviceImages("ios", [device]);
+    registerDirectSessionDevice("late-destroy-session", device);
+    setDeviceToolsDependencies({ timer });
+
+    try {
+      const teardown = teardownTool().handler({
+        ...request("ios", device.deviceId!, device.name),
+        timeoutMs: 10,
+      });
+      await destroyStarted;
+      timer.advanceTime(10);
+
+      expect(responseBody(await teardown).failure).toEqual(
+        expect.objectContaining({ phase: "destroy", code: "operation_failed" }),
+      );
+      expect(IOSCtrlProxyManager.getInstance(device)).toBe(proxy);
+      expect(resolveDirectSessionDevice("late-destroy-session")).toBeDefined();
+
+      releaseDestroy();
+      for (let attempt = 0; attempt < 10; attempt++) {
+        await Promise.resolve();
+      }
+
+      expect(forceStop).toHaveBeenCalledTimes(1);
+      expect(PortManager.getPort(device.deviceId!)).toBeUndefined();
+      expect((IOSCtrlProxyManager as any).instances.get(device.deviceId)).toBeUndefined();
+      expect(resolveDirectSessionDevice("late-destroy-session")).toBeUndefined();
+    } finally {
+      forceStop.mockRestore();
+      IOSCtrlProxyManager.resetInstances();
+      PortManager.release(device.deviceId!);
+    }
+  });
+
+  test("does not evict the CtrlProxy manager after a timed-out destroy later rejects", async () => {
+    const timer = new FakeTimer();
+    const device: DeviceInfo = {
+      platform: "ios",
+      name: "iPhone 16",
+      deviceId: "IOS-DEVICE-1",
+      isRunning: false,
+    };
+    const proxy = IOSCtrlProxyManager.getInstance(device);
+    const forceStop = spyOn(
+      proxy as unknown as { forceStopForShutdown: () => Promise<void> },
+      "forceStopForShutdown",
+    ).mockResolvedValue();
+    let releaseDestroy!: () => void;
+    const destroyStarted = new Promise<void>((resolve) => {
+      manager.destroyStarted = resolve;
+    });
+    manager.destroyGate = new Promise<void>((resolve) => {
+      releaseDestroy = resolve;
+    });
+    manager.destroyError = new Error("destroy failed late");
+    manager.setDeviceImages("ios", [device]);
+    registerDirectSessionDevice("late-rejected-destroy-session", device);
+    setDeviceToolsDependencies({ timer });
+
+    try {
+      const teardown = teardownTool().handler({
+        ...request("ios", device.deviceId!, device.name),
+        timeoutMs: 10,
+      });
+      await destroyStarted;
+      timer.advanceTime(10);
+
+      expect(responseBody(await teardown).failure).toEqual(
+        expect.objectContaining({ phase: "destroy", code: "operation_failed" }),
+      );
+
+      releaseDestroy();
+      for (let attempt = 0; attempt < 10; attempt++) {
+        await Promise.resolve();
+      }
+
+      expect(forceStop).not.toHaveBeenCalled();
+      expect(PortManager.getPort(device.deviceId!)).toBeDefined();
+      expect(IOSCtrlProxyManager.getInstance(device)).toBe(proxy);
+      expect(resolveDirectSessionDevice("late-rejected-destroy-session")).toBeDefined();
+    } finally {
+      forceStop.mockRestore();
+      IOSCtrlProxyManager.resetInstances();
+      PortManager.release(device.deviceId!);
+    }
   });
 
   test("holds the resolved iOS stable target before a name-selected compatibility start boots", async () => {

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -1,7 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, spyOn } from "bun:test";
 import { promises as fsPromises } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { IOSCtrlProxyManager } from "../../src/utils/IOSCtrlProxyManager";
+import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
+import { PortManager } from "../../src/utils/PortManager";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { SessionManager } from "../../src/daemon/sessionManager";
@@ -760,6 +763,53 @@ describe("deleteDevice handler", () => {
     expect(pool.getDevice(device.deviceId!)).toBeNull();
     expect(sessionManager.getSessionForDevice(device.deviceId!)).toBeNull();
   });
+
+  test("evicts a cached iOS manager after complete discovery proves absence", async () => {
+    const device = {
+      platform: "ios" as const,
+      name: "Absent Simulator",
+      deviceId: "11111111-1111-1111-1111-111111111111",
+    };
+    const old = IOSCtrlProxyManager.getInstance(device);
+    const stop = spyOn(
+      old as unknown as { forceStopForShutdown: () => Promise<void> },
+      "forceStopForShutdown",
+    ).mockResolvedValue();
+    try {
+      const response = await teardownTool().handler(request("ios", device.deviceId, device.name));
+      expect(responseBody(response).state).toBe("already_absent");
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(PortManager.getPort(device.deviceId)).toBeUndefined();
+      expect(IOSCtrlProxyManager.getInstance(device)).not.toBe(old);
+    } finally {
+      IOSCtrlProxyManager.resetInstances();
+      stop.mockRestore();
+    }
+  });
+
+  test.each([false, true])(
+    "evicts Android runtime managers for a stopped or absent AVD (absent: %s)",
+    async (absent) => {
+      const device = {
+        platform: "android" as const,
+        name: "Deleted_AVD",
+        deviceId: "emulator-5556",
+      };
+      const old = AndroidCtrlProxyManager.getInstance(device);
+      manager.setBootedDevices("android", []);
+      manager.setDeviceImages(
+        "android",
+        absent ? [] : [{ platform: "android", name: device.name, isRunning: false }],
+      );
+      try {
+        const response = await teardownTool().handler(request("android", device.name, device.name));
+        expect(responseBody(response).state).toBe(absent ? "already_absent" : "destroyed");
+        expect(AndroidCtrlProxyManager.getInstance(device)).not.toBe(old);
+      } finally {
+        AndroidCtrlProxyManager.resetInstances();
+      }
+    },
+  );
 
   test("reports already_absent only after a complete platform inventory finds no target", async () => {
     const response = await teardownTool().handler(request("ios", "IOS-DEVICE-1", "iPhone 16"));

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -764,7 +764,7 @@ describe("deleteDevice handler", () => {
     expect(sessionManager.getSessionForDevice(device.deviceId!)).toBeNull();
   });
 
-  test("evicts a cached iOS manager after complete discovery proves absence", async () => {
+  test.each([false, true])("evicts an absent cached iOS manager by name: %s", async (byName) => {
     const device = {
       platform: "ios" as const,
       name: "Absent Simulator",
@@ -776,7 +776,9 @@ describe("deleteDevice handler", () => {
       "forceStopForShutdown",
     ).mockResolvedValue();
     try {
-      const response = await teardownTool().handler(request("ios", device.deviceId, device.name));
+      const response = await teardownTool().handler(
+        request("ios", byName ? device.name : device.deviceId, device.name),
+      );
       expect(responseBody(response).state).toBe("already_absent");
       expect(stop).toHaveBeenCalledTimes(1);
       expect(PortManager.getPort(device.deviceId)).toBeUndefined();
@@ -1037,10 +1039,13 @@ describe("deleteDevice handler", () => {
     manager.setBootedDevices("android", [booted]);
     manager.setDeviceImages("android", [image]);
 
+    const oldManager = AndroidCtrlProxyManager.getInstance(booted);
     const response = await teardownTool().handler(request("android", stableAvdName, stableAvdName));
     const body = responseBody(response);
 
     expect(body.state).toBe("destroyed");
+    expect(AndroidCtrlProxyManager.getInstance(booted)).not.toBe(oldManager);
+    AndroidCtrlProxyManager.resetInstances();
     expect(manager.wasMethodCalled("killDevice")).toBe(true);
     expect(manager.destroyRequests).toEqual([
       expect.objectContaining({

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -168,6 +168,22 @@ describe("CtrlProxyManager", function () {
       expect(AndroidCtrlProxyManager.getInstance(otherDevice, fakeAdbFactory)).toBe(other);
     });
 
+    test("evicts stopped AVD runtime serials while preserving a same-name physical device", function () {
+      const device = { ...testDevice, deviceId: "emulator-5556", name: "Deleted_AVD" };
+      const physical = { ...device, deviceId: "physical-serial", isEmulator: false };
+      const old = AndroidCtrlProxyManager.getInstance(device, fakeAdbFactory);
+      const retained = AndroidCtrlProxyManager.getInstance(physical, fakeAdbFactory);
+      AndroidCtrlProxyManager.evict("Deleted_AVD", "Deleted_AVD");
+      expect(AndroidCtrlProxyManager.getInstance(device, fakeAdbFactory)).not.toBe(old);
+      expect(AndroidCtrlProxyManager.getInstance(physical, fakeAdbFactory)).toBe(retained);
+    });
+
+    test("preserves a reused serial now belonging to another AVD", function () {
+      const replacement = { ...testDevice, deviceId: "emulator-5556", name: "Replacement_AVD" };
+      const manager = AndroidCtrlProxyManager.getInstance(replacement, fakeAdbFactory);
+      AndroidCtrlProxyManager.evict(replacement.deviceId, "Deleted_AVD");
+      expect(AndroidCtrlProxyManager.getInstance(replacement, fakeAdbFactory)).toBe(manager);
+    });
     test("is a no-op when no instance was ever constructed for the device id", function () {
       expect(() => AndroidCtrlProxyManager.evict("never-constructed-device")).not.toThrow();
     });

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -143,6 +143,36 @@ describe("CtrlProxyManager", function () {
       });
     }
   });
+
+  describe("evict", function () {
+    test("deletes the map entry so a subsequent getInstance constructs a fresh manager", function () {
+      const evicted = accessibilityServiceClient;
+
+      AndroidCtrlProxyManager.evict(testDevice.deviceId);
+
+      const fresh = AndroidCtrlProxyManager.getInstance(testDevice, fakeAdbFactory);
+      expect(fresh).not.toBe(evicted);
+    });
+
+    test("leaves other devices' instances untouched", function () {
+      const otherDevice: BootedDevice = {
+        deviceId: "other-device",
+        platform: "android",
+        isEmulator: true,
+        name: "Other Device",
+      };
+      const other = AndroidCtrlProxyManager.getInstance(otherDevice, fakeAdbFactory);
+
+      AndroidCtrlProxyManager.evict(testDevice.deviceId);
+
+      expect(AndroidCtrlProxyManager.getInstance(otherDevice, fakeAdbFactory)).toBe(other);
+    });
+
+    test("is a no-op when no instance was ever constructed for the device id", function () {
+      expect(() => AndroidCtrlProxyManager.evict("never-constructed-device")).not.toThrow();
+    });
+  });
+
   describe("isInstalled", function () {
     test("should return true when accessibility service package is installed", async function () {
       fakeAdb.setCommandResponse(

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -404,6 +404,54 @@ describe("IOSCtrlProxyManager", function () {
     });
   });
 
+  describe("evict", function () {
+    test("stops the instance, deletes the map entry, and releases the port", async function () {
+      const first = IOSCtrlProxyManager.getInstance(testDevice);
+      expect(PortManager.getPort(testDevice.deviceId)).toBeDefined();
+      const forceStop = spyOn(first as any, "forceStopForShutdown").mockResolvedValue();
+
+      await IOSCtrlProxyManager.evict(testDevice.deviceId);
+
+      expect(forceStop).toHaveBeenCalledTimes(1);
+      expect(PortManager.getPort(testDevice.deviceId)).toBeUndefined();
+      const second = IOSCtrlProxyManager.getInstance(testDevice);
+      expect(second).not.toBe(first);
+    });
+
+    test("leaves other devices' instances and port reservations untouched", async function () {
+      const otherDevice: BootedDevice = {
+        deviceId: "22222222-2222-2222-2222-222222222222",
+        platform: "ios",
+        name: "Other iPhone",
+      };
+      const evicted = IOSCtrlProxyManager.getInstance(testDevice);
+      const other = IOSCtrlProxyManager.getInstance(otherDevice);
+      spyOn(evicted as any, "forceStopForShutdown").mockResolvedValue();
+
+      await IOSCtrlProxyManager.evict(testDevice.deviceId);
+
+      expect(PortManager.getPort(testDevice.deviceId)).toBeUndefined();
+      expect(PortManager.getPort(otherDevice.deviceId)).toBeDefined();
+      expect(IOSCtrlProxyManager.getInstance(otherDevice)).toBe(other);
+    });
+
+    test("is a no-op when no instance was ever constructed for the device id", async function () {
+      // No instance exists for this device after resetInstances() in beforeEach.
+      await expect(IOSCtrlProxyManager.evict(testDevice.deviceId)).resolves.toBeUndefined();
+      expect(PortManager.getPort(testDevice.deviceId)).toBeUndefined();
+    });
+
+    test("still releases the port and clears the map entry when stopping fails", async function () {
+      const first = IOSCtrlProxyManager.getInstance(testDevice);
+      spyOn(first as any, "forceStopForShutdown").mockRejectedValue(new Error("stop failed"));
+
+      await IOSCtrlProxyManager.evict(testDevice.deviceId);
+
+      expect(PortManager.getPort(testDevice.deviceId)).toBeUndefined();
+      expect(IOSCtrlProxyManager.getInstance(testDevice)).not.toBe(first);
+    });
+  });
+
   describe("getServicePort", function () {
     test("should return default port 8765", function () {
       const manager = IOSCtrlProxyManager.getInstance(testDevice);

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -461,6 +461,53 @@ describe("IOSCtrlProxyManager", function () {
       expect(PortManager.getPort(testDevice.deviceId)).toBeUndefined();
     });
 
+    test("does not wait when the eviction deadline has already expired", async function () {
+      const first = IOSCtrlProxyManager.getInstance(testDevice);
+      const timer = new FakeTimer();
+      const forceStop = spyOn(first as any, "forceStopForShutdown").mockImplementation(
+        () => new Promise<void>(() => {}),
+      );
+      let settled = false;
+
+      void IOSCtrlProxyManager.evict(testDevice.deviceId, timer, -1).then(() => {
+        settled = true;
+      });
+      for (let attempt = 0; attempt < 5; attempt++) {
+        await Promise.resolve();
+      }
+
+      expect(settled).toBe(true);
+      expect(forceStop).toHaveBeenCalledTimes(1);
+      expect(timer.now()).toBe(0);
+      expect(PortManager.getPort(testDevice.deviceId)).toBeUndefined();
+    });
+
+    test("caps force-stop waiting at the remaining eviction deadline", async function () {
+      const first = IOSCtrlProxyManager.getInstance(testDevice);
+      const timer = new FakeTimer();
+      const forceStop = spyOn(first as any, "forceStopForShutdown").mockImplementation(
+        () => new Promise<void>(() => {}),
+      );
+      let settled = false;
+
+      void IOSCtrlProxyManager.evict(testDevice.deviceId, timer, 10).then(() => {
+        settled = true;
+      });
+      for (let attempt = 0; attempt < 5; attempt++) {
+        await Promise.resolve();
+      }
+      expect(forceStop).toHaveBeenCalledTimes(1);
+
+      timer.advanceTime(10);
+      for (let attempt = 0; attempt < 5; attempt++) {
+        await Promise.resolve();
+      }
+
+      expect(settled).toBe(true);
+      expect(timer.now()).toBe(10);
+      expect(PortManager.getPort(testDevice.deviceId)).toBeUndefined();
+    });
+
     test("still releases the port and clears the map entry when stopping fails", async function () {
       const first = IOSCtrlProxyManager.getInstance(testDevice);
       spyOn(first as any, "forceStopForShutdown").mockRejectedValue(new Error("stop failed"));

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -450,6 +450,24 @@ describe("IOSCtrlProxyManager", function () {
       expect(PortManager.getPort(testDevice.deviceId)).toBeUndefined();
       expect(IOSCtrlProxyManager.getInstance(testDevice)).not.toBe(first);
     });
+
+    test("releases the port and clears the map entry within the deadline when forceStopForShutdown never resolves", async function () {
+      const first = IOSCtrlProxyManager.getInstance(testDevice);
+      const timer = new FakeTimer();
+      const forceStop = spyOn(first as any, "forceStopForShutdown").mockImplementation(() => {
+        return new Promise<void>(() => {});
+      });
+
+      const evicted = IOSCtrlProxyManager.evict(testDevice.deviceId, timer);
+
+      await Promise.resolve();
+      timer.advanceTime(1_000);
+      await evicted;
+
+      expect(forceStop).toHaveBeenCalledTimes(1);
+      expect(PortManager.getPort(testDevice.deviceId)).toBeUndefined();
+      expect(IOSCtrlProxyManager.getInstance(testDevice)).not.toBe(first);
+    });
   });
 
   describe("getServicePort", function () {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -418,6 +418,26 @@ describe("IOSCtrlProxyManager", function () {
       expect(second).not.toBe(first);
     });
 
+    test("preserves a replacement port while retiring old cleanup", async function () {
+      const first = IOSCtrlProxyManager.getInstance(testDevice);
+      let finish!: () => void;
+      spyOn(
+        first as unknown as { forceStopForShutdown: () => Promise<void> },
+        "forceStopForShutdown",
+      ).mockImplementation(() => {
+        PortManager.release(testDevice.deviceId);
+        return new Promise<void>((resolve) => {
+          finish = resolve;
+        });
+      });
+      const pending = IOSCtrlProxyManager.evict(testDevice.deviceId, fakeTimer);
+      const replacement = IOSCtrlProxyManager.getInstance(testDevice);
+      const port = replacement.getServicePort();
+      finish();
+      await pending;
+      expect(IOSCtrlProxyManager.getInstance(testDevice)).toBe(replacement);
+      expect(PortManager.getPort(testDevice.deviceId)).toBe(port);
+    });
     test("leaves other devices' instances and port reservations untouched", async function () {
       const otherDevice: BootedDevice = {
         deviceId: "22222222-2222-2222-2222-222222222222",


### PR DESCRIPTION
## Summary

IOSCtrlProxyManager kept one instance per device id for the daemon's lifetime, releasing its PortManager reservation only on stop(); a non-booted device destroyed via deleteDevice never ran stop(), so its port reservation leaked permanently toward PortManager's 100-device cap. This adds a static evict(deviceId) on IOSCtrlProxyManager that force-stops both supervisors, releases the port, and deletes the map entry (idempotent no-op if no instance was ever constructed), plus a symmetric AndroidCtrlProxyManager.evict(deviceId) that just deletes the map entry (that manager holds no port reservation). Both are wired into deviceTools.ts's teardown destroy step next to unregisterDirectSessionsForStableIdentity, so eviction runs unconditionally regardless of whether the target was booted.

Part of epic #6372.

Stacked on `work/issue-6416-ios-availability-cache-reopen`; GitHub retargets to `main` once it merges.

## Linked Issue

Closes #6580

## Validation

4 red->green tests in IOSCtrlProxyManager.test.ts (evict: instance stopped + map deleted + port released; sibling devices untouched; no-op when never constructed; port released even if stop fails) plus 3 in CtrlProxyManager.test.ts for the Android seam. Targeted 330/0; broad test/server + test/utils 5714/0 pass.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
