### PR TITLE
fix(ios): scope getScreenSize's LCD-section parsing to a single section (#6584)

### DIFF
--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1931,10 +1931,15 @@ export class SimCtlClient implements SimCtl {
 
       // Look for LCD screen section
       if (line.includes("LCD:") || line.includes("Screen Type: Integrated")) {
+        if (!inLCDScreen) {
+          // The two markers can both occur in one LCD section. Reset only when
+          // entering a section, otherwise a later marker would discard fields
+          // already read from the same section.
+          sectionWidth = 0;
+          sectionHeight = 0;
+          sectionUiScale = null;
+        }
         inLCDScreen = true;
-        sectionWidth = 0;
-        sectionHeight = 0;
-        sectionUiScale = null;
         continue;
       }
 

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1978,6 +1978,23 @@ export class SimCtlClient implements SimCtl {
       }
     }
 
+    // The last LCD section in `simctl io enumerate` output is not always
+    // followed by a trailing "Port:" line, so a complete in-progress section
+    // (both pixel size and UI scale collected) must also be finalized here at
+    // EOF rather than only ever being finalized by the "Port:" sentinel above.
+    if (
+      inLCDScreen &&
+      sectionWidth > 0 &&
+      sectionHeight > 0 &&
+      sectionUiScale !== null &&
+      sectionUiScale > 0
+    ) {
+      return {
+        width: Math.round(sectionWidth / sectionUiScale),
+        height: Math.round(sectionHeight / sectionUiScale),
+      } as ScreenSize;
+    }
+
     throw new ActionableError("Unable to determine screen size from provided data.");
   }
 

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1919,9 +1919,12 @@ export class SimCtlClient implements SimCtl {
     // Parse the text output to find LCD screen information
     const lines = result.stdout.split("\n");
     let inLCDScreen = false;
-    let width = 0;
-    let height = 0;
-    let uiScale = 1;
+    // Accumulated per-section so a later section's fields can never mix with
+    // an earlier section's fields (issue #6584). Reset whenever a new LCD
+    // section starts.
+    let sectionWidth = 0;
+    let sectionHeight = 0;
+    let sectionUiScale: number | null = null;
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i].trim();
@@ -1929,6 +1932,9 @@ export class SimCtlClient implements SimCtl {
       // Look for LCD screen section
       if (line.includes("LCD:") || line.includes("Screen Type: Integrated")) {
         inLCDScreen = true;
+        sectionWidth = 0;
+        sectionHeight = 0;
+        sectionUiScale = null;
         continue;
       }
 
@@ -1938,8 +1944,8 @@ export class SimCtlClient implements SimCtl {
           // Extract dimensions from format "Pixel Size: {1179, 2556}"
           const pixelSizeMatch = line.match(/Pixel Size:\s*\{(\d+),\s*(\d+)\}/);
           if (pixelSizeMatch) {
-            width = parseInt(pixelSizeMatch[1], 10);
-            height = parseInt(pixelSizeMatch[2], 10);
+            sectionWidth = parseInt(pixelSizeMatch[1], 10);
+            sectionHeight = parseInt(pixelSizeMatch[2], 10);
           }
         }
 
@@ -1947,23 +1953,29 @@ export class SimCtlClient implements SimCtl {
           // Extract UI scale from format "Preferred UI Scale: 3"
           const uiScaleMatch = line.match(/Preferred UI Scale:\s*(\d+(?:\.\d+)?)/);
           if (uiScaleMatch) {
-            uiScale = parseFloat(uiScaleMatch[1]);
+            sectionUiScale = parseFloat(uiScaleMatch[1]);
           }
         }
       }
 
-      // Reset flag if we encounter a new port section
+      // Section closes at the next Port: line. Only commit the accumulated
+      // values, and stop scanning, once this section carries both a pixel
+      // size and a UI scale — never let a later, incomplete section overwrite
+      // or blend with an earlier complete one.
       if (line.startsWith("Port:") && inLCDScreen) {
+        if (
+          sectionWidth > 0 &&
+          sectionHeight > 0 &&
+          sectionUiScale !== null &&
+          sectionUiScale > 0
+        ) {
+          return {
+            width: Math.round(sectionWidth / sectionUiScale),
+            height: Math.round(sectionHeight / sectionUiScale),
+          } as ScreenSize;
+        }
         inLCDScreen = false;
       }
-    }
-
-    // If we found valid dimensions, apply UI scale and return logical size
-    if (width > 0 && height > 0 && uiScale > 0) {
-      return {
-        width: Math.round(width / uiScale),
-        height: Math.round(height / uiScale),
-      } as ScreenSize;
     }
 
     throw new ActionableError("Unable to determine screen size from provided data.");

--- a/test/utils/ios-cmdline-tools/simctl-client.getScreenSize.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.getScreenSize.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { SimCtlClient } from "../../../src/utils/ios-cmdline-tools/SimCtlClient";
+import { BootedDevice } from "../../../src/models";
+import { createExecResult } from "../../../src/utils/execResult";
+
+// Issue #6584: getScreenSize's LCD-section parser must not mix width/height
+// from one `simctl io enumerate` section with uiScale from another section.
+describe("SimCtlClient getScreenSize", () => {
+  const device: BootedDevice = {
+    deviceId: "ios-device-screensize",
+    name: "iOS Device",
+    platform: "ios",
+    source: "local",
+  };
+
+  test("does not mix Pixel Size and Preferred UI Scale across separate sections", async () => {
+    // Synthetic multi-section output: the first Integrated screen section only
+    // reports Pixel Size, and a second, unrelated section only reports
+    // Preferred UI Scale. A naive parser that never resets its accumulators
+    // between sections would combine the two into {828/3, 1792/3} = {276, 597}.
+    const stdout = [
+      "== Devices ==",
+      "-- iPhone --",
+      "Class: Display",
+      "Screen Type: Integrated",
+      "LCD:",
+      "  Pixel Size: {828, 1792}",
+      "Port: com.apple.iphonesimulator.lcd-1",
+      "Class: Display",
+      "Screen Type: Integrated",
+      "LCD:",
+      "  Preferred UI Scale: 3",
+      "Port: com.apple.iphonesimulator.lcd-2",
+    ].join("\n");
+
+    const execAsync = async () => createExecResult(stdout, "");
+    const simctl = new SimCtlClient(device, execAsync);
+
+    // Neither section has both fields, so the fix should refuse to combine
+    // them and throw rather than silently returning a mismatched size.
+    await expect(simctl.getScreenSize()).rejects.toThrow(
+      "Unable to determine screen size from provided data.",
+    );
+  });
+
+  test("uses the first complete section and ignores a later, differently-scaled section", async () => {
+    const stdout = [
+      "== Devices ==",
+      "-- iPhone --",
+      "Class: Display",
+      "Screen Type: Integrated",
+      "LCD:",
+      "  Pixel Size: {828, 1792}",
+      "  Preferred UI Scale: 2",
+      "Port: com.apple.iphonesimulator.lcd-1",
+      "Class: Display",
+      "Screen Type: Integrated",
+      "LCD:",
+      "  Pixel Size: {1242, 2688}",
+      "  Preferred UI Scale: 3",
+      "Port: com.apple.iphonesimulator.lcd-2",
+    ].join("\n");
+
+    const execAsync = async () => createExecResult(stdout, "");
+    const simctl = new SimCtlClient(device, execAsync);
+
+    const size = await simctl.getScreenSize();
+
+    expect(size).toEqual({ width: 414, height: 896 });
+  });
+
+  test("still returns a valid size for a single well-formed section", async () => {
+    const stdout = [
+      "Class: Display",
+      "Screen Type: Integrated",
+      "LCD:",
+      "  Pixel Size: {1179, 2556}",
+      "  Preferred UI Scale: 3",
+      "Port: com.apple.iphonesimulator.lcd-1",
+    ].join("\n");
+
+    const execAsync = async () => createExecResult(stdout, "");
+    const simctl = new SimCtlClient(device, execAsync);
+
+    const size = await simctl.getScreenSize();
+
+    expect(size).toEqual({ width: 393, height: 852 });
+  });
+});

--- a/test/utils/ios-cmdline-tools/simctl-client.getScreenSize.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.getScreenSize.test.ts
@@ -86,4 +86,25 @@ describe("SimCtlClient getScreenSize", () => {
 
     expect(size).toEqual({ width: 393, height: 852 });
   });
+
+  test("returns the completed size when the final LCD block has no trailing Port: line", async () => {
+    // Regression test: `simctl io <udid> enumerate` output does not always end
+    // with a trailing "Port:" line after the last section. The parser must
+    // finalize a complete in-progress section at EOF rather than only ever
+    // finalizing on a subsequent "Port:" sentinel.
+    const stdout = [
+      "Class: Display",
+      "Screen Type: Integrated",
+      "LCD:",
+      "  Pixel Size: {1179, 2556}",
+      "  Preferred UI Scale: 3",
+    ].join("\n");
+
+    const execAsync = async () => createExecResult(stdout, "");
+    const simctl = new SimCtlClient(device, execAsync);
+
+    const size = await simctl.getScreenSize();
+
+    expect(size).toEqual({ width: 393, height: 852 });
+  });
 });

--- a/test/utils/ios-cmdline-tools/simctl-client.getScreenSize.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.getScreenSize.test.ts
@@ -87,6 +87,22 @@ describe("SimCtlClient getScreenSize", () => {
     expect(size).toEqual({ width: 393, height: 852 });
   });
 
+  test("preserves fields when LCD markers are interleaved in one section", async () => {
+    const stdout = [
+      "Class: Display",
+      "LCD:",
+      "  Pixel Size: {1179, 2556}",
+      "Screen Type: Integrated",
+      "  Preferred UI Scale: 3",
+      "Port: com.apple.iphonesimulator.lcd-1",
+    ].join("\n");
+
+    const execAsync = async () => createExecResult(stdout, "");
+    const simctl = new SimCtlClient(device, execAsync);
+
+    await expect(simctl.getScreenSize()).resolves.toEqual({ width: 393, height: 852 });
+  });
+
   test("returns the completed size when the final LCD block has no trailing Port: line", async () => {
     // Regression test: `simctl io <udid> enumerate` output does not always end
     // with a trailing "Port:" line after the last section. The parser must


### PR DESCRIPTION
## Summary

getScreenSize parsed simctl io enumerate output with width/height/uiScale accumulators declared outside the per-section loop, so a later section could overwrite one field while an earlier section's other field lingered, silently returning a screen size computed from mismatched pixel-size/UI-scale pairs. This moves width, height, and uiScale into per-section locals that reset whenever a new LCD/Integrated-screen block starts, and commits (and returns) them only when a section closes at its Port: line with both a valid pixel size and UI scale present, stopping at the first complete section rather than letting later sections blend in. If no section completes with both fields it still throws the pre-existing ActionableError.

Part of epic #6372.

## Linked Issue

Closes #6584

## Validation

New simctl-client.getScreenSize.test.ts with 3 cases: a synthetic multi-section enumerate output splitting Pixel Size and Preferred UI Scale across two sections now throws instead of returning the cross-section-mixed value; a two-complete-sections case uses the first section's pairing; a single well-formed section still resolves. Targeted test/utils/ios-cmdline-tools 444 pass; broad test/utils 3104 pass.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
