### PR TITLE
fix(ios): reject name-only iOS boot targets instead of exhausting the boot budget (#6414)

### DIFF
--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -686,7 +686,13 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
           })
         ).process;
       case "ios":
-        return this.simctl.startSimulator(device.deviceId ?? device.name, timeoutMs);
+        if (!device.deviceId) {
+          throw new ActionableError(
+            `Cannot boot iOS simulator '${device.name}' without a simulator UDID: ` +
+              `a name-only target cannot be verified against 'simctl' state after boot`,
+          );
+        }
+        return this.simctl.startSimulator(device.deviceId, timeoutMs);
       default:
         throw new ActionableError("Unknown platform");
     }
@@ -803,11 +809,17 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
           signal,
         );
       case "ios":
+        if (!device.deviceId) {
+          throw new ActionableError(
+            `Cannot wait for iOS simulator '${device.name}' without a simulator UDID: ` +
+              `a name-only target cannot be verified against 'simctl' state after boot`,
+          );
+        }
         // A connected physical device has no simulator lifecycle: `simctl
         // bootstatus` cannot answer for its UDID, and discovery already proved
         // it reachable. Treat successful discovery as readiness rather than
         // shelling out to a tool that would only fail (issue #5620).
-        if (device.deviceId && isIosPhysicalUdid(device.deviceId)) {
+        if (isIosPhysicalUdid(device.deviceId)) {
           return {
             name: device.name,
             platform: "ios",
@@ -821,7 +833,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
         // `startSimulator` has already run `bootstatus -b`. Signal that so the
         // wait doesn't redundantly repeat the full boot-readiness wait; the
         // already-running path (no childProcess) still performs it.
-        return this.simctl.waitForSimulatorReady(device.deviceId ?? device.name, timeoutMs, {
+        return this.simctl.waitForSimulatorReady(device.deviceId, timeoutMs, {
           assumeBooted: Boolean(childProcess),
         });
       default:

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -671,6 +671,17 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
     device: DeviceInfo,
     timeoutMs: number = DEFAULT_DEVICE_READY_TIMEOUT_MS,
   ): Promise<ChildProcess | null> {
+    // Validate the UDID before any simctl running-state probe: a slow/hung
+    // 'simctl list' would otherwise burn the boot budget, and an already-booted
+    // same-named simulator would make isDeviceImageRunning() return true and
+    // mask this guard behind an "already running" error (#6414).
+    if (device.platform === "ios" && !device.deviceId) {
+      throw new ActionableError(
+        `Cannot boot iOS simulator '${device.name}' without a simulator UDID: ` +
+          `a name-only target cannot be verified against 'simctl' state after boot`,
+      );
+    }
+
     const isRunning = await this.isDeviceImageRunning(device);
     if (isRunning) {
       throw new ActionableError(`${device.platform} device '${device.name}' is already running`);

--- a/test/utils/deviceUtils.test.ts
+++ b/test/utils/deviceUtils.test.ts
@@ -259,6 +259,54 @@ describe("MultiPlatformDeviceManager", () => {
     expect(receivedSignal).toBe(controller.signal);
   });
 
+  test("startDevice rejects a name-only iOS DeviceInfo instead of booting by name (#6414)", async () => {
+    const fakeSimctl = {
+      isAvailable: async () => true,
+      getBootedSimulators: async () => [],
+      isSimulatorRunning: async () => false,
+      startSimulator: async () => {
+        throw new Error("simctl bootstatus must not run for a name-only iOS target");
+      },
+    } as unknown as SimCtlClient;
+    const manager = new MultiPlatformDeviceManager(
+      new FakeAdbClient() as unknown as AdbClient,
+      fakeSimctl,
+      null,
+    );
+    const device: DeviceInfo = {
+      name: "iPhone 17 Pro",
+      platform: "ios",
+      isRunning: false,
+    };
+
+    await expect(manager.startDevice(device)).rejects.toThrow(
+      /iPhone 17 Pro.*UDID|UDID.*iPhone 17 Pro/,
+    );
+  });
+
+  test("waitForDeviceReady rejects a name-only iOS DeviceInfo instead of polling bootstatus by name (#6414)", async () => {
+    const fakeSimctl = {
+      isAvailable: async () => true,
+      waitForSimulatorReady: async () => {
+        throw new Error("simctl bootstatus must not run for a name-only iOS target");
+      },
+    } as unknown as SimCtlClient;
+    const manager = new MultiPlatformDeviceManager(
+      new FakeAdbClient() as unknown as AdbClient,
+      fakeSimctl,
+      {} as unknown as AndroidEmulatorClient,
+    );
+    const device: DeviceInfo = {
+      name: "iPhone 17 Pro",
+      platform: "ios",
+      isRunning: false,
+    };
+
+    await expect(manager.waitForDeviceReady(device)).rejects.toThrow(
+      /iPhone 17 Pro.*UDID|UDID.*iPhone 17 Pro/,
+    );
+  });
+
   test("isDeviceImageRunning uses UDID when present for iOS", async () => {
     const fakeSimctl = {
       isAvailable: async () => true,

--- a/test/utils/deviceUtils.test.ts
+++ b/test/utils/deviceUtils.test.ts
@@ -284,6 +284,42 @@ describe("MultiPlatformDeviceManager", () => {
     );
   });
 
+  test("startDevice validates a missing UDID before probing simctl running-state, even when a same-named simulator is already booted (#6414)", async () => {
+    let runningStateProbed = false;
+    const fakeSimctl = {
+      isAvailable: async () => true,
+      getBootedSimulators: async () => {
+        runningStateProbed = true;
+        return [];
+      },
+      // An already-booted simulator that happens to share the target's name:
+      // pre-fix, this made isDeviceImageRunning() return true and the caller
+      // observed "already running" instead of the missing-UDID error.
+      isSimulatorRunning: async () => {
+        runningStateProbed = true;
+        return true;
+      },
+      startSimulator: async () => {
+        throw new Error("simctl bootstatus must not run for a name-only iOS target");
+      },
+    } as unknown as SimCtlClient;
+    const manager = new MultiPlatformDeviceManager(
+      new FakeAdbClient() as unknown as AdbClient,
+      fakeSimctl,
+      null,
+    );
+    const device: DeviceInfo = {
+      name: "iPhone 17 Pro",
+      platform: "ios",
+      isRunning: false,
+    };
+
+    await expect(manager.startDevice(device)).rejects.toThrow(
+      /iPhone 17 Pro.*UDID|UDID.*iPhone 17 Pro/,
+    );
+    expect(runningStateProbed).toBe(false);
+  });
+
   test("waitForDeviceReady rejects a name-only iOS DeviceInfo instead of polling bootstatus by name (#6414)", async () => {
     const fakeSimctl = {
       isAvailable: async () => true,


### PR DESCRIPTION
## Summary

MultiPlatformDeviceManager.startDevice and waitForDeviceReady fell back from device.deviceId to device.name when booting/polling an iOS simulator, but every downstream simctl state check (readSimulatorState, resolveReadySimulator, resolveRegisteredBootSimulator, isAlreadyBootedCoreSimulator405) matches strictly on UDID, so a name-only target could never be verified — it would run bootstatus, fail verification, get shut down, retry, and finally report a healthy simulator as wedged with misleading simctl erase advice. This throws an ActionableError naming the device immediately when device.deviceId is missing for platform ios in both startDevice and waitForDeviceReady, matching the existing precedent in destroyDeviceRepresentation.

Part of epic #6372.

## Linked Issue

Closes #6414

## Validation

Two red->green tests in deviceUtils.test.ts: startDevice and waitForDeviceReady each reject a name-only iOS DeviceInfo (no deviceId) with an ActionableError before touching simctl (the fakes throw if startSimulator/waitForSimulatorReady are invoked). Targeted deviceUtils + bootVerification 61 pass; broad test/utils 3103 pass.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
