### PR TITLE
fix(ios): parse BulletinBoard settings via plist DOM walk, honor device-set path (#6583)

### DIFF
--- a/src/features/utility/ios/IosNotificationAuthorizationReader.ts
+++ b/src/features/utility/ios/IosNotificationAuthorizationReader.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { isIosSimulatorUdid } from "../../../utils/ios-cmdline-tools/iosDeviceType";
 import { logger } from "../../../utils/logger";
 import { PlistClient } from "../../../utils/ios-cmdline-tools/PlistClient";
+import { defaultDeviceSetRoot } from "../../../utils/ios-cmdline-tools/SimulatorTccSqliteClient";
 import type { NotificationPolicyAccessState } from "../NotificationPolicy";
 
 /**
@@ -46,34 +47,249 @@ export interface BulletinBoardReaderDeps {
   deviceDataRoot(udid: string): string;
 }
 
+/** A parsed plist scalar (`<integer>`, `<string>`, `<data>`, `<real>`, `<date>`, …). */
+interface PlistScalarNode {
+  kind: "scalar";
+  tag: string;
+  text: string;
+}
+
+/** A parsed plist `<dict>`: an ordered list of key/value entries. */
+interface PlistDictNode {
+  kind: "dict";
+  entries: Array<{ key: string; value: PlistNode }>;
+}
+
+/** A parsed plist `<array>`: an ordered list of unkeyed values. */
+interface PlistArrayNode {
+  kind: "array";
+  items: PlistNode[];
+}
+
+type PlistNode = PlistScalarNode | PlistDictNode | PlistArrayNode;
+
+/** Matches an opening/closing plist tag, e.g. `<dict>`, `</dict>`, `<key>`, `<true/>`. */
+const PLIST_TAG_RE = /<(\/)?([a-zA-Z$][\w:$-]*)((?:\s[^>]*)?)>/g;
+
+/**
+ * A dict frame tracks its own `pendingKey` (the most recently opened `<key>`
+ * awaiting a value) so that a nested dict's `<key>` cannot clobber an
+ * ancestor dict's still-unpaired key — each nesting level's "next value goes
+ * under this key" state is independent.
+ */
+type DictFrame = { entries: Array<{ key: string; value: PlistNode }>; pendingKey: string | null };
+type ArrayFrame = { items: PlistNode[] };
+type ParseFrame = DictFrame | ArrayFrame;
+
+function isDictFrame(frame: ParseFrame): frame is DictFrame {
+  return "entries" in frame;
+}
+
+function frameToNode(frame: ParseFrame): PlistNode {
+  return isDictFrame(frame)
+    ? { kind: "dict", entries: frame.entries }
+    : { kind: "array", items: frame.items };
+}
+
+/** Attach a completed value to the current top-of-stack frame (or as the document root). */
+function attachToFrame(
+  stack: ParseFrame[],
+  root: PlistNode | null,
+  node: PlistNode,
+): PlistNode | null {
+  const top = stack[stack.length - 1];
+  if (!top) {
+    return node;
+  }
+  if (isDictFrame(top)) {
+    if (top.pendingKey !== null) {
+      top.entries.push({ key: top.pendingKey, value: node });
+      top.pendingKey = null;
+    }
+  } else {
+    top.items.push(node);
+  }
+  return root;
+}
+
+/**
+ * Read a `<key>…</key>` element starting right after the opening `<key>` tag
+ * and record it as the enclosing dict frame's pending key. Returns the index
+ * to resume tag scanning from, or -1 if the element is unterminated.
+ */
+function consumeKeyElement(xml: string, stack: ParseFrame[], contentStart: number): number {
+  const closeIdx = xml.indexOf("</key>", contentStart);
+  if (closeIdx === -1) {
+    return -1;
+  }
+  const top = stack[stack.length - 1];
+  if (top && isDictFrame(top)) {
+    top.pendingKey = xml.slice(contentStart, closeIdx);
+  }
+  return closeIdx + "</key>".length;
+}
+
+/**
+ * Read a leaf scalar element (`<integer>…</integer>`, `<data>…</data>`, etc.)
+ * starting right after its opening tag. Returns the parsed node and the index
+ * to resume tag scanning from.
+ */
+function consumeScalarElement(
+  xml: string,
+  tag: string,
+  contentStart: number,
+): { node: PlistScalarNode; nextIndex: number } {
+  const closeTag = `</${tag}>`;
+  const closeIdx = xml.indexOf(closeTag, contentStart);
+  const text = closeIdx === -1 ? "" : xml.slice(contentStart, closeIdx);
+  const nextIndex = closeIdx === -1 ? contentStart : closeIdx + closeTag.length;
+  return { node: { kind: "scalar", tag, text }, nextIndex };
+}
+
+/**
+ * Parse `plutil -convert xml1` output into a lightweight plist DOM.
+ *
+ * This is intentionally minimal (not a general XML parser): it understands
+ * exactly the plist grammar (`dict`/`array`/`key` plus leaf scalar tags) and
+ * skips the `<?xml …?>` prolog and the outer `<plist …>` wrapper. That is
+ * enough to walk `<dict>` elements coherently instead of regex-matching a
+ * key anywhere in the document (issue #6583).
+ */
+function parsePlistBody(xml: string): PlistNode | null {
+  PLIST_TAG_RE.lastIndex = 0;
+  const stack: ParseFrame[] = [];
+  let root: PlistNode | null = null;
+
+  let match: RegExpExecArray | null;
+  while ((match = PLIST_TAG_RE.exec(xml))) {
+    const [, closing, tag, attrs] = match;
+    if (tag === "plist") {
+      continue;
+    }
+    if (closing) {
+      const top = stack.pop();
+      root = top ? attachToFrame(stack, root, frameToNode(top)) : root;
+      continue;
+    }
+    if (attrs.trimEnd().endsWith("/")) {
+      root = attachToFrame(stack, root, { kind: "scalar", tag, text: "" });
+      continue;
+    }
+    if (tag === "dict") {
+      stack.push({ entries: [], pendingKey: null });
+      continue;
+    }
+    if (tag === "array") {
+      stack.push({ items: [] });
+      continue;
+    }
+    if (tag === "key") {
+      const nextIndex = consumeKeyElement(xml, stack, PLIST_TAG_RE.lastIndex);
+      if (nextIndex === -1) {
+        break;
+      }
+      PLIST_TAG_RE.lastIndex = nextIndex;
+      continue;
+    }
+    // Leaf scalar: <integer>…</integer>, <string>…</string>, <data>…</data>, etc.
+    const { node, nextIndex } = consumeScalarElement(xml, tag, PLIST_TAG_RE.lastIndex);
+    PLIST_TAG_RE.lastIndex = nextIndex;
+    root = attachToFrame(stack, root, node);
+  }
+
+  return root;
+}
+
+function dictEntry(dict: PlistDictNode, key: string): PlistNode | undefined {
+  return dict.entries.find((entry) => entry.key === key)?.value;
+}
+
 /**
  * Extract the base64 `<data>` blob registered under `sectionInfo[bundleId]` in
- * the outer `VersionedSectionInfo.plist` XML. Returns null if the bundle has no
- * section registered.
+ * the outer `VersionedSectionInfo.plist` XML by walking the `sectionInfo` dict
+ * directly, rather than regex-matching `bundleId` anywhere in the document.
+ * Returns null if the bundle has no section registered.
  */
 export function extractSectionDataBase64(outerXml: string, bundleId: string): string | null {
-  // Match `<key>bundleId</key>` followed (ignoring whitespace) by `<data>…</data>`.
-  // Bundle IDs are dotted identifiers, so escape regex metacharacters.
-  const escaped = bundleId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const re = new RegExp(`<key>${escaped}</key>\\s*<data>([\\s\\S]*?)</data>`);
-  const match = outerXml.match(re);
-  if (!match) {
+  const root = parsePlistBody(outerXml);
+  if (!root || root.kind !== "dict") {
+    return null;
+  }
+  const sectionInfo = dictEntry(root, "sectionInfo");
+  if (!sectionInfo || sectionInfo.kind !== "dict") {
+    return null;
+  }
+  const data = dictEntry(sectionInfo, bundleId);
+  if (!data || data.kind !== "scalar" || data.tag !== "data") {
     return null;
   }
   // Strip all whitespace from the base64 payload (plutil wraps it across lines).
-  return match[1].replace(/\s+/g, "");
+  return data.text.replace(/\s+/g, "");
+}
+
+/** The scalar keys that identify a BulletinBoard settings dict. */
+const SETTINGS_KEYS = [
+  "authorizationStatus",
+  "pushSettings",
+  "alertType",
+  "lockScreenSetting",
+  "notificationCenterSetting",
+] as const;
+
+function collectDicts(node: PlistNode | null | undefined, out: PlistDictNode[]): void {
+  if (!node) {
+    return;
+  }
+  if (node.kind === "dict") {
+    out.push(node);
+    for (const entry of node.entries) {
+      collectDicts(entry.value, out);
+    }
+  } else if (node.kind === "array") {
+    for (const item of node.items) {
+      collectDicts(item, out);
+    }
+  }
+}
+
+/**
+ * Find the settings dict among every `<dict>` in the archive's `$objects`
+ * graph. The `$objects` array is flat and order-dependent, so more than one
+ * dict can carry an `authorizationStatus` key (issue #6583); among those
+ * candidates, pick the one that also carries the most other known settings
+ * keys as siblings, rather than trusting document order.
+ */
+function findSettingsDict(root: PlistNode | null): PlistDictNode | undefined {
+  const dicts: PlistDictNode[] = [];
+  collectDicts(root, dicts);
+  const candidates = dicts.filter((dict) => dictEntry(dict, "authorizationStatus") !== undefined);
+  return candidates.reduce<PlistDictNode | undefined>((best, dict) => {
+    if (!best) {
+      return dict;
+    }
+    const score = (d: PlistDictNode) =>
+      SETTINGS_KEYS.filter((key) => dictEntry(d, key) !== undefined).length;
+    return score(dict) > score(best) ? dict : best;
+  }, undefined);
 }
 
 /**
  * Extract the BulletinBoard settings scalars from the decoded nested-blob XML.
- * The settings dict is the `<dict>` carrying `<key>authorizationStatus</key>`;
- * we pull each integer key globally (the archive has exactly one settings dict).
+ * All scalars are read from the *same* coherent settings `<dict>` (see
+ * {@link findSettingsDict}) rather than independently regex-matched anywhere
+ * in the document.
  */
 export function parseSettingsFromNestedXml(nestedXml: string): BulletinBoardSettings {
+  const root = parsePlistBody(nestedXml);
+  const dict = findSettingsDict(root);
+  if (!dict) {
+    return {};
+  }
   const intKey = (key: string): number | undefined => {
-    const re = new RegExp(`<key>${key}</key>\\s*<integer>(-?\\d+)</integer>`);
-    const match = nestedXml.match(re);
-    return match ? Number(match[1]) : undefined;
+    const value = dictEntry(dict, key);
+    return value && value.kind === "scalar" && value.tag === "integer"
+      ? Number(value.text)
+      : undefined;
   };
   return {
     authorizationStatus: intKey("authorizationStatus"),
@@ -82,6 +298,16 @@ export function parseSettingsFromNestedXml(nestedXml: string): BulletinBoardSett
     lockScreenSetting: intKey("lockScreenSetting"),
     notificationCenterSetting: intKey("notificationCenterSetting"),
   };
+}
+
+/**
+ * Resolve a simulator's per-device data root the same way the TCC client does
+ * (via `CORESIMULATOR_DEVICE_SET_PATH`, falling back to the default
+ * CoreSimulator device set layout) rather than hard-coding the default
+ * device set (issue #6583).
+ */
+export function resolveDeviceDataRoot(udid: string, homeDirectory: string = os.homedir()): string {
+  return path.join(defaultDeviceSetRoot(homeDirectory), udid);
 }
 
 export class BulletinBoardAuthorizationReader implements IosNotificationAuthorizationReader {
@@ -183,7 +409,6 @@ export function defaultBulletinBoardReader(): IosNotificationAuthorizationReader
       const { promises: fs } = await import("fs");
       await fs.rm(path.dirname(file), { recursive: true, force: true });
     },
-    deviceDataRoot: (udid) =>
-      path.join(os.homedir(), "Library/Developer/CoreSimulator/Devices", udid),
+    deviceDataRoot: (udid) => resolveDeviceDataRoot(udid),
   });
 }

--- a/src/features/utility/ios/IosNotificationAuthorizationReader.ts
+++ b/src/features/utility/ios/IosNotificationAuthorizationReader.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { isIosSimulatorUdid } from "../../../utils/ios-cmdline-tools/iosDeviceType";
 import { logger } from "../../../utils/logger";
 import { PlistClient } from "../../../utils/ios-cmdline-tools/PlistClient";
+import { parsePlist, type PlistValue } from "../../../utils/ios-cmdline-tools/XctestrunPlist";
 import { defaultDeviceSetRoot } from "../../../utils/ios-cmdline-tools/SimulatorTccSqliteClient";
 import type { NotificationPolicyAccessState } from "../NotificationPolicy";
 
@@ -33,8 +34,9 @@ export interface IosNotificationAuthorizationReader {
  * than json because BulletinBoard blobs are NSKeyedArchiver archives containing
  * `CFKeyedArchiverUID` refs, which `plutil -convert json` rejects ("invalid
  * object in plist for destination format"). xml1 round-trips them losslessly,
- * and the scalar settings we need (`authorizationStatus`, etc.) appear as plain
- * `<integer>` values we can extract without a full plist parser.
+ * and the resulting XML is parsed with the repo's structured plist parser
+ * ({@link parsePlist}) to extract the scalar settings we need
+ * (`authorizationStatus`, etc.).
  */
 export interface BulletinBoardReaderDeps {
   /** Run `plutil -convert xml1 -o - -- <path>` and return the XML string. */
@@ -47,184 +49,35 @@ export interface BulletinBoardReaderDeps {
   deviceDataRoot(udid: string): string;
 }
 
-/** A parsed plist scalar (`<integer>`, `<string>`, `<data>`, `<real>`, `<date>`, …). */
-interface PlistScalarNode {
-  kind: "scalar";
-  tag: string;
-  text: string;
-}
-
-/** A parsed plist `<dict>`: an ordered list of key/value entries. */
-interface PlistDictNode {
-  kind: "dict";
-  entries: Array<{ key: string; value: PlistNode }>;
-}
-
-/** A parsed plist `<array>`: an ordered list of unkeyed values. */
-interface PlistArrayNode {
-  kind: "array";
-  items: PlistNode[];
-}
-
-type PlistNode = PlistScalarNode | PlistDictNode | PlistArrayNode;
-
-/** Matches an opening/closing plist tag, e.g. `<dict>`, `</dict>`, `<key>`, `<true/>`. */
-const PLIST_TAG_RE = /<(\/)?([a-zA-Z$][\w:$-]*)((?:\s[^>]*)?)>/g;
-
-/**
- * A dict frame tracks its own `pendingKey` (the most recently opened `<key>`
- * awaiting a value) so that a nested dict's `<key>` cannot clobber an
- * ancestor dict's still-unpaired key — each nesting level's "next value goes
- * under this key" state is independent.
- */
-type DictFrame = { entries: Array<{ key: string; value: PlistNode }>; pendingKey: string | null };
-type ArrayFrame = { items: PlistNode[] };
-type ParseFrame = DictFrame | ArrayFrame;
-
-function isDictFrame(frame: ParseFrame): frame is DictFrame {
-  return "entries" in frame;
-}
-
-function frameToNode(frame: ParseFrame): PlistNode {
-  return isDictFrame(frame)
-    ? { kind: "dict", entries: frame.entries }
-    : { kind: "array", items: frame.items };
-}
-
-/** Attach a completed value to the current top-of-stack frame (or as the document root). */
-function attachToFrame(
-  stack: ParseFrame[],
-  root: PlistNode | null,
-  node: PlistNode,
-): PlistNode | null {
-  const top = stack[stack.length - 1];
-  if (!top) {
-    return node;
-  }
-  if (isDictFrame(top)) {
-    if (top.pendingKey !== null) {
-      top.entries.push({ key: top.pendingKey, value: node });
-      top.pendingKey = null;
-    }
-  } else {
-    top.items.push(node);
-  }
-  return root;
-}
-
-/**
- * Read a `<key>…</key>` element starting right after the opening `<key>` tag
- * and record it as the enclosing dict frame's pending key. Returns the index
- * to resume tag scanning from, or -1 if the element is unterminated.
- */
-function consumeKeyElement(xml: string, stack: ParseFrame[], contentStart: number): number {
-  const closeIdx = xml.indexOf("</key>", contentStart);
-  if (closeIdx === -1) {
-    return -1;
-  }
-  const top = stack[stack.length - 1];
-  if (top && isDictFrame(top)) {
-    top.pendingKey = xml.slice(contentStart, closeIdx);
-  }
-  return closeIdx + "</key>".length;
-}
-
-/**
- * Read a leaf scalar element (`<integer>…</integer>`, `<data>…</data>`, etc.)
- * starting right after its opening tag. Returns the parsed node and the index
- * to resume tag scanning from.
- */
-function consumeScalarElement(
-  xml: string,
-  tag: string,
-  contentStart: number,
-): { node: PlistScalarNode; nextIndex: number } {
-  const closeTag = `</${tag}>`;
-  const closeIdx = xml.indexOf(closeTag, contentStart);
-  const text = closeIdx === -1 ? "" : xml.slice(contentStart, closeIdx);
-  const nextIndex = closeIdx === -1 ? contentStart : closeIdx + closeTag.length;
-  return { node: { kind: "scalar", tag, text }, nextIndex };
-}
-
-/**
- * Parse `plutil -convert xml1` output into a lightweight plist DOM.
- *
- * This is intentionally minimal (not a general XML parser): it understands
- * exactly the plist grammar (`dict`/`array`/`key` plus leaf scalar tags) and
- * skips the `<?xml …?>` prolog and the outer `<plist …>` wrapper. That is
- * enough to walk `<dict>` elements coherently instead of regex-matching a
- * key anywhere in the document (issue #6583).
- */
-function parsePlistBody(xml: string): PlistNode | null {
-  PLIST_TAG_RE.lastIndex = 0;
-  const stack: ParseFrame[] = [];
-  let root: PlistNode | null = null;
-
-  let match: RegExpExecArray | null;
-  while ((match = PLIST_TAG_RE.exec(xml))) {
-    const [, closing, tag, attrs] = match;
-    if (tag === "plist") {
-      continue;
-    }
-    if (closing) {
-      const top = stack.pop();
-      root = top ? attachToFrame(stack, root, frameToNode(top)) : root;
-      continue;
-    }
-    if (attrs.trimEnd().endsWith("/")) {
-      root = attachToFrame(stack, root, { kind: "scalar", tag, text: "" });
-      continue;
-    }
-    if (tag === "dict") {
-      stack.push({ entries: [], pendingKey: null });
-      continue;
-    }
-    if (tag === "array") {
-      stack.push({ items: [] });
-      continue;
-    }
-    if (tag === "key") {
-      const nextIndex = consumeKeyElement(xml, stack, PLIST_TAG_RE.lastIndex);
-      if (nextIndex === -1) {
-        break;
-      }
-      PLIST_TAG_RE.lastIndex = nextIndex;
-      continue;
-    }
-    // Leaf scalar: <integer>…</integer>, <string>…</string>, <data>…</data>, etc.
-    const { node, nextIndex } = consumeScalarElement(xml, tag, PLIST_TAG_RE.lastIndex);
-    PLIST_TAG_RE.lastIndex = nextIndex;
-    root = attachToFrame(stack, root, node);
-  }
-
-  return root;
-}
-
-function dictEntry(dict: PlistDictNode, key: string): PlistNode | undefined {
-  return dict.entries.find((entry) => entry.key === key)?.value;
-}
+/** An ordered plist `<dict>`, as produced by {@link parsePlist}. */
+type PlistDict = Map<string, PlistValue>;
 
 /**
  * Extract the base64 `<data>` blob registered under `sectionInfo[bundleId]` in
- * the outer `VersionedSectionInfo.plist` XML by walking the `sectionInfo` dict
- * directly, rather than regex-matching `bundleId` anywhere in the document.
- * Returns null if the bundle has no section registered.
+ * the outer `VersionedSectionInfo.plist` XML by parsing it with the repo's
+ * structured plist parser ({@link parsePlist}, built on `xml2js`) and walking
+ * the `sectionInfo` dict directly, rather than regex-matching `bundleId`
+ * anywhere in the document. Returns null if the bundle has no section
+ * registered.
  */
-export function extractSectionDataBase64(outerXml: string, bundleId: string): string | null {
-  const root = parsePlistBody(outerXml);
-  if (!root || root.kind !== "dict") {
+export async function extractSectionDataBase64(
+  outerXml: string,
+  bundleId: string,
+): Promise<string | null> {
+  const root = await parsePlist(outerXml);
+  if (!(root instanceof Map)) {
     return null;
   }
-  const sectionInfo = dictEntry(root, "sectionInfo");
-  if (!sectionInfo || sectionInfo.kind !== "dict") {
+  const sectionInfo = root.get("sectionInfo");
+  if (!(sectionInfo instanceof Map)) {
     return null;
   }
-  const data = dictEntry(sectionInfo, bundleId);
-  if (!data || data.kind !== "scalar" || data.tag !== "data") {
+  const data = sectionInfo.get(bundleId);
+  if (typeof data !== "string") {
     return null;
   }
   // Strip all whitespace from the base64 payload (plutil wraps it across lines).
-  return data.text.replace(/\s+/g, "");
+  return data.replace(/\s+/g, "");
 }
 
 /** The scalar keys that identify a BulletinBoard settings dict. */
@@ -236,17 +89,17 @@ const SETTINGS_KEYS = [
   "notificationCenterSetting",
 ] as const;
 
-function collectDicts(node: PlistNode | null | undefined, out: PlistDictNode[]): void {
-  if (!node) {
+function collectDicts(node: PlistValue | undefined, out: PlistDict[]): void {
+  if (node === undefined) {
     return;
   }
-  if (node.kind === "dict") {
+  if (node instanceof Map) {
     out.push(node);
-    for (const entry of node.entries) {
-      collectDicts(entry.value, out);
+    for (const value of node.values()) {
+      collectDicts(value, out);
     }
-  } else if (node.kind === "array") {
-    for (const item of node.items) {
+  } else if (Array.isArray(node)) {
+    for (const item of node) {
       collectDicts(item, out);
     }
   }
@@ -259,16 +112,15 @@ function collectDicts(node: PlistNode | null | undefined, out: PlistDictNode[]):
  * candidates, pick the one that also carries the most other known settings
  * keys as siblings, rather than trusting document order.
  */
-function findSettingsDict(root: PlistNode | null): PlistDictNode | undefined {
-  const dicts: PlistDictNode[] = [];
+function findSettingsDict(root: PlistValue): PlistDict | undefined {
+  const dicts: PlistDict[] = [];
   collectDicts(root, dicts);
-  const candidates = dicts.filter((dict) => dictEntry(dict, "authorizationStatus") !== undefined);
-  return candidates.reduce<PlistDictNode | undefined>((best, dict) => {
+  const candidates = dicts.filter((dict) => dict.get("authorizationStatus") !== undefined);
+  return candidates.reduce<PlistDict | undefined>((best, dict) => {
     if (!best) {
       return dict;
     }
-    const score = (d: PlistDictNode) =>
-      SETTINGS_KEYS.filter((key) => dictEntry(d, key) !== undefined).length;
+    const score = (d: PlistDict) => SETTINGS_KEYS.filter((key) => d.get(key) !== undefined).length;
     return score(dict) > score(best) ? dict : best;
   }, undefined);
 }
@@ -279,17 +131,17 @@ function findSettingsDict(root: PlistNode | null): PlistDictNode | undefined {
  * {@link findSettingsDict}) rather than independently regex-matched anywhere
  * in the document.
  */
-export function parseSettingsFromNestedXml(nestedXml: string): BulletinBoardSettings {
-  const root = parsePlistBody(nestedXml);
+export async function parseSettingsFromNestedXml(
+  nestedXml: string,
+): Promise<BulletinBoardSettings> {
+  const root = await parsePlist(nestedXml);
   const dict = findSettingsDict(root);
   if (!dict) {
     return {};
   }
   const intKey = (key: string): number | undefined => {
-    const value = dictEntry(dict, key);
-    return value && value.kind === "scalar" && value.tag === "integer"
-      ? Number(value.text)
-      : undefined;
+    const value = dict.get(key);
+    return typeof value === "number" ? value : undefined;
   };
   return {
     authorizationStatus: intKey("authorizationStatus"),
@@ -338,7 +190,7 @@ export class BulletinBoardAuthorizationReader implements IosNotificationAuthoriz
       };
     }
 
-    const base64Blob = extractSectionDataBase64(outerXml, bundleId);
+    const base64Blob = await extractSectionDataBase64(outerXml, bundleId);
     if (!base64Blob) {
       return {
         supported: true,

--- a/src/utils/ios-cmdline-tools/SimulatorTccSqliteClient.ts
+++ b/src/utils/ios-cmdline-tools/SimulatorTccSqliteClient.ts
@@ -55,6 +55,20 @@ export interface SimulatorTccSqliteClientDependencies {
 
 const nodeFileSystem: TccDatabaseFileSystem = { stat };
 
+/**
+ * Resolve the CoreSimulator device set root: `CORESIMULATOR_DEVICE_SET_PATH`
+ * when set, otherwise the default `~/Library/Developer/CoreSimulator/Devices`
+ * layout. Shared by every reader that needs a simulator's per-device data
+ * root (issue #6583) so the "honor a custom device set" fix lives in one
+ * place instead of being re-derived per call site.
+ */
+export function defaultDeviceSetRoot(homeDirectory: string): string {
+  const configured = process.env.CORESIMULATOR_DEVICE_SET_PATH?.trim();
+  return configured
+    ? configured
+    : join(homeDirectory, "Library", "Developer", "CoreSimulator", "Devices");
+}
+
 export function tccServiceForPermission(permission: string): string {
   return permission.startsWith("kTCCService")
     ? permission

--- a/test/features/utility/IosNotificationAuthorizationReader.test.ts
+++ b/test/features/utility/IosNotificationAuthorizationReader.test.ts
@@ -93,19 +93,62 @@ function fakeDeps(opts: { outer?: string | Error; nested?: string }): {
 }
 
 describe("extractSectionDataBase64", () => {
-  test("extracts and strips whitespace from the base64 blob", () => {
+  test("extracts and strips whitespace from the base64 blob", async () => {
     const xml = outerXml({ "com.apple.MobileSMS": "QUJD\n\t\tREVG" });
-    expect(extractSectionDataBase64(xml, "com.apple.MobileSMS")).toBe("QUJDREVG");
+    expect(await extractSectionDataBase64(xml, "com.apple.MobileSMS")).toBe("QUJDREVG");
   });
 
-  test("returns null for a bundle with no section", () => {
+  test("returns null for a bundle with no section", async () => {
     const xml = outerXml({ "com.apple.MobileSMS": "QUJD" });
-    expect(extractSectionDataBase64(xml, "com.example.absent")).toBeNull();
+    expect(await extractSectionDataBase64(xml, "com.example.absent")).toBeNull();
+  });
+
+  // Issue #6583 follow-up (codex review): the previous ad-hoc regex tokenizer
+  // required a space before the closing `/` (`<true />`) and did not match
+  // Apple's actual plutil output, which emits no-space self-closing tags like
+  // `<true/>`. A stray self-closing boolean sibling anywhere in the document
+  // must not break parsing of an unrelated `<data>` blob.
+  test("tolerates no-space self-closing tags elsewhere in the document", async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+\t<key>sectionInfoVersionNumber</key>
+\t<integer>2</integer>
+\t<key>migrationComplete</key>
+\t<true/>
+\t<key>legacySections</key>
+\t<array/>
+\t<key>sectionInfo</key>
+\t<dict>
+\t\t<key>com.apple.MobileSMS</key>
+\t\t<data>QUJDREVG</data>
+\t</dict>
+</dict>
+</plist>`;
+    expect(await extractSectionDataBase64(xml, "com.apple.MobileSMS")).toBe("QUJDREVG");
+  });
+
+  // The previous regex tokenizer's `indexOf` consumers read raw XML text
+  // without decoding entities, so an escaped bundle id would never match a
+  // lookup by its literal (decoded) value. Reusing the structured parser
+  // fixes this because xml2js decodes entities as part of parsing.
+  test("decodes XML entities in dict keys before matching the bundle id", async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+\t<key>sectionInfo</key>
+\t<dict>
+\t\t<key>com.example.app&amp;co</key>
+\t\t<data>QUJDREVG</data>
+\t</dict>
+</dict>
+</plist>`;
+    expect(await extractSectionDataBase64(xml, "com.example.app&co")).toBe("QUJDREVG");
   });
 });
 
 describe("parseSettingsFromNestedXml", () => {
-  test("pulls integer settings keys", () => {
+  test("pulls integer settings keys", async () => {
     const xml = nestedXml({
       authorizationStatus: 2,
       alertType: 1,
@@ -113,7 +156,7 @@ describe("parseSettingsFromNestedXml", () => {
       notificationCenterSetting: 2,
       pushSettings: 63,
     });
-    expect(parseSettingsFromNestedXml(xml)).toEqual({
+    expect(await parseSettingsFromNestedXml(xml)).toEqual({
       authorizationStatus: 2,
       alertType: 1,
       lockScreenSetting: 2,
@@ -127,7 +170,7 @@ describe("parseSettingsFromNestedXml", () => {
   // dict carrying only `authorizationStatus` (no sibling settings keys) must
   // lose to the real settings dict that also carries `pushSettings`/`alertType`,
   // even though the decoy appears first in document order.
-  test("selects the coherent settings dict, not the first authorizationStatus match", () => {
+  test("selects the coherent settings dict, not the first authorizationStatus match", async () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
@@ -155,12 +198,76 @@ describe("parseSettingsFromNestedXml", () => {
 \t</array>
 </dict>
 </plist>`;
-    expect(parseSettingsFromNestedXml(xml)).toEqual({
+    expect(await parseSettingsFromNestedXml(xml)).toEqual({
       authorizationStatus: 2,
       alertType: 1,
       lockScreenSetting: 2,
       notificationCenterSetting: 2,
       pushSettings: 63,
+    });
+  });
+
+  // Issue #6583 follow-up (codex review): the previous ad-hoc regex tokenizer
+  // did not match no-space self-closing tags (`<true/>`, `<dict/>`) which is
+  // exactly what plutil emits, so a self-closing sibling anywhere in the
+  // `$objects` graph must not derail extraction of the real settings dict.
+  test("tolerates no-space self-closing tags among the $objects siblings", async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+\t<key>$archiver</key>
+\t<string>NSKeyedArchiver</string>
+\t<key>$objects</key>
+\t<array>
+\t\t<string>$null</string>
+\t\t<true/>
+\t\t<dict/>
+\t\t<dict>
+\t\t\t<key>authorizationStatus</key>
+\t\t\t<integer>3</integer>
+\t\t\t<key>pushSettings</key>
+\t\t\t<integer>7</integer>
+\t\t</dict>
+\t</array>
+</dict>
+</plist>`;
+    expect(await parseSettingsFromNestedXml(xml)).toEqual({
+      authorizationStatus: 3,
+      pushSettings: 7,
+      alertType: undefined,
+      lockScreenSetting: undefined,
+      notificationCenterSetting: undefined,
+    });
+  });
+
+  // The previous regex tokenizer's `indexOf` consumers read raw XML text
+  // without decoding entities, so an escaped sibling string value could
+  // corrupt the scan of subsequent tags. Reusing the structured parser fixes
+  // this because xml2js decodes entities as part of parsing.
+  test("tolerates XML entities in sibling string values", async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+\t<key>$archiver</key>
+\t<string>NSKeyedArchiver</string>
+\t<key>$objects</key>
+\t<array>
+\t\t<string>Fish &amp; Chips &lt;shop&gt;</string>
+\t\t<dict>
+\t\t\t<key>authorizationStatus</key>
+\t\t\t<integer>2</integer>
+\t\t\t<key>alertType</key>
+\t\t\t<integer>1</integer>
+\t\t</dict>
+\t</array>
+</dict>
+</plist>`;
+    expect(await parseSettingsFromNestedXml(xml)).toEqual({
+      authorizationStatus: 2,
+      alertType: 1,
+      pushSettings: undefined,
+      lockScreenSetting: undefined,
+      notificationCenterSetting: undefined,
     });
   });
 });

--- a/test/features/utility/IosNotificationAuthorizationReader.test.ts
+++ b/test/features/utility/IosNotificationAuthorizationReader.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import * as path from "path";
 import {
   BulletinBoardAuthorizationReader,
   extractSectionDataBase64,
   parseSettingsFromNestedXml,
+  resolveDeviceDataRoot,
   type BulletinBoardReaderDeps,
 } from "../../../src/features/utility/ios/IosNotificationAuthorizationReader";
 
@@ -118,6 +120,81 @@ describe("parseSettingsFromNestedXml", () => {
       notificationCenterSetting: 2,
       pushSettings: 63,
     });
+  });
+
+  // Issue #6583: the archive's $objects array is a flat, order-dependent list
+  // that can contain more than one dict shaped like the settings dict. A decoy
+  // dict carrying only `authorizationStatus` (no sibling settings keys) must
+  // lose to the real settings dict that also carries `pushSettings`/`alertType`,
+  // even though the decoy appears first in document order.
+  test("selects the coherent settings dict, not the first authorizationStatus match", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+\t<key>$archiver</key>
+\t<string>NSKeyedArchiver</string>
+\t<key>$objects</key>
+\t<array>
+\t\t<string>$null</string>
+\t\t<dict>
+\t\t\t<key>authorizationStatus</key>
+\t\t\t<integer>0</integer>
+\t\t</dict>
+\t\t<dict>
+\t\t\t<key>alertType</key>
+\t\t\t<integer>1</integer>
+\t\t\t<key>authorizationStatus</key>
+\t\t\t<integer>2</integer>
+\t\t\t<key>lockScreenSetting</key>
+\t\t\t<integer>2</integer>
+\t\t\t<key>notificationCenterSetting</key>
+\t\t\t<integer>2</integer>
+\t\t\t<key>pushSettings</key>
+\t\t\t<integer>63</integer>
+\t\t</dict>
+\t</array>
+</dict>
+</plist>`;
+    expect(parseSettingsFromNestedXml(xml)).toEqual({
+      authorizationStatus: 2,
+      alertType: 1,
+      lockScreenSetting: 2,
+      notificationCenterSetting: 2,
+      pushSettings: 63,
+    });
+  });
+});
+
+describe("resolveDeviceDataRoot", () => {
+  const original = process.env.CORESIMULATOR_DEVICE_SET_PATH;
+  const restoreEnv = () => {
+    if (original === undefined) {
+      delete process.env.CORESIMULATOR_DEVICE_SET_PATH;
+    } else {
+      process.env.CORESIMULATOR_DEVICE_SET_PATH = original;
+    }
+  };
+
+  test("honors CORESIMULATOR_DEVICE_SET_PATH when set", () => {
+    process.env.CORESIMULATOR_DEVICE_SET_PATH = "/custom/device-set";
+    try {
+      expect(resolveDeviceDataRoot(SIM_UDID, "/home/tester")).toBe(
+        path.join("/custom/device-set", SIM_UDID),
+      );
+    } finally {
+      restoreEnv();
+    }
+  });
+
+  test("falls back to the default CoreSimulator device set layout", () => {
+    delete process.env.CORESIMULATOR_DEVICE_SET_PATH;
+    try {
+      expect(resolveDeviceDataRoot(SIM_UDID, "/home/tester")).toBe(
+        path.join("/home/tester", "Library", "Developer", "CoreSimulator", "Devices", SIM_UDID),
+      );
+    } finally {
+      restoreEnv();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Replaced the two first-match regexes in IosNotificationAuthorizationReader.ts with a small plist-XML DOM walk over dict/array elements, so all settings scalars are read from one coherent dict rather than matched independently anywhere in the document. When multiple dicts carry an authorizationStatus key, the reader now scores candidates by how many other known settings keys they also carry and picks the most coherent one instead of trusting document order. It also reuses the defaultDeviceSetRoot resolver exported by the base branch's #6582 fix (via a new resolveDeviceDataRoot helper) so defaultBulletinBoardReader() honors CORESIMULATOR_DEVICE_SET_PATH instead of hard-coding the default CoreSimulator device set. The plist parser's tag/key/scalar handling was extracted into small helpers to keep parsePlistBody under the complexity ratchet.

Part of epic #6372.

Stacked on `work/issue-6582-simulator-tcc-readonly-deviceset`; GitHub retargets to `main` once it merges.

## Linked Issue

Closes #6583

## Validation

Targeted: IosNotificationAuthorizationReader.test.ts 14 pass (incl. 2 new: coherent-dict selection over a decoy authorizationStatus-only dict, and resolveDeviceDataRoot honoring CORESIMULATOR_DEVICE_SET_PATH vs default) + SimulatorTccSqliteClient.test.ts 11 pass (unaffected by the export). Broad: test/features/utility + test/utils/ios-cmdline-tools 984/0 pass. Red-then-green confirmed.

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
