### PR TITLE
feat: configure Android resources and emulator hardware

### DIFF
--- a/docs/design-docs/android-emulator-optimization.md
+++ b/docs/design-docs/android-emulator-optimization.md
@@ -1,0 +1,130 @@
+# Android emulator optimization
+
+Status: implementation and local experiments, September 2026. Controls remain
+independent. No profiles or automatic package disabling.
+
+## Available controls
+
+The resource catalog, restoration receipt, and AVD hardware fields are documented
+in [Device resources](device-resources.md). They cover optional applications,
+animations, screensavers, backup, CPU/RAM, GPU, display geometry and density,
+camera, and audio. Test resource availability separately from performance.
+
+Reuse the existing surfaces for other costs:
+
+- `webrtcStream` configuration has Android FPS (1–60, default 30), output size,
+  bitrate, and optional audio. Stop a stream when no observer needs it.
+- Video recording has its own FPS/size settings. Record on demand.
+- `displayConfig` controls font scale, density and theme. Persistent framebuffer
+  geometry is now part of exact provisioning.
+- `deviceSnapshot` can use emulator VM snapshots. Prepared snapshots still need
+  app/account identity isolation and restore validation; a faster boot is not
+  proof that the resulting session is clean.
+- `AUTOMOBILE_EMULATOR_ARGS` accepts tokenized startup arguments. Experimental
+  `-read-only`, snapshot and boot-animation switches can be investigated through
+  that existing path. Read-only clones of one AVD are not supported as distinct
+  pool identities yet; do not use the escape hatch to bypass pool ownership.
+- Device-pool autolock timeout releases a session; it does not promise emulator
+  shutdown. Idle shutdown and warm-cap policies need explicit lifecycle
+  reservations, ownership checks, pending-cleanup checks, and a bounded
+  reacquisition test before integration.
+
+## Experimental controls and required implementation work
+
+| Surface                                        | Mechanism and next verification                                                             | Why it is not a general resource toggle yet                                                                                     |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Per-app background execution                   | Read/set `RUN_ANY_IN_BACKGROUND` app-op, preserve original mode, verify after resume/reboot | Changes push, jobs and uploads; requires package-specific intent and a richer policy contract                                   |
+| Standby buckets                                | `am get-standby-bucket` / `am set-standby-bucket` with API-aware buckets                    | Buckets are dynamic and charging changes enforcement; a successful write is not proof of scheduling behavior                    |
+| App suspension / force-stop / hibernation      | Separate package operations; observe launch, alarms, jobs and permission changes            | Semantically different from disable-user; hibernation can discard state that cannot be exactly restored                         |
+| ART precompilation                             | Compile a chosen fixture app with speed-profile/speed and measure repeated launch           | Preparation consumes CPU/disk and changes cold-start measurements; cannot restore prior compiled artifacts with a binary switch |
+| Account sync                                   | Privileged/instrumented ContentResolver master/per-authority APIs                           | API-35 `cmd content` has no master-sync setter; needs a permission-tested Android bridge, not guessed shell commands            |
+| Widgets                                        | Inspect active widget hosts/providers, alter only explicitly selected widgets               | Framework is shared with launcher/system_server; no independent universal widget daemon                                         |
+| Cached-app freezer                             | Read effective ActivityManager state, then measure eligible cached work                     | Already effective on the sampled API-35 image; enabling an existing feature is not a new saving                                 |
+| Doze / saver / screen-off                      | Controlled power-state experiments with foreground and push tests                           | Conflicts with ordinary live notification delivery and interactive readiness; guest battery state is not host energy            |
+| Bluetooth / NFC / location                     | Supported platform feature controls and HAL inventory                                       | Dormant emulated hardware may save little; API availability and dependent app behavior need verification                        |
+| Native diagnostics / HALs                      | Root-only init-service inventory, stop/restart experiments, CPU/retry traces                | Critical/restarting services and shared framework processes cannot be treated as optional apps                                  |
+| zRAM / LMKD / heap / low-RAM product flags     | Custom image and host-density benchmarks                                                    | Memory reduction can increase churn and CPU; do not disable LMKD or security controls                                           |
+| ATD / AOSP / Google APIs / Play images         | Compare exact API/ABI/builds and app capability tests                                       | Image substitutions can remove push, billing or screenshot rendering; ATD is not a drop-in visual target                        |
+| Read-only shared snapshots                     | Distinct instance IDs/ports, shared/private accounting, isolation tests                     | Requires multi-instance lifecycle work before pool use                                                                          |
+| Linux CPU quotas / affinity / KSM / Cuttlefish | Linux/KVM worker and explicit limits with throughput tests                                  | Not available as cross-platform controls on a macOS emulator host                                                               |
+
+The supplied host has macOS/arm64 emulator tooling. This does not validate Linux
+KVM/Cuttlefish, Windows hypervisor behavior, custom system images, or realistic
+multi-host fleet density. Google account/Slack workflows need their own
+application fixtures and credentials; an unconfigured AVD cannot validate push,
+login, attachments, or huddles. These are evidence requirements, not claims of
+compatibility from a package list.
+
+## Measurement protocol
+
+`scripts/android/benchmark-emulator-resources.sh` accepts an explicit serial,
+matching emulator PID, output directory, sample count and interval. It records
+host process RSS/CPU readings and guest properties/memory/process state without
+changing the device. Match the PID to its explicit emulator port before sampling.
+RSS includes shared pages and is not unique physical memory. Host percent CPU
+semantics vary by OS; do not derive a savings claim from one ps sample.
+
+For comparative runs, hold exact image/build, emulator version, host load,
+framebuffer, charging, app data and boot/snapshot state constant. Let boot and
+package changes settle before sampling. Compare one change at a time before
+combinations. Repeat baseline/treatment/baseline; measure 1/2/4 concurrent
+instances only on a host with sufficient memory headroom. Existing unrelated
+emulators are not controlled experimental participants.
+
+Measure 5–10 minute idle periods plus launch, scroll/type, attachment, background
+resume, notification and audio/video workflows. Record errors as well as latency.
+Use Perfetto and platform private/shared memory accounting for a density claim.
+Preserve raw evidence. A one-device smoke measurement cannot prove fleet savings.
+
+## Primary references
+
+- [Emulator acceleration](https://developer.android.com/studio/run/emulator-acceleration)
+- [AVD hardware configuration](https://developer.android.com/studio/run/managing-avds)
+- [Emulator startup flags](https://developer.android.com/studio/run/emulator-commandline)
+- [Snapshots](https://developer.android.com/studio/run/emulator-snapshots)
+- [Managed devices and ATD restrictions](https://developer.android.com/studio/test/managed-devices)
+- [Cached-app freezer](https://source.android.com/docs/core/perf/cached-apps-freezer)
+- [App standby](https://developer.android.com/topic/performance/appstandby)
+- [Doze](https://developer.android.com/training/monitoring-device-state/doze-standby)
+- [ART configuration](https://source.android.com/docs/core/runtime/configure/art-service)
+- [ContentResolver sync](<https://developer.android.com/reference/android/content/ContentResolver#setMasterSyncAutomatically(boolean)>)
+- [Init service lifecycle](https://android.googlesource.com/platform/system/core/+/refs/heads/main/init/README.md)
+- [Cuttlefish](https://source.android.com/docs/devices/cuttlefish/get-started)
+
+## Initial local measurements
+
+A disposable Android 15 Google APIs arm64 emulator (emulator 36.4.5, 2 vCPU,
+2048 MB guest RAM, 1080×1920 at 420 dpi, headless/audio-off, GPU auto) was sampled
+on macOS. Auto selected SwiftShader. After excluding the overlap with initial
+smoke validation, 52 baseline samples covered 257 seconds; 60 treatment samples
+covered 297 seconds. The treatment disabled animations, screensavers, Gmail,
+YouTube, Photos, Wellbeing and printing. Exact prior overrides were then restored.
+
+Median emulator-process RSS was 4691.5 MiB before and 4693.1 MiB after. This run
+showed no material host RSS saving. It is not a controlled causal benchmark:
+there was no repeated A/B/A sequence, unrelated host work was running, and no
+logged-in application workflow was exercised. Guest memory also changed while
+background services settled. CPU percentages from this preliminary sampler are
+not used to claim a reduction. Raw results remain in the task's scratch artifacts.
+
+Native follow-up checks on that disposable API-35 image exercised all 21 optional
+package groups: 18 disabled and restored, while Assistant, Dialer and Messages
+were correctly protected as active role holders. Google Play services and GSF
+were included in the reversible mechanism test; this does not validate app
+compatibility while disabled.
+
+More aggressive mechanism probes also succeeded: Maps' background app-op changed
+to `ignore` and back to `default`; its standby bucket changed from 10 to 45 and
+back to 10; forced deep Doze was entered and unforced. On the debuggable image,
+root access allowed `statsd` to remain stopped for three observations and then
+restart successfully. Maps speed-profile compilation returned success. These
+prove command availability and limited state transitions, not performance wins
+or suitability for ordinary interactive workflows. No native service control was
+added to the public catalog based on this short probe.
+
+The persisted hardware fields also booted successfully with 720×1280, 280 dpi,
+two online CPUs, no exposed cameras, audio input/output off and `gpuMode: host`.
+The emulator log identified Apple M3 Max rendering, whereas the earlier auto
+configuration used SwiftShader. A native screenshot rendered the launcher
+correctly. Because resolution, renderer and boot state changed together, this is
+hardware-control validation rather than an isolated GPU performance comparison.

--- a/docs/design-docs/device-resources.md
+++ b/docs/design-docs/device-resources.md
@@ -144,11 +144,9 @@ or restores the exact job without rebooting, then verifies both the override and
 job registration. Runtime discovery is shared within a request. Group membership
 does not overlap, so enabling one resource cannot silently restore another.
 
-Broad `backgroundSync`, `icloudSync`, `googlePlayServices`, and `animations`
-controls remain unsupported. Physical iOS devices and all Android resource
-mutations return `unsupported` with a reason. Android accepts the same configuration
-contract; its service catalog and control implementation are deferred. A request
-may apply supported entries and report unsupported entries in the same result.
+Broad `backgroundSync` and `icloudSync` remain unsupported. Physical iOS devices
+remain unsupported. Android controls are described below; requests can apply
+supported entries and report unsupported entries in the same result.
 
 Results contain `requested`, a `resources` map of observed states for requested
 entries, `services` with per-daemon evidence, `changed` (resource groups with
@@ -173,3 +171,65 @@ purchases, or other automation capabilities work. Continue to report capabilitie
 separately using AutoMobile's existing supported/partial/unavailable/unsupported
 conventions. Only mark a capability unavailable because of a disabled resource
 when its dependency is known for the device and app context.
+
+## Android controls
+
+Android emulator controls are independent and opt-in. Optional-app groups disable
+only installed system packages in a fixed catalog for the current Android user.
+They preserve ContactsProvider, CalendarProvider, MediaProvider, DocumentsUI,
+SystemUI, the launcher, credentials, networking and automation packages. Active
+apps, default role holders, the selected keyboard and enabled accessibility
+services are protected. If role inspection is unavailable, package disablement
+fails closed; older Android versions can still support individual settings.
+
+- `animations` sets the three system animation scales to zero or one.
+- `screensavers` controls dream activation, separately from wallpaper and widgets.
+- `backup` controls Backup Manager for the current user.
+- `mailApp`, `calendarApp`, `contactsApp`, `mapsApp`, `videoApp`, `musicApp`,
+  `photosApp`, `assistantApp`, `digitalWellbeing`, `printing`, `accessibilityApps`,
+  `textToSpeech`, and `wallpaperApps` control optional applications. Disabling an
+  app removes its integrations and intent handlers. Wallpaper picker removal
+  is not equivalent to disabling wallpaper rendering.
+- `healthConnect`, `adServices`, `onDevicePersonalization`, `storeApp`,
+  `dialerApp`, `messagesApp`, `googlePlayServices` and `googleServicesFramework`
+  are explicit feature tradeoffs. Shared Google infrastructure must remain
+  enabled for workloads that depend on its notifications or authentication.
+  Mainline/APEX containers are never removed.
+
+An Android response can include a `restore` receipt. Pass it back as
+`setDeviceResources({restore: receipt, ...deviceTargeting})`, without `resources`,
+to restore the exact previous overrides. Receipts are restricted to the same
+emulator serial, boot ID and user. This prevents accidental restoration onto a
+recycled emulator. They preserve default package state and absent settings;
+`enabled` is an explicit enable operation, not a substitute for restoration.
+Default override restoration may report observed state `unknown` while returning
+`success: true`: the original override was verified, but the runtime's effective
+default was not inferred. Save the receipt from partial-error responses too.
+A request cancelled before returning a response may have made partial changes;
+inspect/reconcile state rather than assuming rollback. Receipts are not a durable
+transaction journal and do not promise restoration across reboot or lost responses.
+
+Android `changed` records targets for which a native write was attempted. Each
+successful target is re-read; failed or ignored writes produce an error result.
+No package availability observation proves it consumes CPU, and no resource
+configuration result promises measured performance gains.
+
+## Android provisioning hardware
+
+`provisionDevice.device.spec.configuration` accepts `memoryMb`, `cpuCores`,
+`gpuMode`, `screenWidth`, `screenHeight`, `screenDensity`, `cameraFront`,
+`cameraBack`, `audioInput`, and `audioOutput`. These persist in the AVD configuration
+before boot. GPU modes are `auto`, `host`, `software`, `swiftshader`, `lavapipe`,
+and `swangle`; actual backend availability depends on the installed emulator and
+host. Camera values are `none` or `emulated`. Existing modern Play-image minimum
+memory checks remain in effect. Replay can reconcile hardware only while the
+AVD is stopped; a mismatched running device is an identity conflict.
+
+Headless launch controls the window independently of audio.
+`AUTOMOBILE_EMULATOR_AUDIO=false` passes `-no-audio`; otherwise the emulator and
+AVD audio settings apply. `AUTOMOBILE_EMULATOR_HEADLESS` retains its existing
+platform defaults. This changes the old implicit headless-audio-off behavior.
+Audio-dependent workflows can now run headless.
+
+Further Android work and the measurement protocol are tracked in
+[Android emulator optimization](android-emulator-optimization.md).

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -7757,12 +7757,122 @@
               "enum": ["enabled", "disabled"]
             },
             "animations": {
-              "description": "System UI animations. Control is currently unsupported.",
+              "description": "Android system animation scales: disabled sets all three to zero; enabled sets them to one. Excludes app-owned animation.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "screensavers": {
+              "description": "Android dream/screensaver activation; excludes wallpaper and widgets.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "backup": {
+              "description": "Android Backup Manager scheduling for the current user; disables backup and restore test behavior.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "mailApp": {
+              "description": "Android optional mail apps, including Gmail. Removes mail intent handlers; preserves other apps' messaging.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "calendarApp": {
+              "description": "Android Calendar app availability; preserves CalendarProvider.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "contactsApp": {
+              "description": "Android Contacts app availability; preserves ContactsProvider.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "mapsApp": {
+              "description": "Android Google Maps app; external navigation intents become unavailable.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "videoApp": {
+              "description": "Android YouTube app; native video links become unavailable.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "musicApp": {
+              "description": "Android YouTube Music app; preserves shared audio playback.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "photosApp": {
+              "description": "Android Google Photos app; changes cloud photo sources and choosers. Preserves MediaProvider and DocumentsUI.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "assistantApp": {
+              "description": "Android Google Search/Assistant app, including voice and home-search integrations.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "digitalWellbeing": {
+              "description": "Android Digital Wellbeing usage tracking, focus, and app limits.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "printing": {
+              "description": "Android print spooler and print recommendations; printing becomes unavailable.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "accessibilityApps": {
+              "description": "Optional Android accessibility apps. Active accessibility services are protected.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "textToSpeech": {
+              "description": "Android Google speech synthesis; speech-dependent functionality becomes unavailable.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "storeApp": {
+              "description": "Android Play Store app; installation, updates, billing and licensing may fail.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "healthConnect": {
+              "description": "Android Health Connect controller and backup app; health integrations become unavailable.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "adServices": {
+              "description": "Android AdServices API package; advertising/privacy APIs may fail. Does not remove mainline/APEX infrastructure.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "onDevicePersonalization": {
+              "description": "Android on-device personalization service package; dependent APIs may fail.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "wallpaperApps": {
+              "description": "Android wallpaper picker and optional live-wallpaper apps; changes wallpaper selection. Does not disable the shared wallpaper framework or widgets.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "dialerApp": {
+              "description": "Optional Android dialer apps. Default role holders remain protected.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "messagesApp": {
+              "description": "Optional Android SMS/Messages apps. Default role holders remain protected; excludes other apps' messaging.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "googleServicesFramework": {
+              "description": "Android Google Services Framework; aggressive control that can break Google account and push integrations.",
               "type": "string",
               "enum": ["enabled", "disabled"]
             },
             "googlePlayServices": {
-              "description": "Google Play infrastructure. Control is unsupported to preserve application behavior.",
+              "description": "Android Google Play services; aggressive control that breaks dependent push, authentication, location and other integrations. Keep enabled for Slack-compatible workflows.",
               "type": "string",
               "enum": ["enabled", "disabled"]
             },
@@ -7814,6 +7924,44 @@
                           "type": "integer",
                           "exclusiveMinimum": 0,
                           "maximum": 9007199254740991
+                        },
+                        "cpuCores": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 16
+                        },
+                        "gpuMode": {
+                          "type": "string",
+                          "enum": ["auto", "host", "software", "swiftshader", "lavapipe", "swangle"]
+                        },
+                        "screenWidth": {
+                          "type": "integer",
+                          "minimum": 240,
+                          "maximum": 7680
+                        },
+                        "screenHeight": {
+                          "type": "integer",
+                          "minimum": 240,
+                          "maximum": 7680
+                        },
+                        "screenDensity": {
+                          "type": "integer",
+                          "minimum": 72,
+                          "maximum": 1000
+                        },
+                        "cameraFront": {
+                          "type": "string",
+                          "enum": ["none", "emulated"]
+                        },
+                        "cameraBack": {
+                          "type": "string",
+                          "enum": ["none", "emulated"]
+                        },
+                        "audioInput": {
+                          "type": "boolean"
+                        },
+                        "audioOutput": {
+                          "type": "boolean"
                         }
                       },
                       "additionalProperties": false
@@ -8630,7 +8778,7 @@
   },
   {
     "name": "setDeviceResources",
-    "description": "Set selected device resources and verify installed services. Wallpaper, widgets, and Live Activities are independent. All settings are opt-in; omitted resources stay unchanged. iOS Simulator controls are runtime-dependent; Android controls report unsupported.",
+    "description": "Set selected device resources and verify native state. All settings are opt-in; omitted resources stay unchanged. iOS Simulator services and Android optional apps/settings are runtime-dependent. Android changes return a restore receipt for exact restoration during the same boot. Disabling Google infrastructure changes push/auth behavior.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -8819,12 +8967,122 @@
               "enum": ["enabled", "disabled"]
             },
             "animations": {
-              "description": "System UI animations. Control is currently unsupported.",
+              "description": "Android system animation scales: disabled sets all three to zero; enabled sets them to one. Excludes app-owned animation.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "screensavers": {
+              "description": "Android dream/screensaver activation; excludes wallpaper and widgets.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "backup": {
+              "description": "Android Backup Manager scheduling for the current user; disables backup and restore test behavior.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "mailApp": {
+              "description": "Android optional mail apps, including Gmail. Removes mail intent handlers; preserves other apps' messaging.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "calendarApp": {
+              "description": "Android Calendar app availability; preserves CalendarProvider.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "contactsApp": {
+              "description": "Android Contacts app availability; preserves ContactsProvider.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "mapsApp": {
+              "description": "Android Google Maps app; external navigation intents become unavailable.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "videoApp": {
+              "description": "Android YouTube app; native video links become unavailable.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "musicApp": {
+              "description": "Android YouTube Music app; preserves shared audio playback.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "photosApp": {
+              "description": "Android Google Photos app; changes cloud photo sources and choosers. Preserves MediaProvider and DocumentsUI.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "assistantApp": {
+              "description": "Android Google Search/Assistant app, including voice and home-search integrations.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "digitalWellbeing": {
+              "description": "Android Digital Wellbeing usage tracking, focus, and app limits.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "printing": {
+              "description": "Android print spooler and print recommendations; printing becomes unavailable.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "accessibilityApps": {
+              "description": "Optional Android accessibility apps. Active accessibility services are protected.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "textToSpeech": {
+              "description": "Android Google speech synthesis; speech-dependent functionality becomes unavailable.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "storeApp": {
+              "description": "Android Play Store app; installation, updates, billing and licensing may fail.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "healthConnect": {
+              "description": "Android Health Connect controller and backup app; health integrations become unavailable.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "adServices": {
+              "description": "Android AdServices API package; advertising/privacy APIs may fail. Does not remove mainline/APEX infrastructure.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "onDevicePersonalization": {
+              "description": "Android on-device personalization service package; dependent APIs may fail.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "wallpaperApps": {
+              "description": "Android wallpaper picker and optional live-wallpaper apps; changes wallpaper selection. Does not disable the shared wallpaper framework or widgets.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "dialerApp": {
+              "description": "Optional Android dialer apps. Default role holders remain protected.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "messagesApp": {
+              "description": "Optional Android SMS/Messages apps. Default role holders remain protected; excludes other apps' messaging.",
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            },
+            "googleServicesFramework": {
+              "description": "Android Google Services Framework; aggressive control that can break Google account and push integrations.",
               "type": "string",
               "enum": ["enabled", "disabled"]
             },
             "googlePlayServices": {
-              "description": "Google Play infrastructure. Control is unsupported to preserve application behavior.",
+              "description": "Android Google Play services; aggressive control that breaks dependent push, authentication, location and other integrations. Keep enabled for Slack-compatible workflows.",
               "type": "string",
               "enum": ["enabled", "disabled"]
             },
@@ -8836,6 +9094,122 @@
           },
           "additionalProperties": false,
           "minProperties": 1
+        },
+        "restore": {
+          "description": "Restore exact prior Android overrides from a returned receipt. Requires the same boot and user. Specify resources or restore, never both.",
+          "type": "object",
+          "properties": {
+            "deviceId": {
+              "type": "string"
+            },
+            "bootId": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$"
+            },
+            "userId": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "entries": {
+              "minItems": 1,
+              "maxItems": 100,
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "resource": {
+                    "type": "string",
+                    "enum": [
+                      "wallpaperRendering",
+                      "widgets",
+                      "liveActivities",
+                      "healthServices",
+                      "homeServices",
+                      "fitnessServices",
+                      "familyServices",
+                      "screenTime",
+                      "newsServices",
+                      "weatherServices",
+                      "tipsServices",
+                      "gameServices",
+                      "mapsSync",
+                      "advertising",
+                      "diagnosticReporting",
+                      "photoAnalysis",
+                      "assistantSuggestions",
+                      "appleIntelligence",
+                      "searchIndexing",
+                      "appStoreServices",
+                      "appleMediaSync",
+                      "mailServices",
+                      "calendarServices",
+                      "reminderServices",
+                      "personalDataSync",
+                      "safariSync",
+                      "icloudSettingsSync",
+                      "messagingMaintenance",
+                      "watchConnectivity",
+                      "carPlay",
+                      "tvRemote",
+                      "findMy",
+                      "continuity",
+                      "walletServices",
+                      "businessServices",
+                      "backgroundSync",
+                      "animations",
+                      "screensavers",
+                      "backup",
+                      "mailApp",
+                      "calendarApp",
+                      "contactsApp",
+                      "mapsApp",
+                      "videoApp",
+                      "musicApp",
+                      "photosApp",
+                      "assistantApp",
+                      "digitalWellbeing",
+                      "printing",
+                      "accessibilityApps",
+                      "textToSpeech",
+                      "storeApp",
+                      "healthConnect",
+                      "adServices",
+                      "onDevicePersonalization",
+                      "wallpaperApps",
+                      "dialerApp",
+                      "messagesApp",
+                      "googleServicesFramework",
+                      "googlePlayServices",
+                      "icloudSync"
+                    ]
+                  },
+                  "target": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": ["package", "global", "secure", "backup"]
+                  },
+                  "value": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": ["resource", "target", "kind", "value"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": ["deviceId", "bootId", "userId", "entries"],
+          "additionalProperties": false
         },
         "timeoutMs": {
           "description": "Total configuration budget in milliseconds. Defaults to 300000.",
@@ -8859,8 +9233,25 @@
           "type": "string"
         }
       },
-      "required": ["resources"],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "oneOf": [
+            {
+              "required": ["resources"],
+              "not": {
+                "required": ["restore"]
+              }
+            },
+            {
+              "required": ["restore"],
+              "not": {
+                "required": ["resources"]
+              }
+            }
+          ]
+        }
+      ]
     }
   },
   {

--- a/scripts/android/benchmark-emulator-resources.sh
+++ b/scripts/android/benchmark-emulator-resources.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Read-only samples for an explicitly selected emulator and host process.
+# RSS includes shared pages; ps CPU percentage semantics depend on the host OS.
+set -euo pipefail
+if [[ $# -lt 3 || $# -gt 5 ]]; then
+  echo "Usage: $0 SERIAL EMULATOR_PID OUTPUT_DIR [SAMPLES=60] [INTERVAL_SECONDS=5]" >&2
+  exit 2
+fi
+serial=$1
+emulator_pid=$2
+output_dir=$3
+samples=${4:-60}
+interval=${5:-5}
+[[ $serial =~ ^emulator-[0-9]+$ && $emulator_pid =~ ^[0-9]+$ && $samples =~ ^[1-9][0-9]*$ && $interval =~ ^[1-9][0-9]*$ ]] || exit 2
+adb_bin=${ADB:-adb}
+command_line=$(ps -p "$emulator_pid" -o command=)
+[[ $command_line == *qemu-system* ]] || { echo "PID is not an emulator process" >&2; exit 2; }
+[[ $command_line == *"-port ${serial#emulator-}"* ]] || { echo "PID/serial port mismatch" >&2; exit 2; }
+mkdir -p "$output_dir"
+printf '%s\n' "$command_line" > "$output_dir/host-command.txt"
+"$adb_bin" -s "$serial" shell getprop > "$output_dir/guest-properties.txt"
+"$adb_bin" -s "$serial" shell dumpsys meminfo > "$output_dir/guest-memory-before.txt"
+"$adb_bin" -s "$serial" shell dumpsys battery > "$output_dir/guest-battery.txt"
+printf 'epoch_seconds,pid,ps_cpu_percent,rss_kib,cpu_time\n' > "$output_dir/host-samples.csv"
+for ((sample=0; sample<samples; sample++)); do
+  metrics=$(ps -p "$emulator_pid" -o pid=,pcpu=,rss=,time=)
+  [[ -n $metrics ]] || { echo "Emulator process exited" >&2; exit 1; }
+  printf '%s,%s\n' "$(date +%s)" "$(awk '{printf "%s,%s,%s,%s", $1,$2,$3,$4}' <<< "$metrics")" >> "$output_dir/host-samples.csv"
+  if ((sample + 1 < samples)); then sleep "$interval"; fi
+done
+"$adb_bin" -s "$serial" shell dumpsys meminfo > "$output_dir/guest-memory-after.txt"
+"$adb_bin" -s "$serial" shell dumpsys cpuinfo > "$output_dir/guest-cpu-after.txt"
+"$adb_bin" -s "$serial" shell dumpsys activity processes > "$output_dir/guest-processes-after.txt"

--- a/src/models/AndroidAvdConfiguration.ts
+++ b/src/models/AndroidAvdConfiguration.ts
@@ -1,0 +1,30 @@
+import { z } from "zod/v4";
+
+/** Persistent emulator hardware. Applied while creating an AVD, before boot. */
+export const androidAvdConfigurationSchema = z
+  .object({
+    memoryMb: z.number().int().positive().optional(),
+    cpuCores: z.number().int().min(1).max(16).optional(),
+    gpuMode: z.enum(["auto", "host", "software", "swiftshader", "lavapipe", "swangle"]).optional(),
+    screenWidth: z.number().int().min(240).max(7680).optional(),
+    screenHeight: z.number().int().min(240).max(7680).optional(),
+    screenDensity: z.number().int().min(72).max(1000).optional(),
+    cameraFront: z.enum(["none", "emulated"]).optional(),
+    cameraBack: z.enum(["none", "emulated"]).optional(),
+    audioInput: z.boolean().optional(),
+    audioOutput: z.boolean().optional(),
+  })
+  .strict();
+export type AndroidAvdConfiguration = z.infer<typeof androidAvdConfigurationSchema>;
+export const androidAvdConfigurationKeys = {
+  memoryMb: "hw.ramSize",
+  cpuCores: "hw.cpu.ncore",
+  gpuMode: "hw.gpu.mode",
+  screenWidth: "hw.lcd.width",
+  screenHeight: "hw.lcd.height",
+  screenDensity: "hw.lcd.density",
+  cameraFront: "hw.camera.front",
+  cameraBack: "hw.camera.back",
+  audioInput: "hw.audioInput",
+  audioOutput: "hw.audioOutput",
+} as const satisfies Record<keyof AndroidAvdConfiguration, string>;

--- a/src/models/AndroidDeviceResource.ts
+++ b/src/models/AndroidDeviceResource.ts
@@ -4,6 +4,7 @@ import type {
   DeviceResourceMap,
   DeviceResourceStatus,
 } from "./DeviceResource";
+import type { AndroidOnlyDeviceResource } from "./deviceResourceDescriptions";
 
 /**
  * Android resource snapshot. googlePlayServices covers the Google Play services
@@ -14,7 +15,8 @@ export interface AndroidDeviceResource extends DeviceResource<
   CommonDeviceResource | "googlePlayServices"
 > {
   platform: "android";
-  resources: DeviceResourceMap & {
-    googlePlayServices: DeviceResourceStatus;
-  };
+  resources: DeviceResourceMap &
+    Partial<Record<AndroidOnlyDeviceResource, DeviceResourceStatus>> & {
+      googlePlayServices: DeviceResourceStatus;
+    };
 }

--- a/src/models/AndroidResourceRestoration.ts
+++ b/src/models/AndroidResourceRestoration.ts
@@ -1,0 +1,33 @@
+import { z } from "zod/v4";
+import {
+  deviceResourceDescriptions,
+  type ConfigurableDeviceResource,
+} from "./deviceResourceDescriptions";
+
+/** Caller-carried receipt, bound to one boot/user. Contains no arbitrary commands. */
+export const androidResourceRestorationSchema = z
+  .object({
+    deviceId: z.string(),
+    bootId: z.string().uuid(),
+    userId: z.number().int().nonnegative(),
+    entries: z
+      .array(
+        z
+          .object({
+            resource: z.enum(
+              Object.keys(deviceResourceDescriptions) as [
+                ConfigurableDeviceResource,
+                ...ConfigurableDeviceResource[],
+              ],
+            ),
+            target: z.string(),
+            kind: z.enum(["package", "global", "secure", "backup"]),
+            value: z.string().nullable(),
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(100),
+  })
+  .strict();
+export type AndroidResourceRestoration = z.infer<typeof androidResourceRestorationSchema>;

--- a/src/models/AppleDeviceResource.ts
+++ b/src/models/AppleDeviceResource.ts
@@ -4,7 +4,10 @@ import type {
   DeviceResourceMap,
   DeviceResourceStatus,
 } from "./DeviceResource";
-import type { ConfigurableDeviceResource } from "./deviceResourceDescriptions";
+import type {
+  ConfigurableDeviceResource,
+  AndroidOnlyDeviceResource,
+} from "./deviceResourceDescriptions";
 
 /**
  * iOS resource snapshot.
@@ -18,7 +21,7 @@ export interface AppleDeviceResource extends DeviceResource<
   platform: "ios";
   resources: DeviceResourceMap &
     Partial<
-      Record<Exclude<ConfigurableDeviceResource, "googlePlayServices">, DeviceResourceStatus>
+      Record<Exclude<ConfigurableDeviceResource, AndroidOnlyDeviceResource>, DeviceResourceStatus>
     > & {
       icloudSync: DeviceResourceStatus;
       photoAnalysis: DeviceResourceStatus;

--- a/src/models/DeviceResourceConfiguration.ts
+++ b/src/models/DeviceResourceConfiguration.ts
@@ -1,4 +1,5 @@
 import type { DeviceResourceStatus } from "./DeviceResource";
+import type { AndroidResourceRestoration } from "./AndroidResourceRestoration";
 import type { ConfigurableDeviceResource } from "./deviceResourceDescriptions";
 export type { ConfigurableDeviceResource } from "./deviceResourceDescriptions";
 
@@ -19,4 +20,6 @@ export interface DeviceResourceConfigurationResult {
   changed: ConfigurableDeviceResource[];
   /** Evidence covers this boot. Persistence is not inferred from a write. */
   verification: "current_boot";
+  /** Android prior overrides; pass to setDeviceResources.restore during this boot. */
+  restore?: AndroidResourceRestoration;
 }

--- a/src/models/deviceResourceDescriptions.ts
+++ b/src/models/deviceResourceDescriptions.ts
@@ -58,11 +58,73 @@ export const deviceResourceDescriptions = {
   businessServices: "Apple business messaging services; excludes ordinary app messaging.",
   backgroundSync:
     "General OS background app scheduling. Control is unsupported to preserve application behavior.",
-  animations: "System UI animations. Control is currently unsupported.",
+  animations:
+    "Android system animation scales: disabled sets all three to zero; enabled sets them to one. Excludes app-owned animation.",
+  screensavers: "Android dream/screensaver activation; excludes wallpaper and widgets.",
+  backup:
+    "Android Backup Manager scheduling for the current user; disables backup and restore test behavior.",
+  mailApp:
+    "Android optional mail apps, including Gmail. Removes mail intent handlers; preserves other apps' messaging.",
+  calendarApp: "Android Calendar app availability; preserves CalendarProvider.",
+  contactsApp: "Android Contacts app availability; preserves ContactsProvider.",
+  mapsApp: "Android Google Maps app; external navigation intents become unavailable.",
+  videoApp: "Android YouTube app; native video links become unavailable.",
+  musicApp: "Android YouTube Music app; preserves shared audio playback.",
+  photosApp:
+    "Android Google Photos app; changes cloud photo sources and choosers. Preserves MediaProvider and DocumentsUI.",
+  assistantApp:
+    "Android Google Search/Assistant app, including voice and home-search integrations.",
+  digitalWellbeing: "Android Digital Wellbeing usage tracking, focus, and app limits.",
+  printing: "Android print spooler and print recommendations; printing becomes unavailable.",
+  accessibilityApps:
+    "Optional Android accessibility apps. Active accessibility services are protected.",
+  textToSpeech:
+    "Android Google speech synthesis; speech-dependent functionality becomes unavailable.",
+  storeApp: "Android Play Store app; installation, updates, billing and licensing may fail.",
+  healthConnect:
+    "Android Health Connect controller and backup app; health integrations become unavailable.",
+  adServices:
+    "Android AdServices API package; advertising/privacy APIs may fail. Does not remove mainline/APEX infrastructure.",
+  onDevicePersonalization:
+    "Android on-device personalization service package; dependent APIs may fail.",
+  wallpaperApps:
+    "Android wallpaper picker and optional live-wallpaper apps; changes wallpaper selection. Does not disable the shared wallpaper framework or widgets.",
+  dialerApp: "Optional Android dialer apps. Default role holders remain protected.",
+  messagesApp:
+    "Optional Android SMS/Messages apps. Default role holders remain protected; excludes other apps' messaging.",
+  googleServicesFramework:
+    "Android Google Services Framework; aggressive control that can break Google account and push integrations.",
   googlePlayServices:
-    "Google Play infrastructure. Control is unsupported to preserve application behavior.",
+    "Android Google Play services; aggressive control that breaks dependent push, authentication, location and other integrations. Keep enabled for Slack-compatible workflows.",
   icloudSync:
     "Broad iCloud/account synchronization. Control is unsupported; use the narrower icloudSettingsSync setting.",
 } as const;
 
 export type ConfigurableDeviceResource = keyof typeof deviceResourceDescriptions;
+
+export const androidOnlyDeviceResources = [
+  "screensavers",
+  "backup",
+  "mailApp",
+  "calendarApp",
+  "contactsApp",
+  "mapsApp",
+  "videoApp",
+  "musicApp",
+  "photosApp",
+  "assistantApp",
+  "digitalWellbeing",
+  "printing",
+  "accessibilityApps",
+  "textToSpeech",
+  "storeApp",
+  "healthConnect",
+  "adServices",
+  "onDevicePersonalization",
+  "wallpaperApps",
+  "dialerApp",
+  "messagesApp",
+  "googleServicesFramework",
+  "googlePlayServices",
+] as const satisfies readonly ConfigurableDeviceResource[];
+export type AndroidOnlyDeviceResource = (typeof androidOnlyDeviceResources)[number];

--- a/src/server/deviceResourceSchemas.ts
+++ b/src/server/deviceResourceSchemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { androidResourceRestorationSchema } from "../models/AndroidResourceRestoration";
 import {
   DEFAULT_DEVICE_RESOURCE_TIMEOUT_MS,
   MAX_DEVICE_READY_TIMEOUT_MS,
@@ -31,19 +32,39 @@ export const deviceResourceConfigurationSchema = withJsonSchemaOverride(
   },
 );
 
-export const setDeviceResourcesSchema = addDeviceTargetingToSchema(
-  z
-    .object({
-      resources: deviceResourceConfigurationSchema,
-      timeoutMs: z
-        .number()
-        .int()
-        .positive()
-        .max(MAX_DEVICE_READY_TIMEOUT_MS)
-        .optional()
-        .describe(
-          `Total configuration budget in milliseconds. Defaults to ${DEFAULT_DEVICE_RESOURCE_TIMEOUT_MS}.`,
-        ),
-    })
-    .strict(),
+export const setDeviceResourcesSchema = withJsonSchemaOverride(
+  addDeviceTargetingToSchema(
+    z
+      .object({
+        resources: deviceResourceConfigurationSchema.optional(),
+        restore: androidResourceRestorationSchema
+          .optional()
+          .describe(
+            "Restore exact prior Android overrides from a returned receipt. Requires the same boot and user. Specify resources or restore, never both.",
+          ),
+        timeoutMs: z
+          .number()
+          .int()
+          .positive()
+          .max(MAX_DEVICE_READY_TIMEOUT_MS)
+          .optional()
+          .describe(
+            `Total configuration budget in milliseconds. Defaults to ${DEFAULT_DEVICE_RESOURCE_TIMEOUT_MS}.`,
+          ),
+      })
+      .strict(),
+  ).refine(
+    (value) => (value.resources !== undefined) !== (value.restore !== undefined),
+    "Specify exactly one of resources or restore.",
+  ),
+  (jsonSchema) => {
+    jsonSchema.allOf = [
+      {
+        oneOf: [
+          { required: ["resources"], not: { required: ["restore"] } },
+          { required: ["restore"], not: { required: ["resources"] } },
+        ],
+      },
+    ];
+  },
 );

--- a/src/server/deviceResourceTools.ts
+++ b/src/server/deviceResourceTools.ts
@@ -22,7 +22,7 @@ import {
 export function registerDeviceResourceTools(dependencies: () => DeviceToolsDependencies): void {
   ToolRegistry.registerDeviceAware(
     "setDeviceResources",
-    "Set selected device resources and verify installed services. Wallpaper, widgets, and Live Activities are independent. All settings are opt-in; omitted resources stay unchanged. iOS Simulator controls are runtime-dependent; Android controls report unsupported.",
+    "Set selected device resources and verify native state. All settings are opt-in; omitted resources stay unchanged. iOS Simulator services and Android optional apps/settings are runtime-dependent. Android changes return a restore receipt for exact restoration during the same boot. Disabling Google infrastructure changes push/auth behavior.",
     setDeviceResourcesSchema,
     async (device, args: z.infer<typeof setDeviceResourcesSchema>, _progress, signal) => {
       const callerSignal = signal ?? getAbortSignal();
@@ -58,7 +58,8 @@ export function registerDeviceResourceTools(dependencies: () => DeviceToolsDepen
             operationSignal.throwIfAborted();
             return deps.deviceResourceControllerFactory().setResources({
               device,
-              resources: parsed.resources,
+              resources: parsed.resources ?? {},
+              restore: parsed.restore,
               deadlineMs,
               signal: operationSignal,
             });

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2,6 +2,7 @@ import { errorMessage } from "../utils/describeUnknownError";
 import type { ChildProcess } from "child_process";
 import { createHash } from "node:crypto";
 import { z } from "zod/v4";
+import { androidAvdConfigurationSchema } from "../models/AndroidAvdConfiguration";
 import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 import { ToolRegistry, ProgressCallback } from "./toolRegistry";
 import { deviceResourceConfigurationSchema } from "./deviceResourceSchemas";
@@ -329,12 +330,7 @@ const androidProvisionDeviceSpecSchema = z
       .describe(
         "Required display cutout class for the exact device type; 'any' accepts every class",
       ),
-    configuration: z
-      .object({
-        memoryMb: z.number().int().positive().optional(),
-      })
-      .strict()
-      .optional(),
+    configuration: androidAvdConfigurationSchema.optional(),
   })
   .strict()
   .superRefine((spec, context) => {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1629,6 +1629,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     this.throwIfLaunchCancelled(avdName, isCancelled);
   }
 
+  private emulatorAudioArguments(): string[] {
+    return process.env.AUTOMOBILE_EMULATOR_AUDIO === "false" ? ["-no-audio"] : [];
+  }
+
   private async startEmulatorProcess(
     avdName: string,
     requestedExtraArgs?: readonly string[],
@@ -1691,8 +1695,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       `Emulator display mode: ${headlessMode.headless ? "headless" : "windowed"} (${headlessMode.reason})`,
     );
     if (headlessMode.headless) {
-      args.push("-no-window", "-no-audio");
+      args.push("-no-window");
     }
+    args.push(...this.emulatorAudioArguments());
     const extraArgsRaw = process.env.AUTOMOBILE_EMULATOR_ARGS;
     if (requestedExtraArgs) {
       args.push(...requestedExtraArgs);

--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -1,4 +1,9 @@
 import { logger } from "../logger";
+import {
+  androidAvdConfigurationSchema,
+  androidAvdConfigurationKeys,
+  type AndroidAvdConfiguration,
+} from "../../models/AndroidAvdConfiguration";
 import { dirname, join } from "node:path";
 import {
   buildAndroidAvdCapabilityInventory,
@@ -12,6 +17,7 @@ export const MIN_AVD_RAM_MB = 2048;
  * Parsed AVD configuration from config.ini
  */
 export interface AvdConfig {
+  hardware?: AndroidAvdConfiguration;
   apiLevel?: number;
   osVersion?: string;
   /** Normalized emulator CPU architecture used by the AVD. */
@@ -240,7 +246,31 @@ export class FileAvdConfigReader implements AvdConfigReader {
  */
 export function parseAvdConfig(content: string): AvdConfig {
   const props = parseKeyValueProperties(content);
+  const hardware: Record<string, unknown> = {};
+  for (const [key, property] of Object.entries(androidAvdConfigurationKeys)) {
+    const raw = props.get(property);
+    if (raw === undefined) {
+      continue;
+    }
+    const value =
+      key === "audioInput" || key === "audioOutput"
+        ? raw === "yes"
+          ? true
+          : raw === "no"
+            ? false
+            : raw
+        : ["memoryMb", "cpuCores", "screenWidth", "screenHeight", "screenDensity"].includes(key)
+          ? Number(raw)
+          : raw;
+    if (
+      androidAvdConfigurationSchema.shape[key as keyof AndroidAvdConfiguration].safeParse(value)
+        .success
+    ) {
+      hardware[key] = value;
+    }
+  }
   return {
+    hardware: hardware as AndroidAvdConfiguration,
     ...parseScreenDimensions(props),
     ...parseRamSize(props),
     ...parseDeviceMetadata(props),

--- a/src/utils/androidDeviceResourceCatalog.ts
+++ b/src/utils/androidDeviceResourceCatalog.ts
@@ -1,0 +1,47 @@
+import type { ConfigurableDeviceResource } from "../models/deviceResourceDescriptions";
+
+/** Whole optional apps, never shared providers, overlays, framework or automation packages. */
+export const androidDeviceResourceCatalog = {
+  mailApp: ["com.google.android.gm", "com.android.email"],
+  calendarApp: ["com.google.android.calendar", "com.android.calendar"],
+  contactsApp: ["com.google.android.contacts", "com.android.contacts"],
+  mapsApp: ["com.google.android.apps.maps"],
+  videoApp: ["com.google.android.youtube"],
+  musicApp: ["com.google.android.apps.youtube.music"],
+  photosApp: ["com.google.android.apps.photos"],
+  assistantApp: ["com.google.android.googlequicksearchbox"],
+  digitalWellbeing: ["com.google.android.apps.wellbeing"],
+  printing: ["com.android.printspooler", "com.google.android.printservice.recommendation"],
+  accessibilityApps: [
+    "com.google.android.marvin.talkback",
+    "com.google.android.accessibility.accessibilitymenu",
+  ],
+  textToSpeech: ["com.google.android.tts"],
+  storeApp: ["com.android.vending"],
+  healthConnect: [
+    "com.google.android.healthconnect.controller",
+    "com.google.android.health.connect.backuprestore",
+  ],
+  adServices: ["com.google.android.adservices.api"],
+  onDevicePersonalization: ["com.google.android.ondevicepersonalization.services"],
+  wallpaperApps: [
+    "com.google.android.apps.wallpaper",
+    "com.google.android.apps.wallpaper.nexus",
+    "com.android.wallpaper.livepicker",
+    "com.android.wallpaper",
+  ],
+  dialerApp: ["com.google.android.dialer"],
+  messagesApp: ["com.google.android.apps.messaging"],
+  googlePlayServices: ["com.google.android.gms"],
+  googleServicesFramework: ["com.google.android.gsf"],
+} as const satisfies Partial<Record<ConfigurableDeviceResource, readonly string[]>>;
+
+export const androidResourceSettings = {
+  animations: {
+    namespace: "global",
+    keys: ["window_animation_scale", "transition_animation_scale", "animator_duration_scale"],
+  },
+  screensavers: { namespace: "secure", keys: ["screensaver_enabled"] },
+} as const satisfies Partial<
+  Record<ConfigurableDeviceResource, { namespace: string; keys: readonly string[] }>
+>;

--- a/src/utils/androidDeviceResourceController.ts
+++ b/src/utils/androidDeviceResourceController.ts
@@ -1,0 +1,420 @@
+import type { DeviceResourceController, DeviceResourceRequest } from "./deviceResourceController";
+import type {
+  ConfigurableDeviceResource,
+  DeviceResourceConfigurationResult,
+} from "../models/DeviceResourceConfiguration";
+import type { DeviceResourceStatus } from "../models/DeviceResource";
+import type { AndroidResourceRestoration } from "../models/AndroidResourceRestoration";
+import {
+  defaultAdbClientFactory,
+  type AdbClientFactory,
+} from "./android-cmdline-tools/AdbClientFactory";
+import type { AdbExecuteOptions } from "./android-cmdline-tools/interfaces/AdbExecutor";
+import { defaultTimer, type Timer } from "./SystemTimer";
+import {
+  androidDeviceResourceCatalog,
+  androidResourceSettings,
+} from "./androidDeviceResourceCatalog";
+import { shellQuote } from "./shellQuote";
+import { errorMessage } from "./describeUnknownError";
+
+type Entry = AndroidResourceRestoration["entries"][number];
+interface Run {
+  request: DeviceResourceRequest;
+  result: DeviceResourceConfigurationResult;
+  user: string;
+  command(args: string[]): Promise<string>;
+}
+const packageCatalog: Partial<Record<ConfigurableDeviceResource, readonly string[]>> =
+  androidDeviceResourceCatalog;
+const settingsCatalog: Partial<
+  Record<ConfigurableDeviceResource, { namespace: "global" | "secure"; keys: readonly string[] }>
+> = androidResourceSettings;
+const packageVerbs = [
+  "default-state",
+  "enable",
+  "disable",
+  "disable-user",
+  "disable-until-used",
+] as const;
+
+/** Reads native state before and after writes. Requested state never substitutes for observation. */
+export class AndroidDeviceResourceController implements DeviceResourceController {
+  constructor(
+    private readonly adbFactory: Pick<AdbClientFactory, "create"> = defaultAdbClientFactory,
+    private readonly timer: Pick<Timer, "now"> = defaultTimer,
+  ) {}
+
+  async setResources(request: DeviceResourceRequest): Promise<DeviceResourceConfigurationResult> {
+    const result: DeviceResourceConfigurationResult = {
+      success: true,
+      requested: request.resources,
+      resources: {},
+      services: {},
+      changed: [],
+      verification: "current_boot",
+    };
+    const keys = request.restore
+      ? ([
+          ...new Set(request.restore.entries.map((entry) => entry.resource)),
+        ] as ConfigurableDeviceResource[])
+      : (Object.keys(request.resources) as ConfigurableDeviceResource[]).filter(
+          (key) => request.resources[key] !== undefined,
+        );
+    const supported = this.supportedResources(request, result, keys);
+    if (!supported.length) {
+      return result;
+    }
+    return this.runResources(request, result, supported);
+  }
+
+  private supportedResources(
+    request: DeviceResourceRequest,
+    result: DeviceResourceConfigurationResult,
+    keys: ConfigurableDeviceResource[],
+  ): ConfigurableDeviceResource[] {
+    const supported = keys.filter(
+      (key) => packageCatalog[key] || settingsCatalog[key] || key === "backup",
+    );
+    for (const key of keys.filter((key) => !supported.includes(key))) {
+      result.resources[key] = {
+        state: "unsupported",
+        reason: "No Android implementation for this resource; no changes made.",
+      };
+      result.success = false;
+    }
+    if (request.device.platform !== "android" || !/^emulator-\d+$/.test(request.device.deviceId)) {
+      for (const key of supported) {
+        result.resources[key] = {
+          state: "unsupported",
+          reason: "Resource optimization requires an Android emulator.",
+        };
+      }
+      result.success = false;
+      return [];
+    }
+    return supported;
+  }
+
+  private async runResources(
+    request: DeviceResourceRequest,
+    result: DeviceResourceConfigurationResult,
+    supported: ConfigurableDeviceResource[],
+  ): Promise<DeviceResourceConfigurationResult> {
+    const adb = this.adbFactory.create(request.device);
+    const run: Run = {
+      request,
+      result,
+      user: "",
+      command: async (args) => {
+        request.signal?.throwIfAborted();
+        const timeoutMs = request.deadlineMs - this.timer.now();
+        if (timeoutMs <= 0) {
+          throw new Error("Android resource configuration deadline expired");
+        }
+        const options: AdbExecuteOptions = {
+          timeoutMs,
+          signal: request.signal,
+          noRetry: true,
+          waitForProcessSettlementAfterAbort: true,
+        };
+        const output = await adb.execute(["shell", args.map(shellQuote).join(" ")], options);
+        request.signal?.throwIfAborted();
+        return output.stdout.trim();
+      },
+    };
+    try {
+      await this.identifyRun(run);
+      for (const resource of supported) {
+        await this.configureResource(run, resource);
+      }
+    } catch (error) {
+      request.signal?.throwIfAborted();
+      for (const resource of supported) {
+        result.resources[resource] ??= { state: "unknown", reason: errorMessage(error) };
+      }
+      result.success = false;
+    }
+    if (!result.restore?.entries.length) {
+      delete result.restore;
+    }
+    return result;
+  }
+
+  private async identifyRun(run: Run): Promise<void> {
+    run.user = await run.command(["am", "get-current-user"]);
+    if (!/^\d+$/.test(run.user)) {
+      throw new Error("Cannot determine Android foreground user");
+    }
+    const bootId = await run.command(["cat", "/proc/sys/kernel/random/boot_id"]);
+    if (!/^[a-f\d]{8}-(?:[a-f\d]{4}-){3}[a-f\d]{12}$/i.test(bootId)) {
+      throw new Error("Cannot identify this Android boot");
+    }
+    const { request } = run;
+    run.result.restore = {
+      deviceId: request.device.deviceId,
+      bootId,
+      userId: Number(run.user),
+      entries: [],
+    };
+    if (!request.restore) {
+      return;
+    }
+    if (
+      request.restore.deviceId !== request.device.deviceId ||
+      request.restore.bootId !== bootId ||
+      request.restore.userId !== Number(run.user)
+    ) {
+      throw new Error("Restoration receipt belongs to a different device, boot or user");
+    }
+    if (!request.restore.entries.every((entry) => this.validEntry(entry))) {
+      throw new Error("Restoration receipt contains unsupported targets or values");
+    }
+    if (
+      new Set(request.restore.entries.map((entry) => `${entry.kind}:${entry.target}`)).size !==
+      request.restore.entries.length
+    ) {
+      throw new Error("Restoration receipt contains duplicate targets");
+    }
+  }
+
+  private async configureResource(run: Run, resource: ConfigurableDeviceResource): Promise<void> {
+    const { request, result } = run;
+    try {
+      const entries = request.restore
+        ? request.restore.entries.filter((entry) => entry.resource === resource)
+        : await this.discover(run, resource);
+      if (!entries.length) {
+        result.resources[resource] = {
+          state: "unsupported",
+          reason: "No compatible installed targets for this resource.",
+        };
+        result.success = false;
+        return;
+      }
+      const evidence: Record<string, DeviceResourceStatus> = {};
+      result.services![resource] = evidence;
+      if (
+        entries.some((entry) => entry.kind === "package" && this.desiredValue(run, entry) !== "1")
+      ) {
+        await this.protectActivePackages(run, entries);
+      }
+      for (const entry of entries) {
+        evidence[entry.target] = await this.configureEntry(run, entry);
+      }
+      const states = Object.values(evidence).map((value) => value.state);
+      result.resources[resource] = {
+        state: states.every((state) => state === states[0]) ? states[0]! : "unknown",
+        ...(request.restore ? { reason: "Exact prior overrides restored and verified." } : {}),
+      };
+    } catch (error) {
+      request.signal?.throwIfAborted();
+      result.resources[resource] = { state: "unknown", reason: errorMessage(error) };
+      result.success = false;
+    }
+  }
+
+  private desiredValue(run: Run, entry: Entry): string | null {
+    if (run.request.restore) {
+      return entry.value;
+    }
+    if (run.request.resources[entry.resource as ConfigurableDeviceResource] !== "disabled") {
+      return "1";
+    }
+    return entry.kind === "package" ? "3" : "0";
+  }
+
+  private async configureEntry(run: Run, entry: Entry): Promise<DeviceResourceStatus> {
+    const before = await this.read(run, entry);
+    const desired = this.desiredValue(run, entry);
+    const resource = entry.resource as ConfigurableDeviceResource;
+    if (before !== desired) {
+      run.result.restore!.entries.push({ ...entry, value: before });
+      if (!run.result.changed.includes(resource)) {
+        run.result.changed.push(resource);
+      }
+      await this.write(run, entry, desired);
+    }
+    const after = await this.read(run, entry);
+    if (after !== desired) {
+      throw new Error(`Native state for ${entry.target} did not match requested value`);
+    }
+    return {
+      state: this.state(entry, after),
+      reason: `Verified value ${after ?? "default"} for user ${run.user}.`,
+    };
+  }
+
+  private validEntry(entry: Entry): boolean {
+    const resource = entry.resource as ConfigurableDeviceResource;
+    if (entry.kind === "package") {
+      return (
+        !!packageCatalog[resource]?.includes(entry.target) && /^[0-4]$/.test(String(entry.value))
+      );
+    }
+    if (entry.kind === "backup") {
+      return (
+        resource === "backup" &&
+        entry.target === "backup" &&
+        ["0", "1"].includes(String(entry.value))
+      );
+    }
+    const setting = settingsCatalog[resource];
+    return (
+      setting?.namespace === entry.kind &&
+      setting.keys.includes(entry.target) &&
+      (entry.value === null || /^(?:\d+(?:\.\d+)?|\.\d+)$/.test(entry.value))
+    );
+  }
+
+  private async discover(run: Run, resource: ConfigurableDeviceResource): Promise<Entry[]> {
+    const packages = packageCatalog[resource];
+    if (packages) {
+      const output = await run.command(["pm", "list", "packages", "-s", "--user", run.user]);
+      const installed = new Set(
+        output
+          .split(/\r?\n/)
+          .filter((line) => line.startsWith("package:"))
+          .map((line) => line.slice(8)),
+      );
+      return packages
+        .filter((name) => installed.has(name))
+        .map((target) => ({ resource, kind: "package", target, value: null }));
+    }
+    const settings = settingsCatalog[resource];
+    if (settings) {
+      return settings.keys.map((target) => ({
+        resource,
+        kind: settings.namespace,
+        target,
+        value: null,
+      }));
+    }
+    return [{ resource, kind: "backup", target: "backup", value: null }];
+  }
+
+  private async protectActivePackages(run: Run, entries: Entry[]): Promise<void> {
+    const targets = entries
+      .filter((entry) => entry.kind === "package")
+      .map((entry) => entry.target);
+    const activity = await run.command(["dumpsys", "activity", "activities"]);
+    const input = await run.command([
+      "settings",
+      "--user",
+      run.user,
+      "get",
+      "secure",
+      "default_input_method",
+    ]);
+    const accessibility = await run.command([
+      "settings",
+      "--user",
+      run.user,
+      "get",
+      "secure",
+      "enabled_accessibility_services",
+    ]);
+    const roles: string[] = [];
+    for (const role of ["HOME", "BROWSER", "DIALER", "SMS", "ASSISTANT"]) {
+      const output = await run.command([
+        "cmd",
+        "role",
+        "get-role-holders",
+        "--user",
+        run.user,
+        `android.app.role.${role}`,
+      ]);
+      if (/unknown|error|not found|exception/i.test(output)) {
+        throw new Error("Cannot verify protected Android role holders on this runtime");
+      }
+      roles.push(output);
+    }
+    for (const target of targets) {
+      if (
+        input.startsWith(`${target}/`) ||
+        accessibility.split(":").some((service) => service.startsWith(`${target}/`)) ||
+        roles.some((output) => output.split(/\s+/).includes(target)) ||
+        activity
+          .split("\n")
+          .some(
+            (line) =>
+              /(?:mResumedActivity|topResumedActivity)/.test(line) && line.includes(`${target}/`),
+          )
+      ) {
+        throw new Error(
+          `${target} is an active app, role holder, input method or accessibility service; leave it available`,
+        );
+      }
+    }
+  }
+
+  private async read(run: Run, entry: Entry): Promise<string | null> {
+    if (entry.kind === "package") {
+      const output = await run.command(["dumpsys", "package", entry.target]);
+      const lines = output
+        .split("\n")
+        .filter(
+          (line) => line.trimStart().startsWith(`User ${run.user}:`) && /\binstalled=/.test(line),
+        );
+      const match = lines.length === 1 ? /\benabled=([0-4])\b/.exec(lines[0]!) : null;
+      if (
+        !match ||
+        !/\binstalled=true\b/.test(lines[0]!) ||
+        /\b(?:hidden|suspended)=true\b/.test(lines[0]!)
+      ) {
+        throw new Error(`Cannot verify installed package override for ${entry.target}`);
+      }
+      return match[1]!;
+    }
+    if (entry.kind === "backup") {
+      const output = await run.command(["bmgr", "--user", run.user, "enabled"]);
+      if (output === "Backup Manager currently enabled") {
+        return "1";
+      }
+      if (output === "Backup Manager currently disabled") {
+        return "0";
+      }
+      throw new Error("Cannot verify Backup Manager state");
+    }
+    const value = await run.command([
+      "settings",
+      "--user",
+      run.user,
+      "get",
+      entry.kind,
+      entry.target,
+    ]);
+    if (value === "null") {
+      return null;
+    }
+    if (!/^(?:\d+(?:\.\d+)?|\.\d+)$/.test(value)) {
+      throw new Error(`Cannot verify setting ${entry.target}`);
+    }
+    return value;
+  }
+
+  private async write(run: Run, entry: Entry, value: string | null): Promise<void> {
+    if (entry.kind === "package") {
+      await run.command(["pm", packageVerbs[Number(value)]!, "--user", run.user, entry.target]);
+    } else if (entry.kind === "backup") {
+      await run.command(["bmgr", "--user", run.user, "enable", value === "1" ? "true" : "false"]);
+    } else {
+      await run.command([
+        "settings",
+        "--user",
+        run.user,
+        value === null ? "delete" : "put",
+        entry.kind,
+        entry.target,
+        ...(value === null ? [] : [value]),
+      ]);
+    }
+  }
+
+  private state(entry: Entry, value: string | null): DeviceResourceStatus["state"] {
+    if (entry.kind === "package") {
+      return value === "1" ? "enabled" : value === "0" ? "unknown" : "disabled";
+    }
+    return value === null ? "unknown" : Number(value) === 0 ? "disabled" : "enabled";
+  }
+}

--- a/src/utils/deviceResourceController.ts
+++ b/src/utils/deviceResourceController.ts
@@ -16,12 +16,15 @@ import { defaultTimer, type Timer } from "./SystemTimer";
 import { errorMessage } from "./describeUnknownError";
 import { logger } from "./logger";
 import { iosDeviceResourceCatalog, iosDeviceResourcePlistNames } from "./iosDeviceResourceCatalog";
+import { AndroidDeviceResourceController } from "./androidDeviceResourceController";
+import type { AndroidResourceRestoration } from "../models/AndroidResourceRestoration";
 
 export interface DeviceResourceRequest {
   device: BootedDevice;
   resources: DeviceResourceConfiguration;
   deadlineMs: number;
   signal?: AbortSignal;
+  restore?: AndroidResourceRestoration;
 }
 
 export interface DeviceResourceController {
@@ -80,9 +83,16 @@ export class DefaultDeviceResourceController implements DeviceResourceController
     private readonly plist: Pick<PlistReader, "readJsonFile"> = new PlistClient(),
     private readonly timer: Pick<Timer, "now" | "sleep"> = defaultTimer,
     private readonly readDirectory: (path: string) => Promise<string[]> = readdir,
+    private readonly android: DeviceResourceController = new AndroidDeviceResourceController(),
   ) {}
 
   async setResources(request: DeviceResourceRequest): Promise<DeviceResourceConfigurationResult> {
+    if (request.device.platform === "android") {
+      return this.android.setResources(request);
+    }
+    if (request.restore) {
+      throw new Error("Android resource restoration requires an Android emulator");
+    }
     const result: DeviceResourceConfigurationResult = {
       success: true,
       requested: request.resources,
@@ -119,12 +129,6 @@ export class DefaultDeviceResourceController implements DeviceResourceController
     resource: ConfigurableDeviceResource,
     desired: RequestedDeviceResourceState,
   ): Promise<DeviceResourceStatus> {
-    if (run.request.device.platform === "android") {
-      return {
-        state: "unsupported",
-        reason: "Android resource control is not implemented; no device settings were changed.",
-      };
-    }
     const catalog: Partial<Record<ConfigurableDeviceResource, readonly string[]>> =
       iosDeviceResourceCatalog;
     const labels = catalog[resource];

--- a/src/utils/exactDeviceProvisioning.ts
+++ b/src/utils/exactDeviceProvisioning.ts
@@ -17,6 +17,11 @@ import { SimCtlClient } from "./ios-cmdline-tools/SimCtlClient";
 import { throwIfAborted } from "./toolUtils";
 import { defaultTimer, type Timer } from "./SystemTimer";
 import {
+  androidAvdConfigurationSchema,
+  androidAvdConfigurationKeys,
+  type AndroidAvdConfiguration,
+} from "../models/AndroidAvdConfiguration";
+import {
   classifyDisplayCutout,
   type DisplayCutoutClassification,
   type DisplayCutoutPreference,
@@ -32,9 +37,7 @@ export interface AndroidDeviceSpecification {
   runtime: string;
   deviceType: string;
   displayCutout?: DisplayCutoutPreference;
-  configuration?: {
-    memoryMb?: number;
-  };
+  configuration?: AndroidAvdConfiguration;
 }
 
 export interface IosDeviceSpecification {
@@ -110,6 +113,7 @@ export interface ExactIosSimulatorClient {
 
 export interface AndroidAvdConfigWriter {
   setMemoryMb(avdName: string, memoryMb: number): Promise<void>;
+  setConfiguration?(avdName: string, configuration: AndroidAvdConfiguration): Promise<void>;
 }
 
 interface FileAndroidAvdConfigWriterDependencies {
@@ -145,6 +149,24 @@ export class FileAndroidAvdConfigWriter implements AndroidAvdConfigWriter {
         `Android AVD memoryMb must be a positive integer; got ${memoryMb}.`,
       );
     }
+    return this.setConfiguration(avdName, { memoryMb });
+  }
+
+  async setConfiguration(avdName: string, configuration: AndroidAvdConfiguration): Promise<void> {
+    const validated = androidAvdConfigurationSchema.parse(configuration);
+    const replacements = new Map<string, string>();
+    for (const key of Object.keys(validated) as (keyof AndroidAvdConfiguration)[]) {
+      const value = validated[key];
+      if (value !== undefined) {
+        replacements.set(
+          androidAvdConfigurationKeys[key],
+          typeof value === "boolean" ? (value ? "yes" : "no") : String(value),
+        );
+      }
+    }
+    if (validated.gpuMode !== undefined) {
+      replacements.set("hw.gpu.enabled", "yes");
+    }
     const avdHome = resolveAndroidAvdHome(
       this.dependencies.environment,
       this.dependencies.homeDirectory(),
@@ -152,19 +174,23 @@ export class FileAndroidAvdConfigWriter implements AndroidAvdConfigWriter {
     const configPath = join(avdHome, `${avdName}.avd`, "config.ini");
     const content = await this.dependencies.readFile(configPath, "utf8");
     const lines = content.split(/\r?\n/);
-    let replaced = false;
+    const replaced = new Set<string>();
     const updated = lines.map((line) => {
-      if (line.startsWith("hw.ramSize=")) {
-        replaced = true;
-        return `hw.ramSize=${memoryMb}`;
+      const key = line.slice(0, line.indexOf("=")).trim();
+      if (replacements.has(key)) {
+        replaced.add(key);
+        return `${key}=${replacements.get(key)}`;
       }
       return line;
     });
-    if (!replaced) {
+    for (const [key, value] of replacements) {
+      if (replaced.has(key)) {
+        continue;
+      }
       if (updated.at(-1) !== "") {
         updated.push("");
       }
-      updated.push(`hw.ramSize=${memoryMb}`, "");
+      updated.push(`${key}=${value}`, "");
     }
     await this.dependencies.writeFile(configPath, updated.join("\n"), "utf8");
   }
@@ -233,7 +259,13 @@ function sameAndroidSpecification(
   return (
     sameAndroidDeviceIdentity(spec, config) &&
     (spec.configuration?.memoryMb === undefined ||
-      config?.ramSizeMb === spec.configuration.memoryMb)
+      config?.ramSizeMb === spec.configuration.memoryMb) &&
+    Object.entries(spec.configuration ?? {}).every(
+      ([key, value]) =>
+        key === "memoryMb" ||
+        value === undefined ||
+        config?.hardware?.[key as keyof AndroidAvdConfiguration] === value,
+    )
   );
 }
 
@@ -242,6 +274,22 @@ function sameAndroidSpecification(
  * never falls back to a "close enough" image, runtime, or device profile.
  */
 export class DefaultExactDeviceProvisioner implements ExactDeviceProvisioner {
+  private async configureAndroid(
+    name: string,
+    configuration: AndroidAvdConfiguration,
+  ): Promise<void> {
+    const writer = this.dependencies.androidConfigWriter;
+    if (writer.setConfiguration) {
+      await writer.setConfiguration(name, configuration);
+    } else if (Object.keys(configuration).some((key) => key !== "memoryMb")) {
+      throw new ProvisionDeviceError(
+        "unsupported",
+        "The configured AVD writer does not support emulator hardware controls.",
+      );
+    } else if (configuration.memoryMb !== undefined) {
+      await writer.setMemoryMb(name, configuration.memoryMb);
+    }
+  }
   private readonly lifecycleCoordinator: VirtualDeviceLifecycleCoordinator;
   private readonly timer: Pick<Timer, "now">;
 
@@ -433,13 +481,11 @@ export class DefaultExactDeviceProvisioner implements ExactDeviceProvisioner {
     }
     if (
       request.reconcileExistingConfiguration &&
-      spec.configuration?.memoryMb !== undefined &&
+      spec.configuration !== undefined &&
+      !existing.isRunning &&
       sameAndroidDeviceIdentity(spec, config)
     ) {
-      await this.dependencies.androidConfigWriter.setMemoryMb(
-        existing.name,
-        spec.configuration.memoryMb,
-      );
+      await this.configureAndroid(existing.name, spec.configuration);
       const reconciled = await this.dependencies.androidConfigReader.readConfig(existing.name);
       if (sameAndroidSpecification(spec, reconciled)) {
         return;
@@ -489,11 +535,8 @@ export class DefaultExactDeviceProvisioner implements ExactDeviceProvisioner {
         `Failed to create Android AVD '${request.name}': ${created.message}`,
       );
     }
-    if (spec.configuration?.memoryMb !== undefined) {
-      await this.dependencies.androidConfigWriter.setMemoryMb(
-        request.name,
-        spec.configuration.memoryMb,
-      );
+    if (spec.configuration) {
+      await this.configureAndroid(request.name, spec.configuration);
     }
     return {
       created: true,

--- a/test/server/deviceResourceSchemas.test.ts
+++ b/test/server/deviceResourceSchemas.test.ts
@@ -42,6 +42,21 @@ describe("device resource advertised constraints", () => {
     );
   });
 
+  test.each(["live", "artifact"])("%s schema accepts restoration alone", (source) => {
+    const validate = validators.get(`${source}/setDeviceResources`)!;
+    const restore = {
+      deviceId: "emulator-5580",
+      bootId: "11111111-1111-4111-8111-111111111111",
+      userId: 0,
+      entries: [
+        { resource: "animations", kind: "global", target: "animator_duration_scale", value: null },
+      ],
+    };
+    expect(validate({ restore })).toBe(true);
+    expect(validate({})).toBe(false);
+    expect(validate({ restore, resources: { animations: "disabled" } })).toBe(false);
+  });
+
   test.each(["live", "artifact"])(
     "%s schema requires booting when configuring resources",
     (source) => {
@@ -53,4 +68,21 @@ describe("device resource advertised constraints", () => {
       expect(validate({ operationId: "test", device, boot: false })).toBe(true);
     },
   );
+});
+
+test("restoration and desired resource configuration are mutually exclusive", async () => {
+  const { setDeviceResourcesSchema } = await import("../../src/server/deviceResourceSchemas");
+  const restore = {
+    deviceId: "emulator-5580",
+    bootId: "11111111-1111-4111-8111-111111111111",
+    userId: 0,
+    entries: [
+      { resource: "animations", kind: "global", target: "animator_duration_scale", value: null },
+    ],
+  };
+  expect(setDeviceResourcesSchema.safeParse({ restore }).success).toBe(true);
+  expect(setDeviceResourcesSchema.safeParse({}).success).toBe(false);
+  expect(
+    setDeviceResourcesSchema.safeParse({ restore, resources: { animations: "enabled" } }).success,
+  ).toBe(false);
 });

--- a/test/server/deviceResourceTools.test.ts
+++ b/test/server/deviceResourceTools.test.ts
@@ -83,6 +83,25 @@ describe("setDeviceResources", () => {
     expect(JSON.parse(response.content[0].text).success).toBe(true);
   });
 
+  test("forwards restoration through the same device lifecycle path", async () => {
+    const restore = {
+      deviceId: "emulator-5580",
+      bootId: "11111111-1111-4111-8111-111111111111",
+      userId: 0,
+      entries: [
+        { resource: "animations", kind: "global", target: "animator_duration_scale", value: null },
+      ],
+    };
+    const android = {
+      platform: "android" as const,
+      deviceId: "emulator-5580",
+      name: "resource-lab",
+    };
+    await ToolRegistry.getTool("setDeviceResources")!.deviceAwareHandler!(android, { restore });
+    expect(controller.requests[0]).toMatchObject({ device: android, resources: {}, restore });
+    expect(controller.requests[0]!.signal).toBeDefined();
+  });
+
   test("accepts injected execution metadata and honors the transport deadline", async () => {
     const tool = ToolRegistry.getTool("setDeviceResources")!;
     await tool.deviceAwareHandler!(device, {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
@@ -158,6 +158,7 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
   let fakeFactory: TestAdbClientFactory;
   let fakeAvdConfigReader: FakeAvdConfigReader;
   const savedHeadless = process.env.AUTOMOBILE_EMULATOR_HEADLESS;
+  const savedAudio = process.env.AUTOMOBILE_EMULATOR_AUDIO;
 
   beforeEach(() => {
     fakeTimer = new FakeTimer();
@@ -167,6 +168,11 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
   });
 
   function restoreEnv() {
+    if (savedAudio === undefined) {
+      delete process.env.AUTOMOBILE_EMULATOR_AUDIO;
+    } else {
+      process.env.AUTOMOBILE_EMULATOR_AUDIO = savedAudio;
+    }
     if (savedHeadless === undefined) {
       delete process.env.AUTOMOBILE_EMULATOR_HEADLESS;
     } else {
@@ -187,8 +193,9 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
     return emitter;
   }
 
-  test("passes -no-window -no-audio when headless mode is enabled", async () => {
+  test.each(["true", "false"])("headless mode respects independent audio=%s", async (audio) => {
     process.env.AUTOMOBILE_EMULATOR_HEADLESS = "true";
+    process.env.AUTOMOBILE_EMULATOR_AUDIO = audio;
     let capturedArgs: string[] = [];
     const fakeChild = createFakeChildProcess();
 
@@ -224,7 +231,7 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
         "Pixel_9_Pro", // validateAvdMemory()
       ]);
       expect(capturedArgs).toContain("-no-window");
-      expect(capturedArgs).toContain("-no-audio");
+      expect(capturedArgs.includes("-no-audio")).toBe(audio === "false");
     } finally {
       restoreEnv();
     }

--- a/test/utils/androidDeviceResourceController.test.ts
+++ b/test/utils/androidDeviceResourceController.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, test } from "bun:test";
+import { AndroidDeviceResourceController } from "../../src/utils/androidDeviceResourceController";
+import type { DeviceResourceRequest } from "../../src/utils/deviceResourceController";
+import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { createExecResult } from "../../src/utils/execResult";
+import { androidDeviceResourceCatalog } from "../../src/utils/androidDeviceResourceCatalog";
+import type { AdbExecuteOptions } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+
+const bootId = "11111111-1111-4111-8111-111111111111";
+class ResourceAdb extends FakeAdbExecutor {
+  packages = new Map([["com.google.android.gm", "0"]]);
+  settings = new Map<string, string>();
+  commands: string[][] = [];
+  role = "";
+  ignoreWrites = false;
+  onCommand?: () => void;
+  override async execute(args: string[], options?: AdbExecuteOptions) {
+    options?.signal?.throwIfAborted();
+    const words = args[1]!.slice(1, -1).split("' '");
+    this.commands.push(words);
+    this.onCommand?.();
+    const [verb, command] = words;
+    let output = "";
+    if (verb === "am") {
+      output = "0";
+    } else if (verb === "cat") {
+      output = bootId;
+    } else if (verb === "pm" && command === "list") {
+      output = [...this.packages.keys()].map((name) => `package:${name}`).join("\n");
+    } else if (verb === "dumpsys" && command === "package") {
+      output = ` User 0: installed=true hidden=false suspended=false enabled=${this.packages.get(words[2]!)}\n User 0:\n verification state`;
+    } else if (verb === "dumpsys") {
+      output = "mResumedActivity: com.android.launcher3/.Launcher";
+    } else if (verb === "cmd") {
+      output = this.role;
+    } else if (verb === "settings") {
+      const key = words[5]!;
+      if (words[3] === "get") {
+        output = this.settings.get(key) ?? "null";
+      } else if (!this.ignoreWrites) {
+        if (words[3] === "delete") {
+          this.settings.delete(key);
+        } else {
+          this.settings.set(key, words[6]!);
+        }
+      }
+    } else if (verb === "pm" && !this.ignoreWrites) {
+      this.packages.set(
+        words[4]!,
+        String(
+          ["default-state", "enable", "disable", "disable-user", "disable-until-used"].indexOf(
+            command!,
+          ),
+        ),
+      );
+    } else if (verb !== "pm") {
+      throw new Error(`Unhandled command ${words.join(" ")}`);
+    }
+    return createExecResult(output, "");
+  }
+}
+function setup() {
+  const adb = new ResourceAdb();
+  const timer = new FakeTimer();
+  const controller = new AndroidDeviceResourceController({ create: () => adb }, timer);
+  const request: DeviceResourceRequest = {
+    device: { platform: "android", deviceId: "emulator-5580", name: "resource-test" },
+    resources: { mailApp: "disabled" },
+    deadlineMs: timer.now() + 1000,
+  };
+  return { adb, timer, controller, request };
+}
+describe("Android resource control", () => {
+  test("disables only installed optional apps, verifies state, and restores default override exactly", async () => {
+    const { adb, controller, request } = setup();
+    const disabled = await controller.setResources(request);
+    expect(disabled.success).toBe(true);
+    expect(adb.packages.get("com.google.android.gm")).toBe("3");
+    expect(disabled.restore?.entries[0]?.value).toBe("0");
+    const restored = await controller.setResources({
+      ...request,
+      resources: {},
+      restore: disabled.restore,
+    });
+    expect(restored.success).toBe(true);
+    expect(adb.packages.get("com.google.android.gm")).toBe("0");
+    expect(adb.commands.some((words) => words[1] === "default-state")).toBe(true);
+  });
+  test("does not claim success for ignored package writes and retains restoration receipt", async () => {
+    const { adb, controller, request } = setup();
+    adb.ignoreWrites = true;
+    const result = await controller.setResources(request);
+    expect(result.success).toBe(false);
+    expect(result.resources.mailApp?.state).toBe("unknown");
+    expect(result.restore?.entries).toHaveLength(1);
+  });
+  test("protects role holders before mutating a package group", async () => {
+    const { adb, controller, request } = setup();
+    adb.role = "com.google.android.gm";
+    expect((await controller.setResources(request)).success).toBe(false);
+    expect(adb.packages.get("com.google.android.gm")).toBe("0");
+  });
+  test("reports absent catalogs as unsupported, and is idempotent for already-disabled packages", async () => {
+    const { adb, controller, request } = setup();
+    adb.packages.set("com.google.android.gm", "3");
+    expect((await controller.setResources(request)).changed).toEqual([]);
+    adb.packages.clear();
+    expect((await controller.setResources(request)).resources.mailApp?.state).toBe("unsupported");
+  });
+  test("restores absent animation overrides using delete, preserving a non-default scale", async () => {
+    const { adb, controller, request } = setup();
+    request.resources = { animations: "disabled" };
+    adb.settings.set("window_animation_scale", "0.5");
+    const result = await controller.setResources(request);
+    expect(result.success).toBe(true);
+    expect(adb.settings.get("animator_duration_scale")).toBe("0");
+    expect(
+      (await controller.setResources({ ...request, resources: {}, restore: result.restore }))
+        .success,
+    ).toBe(true);
+    expect(adb.settings.get("window_animation_scale")).toBe("0.5");
+    expect(adb.settings.has("animator_duration_scale")).toBe(false);
+  });
+  test("rejects a receipt from another boot and an injected non-catalog target without writes", async () => {
+    const { adb, controller, request } = setup();
+    const receipt = (await controller.setResources(request)).restore!;
+    const mutations = () =>
+      adb.commands.filter((words) => words[0] === "pm" && words[1] !== "list").length;
+    const count = mutations();
+    expect(
+      (
+        await controller.setResources({
+          ...request,
+          resources: {},
+          restore: { ...receipt, bootId: "22222222-2222-4222-8222-222222222222" },
+        })
+      ).success,
+    ).toBe(false);
+    expect(
+      (
+        await controller.setResources({
+          ...request,
+          resources: {},
+          restore: {
+            ...receipt,
+            entries: [{ ...receipt.entries[0]!, target: "com.android.systemui" }],
+          },
+        })
+      ).success,
+    ).toBe(false);
+    expect(mutations()).toBe(count);
+  });
+  test("propagates cancellation and stops dispatching after deadline", async () => {
+    const { adb, timer, controller, request } = setup();
+    const abort = new AbortController();
+    const reason = new Error("preempted");
+    request.signal = abort.signal;
+    adb.onCommand = () => abort.abort(reason);
+    await expect(controller.setResources(request)).rejects.toBe(reason);
+    expect(adb.commands).toHaveLength(1);
+    adb.onCommand = undefined;
+    request.signal = undefined;
+    request.deadlineMs = timer.now();
+    expect((await controller.setResources(request)).success).toBe(false);
+    expect(adb.commands).toHaveLength(1);
+  });
+  test("does not issue commands for unsupported resources or physical devices", async () => {
+    const { adb, controller, request } = setup();
+    expect(
+      (await controller.setResources({ ...request, resources: { widgets: "disabled" } })).success,
+    ).toBe(false);
+    request.device.deviceId = "physical-device";
+    expect((await controller.setResources(request)).success).toBe(false);
+    expect(adb.commands).toEqual([]);
+  });
+});
+
+test("undefined resource values do not enable an app", async () => {
+  const { adb, controller, request } = setup();
+  request.resources = { mailApp: undefined };
+  expect((await controller.setResources(request)).changed).toEqual([]);
+  expect(adb.commands).toEqual([]);
+});
+
+test("Android package groups do not overlap or contain shared platform providers", () => {
+  const packages = Object.values(androidDeviceResourceCatalog).flat();
+  expect(new Set(packages).size).toBe(packages.length);
+  expect(
+    packages.some((name) =>
+      /providers|systemui|permissioncontroller|webview|launcher|automobile|mainline/.test(name),
+    ),
+  ).toBe(false);
+});
+
+test("duplicate restoration targets are rejected before any writes", async () => {
+  const { adb, controller, request } = setup();
+  const entry = {
+    resource: "mailApp" as const,
+    kind: "package" as const,
+    target: "com.google.android.gm",
+    value: "3",
+  };
+  const result = await controller.setResources({
+    ...request,
+    resources: {},
+    restore: { deviceId: request.device.deviceId, bootId, userId: 0, entries: [entry, entry] },
+  });
+  expect(result.success).toBe(false);
+  expect(adb.packages.get("com.google.android.gm")).toBe("0");
+});

--- a/test/utils/deviceResourceController.test.ts
+++ b/test/utils/deviceResourceController.test.ts
@@ -210,13 +210,13 @@ describe("device resource control", () => {
 
   test("unsupported Android settings run no Apple or Android commands", async () => {
     request.device = { platform: "android", name: "Pixel", deviceId: "emulator-5554" };
-    request.resources = { wallpaperRendering: "disabled", googlePlayServices: "disabled" };
+    request.resources = { wallpaperRendering: "disabled", widgets: "disabled" };
     expect(await controller.setResources(request)).toMatchObject({
       success: false,
       changed: [],
       resources: {
         wallpaperRendering: { state: "unsupported" },
-        googlePlayServices: { state: "unsupported" },
+        widgets: { state: "unsupported" },
       },
     });
     expect(simctl.calls).toEqual([]);

--- a/test/utils/exactDeviceProvisioning.test.ts
+++ b/test/utils/exactDeviceProvisioning.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
+import { parseAvdConfig } from "../../src/utils/android-cmdline-tools/AvdConfigReader";
 import type { DeviceInfo } from "../../src/models";
 import {
   DefaultExactDeviceProvisioner,
@@ -25,6 +26,36 @@ function androidImage(name: string): DeviceInfo {
 }
 
 describe("DefaultExactDeviceProvisioner", () => {
+  test("writes and reads independent hardware options without changing other AVD properties", async () => {
+    let content = "hw.cpu.ncore = 4\nhw.ramSize=2048\nuntouched=yes\n";
+    const writer = new FileAndroidAvdConfigWriter({
+      readFile: async () => content,
+      writeFile: async (_path, updated) => {
+        content = updated;
+      },
+      environment: { ANDROID_AVD_HOME: "/avds" },
+      homeDirectory: () => "/home/test",
+    });
+    const configuration = {
+      cpuCores: 2,
+      gpuMode: "host",
+      screenWidth: 720,
+      screenHeight: 1280,
+      screenDensity: 280,
+      cameraFront: "none",
+      audioInput: false,
+      audioOutput: true,
+    } as const;
+    await writer.setConfiguration("phone", configuration);
+    expect(parseAvdConfig(content).hardware).toMatchObject(configuration);
+    expect(content).toContain("untouched=yes");
+    expect(content).toContain("hw.ramSize=2048");
+    expect(content).toContain("hw.gpu.enabled=yes");
+    expect(content).not.toContain("hw.cpu.ncore = 4");
+    const before = content;
+    await expect(writer.setConfiguration("phone", { cpuCores: 0 })).rejects.toThrow();
+    expect(content).toBe(before);
+  });
   test("updates only hw.ramSize in the conventional AVD config", async () => {
     const writes: Array<{ path: string; content: string }> = [];
     const writer = new FileAndroidAvdConfigWriter({
@@ -442,45 +473,55 @@ describe("DefaultExactDeviceProvisioner", () => {
     }
   });
 
-  test("reconciles requested Android memory on a retry after partial provisioning", async () => {
-    let ramSizeMb = 2048;
-    const writes: number[] = [];
-    const provisioner = new DefaultExactDeviceProvisioner({
-      listDeviceImages: async () => [androidImage("phone-api-36-a")],
-      isCreationAllowed: () => true,
-      avdManager: {} as ExactAndroidAvdClient,
-      androidConfigReader: {
-        readConfig: async () => ({
-          apiLevel: 36,
-          tag: "google_apis",
-          architecture: "x86_64",
-          deviceName: "pixel_9",
-          ramSizeMb,
-        }),
-      },
-      androidConfigWriter: {
-        setMemoryMb: async (_name, memoryMb) => {
-          writes.push(memoryMb);
-          ramSizeMb = memoryMb;
+  test.each([false, true])(
+    "reconciles memory only on a stopped AVD (running=%s)",
+    async (isRunning) => {
+      let ramSizeMb = 2048;
+      const writes: number[] = [];
+      const provisioner = new DefaultExactDeviceProvisioner({
+        listDeviceImages: async () => [{ ...androidImage("phone-api-36-a"), isRunning }],
+        isCreationAllowed: () => true,
+        avdManager: {} as ExactAndroidAvdClient,
+        androidConfigReader: {
+          readConfig: async () => ({
+            apiLevel: 36,
+            tag: "google_apis",
+            architecture: "x86_64",
+            deviceName: "pixel_9",
+            ramSizeMb,
+          }),
         },
-      },
-      iosSimulator: {} as ExactIosSimulatorClient,
-    });
+        androidConfigWriter: {
+          setMemoryMb: async (_name, memoryMb) => {
+            writes.push(memoryMb);
+            ramSizeMb = memoryMb;
+          },
+        },
+        iosSimulator: {} as ExactIosSimulatorClient,
+      });
 
-    const result = await provisioner.provision({
-      platform: "android",
-      name: "phone-api-36-a",
-      spec: ANDROID_SPEC,
-      reconcileExistingConfiguration: true,
-    });
+      const operation = provisioner.provision({
+        platform: "android",
+        name: "phone-api-36-a",
+        spec: ANDROID_SPEC,
+        reconcileExistingConfiguration: true,
+      });
 
-    expect(writes).toEqual([4096]);
-    expect(result).toEqual({
-      created: false,
-      device: androidImage("phone-api-36-a"),
-      resolvedSpec: { ...ANDROID_SPEC, displayCutout: "hole_punch" },
-    });
-  });
+      if (isRunning) {
+        await expect(operation).rejects.toMatchObject({ code: "identity_conflict" });
+        expect(writes).toEqual([]);
+        return;
+      }
+      const result = await operation;
+
+      expect(writes).toEqual([4096]);
+      expect(result).toEqual({
+        created: false,
+        device: androidImage("phone-api-36-a"),
+        resolvedSpec: { ...ANDROID_SPEC, displayCutout: "hole_punch" },
+      });
+    },
+  );
 
   test("does not reconcile a pre-existing Android AVD without creation provenance", async () => {
     const writes: number[] = [];


### PR DESCRIPTION
Android resource requests previously returned unsupported, and exact AVD provisioning exposed only guest memory. This adds independent Android controls to `setDeviceResources` and `provisionDevice.resources`, plus persistent emulator hardware configuration. No profiles or automatic disabling are introduced.

The Android implementation controls 21 optional package groups and animations, screensavers and Backup Manager. It verifies native overrides, protects active apps/default role holders/keyboard/accessibility services, honors deadlines and cancellation, and returns a same-boot/user restoration receipt. Receipts restore exact prior overrides, including default package state and absent settings; they are not a durable rollback journal across cancellation or lost responses. Core shared providers and automation packages are outside the catalog. Google infrastructure controls are explicitly disruptive to dependent integrations.

Provisioning adds CPU cores, GPU mode, display geometry/density, cameras and audio input/output. Reconciliation refuses mismatched running AVDs. Headless launch no longer implicitly disables audio; `AUTOMOBILE_EMULATOR_AUDIO=false` is the independent audio-off control. Existing injected configuration-writer implementations retain their memory-only compatibility seam. No dependencies were added; this uses the existing ADB factory, shell quoting, Timer, Zod and filesystem interfaces.

Validation:
- Full Turbo validation: all seven tasks passed, including the full unit suite and execution-boundary checks. An unrelated 100 ms downloader test timed out once under load, then passed targeted and full reruns without code changes.
- Typecheck baseline gate, format check, schema generation/advertised-contract tests, and shellcheck.
- Disposable API-35 Google APIs arm64 emulator: 18 package groups disabled/restored; three active role holders correctly refused. Settings and exact restoration verified. Hardware boot confirmed 720×1280, 280 dpi, two CPUs, zero cameras and Apple GPU rendering with a usable screenshot. Disposable AVD deleted afterward.
- Two idle sample periods showed no material emulator RSS improvement from optional-app disabling (4691.5 versus 4693.1 MiB median). This is preliminary evidence, not a causal performance claim.
- Experimental background app-op/standby/Doze transitions, statsd stop/restart on a debuggable image, and app precompilation were exercised separately. These mechanisms are documented, not exposed as blanket production switches.

This is a draft within the broader optimization work. The design document records remaining app-policy, sync-bridge, lifecycle/shared-snapshot, custom-image, Linux-host and realistic app-workflow validation work. No Slack compatibility or fleet-throughput gain is claimed from an unconfigured emulator.
