### PR TITLE
fix: reject uncertain readiness and display baselines

### DIFF
--- a/src/features/utility/DisplayConfig.ts
+++ b/src/features/utility/DisplayConfig.ts
@@ -136,16 +136,19 @@ function isAndroidEmulatorSerial(deviceId: string): boolean {
 }
 
 /**
- * Parse `settings get system font_scale`. An unset value ("null"/empty) means the
+ * Parse `settings get system font_scale`. An unset value ("null") means the
  * device is at the AOSP default of 1.0; a malformed value yields `undefined` so
  * the caller does not fabricate a scale it could not read.
  */
 export function parseFontScale(raw: string): number | undefined {
   const value = raw.trim();
-  if (!value || value === "null") {
+  if (value === "null") {
     return DEFAULT_FONT_SCALE;
   }
-  const parsed = Number.parseFloat(value);
+  if (!/^[+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/.test(value)) {
+    return undefined;
+  }
+  const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
@@ -156,7 +159,7 @@ export function parseFontScale(raw: string): number | undefined {
  */
 export function parseFontScaleSnapshot(raw: string): FontScaleInput | undefined {
   const value = raw.trim();
-  return !value || value === "null" ? "default" : parseFontScale(value);
+  return value === "null" ? "default" : parseFontScale(value);
 }
 
 /**
@@ -175,10 +178,25 @@ export function parseWmDensity(raw: string): {
   effective?: number;
   overridden: boolean;
 } {
-  const physicalMatch = raw.match(/Physical density:\s*(\d+)/i);
-  const overrideMatch = raw.match(/Override density:\s*(\d+)/i);
-  const physical = physicalMatch ? Number.parseInt(physicalMatch[1], 10) : undefined;
-  const override = overrideMatch ? Number.parseInt(overrideMatch[1], 10) : undefined;
+  const densities = new Map<string, number>();
+  for (const match of raw.matchAll(/^[ \t]*(Physical|Override) density:[ \t]*([^\r\n]*)/gim)) {
+    const kind = match[1].toLowerCase();
+    const value = match[2].trim();
+    const parsed = Number(value);
+    // A malformed override must not fall back to physical density and invent
+    // an absent override in the restoration payload (#6333).
+    if (
+      !/^\d+$/.test(value) ||
+      !Number.isSafeInteger(parsed) ||
+      parsed <= 0 ||
+      densities.has(kind)
+    ) {
+      return { effective: undefined, overridden: false };
+    }
+    densities.set(kind, parsed);
+  }
+  const physical = densities.get("physical");
+  const override = densities.get("override");
   const overridden = override !== undefined && Number.isFinite(override);
   return {
     ...(physical !== undefined && Number.isFinite(physical) ? { physical } : {}),
@@ -759,13 +777,7 @@ export class DisplayConfig {
     const errors: string[] = [];
     const expectedFontScale = input.reset ? "default" : input.fontScale;
     const appliedFontScale = postMutation.restorableValues.fontScale;
-    if (
-      expectedFontScale !== undefined &&
-      appliedFontScale !== expectedFontScale &&
-      // Android builds may report the reset setting as either absent or the
-      // effective AOSP default. Both represent a successfully reset state.
-      !(expectedFontScale === "default" && appliedFontScale === DEFAULT_FONT_SCALE)
-    ) {
+    if (expectedFontScale !== undefined && appliedFontScale !== expectedFontScale) {
       errors.push(
         `Font scale remained ${String(appliedFontScale)} after requesting ${String(expectedFontScale)}.`,
       );

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -581,9 +581,16 @@ async function ensureAccessibilityServiceReady(
       logger.info(`[A11yRetry] Setup succeeded on attempt ${attempt}/${MAX_ATTEMPTS}`);
     }
 
-    const connected = await perf.track("waitForConnection", () =>
-      awaitReadinessWork(readinessDriver.waitForConnection(), signal),
-    );
+    const connected = await perf.track("waitForConnection", async () => {
+      const ready = await awaitReadinessWork(readinessDriver.waitForConnection(), signal);
+      if (!ready) {
+        throw new ActionableError(
+          `CtrlProxy connection failed for device ${deviceId} (session ${sessionId}). ` +
+            "Retry the operation after the accessibility service is connected.",
+        );
+      }
+      return ready;
+    });
 
     perf.end();
     const timings = perf.getTimings();

--- a/test/features/utility/DisplayConfig.test.ts
+++ b/test/features/utility/DisplayConfig.test.ts
@@ -55,13 +55,14 @@ describe("DisplayConfig parsers", () => {
   test("parseFontScale handles default, unset, and malformed", () => {
     expect(parseFontScale("1.3\n")).toBe(1.3);
     expect(parseFontScale("null")).toBe(1.0);
-    expect(parseFontScale("")).toBe(1.0);
+    expect(parseFontScale("")).toBeUndefined();
+    expect(parseFontScale("1.2e0")).toBe(1.2);
     expect(parseFontScale("garbage")).toBeUndefined();
   });
 
   test("parseFontScaleSnapshot preserves unset separately from explicit 1", () => {
     expect(parseFontScaleSnapshot("null")).toBe("default");
-    expect(parseFontScaleSnapshot("")).toBe("default");
+    expect(parseFontScaleSnapshot("")).toBeUndefined();
     expect(parseFontScaleSnapshot("1.0")).toBe(1.0);
   });
 
@@ -96,6 +97,49 @@ describe("DisplayConfig parsers", () => {
 });
 
 describe("DisplayConfig getConfig", () => {
+  test.each(["1.2garbage", "1.2.3", "1e", "Infinity", "-1", "", "  ", "0x1", "0b1"])(
+    "rejects malformed font baseline %s before mutation",
+    async (fontScale) => {
+      const adbFactory = new FakeAdbClientFactory();
+      seedReads(adbFactory, { fontScale });
+      const result = await new DisplayConfig(androidEmulator, { adbFactory }).setConfig({
+        fontScale: 2,
+      });
+      expect(result.success).toBe(false);
+      expect(result.previous).toBeUndefined();
+      expect(
+        adbFactory
+          .getFakeClient()
+          .getCommandCalls()
+          .some((call) => call.command.includes("settings put")),
+      ).toBe(false);
+    },
+  );
+
+  test.each(["440junk", "440.5", "0", "-440"])(
+    "rejects malformed density baseline %s",
+    async (density) => {
+      const adbFactory = new FakeAdbClientFactory();
+      seedReads(adbFactory, { density: `Physical density: 440\nOverride density: ${density}\n` });
+      const result = await new DisplayConfig(androidEmulator, { adbFactory }).getConfig();
+      expect(result.success).toBe(false);
+      expect(result.current).toBeUndefined();
+    },
+  );
+
+  test.each([{ fontScale: "default" as const }, { reset: true }])(
+    "does not confirm font reset while an explicit scale of one remains",
+    async (input) => {
+      const adbFactory = new FakeAdbClientFactory();
+      seedReads(adbFactory, { fontScale: "1.0\n" });
+      const result = await new DisplayConfig(androidEmulator, { adbFactory }).setConfig(input);
+      expect(result.success).toBe(false);
+      expect(result.previous?.fontScale).toBe(1);
+      expect(result.applied?.fontScale).toBe(1);
+      expect(result.error).toContain("Font scale remained");
+    },
+  );
+
   test("reads font scale, effective density, and theme", async () => {
     const adbFactory = new FakeAdbClientFactory();
     seedReads(adbFactory, {
@@ -335,7 +379,7 @@ describe("DisplayConfig setConfig", () => {
 
   test("reset restores font scale, density, and theme to defaults", async () => {
     const adbFactory = new FakeAdbClientFactory();
-    seedReads(adbFactory);
+    seedReads(adbFactory, { fontScale: "null\n" });
 
     const result = await new DisplayConfig(androidEmulator, { adbFactory }).setConfig({
       reset: true,

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -111,6 +111,46 @@ describe("ToolExecutionContext", () => {
     expect(passed.platform).toBe("android");
   });
 
+  test.each(["new", "persisted"])(
+    "rejects a failed proxy connection for a %s session and allows retry",
+    async (entrypoint) => {
+      let connected = false;
+      let setupCalls = 0;
+      setDeviceReadinessProxyDriverProviderForTesting(() => ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls++;
+          return { success: true, message: "ok" };
+        },
+        waitForConnection: async () => connected,
+        isInstalled: async () => true,
+        isVersionCompatible: async () => true,
+      }));
+      if (entrypoint === "persisted") {
+        await sessionManager.createSession("connection-failure", "device-1", "android");
+        sessionManager.setDeviceReadiness("connection-failure", "booted");
+      }
+      await expect(
+        createToolExecutionContext(
+          "connection-failure",
+          sessionManager,
+          devicePool,
+          sessionOptions,
+        ),
+      ).rejects.toThrow("CtrlProxy connection");
+      expect(sessionManager.getDeviceReadiness("connection-failure")).not.toBe("automationReady");
+      connected = true;
+      await createToolExecutionContext(
+        "connection-failure",
+        sessionManager,
+        devicePool,
+        sessionOptions,
+      );
+      expect(sessionManager.getDeviceReadiness("connection-failure")).toBe("automationReady");
+      expect(setupCalls).toBe(2);
+    },
+  );
+
   test("does not run accessibility setup when a pooled emulator serial is stale", async () => {
     const staleDeviceManager = new FakeDeviceManager();
     const stalePool = new DevicePool(


### PR DESCRIPTION
## Summary

Readiness setup could return successfully after CtrlProxy reported that its connection failed, promoting a disconnected device to `automationReady`. Reject that result in the shared setup path; both fresh and persisted sessions retain their prior readiness and can retry.

Display configuration could parse numeric prefixes or empty output into a restoration baseline and report a successful font reset while an explicit `1.0` override remained. Require complete finite positive decimal font values, valid whole density fields, and literal `null` to confirm an absent font override. Preserve effective numeric values separately from restoration tokens.

This addresses confirmed W3/W4 residuals from [issue 6333](https://github.com/kaeawc/auto-mobile/issues/6333). It deliberately leaves the umbrella open: shared deadline propagation, shared quiet-period settling, the full entrypoint harness, and the separate readiness-marker race still need work. Recording ownership/timer, socket reclaim, log ownership, and the reported barrier examples already have fixes on inspected main; 81 existing regression tests passed.

## Validation

- 11 initial regression failures reproduced before the fixes.
- 96 focused tests pass, including new/persisted readiness retry and malformed-baseline/reset cases.
- `bun run turbo:validate --env-mode=loose`: all 7 tasks pass.
- `bun run typecheck`: no new errors; existing baseline unchanged.
- Runtime, delivery, and parsing/restore review completed; findings fixed and rechecked.

No new dependencies. Existing injected drivers and fakes cover readiness; built-in numeric conversion with local shell-output validation covers display reads.
