### PR TITLE
fix: address remaining highlight lifecycle and test feedback

### DIFF
--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -74,6 +74,7 @@ class WebSocketServerIntegrationTest {
                   when {
                     highlightId.isNullOrBlank() -> "Missing highlight id"
                     shape == null -> "Missing highlight shape"
+                    shape.type != "circle" -> "Only hand-drawn circle highlights are supported"
                     else -> null
                   }
                 enqueueHighlightResponse(requestId, error == null, error)
@@ -567,7 +568,7 @@ class WebSocketServerIntegrationTest {
 
         val requestId = "req-add"
         val message =
-          """{"type":"add_highlight","requestId":"$requestId","id":"highlight-1","shape":{"type":"box","bounds":{"x":10,"y":20,"width":100,"height":80},"style":{"strokeColor":"#FF0000","strokeWidth":4,"dashPattern":null}}}"""
+          """{"type":"add_highlight","requestId":"$requestId","id":"highlight-1","shape":{"type":"circle","bounds":{"x":10,"y":20,"width":100,"height":80}}}"""
         send(Frame.Text(message))
 
         val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
@@ -582,7 +583,7 @@ class WebSocketServerIntegrationTest {
   }
 
   @Test
-  fun `add_path_highlight returns highlight response`() = runBlocking {
+  fun `unsupported highlights return error responses`() = runBlocking {
     server.start()
 
     val client = HttpClient(CIO) { install(WebSockets) }
@@ -595,17 +596,23 @@ class WebSocketServerIntegrationTest {
       ) {
         incoming.receive() // Connection message
 
-        val requestId = "req-add-path"
-        val message =
-          """{"type":"add_highlight","requestId":"$requestId","id":"path-1","shape":{"type":"path","points":[{"x":10,"y":20},{"x":40,"y":35},{"x":80,"y":25}],"style":{"strokeColor":"#FF8800","strokeWidth":5,"smoothing":"catmull-rom","tension":0.6}}}"""
-        send(Frame.Text(message))
+        for (shapeType in listOf("box", "path")) {
+          val requestId = "req-add-$shapeType"
+          val message =
+            """{"type":"add_highlight","requestId":"$requestId","id":"unsupported-1","shape":{"type":"$shapeType","bounds":{"x":10,"y":20,"width":100,"height":80}}}"""
+          send(Frame.Text(message))
 
-        val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
-        val responseJson = json.parseToJsonElement(responseFrame.readText()).jsonObject
+          val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
+          val responseJson = json.parseToJsonElement(responseFrame.readText()).jsonObject
 
-        assertEquals("highlight_response", responseJson["type"]?.jsonPrimitive?.content)
-        assertEquals(requestId, responseJson["requestId"]?.jsonPrimitive?.content)
-        assertEquals("true", responseJson["success"]?.jsonPrimitive?.content)
+          assertEquals("highlight_response", responseJson["type"]?.jsonPrimitive?.content)
+          assertEquals(requestId, responseJson["requestId"]?.jsonPrimitive?.content)
+          assertEquals("false", responseJson["success"]?.jsonPrimitive?.content)
+          assertEquals(
+            "Only hand-drawn circle highlights are supported",
+            responseJson["error"]?.jsonPrimitive?.content,
+          )
+        }
       }
     }
   }
@@ -626,7 +633,7 @@ class WebSocketServerIntegrationTest {
 
         val requestId = "req-invalid"
         val message =
-          """{"type":"add_highlight","requestId":"$requestId","shape":{"type":"box","bounds":{"x":10,"y":20,"width":100,"height":80},"style":{"strokeColor":"#FF0000","strokeWidth":4,"dashPattern":null}}}"""
+          """{"type":"add_highlight","requestId":"$requestId","shape":{"type":"circle","bounds":{"x":10,"y":20,"width":100,"height":80}}}"""
         send(Frame.Text(message))
 
         val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorHighlightOverlay.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorHighlightOverlay.swift
@@ -200,17 +200,21 @@ final class SimulatorHighlightHost {
     private let makeOverlay: OverlayFactory
     private let replySink: (SimulatorHighlightReply) -> Void
     private var inputTask: Task<Void, Never>?
+    private var refreshTask: Task<Void, Never>?
+    private let waitForFrame: () async throws -> Void
 
     init(
         deviceName: String,
         now: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
         makeOverlay: OverlayFactory? = nil,
+        waitForFrame: @escaping () async throws -> Void = { try await Task.sleep(nanoseconds: 16_666_667) },
         replySink: @escaping (SimulatorHighlightReply) -> Void = { reply in
             if let data = try? JSONEncoder().encode(reply) {
                 FileHandle.standardOutput.write(data + Data([10]))
             }
         }
     ) {
+        self.waitForFrame = waitForFrame
         self.now = now
         self.replySink = replySink
         self.makeOverlay = makeOverlay ?? { request in
@@ -226,6 +230,7 @@ final class SimulatorHighlightHost {
                 let overlay = try await makeOverlay(request)
                 overlays.removeValue(forKey: request.id)?.overlay.close()
                 overlays[request.id] = (overlay, now() + HandDrawnCircle.duration)
+                startRefreshing()
                 reply(requestId: request.requestId, error: nil)
             } catch { reply(requestId: request.requestId, error: String(describing: error)) }
         } catch {
@@ -252,6 +257,19 @@ final class SimulatorHighlightHost {
         }
     }
 
+    private func startRefreshing() {
+        guard refreshTask == nil else { return }
+        refreshTask = Task { [weak self] in
+            guard let self else { return }
+            defer { refreshTask = nil }
+            while !overlays.isEmpty, !Task.isCancelled {
+                do { try await waitForFrame() } catch { return }
+                guard !Task.isCancelled else { return }
+                await refresh()
+            }
+        }
+    }
+
     func refresh() async {
         for (id, entry) in overlays {
             if now() >= entry.deadline {
@@ -271,6 +289,7 @@ final class SimulatorHighlightHost {
 
     func close() {
         inputTask?.cancel()
+        refreshTask?.cancel()
         for entry in overlays.values {
             entry.overlay.close()
         }

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -172,10 +172,6 @@ case let .highlightSimulator(deviceName, json):
             }
             Task { @MainActor in host.enqueue(data) }
         }
-        while true {
-            try? await Task.sleep(nanoseconds: 16_666_667)
-            await host.refresh()
-        }
     }
     NSApplication.shared.run()
 

--- a/ios/screen-capture/Tests/ScreenCaptureHelperTests/SimulatorHighlightTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureHelperTests/SimulatorHighlightTests.swift
@@ -89,6 +89,64 @@ final class SimulatorHighlightHostTests: XCTestCase {
         }
     }
 
+    @MainActor
+    private final class FrameClock {
+        var waits = 0
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        func wait() async {
+            waits += 1
+            await withCheckedContinuation { continuation = $0 }
+        }
+
+        func advance() {
+            let pending = continuation
+            continuation = nil
+            pending?.resume()
+        }
+    }
+
+    func testRefreshLoopParksAfterExpiryAndRestartsForNextHighlight() async {
+        let clock = FrameClock()
+        var now: TimeInterval = 0
+        var created: [FakeOverlay] = []
+        let host = SimulatorHighlightHost(deviceName: "iPhone", now: { now }, makeOverlay: { _ in
+            let overlay = FakeOverlay()
+            created.append(overlay)
+            return overlay
+        }, waitForFrame: { await clock.wait() }, replySink: { _ in })
+        let command = Data(
+            #"{"requestId":"1","id":"same","shape":{"type":"circle","bounds":{"x":0,"y":0,"width":10,"height":10}}}"#
+                .utf8
+        )
+        XCTAssertEqual(clock.waits, 0)
+        await host.receive(command)
+        for _ in 0 ..< 100 where clock.waits == 0 {
+            await Task.yield()
+        }
+        XCTAssertEqual(clock.waits, 1)
+        now = 2
+        clock.advance()
+        for _ in 0 ..< 100 {
+            await Task.yield()
+        }
+        XCTAssertTrue(created[0].closed)
+        XCTAssertEqual(clock.waits, 1, "Expired overlays must not schedule further frames")
+        await host.receive(command)
+        for _ in 0 ..< 100 where clock.waits == 1 {
+            await Task.yield()
+        }
+        XCTAssertEqual(clock.waits, 2)
+        XCTAssertFalse(created[1].closed)
+        host.close()
+        clock.advance()
+        for _ in 0 ..< 100 {
+            await Task.yield()
+        }
+        XCTAssertTrue(created[1].closed)
+        XCTAssertEqual(clock.waits, 2, "Shutdown must stop refreshing")
+    }
+
     func testReplacementGetsItsOwnDeadlineAndHostAcceptsMoreCommandsAfterExpiry() async {
         var now: TimeInterval = 0
         var created: [FakeOverlay] = []

--- a/src/features/debug/SimulatorHighlights.ts
+++ b/src/features/debug/SimulatorHighlights.ts
@@ -167,19 +167,27 @@ export class SimulatorHighlights {
   private watchHost(key: string, host: OverlayHost): void {
     let stdout = "";
     let stderr = "";
+    let failed = false;
     const fail = (error: string) => {
+      if (failed) {
+        return;
+      }
+      failed = true;
       if (this.hosts.get(key) === host) {
         this.hosts.delete(key);
       }
       for (const finish of host.pending.values()) {
         finish({ success: false, error });
       }
+      host.child.kill();
     };
     host.child.stdout?.on("data", (chunk: Buffer) => {
+      if (failed) {
+        return;
+      }
       stdout += chunk.toString();
       if (stdout.length > 65536) {
         fail("Invalid highlight acknowledgement");
-        host.child.kill();
         return;
       }
       let newline: number;
@@ -194,6 +202,7 @@ export class SimulatorHighlights {
           });
         } catch (error) {
           fail(`Invalid highlight acknowledgement: ${error}`);
+          return;
         }
       }
     });

--- a/test/features/debug/SimulatorHighlights.test.ts
+++ b/test/features/debug/SimulatorHighlights.test.ts
@@ -87,6 +87,35 @@ describe("SimulatorHighlights", () => {
     expect(JSON.parse(executor.args[3])).toMatchObject({ id: "a", shape });
     child.emit("exit", 0);
   });
+  for (const invalid of ["not json\n", '{"requestId":1,"success":true}\n', "x".repeat(65537)]) {
+    test(`terminates invalid acknowledgement hosts (${invalid.length} bytes)`, async () => {
+      const { client, executor } = setup();
+      const first = client.requestAddHighlight("first", shape);
+      const second = client.requestAddHighlight("second", shape);
+      await spawned();
+      const child = executor.children[0];
+      child.stdout.emit("data", Buffer.from(invalid));
+      expect((await first).success).toBe(false);
+      expect((await second).success).toBe(false);
+      expect(child.killed).toBe(true);
+      const replacement = client.requestAddHighlight("replacement", shape);
+      await spawned();
+      expect(executor.children).toHaveLength(2);
+      // A delayed exit from the failed host must not evict its replacement.
+      child.emit("exit", 1);
+      executor.children[1].stdout.emit(
+        "data",
+        Buffer.from(
+          JSON.stringify({
+            requestId: JSON.parse(executor.args[3]).requestId,
+            success: true,
+          }) + "\n",
+        ),
+      );
+      expect(await replacement).toEqual({ success: true });
+      executor.children[1].emit("exit", 0);
+    });
+  }
   test("reports a native permission failure without success", async () => {
     const { client, executor } = setup();
     const pending = client.requestAddHighlight("b", shape);


### PR DESCRIPTION
Retained Simulator highlight helpers now stop scheduling frames when the last overlay expires and resume when another highlight arrives. Invalid or oversized acknowledgements fail pending requests and terminate the unusable helper, so replacement requests cannot accumulate orphan processes.

Update Android WebSocket fixtures to send circles for successful requests and verify box/path rejection. The original review predicted a CI failure, but those tests passed because their fake accepted every shape; the fake now reflects the circle-only contract.

Follow-up to all three remaining findings on [PR #6774](https://github.com/kaeawc/auto-mobile/pull/6774):
- [Circle-only WebSocket fixtures](https://github.com/kaeawc/auto-mobile/pull/6774#discussion_r3973811007)
- [Park inactive overlay hosts](https://github.com/kaeawc/auto-mobile/pull/6774#discussion_r3973811012)
- [Terminate invalid acknowledgement helpers](https://github.com/kaeawc/auto-mobile/pull/6774#discussion_r3973811020)

Validation: 30 Android WebSocket/overlay tests, 151 native capture tests, and 8 TypeScript helper tests passed. Regression coverage checks expiry, resumed animation, shutdown, malformed/schema-invalid/oversized acknowledgements, pending requests, and replacement-host isolation. Formatting, SwiftLint, TypeScript lint, type-check baseline gate, and build passed. Native tests used installed Swift 6.2 with only the tools-version declaration temporarily lowered; the committed Swift 6.3 requirement is unchanged.

The refresh loop uses the existing host with an injected frame wait and Foundation uptime; no new helper library or dependency is added. Idle processes remain alive for ScreenCaptureKit compatibility.
