### PR TITLE
fix: harden device provisioning readiness

### DIFF
--- a/docs/design-docs/device-resources.md
+++ b/docs/design-docs/device-resources.md
@@ -165,6 +165,9 @@ evidence intact. Provisioning returns that same result under `resources` and
 also marks the response as an error if configuration is incomplete; it retains
 the provisioned device identity and session so the caller can inspect or retry.
 Device boot/readiness and resource-configuration success are separate facts.
+Booted provisioning responses expose the session as `sessionUuid` and retain
+`sessionId` as an equal compatibility alias, including resource failures and
+replayed operations. With `boot: false`, neither session field is present.
 
 ## Automation capabilities
 

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1844,7 +1844,7 @@ export class DaemonMcpProxy {
     delete callerArgs[DAEMON_BOUND_SESSION_PARAM];
     delete callerArgs[DAEMON_RELEASED_SESSION_PARAM];
     delete callerArgs[DAEMON_TOOL_SELECTION_PROFILE_PARAM];
-    // Device-session acquisition (getAndroid/getApple/startDevice) mints a NEW
+    // Device-session acquisition (including booted provisionDevice) mints a NEW
     // session in its RESULT and is never routed to — or fenced by — the connection's
     // bound session: it must be admitted even on a terminally fenced connection so
     // the client can recover in-band (issue #5689). Forward its raw args and bind
@@ -1883,6 +1883,12 @@ export class DaemonMcpProxy {
         isSessionAcquisition,
       );
       if (result?.isError) {
+        // Provisioning retains its usable device session when optional resource
+        // configuration fails. Own that result-minted session before returning
+        // the evidence-bearing error, so the caller can inspect or retry it.
+        if (name === "provisionDevice") {
+          await this.bindResultMintedDeviceSession(name, result, callReleaseEpoch);
+        }
         this.refreshReplayLeaseForBoundSessionResult(forwardedArgs, callReleaseEpoch);
         return result;
       }
@@ -2406,7 +2412,7 @@ export class DaemonMcpProxy {
     throw new DaemonBoundSessionExpiredError(forwardedUuid, reason);
   }
 
-  // Bind and heartbeat the device session a getAndroid/getApple/startDevice call
+  // Bind and heartbeat the device session an acquisition call
   // minted in its RESULT — the proxy equivalent of the direct-path bind in
   // src/server/index.ts. Without this the daemon never sees an ownership heartbeat
   // for a result-minted session and reaps it under the pre-first-heartbeat grace

--- a/src/server/deviceSessionResult.ts
+++ b/src/server/deviceSessionResult.ts
@@ -2,12 +2,17 @@ import { logger } from "../utils/logger";
 
 /**
  * The tools that acquire a device and mint a device session, returning its
- * `sessionId` in the tool RESULT (not the request args). Both the direct MCP
+ * `sessionUuid` in the tool RESULT (not the request args). Both the direct MCP
  * server (`src/server/index.ts`) and the daemon proxy (`DaemonMcpProxy`) must
  * bind the session these tools mint — the proxy additionally heartbeats it so
  * the daemon does not reap a result-minted session (issue #5689).
  */
-export const DEVICE_SESSION_ACQUISITION_TOOLS = ["getAndroid", "getApple", "startDevice"] as const;
+export const DEVICE_SESSION_ACQUISITION_TOOLS = [
+  "getAndroid",
+  "getApple",
+  "startDevice",
+  "provisionDevice",
+] as const;
 
 /** Whether `name` is a device-session acquisition tool (see above). */
 export function isDeviceSessionAcquisitionTool(name: string): boolean {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -3247,10 +3247,15 @@ function createProvisionDeviceResponse(result: Record<string, unknown>) {
   const device = result.device as { name: string; platform: string };
   const resources = result.resources as DeviceResourceConfigurationResult | undefined;
   const resourceFailure = resources?.success === false;
+  const sessionId = typeof result.sessionId === "string" ? result.sessionId : undefined;
   return {
     ...createJSONToolResponse({
       message: `${device.platform} '${device.name}' provisioned (${result.lifecycleState})${resourceFailure ? "; requested resource configuration was not fully applied" : ""}`,
       ...result,
+      // `sessionId` remains the persisted daemon-internal handle for replay and
+      // recovery. Public preparation APIs use `sessionUuid`; retain sessionId
+      // as a compatibility alias for provisionDevice's existing consumers.
+      ...(sessionId ? { sessionUuid: sessionId, sessionId } : {}),
       ...(resources ? { success: resources.success } : {}),
     }),
     ...(resourceFailure ? { isError: true } : {}),

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -1,4 +1,6 @@
 import { errorMessage } from "./describeUnknownError";
+import { toActionableError } from "../models/ActionableError";
+import { isAndroidFrameworkUnavailable } from "./android-cmdline-tools/isAndroidFrameworkUnavailable";
 import {
   AdbClientFactory,
   defaultAdbClientFactory,
@@ -732,6 +734,10 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
         undefined,
         true,
       );
+      const diagnostic = `${result.stdout}\n${result.stderr}`;
+      if (isAndroidFrameworkUnavailable(diagnostic)) {
+        throw new ActionableError(diagnostic);
+      }
       const isInstalled = result.stdout.includes(AndroidCtrlProxyManager.PACKAGE);
 
       // Cache the result
@@ -745,6 +751,11 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       );
       return isInstalled;
     } catch (error) {
+      // Preserve boot failures for the readiness retry loop; false means that
+      // inspection completed without finding the installed runner.
+      if (isAndroidFrameworkUnavailable(error)) {
+        throw toActionableError(error, "Android framework unavailable");
+      }
       logger.warn(`[CTRL_PROXY] Error checking installation status: ${error}`);
       return false;
     }
@@ -772,6 +783,10 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       const result = await this.adb.executeCommand(
         "shell settings get secure enabled_accessibility_services",
       );
+      const diagnostic = `${result.stdout}\n${result.stderr}`;
+      if (isAndroidFrameworkUnavailable(diagnostic)) {
+        throw new ActionableError(diagnostic);
+      }
       const isEnabled = result.stdout.includes(AndroidCtrlProxyManager.PACKAGE);
 
       // Cache the result
@@ -785,6 +800,10 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       );
       return isEnabled;
     } catch (error) {
+      // A missing settings service during boot is not a disabled runner.
+      if (isAndroidFrameworkUnavailable(error)) {
+        throw toActionableError(error, "Android framework unavailable");
+      }
       logger.warn(`[CTRL_PROXY] Error checking enabled status: ${error}`);
       return false;
     }

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -142,6 +142,12 @@ export interface AndroidRunnerConnectDiagnostic {
   primaryUserStartState?: string;
 }
 
+export interface AndroidFrameworkReadinessResult {
+  ready: boolean;
+  unavailableResources?: string[];
+  diagnostic?: string;
+}
+
 interface SystemUiAnrReadinessClient {
   getAccessibilityHierarchy: NonNullable<ReadinessClient["getAccessibilityHierarchy"]>;
   requestTapCoordinates: NonNullable<ReadinessClient["requestTapCoordinates"]>;
@@ -149,6 +155,11 @@ interface SystemUiAnrReadinessClient {
 
 export interface RunnerReadinessDependencies {
   timer: Timer;
+  getAndroidFrameworkReadiness?(
+    device: BootedDevice,
+    signal: AbortSignal,
+    timeoutMs: number,
+  ): Promise<AndroidFrameworkReadinessResult>;
   getAndroidManager(device: BootedDevice): ReadinessAndroidManager;
   getAndroidClient(device: BootedDevice): ReadinessClient;
   getIosManager(device: BootedDevice): ReadinessIosManager;
@@ -234,6 +245,7 @@ export class RunnerReadinessService {
   }
 
   private async ensureAndroidReady(context: ReadinessAttemptContext): Promise<void> {
+    this.inspectAndroidFrameworkBestEffort(context);
     const manager = this.dependencies.getAndroidManager(context.device);
     const client = this.dependencies.getAndroidClient(context.device);
     if (context.skipCtrlProxyDownload) {
@@ -266,6 +278,38 @@ export class RunnerReadinessService {
     await this.setupAndroidRunner(context, manager);
     await this.waitForResponsiveClient(context, client);
     await this.recoverSystemUiAnrIfPresent(context, client);
+  }
+
+  private inspectAndroidFrameworkBestEffort(context: ReadinessAttemptContext): void {
+    const probe = this.dependencies.getAndroidFrameworkReadiness;
+    if (!probe) {
+      return;
+    }
+    const remainingMs = Math.max(0, context.totalDeadlineMs - this.dependencies.timer.now());
+    if (remainingMs <= 0) {
+      return;
+    }
+    const inspectionSignal = context.signal ?? new AbortController().signal;
+    void probe(
+      context.device,
+      inspectionSignal,
+      Math.min(READINESS_PROBE_TIMEOUT_MS, remainingMs),
+    ).then(
+      (result) => {
+        if (!result.ready) {
+          logger.debug(
+            `Android framework inspection is not ready yet: ${
+              result.unavailableResources?.join(", ") ?? "unknown resources"
+            }`,
+          );
+        }
+      },
+      (error: unknown) => {
+        // Framework inspection is diagnostic only; required runner readiness
+        // below owns the request outcome and cancellation.
+        logger.debug(`Android framework inspection failed: ${errorMessage(error)}`);
+      },
+    );
   }
 
   private async ensureAndroidReadyWithoutDownloads(
@@ -926,11 +970,60 @@ function normalizeDiagnostic(error: unknown): string {
   return `${redacted.slice(0, half)}\n...[diagnostic truncated]...\n${redacted.slice(-half)}`;
 }
 
+async function getDefaultAndroidFrameworkReadiness(
+  device: BootedDevice,
+  signal: AbortSignal,
+  timeoutMs: number,
+): Promise<AndroidFrameworkReadinessResult> {
+  const adb = defaultAdbClientFactory.create(device);
+  const [packageLookup, settingsLookup] = await Promise.allSettled([
+    adb.execute(["shell", "cmd", "package", "path", "android"], {
+      timeoutMs,
+      noRetry: true,
+      signal,
+    }),
+    adb.execute(["shell", "settings", "get", "secure", "accessibility_enabled"], {
+      timeoutMs,
+      noRetry: true,
+      signal,
+    }),
+  ]);
+  signal.throwIfAborted();
+
+  const unavailableResources: string[] = [];
+  const diagnostics: string[] = [];
+  if (packageLookup.status === "rejected" || !packageLookup.value.stdout.includes("package:")) {
+    unavailableResources.push("package");
+    diagnostics.push(
+      packageLookup.status === "rejected"
+        ? `package: ${normalizeDiagnostic(packageLookup.reason)}`
+        : `package: ${normalizeDiagnostic(packageLookup.value.stdout || packageLookup.value.stderr)}`,
+    );
+  }
+  if (
+    settingsLookup.status === "rejected" ||
+    settingsLookup.value.stdout.includes("Can't find service")
+  ) {
+    unavailableResources.push("settings");
+    diagnostics.push(
+      settingsLookup.status === "rejected"
+        ? `settings: ${normalizeDiagnostic(settingsLookup.reason)}`
+        : `settings: ${normalizeDiagnostic(settingsLookup.value.stdout || settingsLookup.value.stderr)}`,
+    );
+  }
+  return {
+    ready: unavailableResources.length === 0,
+    ...(unavailableResources.length > 0 ? { unavailableResources } : {}),
+    ...(diagnostics.length > 0 ? { diagnostic: diagnostics.join("; ") } : {}),
+  };
+}
+
 export function createDefaultRunnerReadinessService(
   timer: Timer = defaultTimer,
 ): RunnerReadinessService {
   return new RunnerReadinessService({
     timer,
+    getAndroidFrameworkReadiness: getDefaultAndroidFrameworkReadiness,
     getAndroidManager: (device) => AndroidCtrlProxyManager.getInstance(device),
     getAndroidClient: (device) => AndroidCtrlProxyClient.getInstance(device),
     getIosManager: (device) => IOSCtrlProxyManager.getInstance(device),

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -8,6 +8,8 @@ import { IOSCtrlProxyManager } from "./IOSCtrlProxyManager";
 import { checkIosCtrlProxyOverride } from "./iosCtrlProxyOverride";
 import { redactAndroidCommandOutput } from "./android-cmdline-tools/redactAndroidCommandOutput";
 import { defaultAdbClientFactory } from "./android-cmdline-tools/AdbClientFactory";
+import { isAndroidFrameworkUnavailable } from "./android-cmdline-tools/isAndroidFrameworkUnavailable";
+import { DefaultRetryExecutor } from "./retry/RetryExecutor";
 import { defaultTimer, type Timer } from "./SystemTimer";
 import {
   acquireDeviceReadinessLock,
@@ -40,7 +42,14 @@ type RunnerReadinessPhase =
   | "runner-connect"
   | "runner-health";
 
-export class RunnerReadinessError extends ActionableError {}
+export class RunnerReadinessError extends ActionableError {
+  constructor(
+    message: string,
+    readonly retryableAndroidFrameworkFailure = false,
+  ) {
+    super(message);
+  }
+}
 
 export class SystemUiAnrRecoveryRequiredError extends RunnerReadinessError {}
 
@@ -245,7 +254,51 @@ export class RunnerReadinessService {
   }
 
   private async ensureAndroidReady(context: ReadinessAttemptContext): Promise<void> {
-    this.inspectAndroidFrameworkBestEffort(context);
+    this.throwIfCallerCancelled(context);
+    const finishInspection = this.inspectAndroidFrameworkBestEffort(context);
+    try {
+      let lastDiagnostic = "Android framework readiness budget exhausted";
+      await new DefaultRetryExecutor(this.dependencies.timer).executeOrThrow(
+        async (attempt) => {
+          this.throwIfCallerCancelled(context);
+          if (this.remainingForPhase(context, "runner-setup") <= 0) {
+            this.fail(context, "runner-setup", attempt, lastDiagnostic);
+          }
+          if (attempt > 1) {
+            this.dependencies.getAndroidManager(context.device).resetSetupState();
+          }
+          await this.ensureAndroidReadyAttempt(context);
+          this.throwIfCallerCancelled(context);
+        },
+        {
+          maxAttempts:
+            Math.ceil(this.remainingForPhase(context, "runner-setup") / READINESS_RETRY_DELAY_MS) +
+            1,
+          signal: context.signal,
+          delays: () =>
+            Math.min(READINESS_RETRY_DELAY_MS, this.remainingForPhase(context, "runner-setup")),
+          // Retry required setup only when Android explicitly reports a missing
+          // boot service. Optional inspection never determines readiness.
+          shouldRetry: (error) =>
+            error instanceof RunnerReadinessError &&
+            error.retryableAndroidFrameworkFailure &&
+            this.remainingForPhase(context, "runner-setup") > 0,
+          onRetry: (error) => {
+            lastDiagnostic = normalizeDiagnostic(error);
+            logger.debug(`Retrying Android framework setup: ${lastDiagnostic}`);
+          },
+        },
+      );
+    } catch (error) {
+      this.throwIfCallerCancelled(context, error);
+      throw error;
+    } finally {
+      await finishInspection?.();
+      this.throwIfCallerCancelled(context);
+    }
+  }
+
+  private async ensureAndroidReadyAttempt(context: ReadinessAttemptContext): Promise<void> {
     const manager = this.dependencies.getAndroidManager(context.device);
     const client = this.dependencies.getAndroidClient(context.device);
     if (context.skipCtrlProxyDownload) {
@@ -263,9 +316,12 @@ export class RunnerReadinessService {
     );
     this.assertAndroidCompatibility(context, compatibility);
 
-    const [installed, enabled] = await this.runPhase(context, "runner-setup", 1, (signal) =>
-      Promise.all([manager.isInstalled(signal), manager.isEnabled(signal)]),
-    );
+    // Read sequentially so a transient failure cannot leave a sibling ADB
+    // command running when the next setup attempt starts.
+    const [installed, enabled] = await this.runPhase(context, "runner-setup", 1, async (signal) => [
+      await manager.isInstalled(signal),
+      await manager.isEnabled(signal),
+    ]);
     if (await this.isResponsiveFastPath(context, client, installed && enabled)) {
       await this.recoverSystemUiAnrIfPresent(context, client);
       return;
@@ -280,7 +336,9 @@ export class RunnerReadinessService {
     await this.recoverSystemUiAnrIfPresent(context, client);
   }
 
-  private inspectAndroidFrameworkBestEffort(context: ReadinessAttemptContext): void {
+  private inspectAndroidFrameworkBestEffort(
+    context: ReadinessAttemptContext,
+  ): (() => Promise<void>) | undefined {
     const probe = this.dependencies.getAndroidFrameworkReadiness;
     if (!probe) {
       return;
@@ -289,27 +347,46 @@ export class RunnerReadinessService {
     if (remainingMs <= 0) {
       return;
     }
-    const inspectionSignal = context.signal ?? new AbortController().signal;
-    void probe(
-      context.device,
-      inspectionSignal,
-      Math.min(READINESS_PROBE_TIMEOUT_MS, remainingMs),
-    ).then(
-      (result) => {
-        if (!result.ready) {
-          logger.debug(
-            `Android framework inspection is not ready yet: ${
-              result.unavailableResources?.join(", ") ?? "unknown resources"
-            }`,
-          );
-        }
-      },
-      (error: unknown) => {
-        // Framework inspection is diagnostic only; required runner readiness
-        // below owns the request outcome and cancellation.
-        logger.debug(`Android framework inspection failed: ${errorMessage(error)}`);
-      },
+    const controller = new AbortController();
+    const inspectionSignal = context.signal
+      ? AbortSignal.any([context.signal, controller.signal])
+      : controller.signal;
+    const timeoutMs = Math.min(READINESS_PROBE_TIMEOUT_MS, remainingMs);
+    const timeout = this.dependencies.timer.setTimeout(
+      () => controller.abort(new Error("Android framework inspection timed out")),
+      timeoutMs,
     );
+    // Defer invocation so synchronous injected failures follow the same
+    // diagnostic-only rejection path as asynchronous ADB failures.
+    const inspection = Promise.resolve()
+      .then(() => {
+        inspectionSignal.throwIfAborted();
+        return probe(context.device, inspectionSignal, timeoutMs);
+      })
+      .then(
+        (result) => {
+          if (!result.ready) {
+            logger.debug(
+              `Android framework inspection is not ready yet: ${
+                result.unavailableResources?.join(", ") ?? "unknown resources"
+              }${result.diagnostic ? `; ${normalizeDiagnostic(result.diagnostic)}` : ""}`,
+            );
+          }
+        },
+        (error: unknown) => {
+          // Framework inspection is diagnostic only; required runner readiness
+          // below owns the request outcome and cancellation.
+          logger.debug(`Android framework inspection failed: ${normalizeDiagnostic(error)}`);
+        },
+      )
+      .finally(() => this.dependencies.timer.clearTimeout(timeout));
+    return async () => {
+      controller.abort(new Error("Android readiness inspection finished"));
+      this.dependencies.timer.clearTimeout(timeout);
+      // Bound cleanup even for a broken injected probe that ignores abort;
+      // production ADB commands observe the signal and settle here.
+      await this.awaitAbortSettlement(inspection);
+    };
   }
 
   private async ensureAndroidReadyWithoutDownloads(
@@ -317,9 +394,10 @@ export class RunnerReadinessService {
     manager: ReadinessAndroidManager,
     client: ReadinessClient,
   ): Promise<void> {
-    const [installed, enabled] = await this.runPhase(context, "runner-setup", 1, (signal) =>
-      Promise.all([manager.isInstalled(signal), manager.isEnabled(signal)]),
-    );
+    const [installed, enabled] = await this.runPhase(context, "runner-setup", 1, async (signal) => [
+      await manager.isInstalled(signal),
+      await manager.isEnabled(signal),
+    ]);
     if (!installed) {
       this.fail(
         context,
@@ -616,9 +694,10 @@ export class RunnerReadinessService {
     if (!setup.success) {
       this.fail(context, "runner-setup", 1, setup.error ?? setup.message);
     }
-    const [installed, enabled] = await this.runPhase(context, "runner-setup", 1, (signal) =>
-      Promise.all([manager.isInstalled(signal), manager.isEnabled(signal)]),
-    );
+    const [installed, enabled] = await this.runPhase(context, "runner-setup", 1, async (signal) => [
+      await manager.isInstalled(signal),
+      await manager.isEnabled(signal),
+    ]);
     if (!installed || !enabled) {
       this.fail(
         context,
@@ -956,6 +1035,9 @@ export class RunnerReadinessService {
     throw new RunnerReadinessError(
       `${context.operationName ?? "startDevice"} automation runner readiness failed: ${mapping} phase=${phase} ` +
         `attempts=${attempts} remainingBudgetMs=${this.remainingForPhase(context, phase)}: ${normalizeDiagnostic(detail)}`,
+      device.platform === "android" &&
+        RunnerReadinessService.isSetupPhase(phase) &&
+        isAndroidFrameworkUnavailable(detail),
     );
   }
 }
@@ -1002,7 +1084,7 @@ async function getDefaultAndroidFrameworkReadiness(
   }
   if (
     settingsLookup.status === "rejected" ||
-    settingsLookup.value.stdout.includes("Can't find service")
+    isAndroidFrameworkUnavailable(`${settingsLookup.value.stdout}\n${settingsLookup.value.stderr}`)
   ) {
     unavailableResources.push("settings");
     diagnostics.push(

--- a/src/utils/android-cmdline-tools/isAndroidFrameworkUnavailable.ts
+++ b/src/utils/android-cmdline-tools/isAndroidFrameworkUnavailable.ts
@@ -1,0 +1,8 @@
+import { errorMessage } from "../describeUnknownError";
+
+/** Only missing framework services identify a retryable Android boot failure. */
+export function isAndroidFrameworkUnavailable(error: unknown): boolean {
+  return /\b(?:can't|cannot) find service:\s*(?:package|settings)(?=$|[\s"'.,;])/i.test(
+    errorMessage(error),
+  );
+}

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -3914,6 +3914,101 @@ describe("DaemonMcpProxy", () => {
   });
 
   describe("fresh session screenshot binding (#5663)", () => {
+    test.each([false, true])(
+      "binds and heartbeats a provisioned session even when resource configuration failed: %s",
+      async (isError) => {
+        const result = {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                sessionUuid: "provisioned-session",
+                sessionId: "provisioned-session",
+              }),
+            },
+          ],
+          isError,
+        };
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+          toolResultFor: (name) =>
+            name === "provisionDevice"
+              ? result
+              : name === "getAndroid"
+                ? {
+                    content: [
+                      { type: "text", text: JSON.stringify({ sessionUuid: "released-session" }) },
+                    ],
+                  }
+                : undefined,
+        });
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: matchingDaemonManager(),
+          autoStartDaemon: false,
+          timer: new FakeTimer(),
+        });
+
+        try {
+          await proxy.callTool("getAndroid", {});
+          fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "released-session");
+          expect(await proxy.callTool("provisionDevice", {})).toEqual(result);
+          expect(fakeClient.callToolCalls.at(-1)).toEqual({
+            toolName: "provisionDevice",
+            params: {},
+          });
+          expect(
+            fakeClient.callDaemonMethodCalls.filter((call) => call.method === "daemon/heartbeat"),
+          ).toEqual([
+            { method: "daemon/heartbeat", params: { sessionId: "released-session" } },
+            { method: "daemon/heartbeat", params: { sessionId: "provisioned-session" } },
+          ]);
+          await proxy.callTool("observe", {});
+          expect(fakeClient.callToolCalls.at(-1)).toEqual({
+            toolName: "observe",
+            params: { sessionUuid: "provisioned-session" },
+          });
+          await proxy.readResource("automobile:device-session/provisioned-session/screenshot");
+          expect(fakeClient.readResourceParams).toEqual([{ sessionUuid: "provisioned-session" }]);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      },
+    );
+
+    test.each([false, true])(
+      "does not bind provisioning without a minted session (isError: %s)",
+      async (isError) => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+          toolResult: {
+            content: [{ type: "text", text: JSON.stringify({ lifecycleState: "created" }) }],
+            isError,
+          },
+        });
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: matchingDaemonManager(),
+          autoStartDaemon: false,
+          timer: new FakeTimer(),
+        });
+        try {
+          await proxy.callTool("provisionDevice", { boot: false });
+          expect(
+            fakeClient.callDaemonMethodCalls.filter((call) => call.method === "daemon/heartbeat"),
+          ).toEqual([]);
+          await proxy.callTool("observe", {});
+          expect(fakeClient.callToolCalls.at(-1)).toEqual({ toolName: "observe", params: {} });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      },
+    );
+
     // A device-session acquisition tool mints its session id in the RESULT. This
     // models getAndroid/getApple returning `{ sessionId }`.
     const mintingResult = (sessionUuid: string) => ({

--- a/test/server/deviceTools.provisionDevice.test.ts
+++ b/test/server/deviceTools.provisionDevice.test.ts
@@ -706,8 +706,49 @@ describe("provisionDevice handler", () => {
     expect(result).toMatchObject({
       lifecycleState: "ready",
       readiness: { mode: "automation", status: "automation_ready" },
+      sessionUuid: expect.any(String),
       sessionId: expect.any(String),
     });
+  });
+
+  test.each(["android", "ios"] as const)(
+    "exposes sessionUuid for fresh booted %s provisioning while retaining sessionId",
+    async (platform) => {
+      exactProvisioner.provision = async () => provisionedTestDevice(platform, false);
+      deviceManager.setBootedDevices(platform, [
+        {
+          name: provisionTestArgs(platform, "unused").device.name,
+          platform,
+          deviceId: platform === "android" ? "emulator-5554" : "SIM-123",
+        },
+      ]);
+
+      const response = JSON.parse(
+        (
+          (await ToolRegistry.getTool("provisionDevice")!.handler({
+            ...provisionTestArgs(platform, `operation-public-session-${platform}`),
+            readiness: "none",
+          })) as any
+        ).content[0].text,
+      );
+
+      expect(response.sessionUuid).toEqual(expect.any(String));
+    },
+  );
+
+  test("does not expose a session for boot:false provisioning", async () => {
+    const response = JSON.parse(
+      (
+        (await ToolRegistry.getTool("provisionDevice")!.handler({
+          ...provisionTestArgs("android", "operation-no-session"),
+          boot: false,
+          readiness: "none",
+        })) as any
+      ).content[0].text,
+    );
+
+    expect(response.sessionUuid).toBeUndefined();
+    expect(response.sessionId).toBeUndefined();
   });
 
   for (const platform of ["android", "ios"] as const) {
@@ -1568,8 +1609,9 @@ describe("provisionDevice handler", () => {
     );
 
     expect(readinessCalls).toBe(0);
+    expect(response.sessionUuid).toEqual(expect.any(String));
     expect(response.sessionId).toEqual(expect.any(String));
-    expect(sessionManager.getDeviceReadiness(response.sessionId)).toBe("booted");
+    expect(sessionManager.getDeviceReadiness(response.sessionUuid)).toBe("booted");
     sessionManager.stopCleanupTimer();
   });
 
@@ -1624,7 +1666,8 @@ describe("provisionDevice handler", () => {
           })) as any
         ).content[0].text,
       );
-      const sessionUuid = response.sessionId as string;
+      const sessionUuid = response.sessionUuid as string;
+      expect(response.sessionId).toEqual(expect.any(String));
       expect(sessionManager.getDeviceReadiness(sessionUuid)).toBe("booted");
 
       ToolRegistry.registerDeviceAware(

--- a/test/server/deviceTools.provisionDevice.test.ts
+++ b/test/server/deviceTools.provisionDevice.test.ts
@@ -342,7 +342,14 @@ describe("provisionDevice handler", () => {
     });
     expect(readinessBudget).toBeGreaterThan(0);
     expect((response as any).isError).toBe(true);
-    expect(JSON.parse((response as any).content[0].text)).toMatchObject({
+    const payload = JSON.parse((response as any).content[0].text);
+    expect(Object.hasOwn(payload, "sessionUuid")).toBe(true);
+    expect(Object.hasOwn(payload, "sessionId")).toBe(true);
+    expect(payload.sessionUuid).toBe(payload.sessionId);
+    const persisted = operationStore.getStoredResult("resource-timeout")!;
+    expect(persisted.sessionId).toBe(payload.sessionUuid);
+    expect(Object.hasOwn(persisted, "sessionUuid")).toBe(false);
+    expect(payload).toMatchObject({
       success: false,
       created: true,
       device: { deviceId: "emulator-5554" },
@@ -733,23 +740,35 @@ describe("provisionDevice handler", () => {
       );
 
       expect(response.sessionUuid).toEqual(expect.any(String));
+      expect(Object.hasOwn(response, "sessionUuid")).toBe(true);
+      expect(Object.hasOwn(response, "sessionId")).toBe(true);
+      expect(response.sessionUuid).toBe(response.sessionId);
+      const persisted = operationStore.getStoredResult(`operation-public-session-${platform}`)!;
+      expect(persisted.sessionId).toBe(response.sessionUuid);
+      expect(Object.hasOwn(persisted, "sessionUuid")).toBe(false);
     },
   );
 
-  test("does not expose a session for boot:false provisioning", async () => {
-    const response = JSON.parse(
-      (
-        (await ToolRegistry.getTool("provisionDevice")!.handler({
-          ...provisionTestArgs("android", "operation-no-session"),
-          boot: false,
-          readiness: "none",
-        })) as any
-      ).content[0].text,
-    );
+  test.each(["android", "ios"] as const)(
+    "does not expose a session for boot:false %s provisioning",
+    async (platform) => {
+      const response = JSON.parse(
+        (
+          (await ToolRegistry.getTool("provisionDevice")!.handler({
+            ...provisionTestArgs(platform, "operation-no-session"),
+            boot: false,
+            readiness: "none",
+          })) as any
+        ).content[0].text,
+      );
 
-    expect(response.sessionUuid).toBeUndefined();
-    expect(response.sessionId).toBeUndefined();
-  });
+      expect(Object.hasOwn(response, "sessionUuid")).toBe(false);
+      expect(Object.hasOwn(response, "sessionId")).toBe(false);
+      const persisted = operationStore.getStoredResult("operation-no-session")!;
+      expect(Object.hasOwn(persisted, "sessionUuid")).toBe(false);
+      expect(Object.hasOwn(persisted, "sessionId")).toBe(false);
+    },
+  );
 
   for (const platform of ["android", "ios"] as const) {
     test(`${platform}: cleans up a newly created device when readiness fails`, async () => {
@@ -1461,11 +1480,19 @@ describe("provisionDevice handler", () => {
     expect(exactProvisioner.requests).toHaveLength(2);
     expect(exactProvisioner.requests[1]?.reconcileExistingConfiguration).toBe(false);
     expect(deviceManager.getCallCount("getBootedDevices")).toBeGreaterThanOrEqual(2);
+    for (const response of [first, second]) {
+      expect(Object.hasOwn(response, "sessionUuid")).toBe(true);
+      expect(Object.hasOwn(response, "sessionId")).toBe(true);
+      expect(response.sessionUuid).toBe(response.sessionId);
+    }
     expect(second).toMatchObject({
       lifecycleState: "ready",
       sessionId: expect.any(String),
     });
-    expect(second.sessionId).not.toBe(first.sessionId);
+    expect(second.sessionUuid).not.toBe(first.sessionUuid);
+    const persisted = operationStore.getStoredResult(args.operationId)!;
+    expect(persisted.sessionId).toBe(second.sessionUuid);
+    expect(Object.hasOwn(persisted, "sessionUuid")).toBe(false);
   });
 
   test.each([false, true])(
@@ -1528,7 +1555,15 @@ describe("provisionDevice handler", () => {
       const first = JSON.parse(((await tool.handler(args)) as any).content[0].text);
       const second = JSON.parse(((await tool.handler(args)) as any).content[0].text);
 
+      for (const response of [first, second]) {
+        expect(Object.hasOwn(response, "sessionUuid")).toBe(true);
+        expect(Object.hasOwn(response, "sessionId")).toBe(true);
+        expect(response.sessionUuid).toBe(response.sessionId);
+      }
       expect(second).toEqual(first);
+      const persisted = operationStore.getStoredResult(args.operationId)!;
+      expect(persisted.sessionId).toBe(second.sessionUuid);
+      expect(Object.hasOwn(persisted, "sessionUuid")).toBe(false);
       expect(exactProvisioner.requests).toHaveLength(1);
       expect(deviceManager.getCallCount("startDevice")).toBe(1);
       expect(readinessCalls).toBe(2);
@@ -1544,12 +1579,19 @@ describe("provisionDevice handler", () => {
         };
         const drift = await tool.handler(args);
         expect((drift as any).isError).toBe(true);
-        expect(JSON.parse((drift as any).content[0].text).sessionId).toBe(first.sessionId);
+        const driftPayload = JSON.parse((drift as any).content[0].text);
+        expect(Object.hasOwn(driftPayload, "sessionUuid")).toBe(true);
+        expect(Object.hasOwn(driftPayload, "sessionId")).toBe(true);
+        expect(driftPayload.sessionUuid).toBe(driftPayload.sessionId);
+        expect(driftPayload.sessionUuid).toBe(first.sessionUuid);
         expect(exactProvisioner.requests).toHaveLength(1);
         expect(readinessCalls).toBe(3);
         expect(operationStore.getStoredResult(args.operationId)?.resources).toMatchObject({
           success: false,
         });
+        const persistedDrift = operationStore.getStoredResult(args.operationId)!;
+        expect(persistedDrift.sessionId).toBe(driftPayload.sessionUuid);
+        expect(Object.hasOwn(persistedDrift, "sessionUuid")).toBe(false);
       }
       sessionManager.stopCleanupTimer();
     },
@@ -1771,10 +1813,18 @@ describe("provisionDevice handler", () => {
         ).content[0].text,
       );
 
+      for (const response of [first, second]) {
+        expect(Object.hasOwn(response, "sessionUuid")).toBe(true);
+        expect(Object.hasOwn(response, "sessionId")).toBe(true);
+        expect(response.sessionUuid).toBe(response.sessionId);
+      }
       expect(second).toEqual(first);
       expect(pool.resolveAutolockSessionForMcpSession("mcp-session-reconnected", "android")).toBe(
         first.sessionId,
       );
+      const persisted = operationStore.getStoredResult(args.operationId)!;
+      expect(persisted.sessionId).toBe(second.sessionUuid);
+      expect(Object.hasOwn(persisted, "sessionUuid")).toBe(false);
     } finally {
       sessionManager.stopCleanupTimer();
       if (originalAutolock === undefined) {
@@ -1890,11 +1940,19 @@ describe("provisionDevice handler", () => {
     pooledDevice.status = "error";
     const second = JSON.parse(((await tool.handler(args)) as any).content[0].text);
 
+    for (const response of [first, second]) {
+      expect(Object.hasOwn(response, "sessionUuid")).toBe(true);
+      expect(Object.hasOwn(response, "sessionId")).toBe(true);
+      expect(response.sessionUuid).toBe(response.sessionId);
+    }
     expect(second).toMatchObject({
       lifecycleState: "ready",
       sessionId: expect.any(String),
     });
-    expect(second.sessionId).not.toBe(first.sessionId);
+    expect(second.sessionUuid).not.toBe(first.sessionUuid);
+    const persisted = operationStore.getStoredResult(args.operationId)!;
+    expect(persisted.sessionId).toBe(second.sessionUuid);
+    expect(Object.hasOwn(persisted, "sessionUuid")).toBe(false);
     expect(exactProvisioner.requests).toHaveLength(2);
     expect(pool.getDevice(bootedDevice.deviceId)?.status).toBe("busy");
     sessionManager.stopCleanupTimer();

--- a/test/server/sessionResourceBinding.integration.test.ts
+++ b/test/server/sessionResourceBinding.integration.test.ts
@@ -15,45 +15,58 @@ describe("session-scoped resource binding", () => {
     ResourceRegistry.clearResources();
   });
 
-  test("binds the session returned by direct getAndroid for later resource reads", async () => {
-    fixture = new McpTestFixture();
-    await fixture.setup();
+  test.each([
+    { toolName: "getAndroid", isError: false },
+    { toolName: "getApple", isError: false },
+    { toolName: "startDevice", isError: false },
+    { toolName: "provisionDevice", isError: false },
+    { toolName: "provisionDevice", isError: true },
+  ])(
+    "binds direct acquisition results for later resource reads: %j",
+    async ({ toolName, isError }) => {
+      fixture = new McpTestFixture();
+      await fixture.setup();
 
-    ToolRegistry.clearTools();
-    ToolRegistry.register("getAndroid", "getAndroid", z.object({}), async () =>
-      createJSONToolResponse({ sessionId: "direct-session-1" }),
-    );
-    ResourceRegistry.registerTemplateWithReadContext(
-      "automobile:test-session-binding/{sessionUuid}",
-      "Session binding test",
-      "Returns the bound session for transport binding coverage.",
-      "application/json",
-      async (_params, context) => ({
-        uri: "automobile:test-session-binding/direct-session-1",
-        text: JSON.stringify({ sessionUuid: context.sessionUuid }),
-      }),
-    );
+      ToolRegistry.clearTools();
+      ToolRegistry.register(toolName, toolName, z.object({}), async () => ({
+        ...createJSONToolResponse({
+          sessionUuid: "direct-session-1",
+          sessionId: "direct-session-1",
+        }),
+        isError,
+      }));
+      ResourceRegistry.registerTemplateWithReadContext(
+        "automobile:test-session-binding/{sessionUuid}",
+        "Session binding test",
+        "Returns the bound session for transport binding coverage.",
+        "application/json",
+        async (_params, context) => ({
+          uri: "automobile:test-session-binding/direct-session-1",
+          text: JSON.stringify({ sessionUuid: context.sessionUuid }),
+        }),
+      );
 
-    const { client } = fixture.getContext();
-    await client.request(
-      {
-        method: "tools/call",
-        params: { name: "getAndroid", arguments: {} },
-      },
-      z.any(),
-    );
-    const response = await client.request(
-      {
-        method: "resources/read",
-        params: { uri: "automobile:test-session-binding/direct-session-1" },
-      },
-      z.object({
-        contents: z.array(z.object({ text: z.string().optional() })),
-      }),
-    );
+      const { client } = fixture.getContext();
+      await client.request(
+        {
+          method: "tools/call",
+          params: { name: toolName, arguments: {} },
+        },
+        z.any(),
+      );
+      const response = await client.request(
+        {
+          method: "resources/read",
+          params: { uri: "automobile:test-session-binding/direct-session-1" },
+        },
+        z.object({
+          contents: z.array(z.object({ text: z.string().optional() })),
+        }),
+      );
 
-    expect(JSON.parse(response.contents[0].text!)).toEqual({
-      sessionUuid: "direct-session-1",
-    });
-  });
+      expect(JSON.parse(response.contents[0].text!)).toEqual({
+        sessionUuid: "direct-session-1",
+      });
+    },
+  );
 });

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -99,6 +99,50 @@ describe("CtrlProxyManager", function () {
       process.env[DAEMON_LAUNCH_CWD_ENV] = originalLaunchCwdEnv;
     }
   });
+
+  describe("framework boot failures", () => {
+    for (const { method, command, service, readyOutput } of [
+      {
+        method: "isInstalled" as const,
+        command: `shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`,
+        service: "package",
+        readyOutput: `package:${AndroidCtrlProxyManager.PACKAGE}`,
+      },
+      {
+        method: "isEnabled" as const,
+        command: "shell settings get secure enabled_accessibility_services",
+        service: "settings",
+        readyOutput: `${AndroidCtrlProxyManager.PACKAGE}/.CtrlProxy`,
+      },
+    ]) {
+      test.each(["stdout", "stderr"] as const)(
+        `${method} preserves missing service output from %s and recovers`,
+        async (stream) => {
+          const diagnostic = `cmd: Can't find service: ${service}`;
+          fakeAdb.setCommandResponseSequence(command, [
+            { stdout: "", stderr: "", [stream]: diagnostic },
+            { stdout: readyOutput, stderr: "" },
+          ]);
+
+          await expect(accessibilityServiceClient[method]()).rejects.toThrow(diagnostic);
+          await expect(accessibilityServiceClient[method]()).resolves.toBe(true);
+        },
+      );
+
+      test(`${method} preserves a thrown missing service error`, async () => {
+        const diagnostic = `Can't find service: ${service}`;
+        fakeAdb.setCommandError(command, new Error(diagnostic));
+
+        await expect(accessibilityServiceClient[method]()).rejects.toThrow(diagnostic);
+      });
+
+      test(`${method} retains the false result for permission failures`, async () => {
+        fakeAdb.setCommandError(command, new Error("Permission denied"));
+
+        await expect(accessibilityServiceClient[method]()).resolves.toBe(false);
+      });
+    }
+  });
   describe("isInstalled", function () {
     test("should return true when accessibility service package is installed", async function () {
       fakeAdb.setCommandResponse(

--- a/test/utils/RunnerReadinessService.test.ts
+++ b/test/utils/RunnerReadinessService.test.ts
@@ -303,17 +303,14 @@ function appScreenMimickingEnglishSystemUiAnr(): ViewHierarchyResult {
 describe("RunnerReadinessService", () => {
   test("does not let Android framework inspection block runner setup", async () => {
     const inspectionStarted = Promise.withResolvers<void>();
+    const inspection = Promise.withResolvers<AndroidFrameworkReadinessResult>();
     const androidClient = new FakeReadinessClient();
     androidClient.connected = false;
     const { service, androidManager } = createService({
       androidClient,
       getAndroidFrameworkReadiness: async () => {
         inspectionStarted.resolve();
-        return {
-          ready: false,
-          unavailableResources: ["package", "settings"],
-          diagnostic: "cmd: Can't find service: package",
-        };
+        return inspection.promise;
       },
     });
 
@@ -325,6 +322,293 @@ describe("RunnerReadinessService", () => {
     });
     await inspectionStarted.promise;
     expect(androidManager.setupCalls).toBe(1);
+    inspection.resolve({ ready: true });
+  });
+
+  test.each(["throw", "reject"])("contains a diagnostic probe that %ss", async (failure) => {
+    const { service } = createService({
+      getAndroidFrameworkReadiness: () => {
+        const error = new Error("diagnostic unavailable");
+        if (failure === "throw") {
+          throw error;
+        }
+        return Promise.reject(error);
+      },
+    });
+    await service.ensureReady({
+      device: androidDevice(),
+      requestedIdentity: "android",
+      totalDeadlineMs: 30_000,
+      readinessTimeoutMs: 10_000,
+    });
+  });
+
+  test("settles owned diagnostic work before successive readiness calls return", async () => {
+    let active = 0;
+    const signals: AbortSignal[] = [];
+    const androidClient = new FakeReadinessClient();
+    androidClient.healthResults = [true, true];
+    const { service } = createService({
+      androidClient,
+      getAndroidFrameworkReadiness: async (_device, signal) => {
+        active++;
+        signals.push(signal);
+        try {
+          return await new Promise<AndroidFrameworkReadinessResult>((_resolve, reject) => {
+            signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+          });
+        } finally {
+          active--;
+        }
+      },
+    });
+    for (let i = 0; i < 2; i++) {
+      await service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "android",
+        totalDeadlineMs: 30_000,
+        readinessTimeoutMs: 10_000,
+      });
+      expect(active).toBe(0);
+      expect(signals[i]?.aborted).toBe(true);
+    }
+  });
+
+  test.each(["package", "settings"])(
+    "retries required setup when %s appears later",
+    async (resource) => {
+      const manager = new FakeAndroidManager();
+      let attempts = 0;
+      manager.ensureCompatibleVersion = async () => {
+        attempts++;
+        return attempts === 1
+          ? { status: "failed", error: `Can't find service: ${resource}` }
+          : { status: "compatible" };
+      };
+      const { service, timer } = createService({ androidManager: manager });
+      await service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "android",
+        totalDeadlineMs: 1_000,
+        readinessTimeoutMs: 500,
+      });
+      expect(attempts).toBe(2);
+      expect(timer.now()).toBe(250);
+    },
+  );
+
+  test("retries thrown framework setup failures and resets the setup gate", async () => {
+    const manager = new FakeAndroidManager();
+    manager.installed = false;
+    manager.setup = async () => {
+      manager.setupCalls++;
+      if (manager.setupCalls === 1) {
+        throw new Error("Can't find service: settings");
+      }
+      manager.installed = true;
+      return { success: true, message: "ready" };
+    };
+    const { service } = createService({ androidManager: manager });
+    await service.ensureReady({
+      device: androidDevice(),
+      requestedIdentity: "android",
+      totalDeadlineMs: 1_000,
+      readinessTimeoutMs: 500,
+    });
+    expect(manager.setupCalls).toBe(2);
+    expect(manager.resetSetupStateCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  test("stops transient setup retries at the shared absolute deadline", async () => {
+    const manager = new FakeAndroidManager();
+    let attempts = 0;
+    manager.ensureCompatibleVersion = async () => {
+      attempts++;
+      throw new Error("Can't find service: package");
+    };
+    const { service, timer } = createService({ androidManager: manager });
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "android",
+        totalDeadlineMs: 600,
+        readinessTimeoutMs: 500,
+      }),
+    ).rejects.toThrow(/Can't find service: package/);
+    expect(attempts).toBe(3);
+    expect(timer.now()).toBe(600);
+  });
+
+  test.each(["package", "settings"])(
+    "retries missing %s with runner downloads disabled",
+    async (resource) => {
+      const manager = new FakeAndroidManager();
+      let reads = 0;
+      const read = async () => {
+        reads++;
+        if (reads === 1) {
+          throw new Error(`Can't find service: ${resource}`);
+        }
+        return true;
+      };
+      if (resource === "package") {
+        manager.isInstalled = read;
+      } else {
+        manager.isEnabled = read;
+      }
+      const { service } = createService({ androidManager: manager });
+      await service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "android",
+        totalDeadlineMs: 1_000,
+        readinessTimeoutMs: 500,
+        skipCtrlProxyDownload: true,
+      });
+      expect(reads).toBe(2);
+      expect(manager.setupCalls).toBe(0);
+    },
+  );
+
+  test("does not retry permanent setup errors because an optional probe is unready", async () => {
+    const manager = new FakeAndroidManager();
+    let attempts = 0;
+    manager.ensureCompatibleVersion = async () => {
+      attempts++;
+      return { status: "failed", error: "INSTALL_FAILED_INVALID_APK" };
+    };
+    const { service, timer } = createService({
+      androidManager: manager,
+      getAndroidFrameworkReadiness: async () => ({
+        ready: false,
+        unavailableResources: ["package"],
+      }),
+    });
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "android",
+        totalDeadlineMs: 30_000,
+        readinessTimeoutMs: 10_000,
+      }),
+    ).rejects.toThrow("INSTALL_FAILED_INVALID_APK");
+    expect(attempts).toBe(1);
+    expect(timer.now()).toBe(0);
+  });
+
+  test("classifies the setup failure without treating device names as diagnostics", async () => {
+    const manager = new FakeAndroidManager();
+    let attempts = 0;
+    manager.ensureCompatibleVersion = async () => {
+      attempts++;
+      return { status: "failed", error: "INSTALL_FAILED_INVALID_APK" };
+    };
+    const { service } = createService({ androidManager: manager });
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "Can't find service: package ",
+        totalDeadlineMs: 1_000,
+        readinessTimeoutMs: 500,
+      }),
+    ).rejects.toThrow("INSTALL_FAILED_INVALID_APK");
+    expect(attempts).toBe(1);
+  });
+
+  test("does not leave a sibling status read running across a framework retry", async () => {
+    const manager = new FakeAndroidManager();
+    let installationReads = 0;
+    let active = 0;
+    manager.isInstalled = async () => {
+      installationReads++;
+      if (installationReads === 1) {
+        throw new Error("Can't find service: package");
+      }
+      return true;
+    };
+    manager.isEnabled = async () => {
+      if (installationReads === 1) {
+        active++;
+        return new Promise<boolean>(() => {});
+      }
+      return true;
+    };
+    const { service } = createService({ androidManager: manager });
+    await service.ensureReady({
+      device: androidDevice(),
+      requestedIdentity: "android",
+      totalDeadlineMs: 1_000,
+      readinessTimeoutMs: 500,
+    });
+    expect(installationReads).toBe(2);
+    expect(active).toBe(0);
+  });
+
+  test.each(["failure", "cancellation"])(
+    "aborts diagnostic work when required readiness ends in %s",
+    async (outcome) => {
+      const controller = new AbortController();
+      let inspectionSignal: AbortSignal | undefined;
+      let settled = false;
+      const manager = new FakeAndroidManager();
+      manager.ensureCompatibleVersion = async () => {
+        if (outcome === "cancellation") {
+          controller.abort(new Error("caller cancelled"));
+        }
+        throw new Error("required setup failed");
+      };
+      const { service } = createService({
+        androidManager: manager,
+        getAndroidFrameworkReadiness: async (_device, signal) => {
+          inspectionSignal = signal;
+          try {
+            signal.throwIfAborted();
+            return await new Promise<AndroidFrameworkReadinessResult>((_resolve, reject) => {
+              signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+            });
+          } finally {
+            settled = true;
+          }
+        },
+      });
+      await expect(
+        service.ensureReady({
+          device: androidDevice(),
+          requestedIdentity: "android",
+          totalDeadlineMs: 30_000,
+          readinessTimeoutMs: 10_000,
+          signal: controller.signal,
+        }),
+      ).rejects.toThrow(outcome === "cancellation" ? "caller cancelled" : "required setup failed");
+      // Cancellation can prevent the deferred probe from starting at all.
+      if (inspectionSignal) {
+        expect(inspectionSignal.aborted).toBe(true);
+        expect(settled).toBe(true);
+      }
+    },
+  );
+
+  test("cancels a transient retry delay without starting another setup", async () => {
+    const timer = new FakeTimer();
+    const controller = new AbortController();
+    const manager = new FakeAndroidManager();
+    let attempts = 0;
+    manager.ensureCompatibleVersion = async () => {
+      attempts++;
+      throw new Error("Can't find service: package");
+    };
+    const { service } = createService({ timer, androidManager: manager, autoAdvance: false });
+    const ready = service.ensureReady({
+      device: androidDevice(),
+      requestedIdentity: "android",
+      totalDeadlineMs: 30_000,
+      readinessTimeoutMs: 10_000,
+      signal: controller.signal,
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    controller.abort(new Error("caller cancelled"));
+    await expect(ready).rejects.toThrow("caller cancelled");
+    expect(attempts).toBe(1);
+    expect(timer.now()).toBe(0);
   });
 
   test("does not let a permanent framework inspection failure prevent readiness", async () => {
@@ -345,6 +629,32 @@ describe("RunnerReadinessService", () => {
         signal: controller.signal,
       }),
     ).resolves.toBeUndefined();
+  });
+
+  test("propagates cancellation arriving while diagnostic work settles", async () => {
+    const controller = new AbortController();
+    const { service } = createService({
+      getAndroidFrameworkReadiness: async (_device, signal) =>
+        new Promise<AndroidFrameworkReadinessResult>((resolve) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              controller.abort(new Error("cancelled during diagnostic cleanup"));
+              resolve({ ready: true });
+            },
+            { once: true },
+          );
+        }),
+    });
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "android",
+        totalDeadlineMs: 30_000,
+        readinessTimeoutMs: 10_000,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("cancelled during diagnostic cleanup");
   });
 
   test("keeps an already-ready Android device on the fast path", async () => {

--- a/test/utils/RunnerReadinessService.test.ts
+++ b/test/utils/RunnerReadinessService.test.ts
@@ -3,6 +3,7 @@ import type { BootedDevice } from "../../src/models";
 import {
   RunnerReadinessService,
   SystemUiAnrRecoveryRequiredError,
+  type AndroidFrameworkReadinessResult,
   type ReadinessAndroidManager,
   type ReadinessClient,
   type ReadinessIosManager,
@@ -187,6 +188,11 @@ function createService(
     getIosClient?: (device: BootedDevice, port: number) => FakeReadinessClient;
     autoAdvance?: boolean;
     awaitIosStartupMaintenance?: () => Promise<void>;
+    getAndroidFrameworkReadiness?: (
+      device: BootedDevice,
+      signal: AbortSignal,
+      timeoutMs: number,
+    ) => Promise<AndroidFrameworkReadinessResult>;
     getAndroidRunnerConnectDiagnostic?: () => Promise<{
       deviceLock: { locked: boolean; keyguardShowing: boolean; secure?: boolean } | null;
       primaryUserStartState?: string;
@@ -209,6 +215,7 @@ function createService(
     iosClient,
     service: new RunnerReadinessService({
       timer,
+      getAndroidFrameworkReadiness: options.getAndroidFrameworkReadiness,
       getAndroidManager: () => androidManager,
       getAndroidClient: () => androidClient,
       getIosManager: () => iosManager,
@@ -294,6 +301,52 @@ function appScreenMimickingEnglishSystemUiAnr(): ViewHierarchyResult {
 }
 
 describe("RunnerReadinessService", () => {
+  test("does not let Android framework inspection block runner setup", async () => {
+    const inspectionStarted = Promise.withResolvers<void>();
+    const androidClient = new FakeReadinessClient();
+    androidClient.connected = false;
+    const { service, androidManager } = createService({
+      androidClient,
+      getAndroidFrameworkReadiness: async () => {
+        inspectionStarted.resolve();
+        return {
+          ready: false,
+          unavailableResources: ["package", "settings"],
+          diagnostic: "cmd: Can't find service: package",
+        };
+      },
+    });
+
+    await service.ensureReady({
+      device: androidDevice(),
+      requestedIdentity: "platform=android name=Pixel_9_Pro",
+      totalDeadlineMs: 30_000,
+      readinessTimeoutMs: 10_000,
+    });
+    await inspectionStarted.promise;
+    expect(androidManager.setupCalls).toBe(1);
+  });
+
+  test("does not let a permanent framework inspection failure prevent readiness", async () => {
+    const controller = new AbortController();
+    const { service } = createService({
+      getAndroidFrameworkReadiness: async () => ({
+        ready: false,
+        unavailableResources: ["package", "settings"],
+      }),
+    });
+
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "platform=android name=Pixel_9_Pro",
+        totalDeadlineMs: 30_000,
+        readinessTimeoutMs: 10_000,
+        signal: controller.signal,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   test("keeps an already-ready Android device on the fast path", async () => {
     const { service, androidManager, androidClient } = createService();
 

--- a/test/utils/android-cmdline-tools/isAndroidFrameworkUnavailable.test.ts
+++ b/test/utils/android-cmdline-tools/isAndroidFrameworkUnavailable.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { isAndroidFrameworkUnavailable } from "../../../src/utils/android-cmdline-tools/isAndroidFrameworkUnavailable";
+
+describe("isAndroidFrameworkUnavailable", () => {
+  test.each([
+    "cmd: Can't find service: package",
+    "Can't find service: settings\n",
+    "Cannot find service: package",
+    new Error("runner setup failed: Can't find service: settings; retry later"),
+  ])("recognizes an unavailable package/settings service: %s", (diagnostic) => {
+    expect(isAndroidFrameworkUnavailable(diagnostic)).toBe(true);
+  });
+
+  test.each([
+    "Permission denied",
+    "adb: device offline",
+    "device unauthorized",
+    "INSTALL_FAILED_INVALID_APK",
+    "Can't find service: accessibility",
+    "Can't find service: package_installer",
+    "Can't find service: settings_backup",
+    "Package not found",
+    "settings permission denied",
+    undefined,
+  ])("does not retry unrelated failures: %s", (diagnostic) => {
+    expect(isAndroidFrameworkUnavailable(diagnostic)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Booted `provisionDevice` results expose `sessionUuid` alongside the equal `sessionId` compatibility alias. Both direct MCP connections and the daemon proxy bind these acquired sessions; the proxy starts ownership heartbeats even when optional resource configuration returns an error with a retained session. Replay storage continues to use only `sessionId`.

Android runner setup retries explicit missing package/settings service failures within the original absolute deadline. Manager status reads preserve these transient failures, including when downloads are disabled. Permanent setup failures remain terminal. The existing retry executor provides cancellation-aware backoff, and status reads finish before another attempt begins.

Optional framework inspection stays diagnostic: synchronous throws and rejected promises cannot prevent readiness. Inspection has its own bounded lifetime, aborts when readiness settles, and observes bounded cleanup. Logs include redacted diagnostics.

## Validation

- 380 tests passed across provisioning, direct session binding, daemon proxy, Android manager, framework failure classification, and runner readiness suites.
- Regression coverage includes retained-session errors, Android/iOS aliases and persistence, replay/rebound, disabled boot/downloads, pending/rejecting/throwing probes, transient recovery, absolute deadlines, cancellation, and overlapping status reads.
- `bun run lint`: no new violations; all 13 boundary checks passed.
- `bun run build`, `bun run format:check`, and `git diff --check` passed.
- `bun run typecheck`: no new errors against the existing baseline.

The narrow framework classifier uses the standard library and existing error-message utility; no dependency was added.
