### PR TITLE
fix: enforce session ownership and safe device recovery

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -34,7 +34,7 @@ import { didSourceSucceedForDevice, type DiscoverySource } from "../utils/discov
 import { consolePortFromSerial } from "../utils/android-cmdline-tools/EmulatorConsoleClient";
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
-import { runWithAbortSignal } from "../utils/AbortContext";
+import { getAbortSignal, runWithAbortSignal } from "../utils/AbortContext";
 import { AndroidCommandOutputStreamRedactor } from "../utils/android-cmdline-tools/redactAndroidCommandOutput";
 import { boundedEmulatorOutputTail } from "../utils/android-cmdline-tools/AndroidEmulatorClient";
 import {
@@ -95,6 +95,15 @@ export class DevicePoolError extends Error {
 export type DeviceStatus = "idle" | "busy" | "error";
 type AndroidRediscoveryVerification = "rediscovered" | "not-rediscovered" | "unknown";
 export type CurrentDisconnectStatus = "current" | "recovered" | "unknown";
+class UnconfirmedRecoveryShutdownError extends ActionableError {
+  constructor(avdName: string, cause: unknown) {
+    super(
+      `Shutdown of Android emulator '${avdName}' is unconfirmed; recovery ownership remains quarantined`,
+      { cause },
+    );
+  }
+}
+
 export type SessionPreservingRecoveryResult =
   | "not-attempted"
   | "deferred"
@@ -2403,6 +2412,10 @@ export class DevicePool {
       finalized = true;
       return "released";
     } catch (error) {
+      if (error instanceof UnconfirmedRecoveryShutdownError) {
+        await this.completeEmulatorLossRecovery(incidentId, "exhausted");
+        return "deferred";
+      }
       try {
         await this.releasePreservedSessionAfterRecoveryFailure(device, session, incidentId);
         finalized = true;
@@ -2596,6 +2609,12 @@ export class DevicePool {
       }
       return recovered ? "recovered" : "released";
     } catch (error) {
+      if (error instanceof UnconfirmedRecoveryShutdownError) {
+        this.adbServerResetQuarantinedSessions.add(session.sessionId);
+        this.recoveringSessionLosses.set(session.sessionId, { deviceId: device.id, incidentId });
+        await this.completeEmulatorLossRecovery(incidentId, "exhausted");
+        return "deferred";
+      }
       try {
         await this.releasePreservedAdbResetSessionIfDetached(device, session, incidentId);
         await this.refreshEmulatorLossRecoverySettlement(incidentId, "exhausted");
@@ -2939,10 +2958,13 @@ export class DevicePool {
       for (const device of cohort) {
         if (device.adbServerResetSessionId) {
           const sessionId = device.adbServerResetSessionId;
-          if (this.canReleaseAdbServerResetSessionFence(device, sessionId)) {
-            this.adbServerResetQuarantinedSessions.delete(sessionId);
-            this.recoveringSessionLosses.delete(sessionId);
+          if (!this.canReleaseAdbServerResetSessionFence(device, sessionId)) {
+            // An unsettled owner must retain both its session fence and the
+            // AVD reservation, including after the cohort caller's finally.
+            continue;
           }
+          this.adbServerResetQuarantinedSessions.delete(sessionId);
+          this.recoveringSessionLosses.delete(sessionId);
         }
         if (!device.avdName) {
           continue;
@@ -3181,6 +3203,9 @@ export class DevicePool {
           error,
         );
         await this.completeEmulatorLossRecovery(incidentId, "exhausted");
+        if (error instanceof UnconfirmedRecoveryShutdownError) {
+          throw error;
+        }
         return false;
       }
       if (replacementState === "same-avd") {
@@ -3357,7 +3382,7 @@ export class DevicePool {
     const hadTrackedProcess = this.startedDeviceProcesses.has(device.id);
     await this.stopTrackedEmulatorProcess(device.id, retainLeaseUntil);
     if (!hadTrackedProcess) {
-      await this.stopDiscoveredEmulatorByAvdName(avdName);
+      await this.stopDiscoveredEmulatorByAvdName(avdName, retainLeaseUntil);
     }
     return "stopped";
   }
@@ -3546,24 +3571,87 @@ export class DevicePool {
     this.startedDeviceProcessOutput.delete(deviceId);
   }
 
-  private async stopDiscoveredEmulatorByAvdName(avdName: string): Promise<void> {
-    try {
-      const booted = await this.deviceManager.getBootedDevices("android");
+  private async stopDiscoveredEmulatorByAvdName(
+    avdName: string,
+    retainLeaseUntil: (settlement: Promise<unknown>) => void,
+  ): Promise<void> {
+    const timeoutMs = 30_000;
+    const deadlineMs = this.timer.now() + timeoutMs;
+    const deadlineController = new AbortController();
+    const callerSignal = getAbortSignal();
+    const signal = callerSignal
+      ? AbortSignal.any([callerSignal, deadlineController.signal])
+      : deadlineController.signal;
+    const timeoutError = new ActionableError(
+      `Android emulator '${avdName}' shutdown was not confirmed within ${timeoutMs}ms; recovery will not relaunch it`,
+    );
+    const timeout = this.timer.setTimeout(() => deadlineController.abort(timeoutError), timeoutMs);
+    let removeAbortListener: (() => void) | undefined;
+    const cancelled = new Promise<never>((_resolve, reject) => {
+      const abort = () => reject(signal.reason);
+      if (signal.aborted) {
+        abort();
+      } else {
+        signal.addEventListener("abort", abort, { once: true });
+        removeAbortListener = () => signal.removeEventListener("abort", abort);
+      }
+    });
+    const shutdown = runWithAbortSignal(signal, async () => {
+      const discover = async () => {
+        signal.throwIfAborted();
+        const discovery = await this.deviceManager.getBootedDevicesDetailed("android", {
+          bypassAndroidDeviceListCache: true,
+        });
+        signal.throwIfAborted();
+        if (!discovery.succeededPlatforms.has("android")) {
+          throw new ActionableError(
+            `Android discovery failed while confirming '${avdName}' shutdown; recovery will not relaunch it`,
+          );
+        }
+        if (discovery.devices.some((device) => device.name.startsWith("Unknown ("))) {
+          throw new ActionableError(
+            `Android discovery contains an unresolved emulator identity while stopping '${avdName}'; recovery will not relaunch it`,
+          );
+        }
+        return discovery.devices;
+      };
+      const booted = await discover();
       const matchingAvd = booted.find(
         (device) => device.platform === "android" && device.name === avdName,
       );
       if (!matchingAvd) {
         return;
       }
-      await this.deviceManager.killDevice(matchingAvd);
-      logger.info(`[DevicePool] Stopped untracked Android emulator ${avdName} before recovery`);
+      await this.deviceManager.killDevice(matchingAvd, {
+        timeoutMs: Math.max(1, deadlineMs - this.timer.now()),
+        signal,
+      });
+      signal.throwIfAborted();
+      for (;;) {
+        const devices = await discover();
+        // A same-AVD replacement still holds the image's locks; a different
+        // AVD reusing the old serial must be preserved without another kill.
+        const stillPresent = devices.some((device) => device.name === avdName);
+        if (!stillPresent) {
+          logger.info(
+            `[DevicePool] Confirmed untracked Android emulator ${avdName} stopped before recovery`,
+          );
+          return;
+        }
+        await this.timer.sleep(Math.min(1_000, Math.max(0, deadlineMs - this.timer.now())));
+        signal.throwIfAborted();
+      }
+    });
+    try {
+      await Promise.race([shutdown, cancelled]);
     } catch (error) {
-      // ADB may still be rebuilding after a process-wide kill-server. The
-      // bounded launch retries below make another recovery attempt without
-      // ever selecting an emulator by its recycled serial.
-      logger.warn(
-        `[DevicePool] Could not stop untracked Android emulator ${avdName} before recovery: ${error}`,
-      );
+      // A late command must settle before another lifecycle owner may mutate
+      // this AVD. Failure propagates before pool/session detachment or relaunch.
+      retainLeaseUntil(shutdown);
+      throw new UnconfirmedRecoveryShutdownError(avdName, error);
+    } finally {
+      this.timer.clearTimeout(timeout);
+      removeAbortListener?.();
     }
   }
 
@@ -4225,6 +4313,7 @@ export class DevicePool {
     unavailableMessage: string,
     readinessReservationOwners?: ReadonlySet<symbol>,
   ): Promise<void> {
+    this.assertDeviceCleanupComplete(device.id);
     if (device.status !== "idle" || device.sessionId) {
       return;
     }
@@ -4255,6 +4344,15 @@ export class DevicePool {
       `Unable to verify iOS ${noun} '${device.id}' is still booted before assignment.\n` +
         `iOS ${noun} discovery failed, so AutoMobile did not assign this pooled UDID.`,
     );
+  }
+
+  /** Exact-device acquisition must honor the same cleanup quarantine as allocation. */
+  assertDeviceCleanupComplete(deviceId: string): void {
+    if (this.sessionManager.hasDeviceCleanupInProgress(deviceId)) {
+      throw new ActionableError(
+        `Device '${deviceId}' is still completing session cleanup; retry after cleanup finishes.`,
+      );
+    }
   }
 
   /**
@@ -5337,6 +5435,7 @@ export class DevicePool {
         readinessReservationOwners,
       );
 
+      this.assertDeviceCleanupComplete(deviceId);
       if (device.sessionId) {
         const existingSession = this.sessionManager.getSession(device.sessionId);
         if (
@@ -5359,6 +5458,8 @@ export class DevicePool {
           );
         }
 
+        // Looking up an expired owner may itself start its release.
+        this.assertDeviceCleanupComplete(deviceId);
         device.sessionId = null;
         device.status = "idle";
       }
@@ -5742,6 +5843,7 @@ export class DevicePool {
       return reusedSessionId;
     }
 
+    this.assertDeviceCleanupComplete(deviceId);
     const sessionId = this.idGenerator.next();
     const assignmentSnapshot = this.snapshotSessionAssignment(device);
     device.sessionId = sessionId;

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -486,6 +486,16 @@ export class SessionManager {
     return this.pendingDeviceCleanups.get(deviceId) ?? null;
   }
 
+  /** Release owns the device until both bounded teardown and any overflow work settle. */
+  hasDeviceCleanupInProgress(deviceId: string): boolean {
+    return (
+      this.pendingDeviceCleanups.has(deviceId) ||
+      Array.from(this.activeReleasePromises).some(
+        (release) => release.session.assignedDevice === deviceId,
+      )
+    );
+  }
+
   /**
    * Keep sessions assigned while their work is still running, even if their
    * idle timeout elapses. The daemon supplies the execution tracker; tests can

--- a/src/processLifecycle.ts
+++ b/src/processLifecycle.ts
@@ -4,8 +4,9 @@ import { writeEmergencyLog } from "./utils/loggingConfig";
 export type ShutdownSignal = "SIGINT" | "SIGTERM" | "stdin";
 
 // A clean recording finalization alone requires one second. Leave enough time
-// for every child owner to receive a bounded stop or force-stop attempt.
-const PROCESS_SHUTDOWN_TIMEOUT_MS = 10_000;
+// for every child owner to receive a bounded stop or force-stop attempt, while
+// leaving the finalization tail below the daemon supervisor's 10-second kill.
+const PROCESS_SHUTDOWN_TIMEOUT_MS = 9_000;
 const PROCESS_SHUTDOWN_FINALIZATION_TIMEOUT_MS = 100;
 
 export interface StdinShutdownSource {
@@ -72,11 +73,11 @@ export class ProcessLifecycleHandlers {
   private installed = false;
   private stdinShutdownHandlersInstalled = false;
   private shutdownInProgress = false;
-  private stdinShutdownTimeoutArmed = false;
-  private stdinShutdownTimeoutHandle: NodeJS.Timeout | undefined;
-  private resolveStdinShutdownTimeout!: (value: false) => void;
-  private readonly stdinShutdownTimeout = new Promise<false>((resolve) => {
-    this.resolveStdinShutdownTimeout = resolve;
+  private shutdownTimeoutArmed = false;
+  private shutdownTimeoutHandle: NodeJS.Timeout | undefined;
+  private resolveShutdownTimeout!: (value: false) => void;
+  private readonly shutdownTimeout = new Promise<false>((resolve) => {
+    this.resolveShutdownTimeout = resolve;
   });
   private shutdownHandler: ProcessShutdownHandler | undefined;
   private shutdownTimeoutHandler: ProcessShutdownTimeoutHandler | undefined;
@@ -136,9 +137,6 @@ export class ProcessLifecycleHandlers {
 
   private async shutdown(signal: ShutdownSignal): Promise<void> {
     if (this.shutdownInProgress) {
-      if (signal === "stdin") {
-        this.armStdinShutdownTimeout();
-      }
       return;
     }
     this.shutdownInProgress = true;
@@ -163,27 +161,25 @@ export class ProcessLifecycleHandlers {
       return true;
     }
 
-    if (signal === "stdin") {
-      this.armStdinShutdownTimeout();
-    }
+    this.armShutdownTimeout();
 
     try {
-      return (await Promise.race([handler(signal), this.stdinShutdownTimeout])) !== false;
+      return (await Promise.race([handler(signal), this.shutdownTimeout])) !== false;
     } finally {
-      if (this.stdinShutdownTimeoutHandle !== undefined) {
-        this.timer.clearTimeout(this.stdinShutdownTimeoutHandle);
-        this.stdinShutdownTimeoutHandle = undefined;
+      if (this.shutdownTimeoutHandle !== undefined) {
+        this.timer.clearTimeout(this.shutdownTimeoutHandle);
+        this.shutdownTimeoutHandle = undefined;
       }
     }
   }
 
-  private armStdinShutdownTimeout(): void {
-    if (this.stdinShutdownTimeoutArmed) {
+  private armShutdownTimeout(): void {
+    if (this.shutdownTimeoutArmed) {
       return;
     }
-    this.stdinShutdownTimeoutArmed = true;
-    this.stdinShutdownTimeoutHandle = this.timer.setTimeout(() => {
-      this.resolveStdinShutdownTimeout(false);
+    this.shutdownTimeoutArmed = true;
+    this.shutdownTimeoutHandle = this.timer.setTimeout(() => {
+      this.resolveShutdownTimeout(false);
     }, this.shutdownTimeoutMs);
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -538,6 +538,11 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     }
 
     const sessionId = options.sessionContext?.sessionId;
+    // Forwarded identity is trusted only on the daemon's internal transport.
+    // Direct callers cannot override their connection's autolock ownership.
+    const requestMcpSessionId = daemonMode ? extractInternalMcpSessionId(toolParams) : undefined;
+    const implicitAutolockMcpSessionId =
+      requestMcpSessionId ?? (!daemonMode ? sessionId : undefined);
     const routingSessionUuid = sessionToolBinding.effectiveSessionUuid(sessionId, toolParams);
     let connectionProfileUuid = sessionToolBinding.connectionToolSelectionProfileUuid(sessionId);
     const rawRequestedToolSelectionProfileUuid = (toolParams as Record<string, unknown>)
@@ -556,7 +561,8 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     // #6069: enforce connection ownership on the DEVICE-routing path. If this
     // connection already holds an active device session — whether seeded at
     // construction or acquired mid-connection via getAndroid/getApple (recorded
-    // by `bind()`) — a device tool that names a DIFFERENT `sessionUuid` must be
+    // by `bind()`), or held in the pool by this client through autolock (#6729)
+    // — a device tool that names a DIFFERENT `sessionUuid` must be
     // rejected, not routed. Without this, a later call carrying a fabricated,
     // typo'd, or stale id on a connection that already owns a device was handed
     // off to session admission/creation and auto-assigned a SECOND, foreign
@@ -572,7 +578,13 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         typeof rawExplicitSessionUuid === "string" && rawExplicitSessionUuid.trim().length > 0
           ? rawExplicitSessionUuid
           : undefined;
-      const boundDeviceSessionUuid = sessionToolBinding.boundDeviceSessionUuid(sessionId);
+      const boundDeviceSessionUuid =
+        sessionToolBinding.boundDeviceSessionUuid(sessionId) ??
+        (explicitSessionUuid && DaemonState.getInstance().isInitialized()
+          ? DaemonState.getInstance()
+              .getDevicePool()
+              .resolveAutolockSessionForMcpSession(implicitAutolockMcpSessionId)
+          : undefined);
       if (
         boundDeviceSessionUuid &&
         explicitSessionUuid &&
@@ -646,7 +658,6 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       connectionProfileUuid,
     );
 
-    const requestMcpSessionId = extractInternalMcpSessionId(toolParams);
     // Only ever honor these two when the call is DAEMON-forwarded. Extraction
     // happens on the RAW `toolParams` before schema validation, and a direct
     // (non-daemon, e.g. stdio) caller controls those raw arguments outright --
@@ -668,8 +679,6 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     const requestLiveDeadlineKey = daemonMode
       ? extractInternalLiveDeadlineKey(toolParams)
       : undefined;
-    const implicitAutolockMcpSessionId =
-      requestMcpSessionId ?? (!daemonMode ? sessionId : undefined);
     const rawSessionUuid =
       toolParams && typeof toolParams === "object" && "sessionUuid" in toolParams
         ? (toolParams as { sessionUuid?: string }).sessionUuid

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -509,6 +509,7 @@ export function registerUtilityTools() {
         if (!pooledDevice) {
           throw new ActionableError(`Device '${args.deviceId}' not found in device pool`);
         }
+        devicePool.assertDeviceCleanupComplete(args.deviceId);
         if (pooledDevice.sessionId && pooledDevice.sessionId !== args.sessionUuid) {
           const owningSession = sessionManager.getSession(pooledDevice.sessionId);
           if (owningSession) {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -187,9 +187,9 @@ export interface AndroidEmulator {
   launchEmulator(request: AndroidEmulatorLaunchRequest): Promise<AndroidEmulatorLaunchHandle>;
 
   /**
-   * Kill a running emulator
+   * Request termination of the expected running emulator.
    * @param device - The device to kill
-   * @returns Promise that resolves when emulator is stopped
+   * @returns The checked target after ADB accepts termination; callers confirm disappearance.
    */
   killDevice(
     device: BootedDevice,
@@ -2194,9 +2194,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   }
 
   /**
-   * Kill a running emulator
+   * Request termination of the expected running emulator.
    * @param device - The device to kill
-   * @returns Promise that resolves when emulator is stopped
+   * @returns The checked target after ADB accepts termination; callers confirm disappearance.
    */
   async killDevice(
     device: BootedDevice,
@@ -2215,16 +2215,30 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       throw new ActionableError(`Emulator '${device.name}' is not running`);
     }
 
-    // Use ADB to stop the emulator
-    const adb = this.adbFactory.create(emulator);
-    await adb.execute(["emu", "kill"], {
+    if (
+      emulator.name !== device.name ||
+      emulator.platform !== device.platform ||
+      (device.transportId !== undefined && emulator.transportId !== device.transportId)
+    ) {
+      throw new ActionableError(
+        `Emulator '${device.deviceId}' identity changed before termination; refusing to kill its replacement.`,
+      );
+    }
+
+    // A serial can be reused after discovery. Pin the destructive command to
+    // the checked ADB transport when available; a disconnected transport fails
+    // instead of selecting a new emulator that inherited the serial. Older
+    // callers without an expected transport may still match a cold-boot AVD.
+    const adb = this.adbFactory.create(emulator.transportId ? null : emulator);
+    const targetArgs = emulator.transportId ? ["-t", emulator.transportId] : [];
+    await adb.execute([...targetArgs, "emu", "kill"], {
       timeoutMs: options.timeoutMs,
       noRetry: true,
       signal: options.signal,
       waitForProcessSettlementAfterAbort: true,
     });
 
-    logger.info(`Killed emulator '${device.name}'`);
+    logger.info(`Requested termination of emulator '${device.name}'`);
     return emulator;
   }
 

--- a/src/utils/virtualDeviceLifecycleCoordinator.ts
+++ b/src/utils/virtualDeviceLifecycleCoordinator.ts
@@ -189,19 +189,34 @@ export class InMemoryVirtualDeviceLifecycleCoordinator implements VirtualDeviceL
     options: VirtualDeviceLifecycleReservationOptions,
     controller: AbortController,
   ): Promise<LifecycleOwner> {
+    if (options.signal?.aborted) {
+      throw reservationCancellationError(options.signal, options.operation);
+    }
     const state = this.states.get(key) ?? { waiters: [] };
     this.states.set(key, state);
     if (!state.owner) {
       return this.assignOwner(key, state, options.operation, controller);
     }
-
-    if (options.operation === "teardown" && state.owner.operation !== "teardown") {
-      state.owner.controller.abort(new DeviceLifecyclePreemptedError(identity));
-    }
-
     const remainingMs = options.deadlineMs - this.timer.now();
     if (remainingMs <= 0) {
       throw this.timeoutError(identity, options.operation);
+    }
+
+    if (options.operation === "teardown") {
+      const preempted = new DeviceLifecyclePreemptedError(identity);
+      if (state.owner.operation !== "teardown") {
+        state.owner.controller.abort(preempted);
+      }
+      // Existing waiters may have resolved this identity before queueing. An
+      // explicit teardown invalidates that work, including behind another
+      // teardown; transferred provision cleanup keeps its existing semantics.
+      for (const waiter of [...state.waiters]) {
+        if (waiter.operation !== "teardown") {
+          this.removeWaiter(key, state, waiter);
+          waiter.controller.abort(preempted);
+          waiter.reject(preempted);
+        }
+      }
     }
 
     let timeout: NodeJS.Timeout | undefined;

--- a/test/daemon/adbServerResetRecovery.test.ts
+++ b/test/daemon/adbServerResetRecovery.test.ts
@@ -16,6 +16,13 @@ import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersiste
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
 
+// Recovery must observe disappearance after shutdown, not merely a command ack.
+class StoppedDeviceManager extends FakeDeviceManager {
+  override async killDevice(device: BootedDevice): Promise<void> {
+    this.bootedDevices = this.bootedDevices.filter((booted) => booted.deviceId !== device.deviceId);
+  }
+}
+
 describe("ADB server reset session recovery", () => {
   test("rebinds a live session only after restarting its recorded AVD", async () => {
     class ReplacementSerialDeviceManager extends FakeDeviceManager {
@@ -321,7 +328,7 @@ describe("ADB server reset session recovery", () => {
   test("retains captured session identity between cohort detachment and recovery", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const pool = new DevicePool(
       sessionManager,
       "daemon-session",
@@ -375,7 +382,7 @@ describe("ADB server reset session recovery", () => {
   test("refuses to rebind when the original AVD identity was never recorded", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const pool = new DevicePool(
       sessionManager,
       "daemon-session",
@@ -406,7 +413,7 @@ describe("ADB server reset session recovery", () => {
   test("detaches every reset-cohort serial while retaining bound session mappings", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const pool = new DevicePool(
       sessionManager,
       "daemon-session",
@@ -468,7 +475,7 @@ describe("ADB server reset session recovery", () => {
   test("defers the entire reset cohort while named startup holds a matching lease", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const pool = new DevicePool(
       sessionManager,
       "daemon-session",
@@ -523,7 +530,7 @@ describe("ADB server reset session recovery", () => {
   test("does not partially detach a cohort when an idle tracked process cannot stop", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const pool = new DevicePool(
       sessionManager,
       "daemon-session",
@@ -600,7 +607,7 @@ describe("ADB server reset session recovery", () => {
   test("cancels cohort session executions before detaching reusable serials", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const cancellations: Array<{
       sessionId: string;
       reason: string;
@@ -688,7 +695,7 @@ describe("ADB server reset session recovery", () => {
   test("keeps recovery fenced until it observes the captured session release", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const device: BootedDevice = {
       platform: "android",
       name: "Pixel_8_API_35",
@@ -750,7 +757,7 @@ describe("ADB server reset session recovery", () => {
   test("settles an incident when heartbeat release wins during reset preparation", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const backingStore = new InMemoryEmulatorLossIncidentStore(timer);
     const openStarted = Promise.withResolvers<void>();
     const releaseOpen = Promise.withResolvers<void>();
@@ -829,7 +836,7 @@ describe("ADB server reset session recovery", () => {
   });
 
   test("recovers both captured AVDs when the first reuses the second serial", async () => {
-    class SwappedSerialDeviceManager extends FakeDeviceManager {
+    class SwappedSerialDeviceManager extends StoppedDeviceManager {
       override async startDevice(device: DeviceInfo): Promise<ChildProcess> {
         this.startedDevices.push(device);
         const deviceId = device.name === "Pixel_8_API_35" ? "emulator-5556" : "emulator-5558";
@@ -925,7 +932,7 @@ describe("ADB server reset session recovery", () => {
   test("rebinds the preserved session before accepting a same-AVD replacement", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const pool = new DevicePool(
       sessionManager,
       "daemon-session",
@@ -978,7 +985,7 @@ describe("ADB server reset session recovery", () => {
   test("does not overwrite a same-AVD replacement owned by another session", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const pool = new DevicePool(
       sessionManager,
       "daemon-session",
@@ -1035,7 +1042,7 @@ describe("ADB server reset session recovery", () => {
   test("cancels a detached reset member and releases its preserved session", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const releasedSessionIds: string[] = [];
     const pool = new DevicePool(
       sessionManager,
@@ -1087,7 +1094,7 @@ describe("ADB server reset session recovery", () => {
   test("stops the process retained from a detached reset cohort member", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const pool = new DevicePool(
       sessionManager,
       "daemon-session",
@@ -1146,7 +1153,7 @@ describe("ADB server reset session recovery", () => {
   test("terminates a tracked idle reset-cohort emulator before detaching it", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const pool = new DevicePool(
       sessionManager,
       "daemon-session",
@@ -1201,7 +1208,7 @@ describe("ADB server reset session recovery", () => {
   test("keeps active sessions quarantined when idle cohort process stop fails", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const incidents = new InMemoryEmulatorLossIncidentStore(timer);
     const pool = new DevicePool(
       sessionManager,
@@ -1304,7 +1311,7 @@ describe("ADB server reset session recovery", () => {
   test("does not recreate an absent preserved session for a recovery replacement", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const pool = new DevicePool(
       sessionManager,
       "daemon-session",
@@ -1349,7 +1356,7 @@ describe("ADB server reset session recovery", () => {
   });
 
   test("cancels the reserved AVD when an earlier recovery reuses its serial", async () => {
-    class SwappedSerialDeviceManager extends FakeDeviceManager {
+    class SwappedSerialDeviceManager extends StoppedDeviceManager {
       override async startDevice(device: DeviceInfo): Promise<ChildProcess> {
         this.startedDevices.push(device);
         const deviceId = device.name === "Pixel_8_API_35" ? "emulator-5556" : "emulator-5558";
@@ -1425,7 +1432,7 @@ describe("ADB server reset session recovery", () => {
   test("cancels reset reservation waits when the caller aborts", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const pool = new DevicePool(
       sessionManager,
       "daemon-session",
@@ -1462,7 +1469,7 @@ describe("ADB server reset session recovery", () => {
   test("releases the preserved session when reboot rejects after detaching the old serial", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const releasedSessionIds: string[] = [];
     const incidentStore = new InMemoryEmulatorLossIncidentStore(timer);
     const reboot: AndroidDeviceReboot = {
@@ -1549,7 +1556,7 @@ describe("ADB server reset session recovery", () => {
     timer.enableAutoAdvance();
     const persistence = new FakeDeviceSessionPersistence();
     const sessionManager = new SessionManager(timer, persistence);
-    const manager = new FakeDeviceManager();
+    const manager = new StoppedDeviceManager();
     const incidentStore = new TransientCompletionFailureStore(timer);
     let releaseAttempts = 0;
     const reboot: AndroidDeviceReboot = {

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -489,7 +489,7 @@ describe("DevicePool autolock", () => {
       }
     });
 
-    it("does not release a same-UUID replacement after deferred teardown", async () => {
+    it("quarantines same-UUID reacquisition until deferred teardown settles", async () => {
       let finishRestore!: () => void;
       const restoration = new Promise<void>((resolve) => {
         finishRestore = resolve;
@@ -532,12 +532,13 @@ describe("DevicePool autolock", () => {
         await restoringManager.waitForSessionRelease("reused-session");
         await release;
         await restoringPool.releaseDevice("emulator-5554", "reused-session");
-        await restoringPool.bindOrReuseDeviceSession("reused-session", "emulator-5554", "android");
-
+        await expect(
+          restoringPool.bindOrReuseDeviceSession("reused-session", "emulator-5554", "android"),
+        ).rejects.toThrow("cleanup");
+        const cleanup = restoringManager.getPendingDeviceCleanup("emulator-5554");
         finishRestore();
-        for (let attempt = 0; attempt < 10; attempt++) {
-          await new Promise<void>((resolve) => setImmediate(resolve));
-        }
+        await cleanup;
+        await restoringPool.bindOrReuseDeviceSession("reused-session", "emulator-5554", "android");
 
         expect(restoringPool.getDevice("emulator-5554")).toMatchObject({
           sessionId: "reused-session",

--- a/test/daemon/devicePool.cleanupQuarantine.test.ts
+++ b/test/daemon/devicePool.cleanupQuarantine.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "bun:test";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
+import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { registerUtilityTools } from "../../src/server/utilityTools";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+
+for (const route of ["direct", "autolock", "setActiveDevice"] as const) {
+  for (const cleanupKind of ["setup", "keep-awake", "biometric", "network"] as const) {
+    for (const phase of ["release-in-flight", "pending-cleanup"] as const) {
+      test(`rejects ${route} acquisition during ${phase} ${cleanupKind} and permits it after cleanup`, async () => {
+        const previousAutolock = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+        process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+        const timer = new FakeTimer();
+        const finished = Promise.withResolvers<void>();
+        const started = Promise.withResolvers<void>();
+        const restore = async () => {
+          started.resolve();
+          await finished.promise;
+        };
+        const manager = new SessionManager(
+          timer,
+          new FakeDeviceSessionPersistence(),
+          () => new FakeDbWriteBarrier(),
+          () => ({ restore }),
+          () => ({ restore }),
+          () => ({ restore }),
+        );
+        const utils = new FakeDeviceUtils();
+        const device = { deviceId: "emulator-5554", name: "Pixel A", platform: "android" as const };
+        utils.setBootedDevices("android", [device]);
+        const pool = new DevicePool(manager, "daemon-test", timer, undefined, utils);
+        await pool.initializeWithDevices([device]);
+        if (route === "setActiveDevice") {
+          DaemonState.getInstance().initialize(manager, pool);
+          ToolRegistry.clearTools();
+          registerUtilityTools();
+        }
+        let setup: Promise<void> | undefined;
+        let release: Promise<string | null> | undefined;
+        try {
+          await pool.bindOrReuseDeviceSession("old-owner", device.deviceId, "android");
+          if (cleanupKind === "setup") {
+            setup = manager.trackSessionSetup(manager.getSession("old-owner")!, restore);
+            await started.promise;
+          } else if (cleanupKind === "keep-awake") {
+            manager.setKeepScreenAwake("old-owner", { applied: true });
+          } else if (cleanupKind === "biometric") {
+            manager.setBiometricEnrollment("old-owner", { initialEnrollment: "not_enrolled" });
+          } else {
+            manager.setNetworkCondition("old-owner", { initialProfile: "none" });
+          }
+          if (phase === "release-in-flight") {
+            timer.setCurrentTime(31 * 60 * 1000);
+          }
+          release = manager.releaseSession("old-owner", "lazy-expiry", true);
+          await started.promise;
+          if (phase === "release-in-flight") {
+            expect(manager.getSession("old-owner")).toBeNull();
+          }
+          if (phase === "pending-cleanup") {
+            await timer.advanceTimeAsync(1000);
+            await release;
+            await pool.releaseDevice(device.deviceId, "old-owner");
+            expect(manager.getPendingDeviceCleanup(device.deviceId)).not.toBeNull();
+            expect(pool.getDevice(device.deviceId)?.status).toBe("busy");
+            expect(pool.getStats().idle).toBe(0);
+          }
+          const acquire = async () =>
+            route === "setActiveDevice"
+              ? (await ToolRegistry.getTool("setActiveDevice")!.handler({
+                  sessionUuid: "new-owner",
+                  deviceId: device.deviceId,
+                  platform: "android",
+                }),
+                "new-owner")
+              : route === "direct"
+                ? pool.bindOrReuseDeviceSession(
+                    "new-owner",
+                    device.deviceId,
+                    "android",
+                    undefined,
+                    undefined,
+                    undefined,
+                    true,
+                  )
+                : pool.autolockDevice(device.deviceId, "android", "new-client");
+          await expect(acquire()).rejects.toThrow("cleanup");
+          expect(pool.getDevice(device.deviceId)?.sessionId).toBe("old-owner");
+          if (phase === "pending-cleanup") {
+            expect(manager.getPendingDeviceCleanup(device.deviceId)).not.toBeNull();
+          }
+          finished.resolve();
+          await setup;
+          await release;
+          await manager.getPendingDeviceCleanup(device.deviceId);
+          const newOwner = await acquire();
+          expect(pool.getDevice(device.deviceId)?.sessionId).toBe(newOwner);
+          await pool.releaseDevice(device.deviceId, "old-owner");
+          expect(pool.getDevice(device.deviceId)?.sessionId).toBe(newOwner);
+        } finally {
+          finished.resolve();
+          await setup;
+          await release;
+          await manager.getPendingDeviceCleanup(device.deviceId);
+          manager.stopCleanupTimer();
+          if (route === "setActiveDevice") {
+            DaemonState.getInstance().reset();
+            ToolRegistry.clearTools();
+          }
+          if (previousAutolock === undefined) {
+            delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+          } else {
+            process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = previousAutolock;
+          }
+        }
+      });
+    }
+  }
+}

--- a/test/daemon/devicePool.recoveryShutdown.test.ts
+++ b/test/daemon/devicePool.recoveryShutdown.test.ts
@@ -1,0 +1,247 @@
+import { expect, test } from "bun:test";
+import type { ChildProcess } from "node:child_process";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import type { BootedDevice, DeviceInfo } from "../../src/models";
+import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
+import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+const original: BootedDevice = {
+  name: "Pixel_8_API_35",
+  platform: "android",
+  deviceId: "emulator-5554",
+  transportId: "1",
+};
+const image: DeviceInfo = {
+  name: original.name,
+  platform: "android",
+  isRunning: true,
+  source: "local",
+};
+class LaggingShutdownManager extends FakeDeviceManager {
+  readonly killAccepted = Promise.withResolvers<void>();
+  override async killDevice(): Promise<void> {
+    this.killAccepted.resolve();
+  }
+  override async startDevice(device: DeviceInfo): Promise<ChildProcess> {
+    this.startedDevices.push(device);
+    this.bootedDevices = [{ ...original, deviceId: "emulator-5560", transportId: "2" }];
+    return { pid: 0 } as ChildProcess;
+  }
+  override async waitForDeviceReady(): Promise<BootedDevice> {
+    return this.bootedDevices[0];
+  }
+}
+async function setup() {
+  const timer = new FakeTimer();
+  const sessions = new SessionManager(timer, new FakeDeviceSessionPersistence());
+  const manager = new LaggingShutdownManager();
+  const pool = new DevicePool(
+    sessions,
+    "daemon",
+    timer,
+    new FakeInstalledAppsRepository(),
+    manager,
+    new DefaultRetryExecutor(timer),
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    { onLoss: true, maxAttempts: 1 },
+  );
+  manager.bootedDevices = [original];
+  await pool.addDevice(original, image);
+  await pool.bindOrReuseDeviceSession(
+    "session",
+    original.deviceId,
+    "android",
+    image,
+    undefined,
+    original,
+  );
+  const captured = pool.getDevice(original.deviceId)!;
+  return { timer, sessions, manager, pool, captured };
+}
+async function flush(): Promise<void> {
+  for (let i = 0; i < 40; i++) {
+    await Promise.resolve();
+  }
+}
+
+test("recovery waits for checked disappearance after an untracked emulator acknowledges kill", async () => {
+  const { timer, sessions, manager, pool, captured } = await setup();
+  try {
+    const recovery = pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+      original.deviceId,
+      captured,
+    );
+    await manager.killAccepted.promise;
+    await flush();
+    expect(manager.startedDevices).toHaveLength(0);
+    expect(pool.getDevice(original.deviceId)).toBe(captured);
+    manager.bootedDevices = [];
+    timer.advanceTime(1_000);
+    expect(await recovery).toBe(true);
+    expect(manager.startedDevices).toHaveLength(1);
+  } finally {
+    sessions.stopCleanupTimer();
+  }
+});
+
+test("recovery fails within its shutdown bound and preserves the old ownership when disappearance is unconfirmed", async () => {
+  const { timer, sessions, manager, pool, captured } = await setup();
+  try {
+    const recovery = pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+      original.deviceId,
+      captured,
+    );
+    await manager.killAccepted.promise;
+    await flush();
+    timer.advanceTime(30_000);
+    expect(await recovery).toBe(false);
+    expect(manager.startedDevices).toHaveLength(0);
+    expect(pool.getDevice(original.deviceId)).toBe(captured);
+    expect(sessions.getSession("session")?.assignedDevice).toBe(original.deviceId);
+  } finally {
+    sessions.stopCleanupTimer();
+  }
+});
+
+test("failed or unresolved Android discovery cannot authorize a recovery relaunch", async () => {
+  for (const unresolved of [false, true]) {
+    const { sessions, manager, pool, captured } = await setup();
+    try {
+      if (unresolved) {
+        manager.bootedDevices = [{ ...original, name: "Unknown (emulator-5554)" }];
+      } else {
+        manager.failedPlatforms.add("android");
+      }
+      expect(
+        await pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(original.deviceId, captured),
+      ).toBe(false);
+      expect(manager.startedDevices).toHaveLength(0);
+      expect(pool.getDevice(original.deviceId)).toBe(captured);
+    } finally {
+      sessions.stopCleanupTimer();
+    }
+  }
+});
+
+test("hung checked discovery times out without a late kill or relaunch", async () => {
+  const { timer, sessions, manager, pool, captured } = await setup();
+  const scan =
+    Promise.withResolvers<Awaited<ReturnType<FakeDeviceManager["getBootedDevicesDetailed"]>>>();
+  const entered = Promise.withResolvers<void>();
+  manager.getBootedDevicesDetailed = async () => {
+    entered.resolve();
+    return scan.promise;
+  };
+  try {
+    const recovery = pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+      original.deviceId,
+      captured,
+    );
+    await entered.promise;
+    timer.advanceTime(30_000);
+    expect(await recovery).toBe(false);
+    scan.resolve({ devices: [original], succeededPlatforms: new Set(["android"]) });
+    await flush();
+    expect(manager.startedDevices).toHaveLength(0);
+    expect(pool.getDevice(original.deviceId)).toBe(captured);
+    expect(sessions.getSession("session")?.assignedDevice).toBe(original.deviceId);
+  } finally {
+    sessions.stopCleanupTimer();
+  }
+});
+
+test("a different AVD reusing the serial is preserved after shutdown", async () => {
+  const { timer, sessions, manager, pool, captured } = await setup();
+  let killCalls = 0;
+  manager.killDevice = async () => {
+    killCalls++;
+    manager.killAccepted.resolve();
+  };
+  try {
+    const recovery = pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+      original.deviceId,
+      captured,
+    );
+    await manager.killAccepted.promise;
+    await flush();
+    manager.bootedDevices = [{ ...original, name: "Pixel_9", transportId: "new" }];
+    timer.advanceTime(1_000);
+    expect(await recovery).toBe(true);
+    expect(killCalls).toBe(1);
+    expect(manager.startedDevices).toHaveLength(1);
+  } finally {
+    sessions.stopCleanupTimer();
+  }
+});
+
+test("detached ADB-reset ownership remains quarantined when emulator shutdown is unconfirmed", async () => {
+  const { timer, sessions, manager, pool, captured } = await setup();
+  try {
+    const cohort = await pool.detachAdbServerResetCohort([captured]);
+    expect(cohort.devices).toHaveLength(1);
+    const recovery = pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+      original.deviceId,
+      captured,
+    );
+    await manager.killAccepted.promise;
+    await flush();
+    timer.advanceTime(30_000);
+    expect(await recovery).toBe(false);
+    expect(manager.startedDevices).toHaveLength(0);
+    expect(sessions.getSession("session")?.assignedDevice).toBe(original.deviceId);
+    await pool.releaseAdbServerResetCohortReservations(cohort.devices);
+    expect(pool.isSessionRecoveryInFlight("session")).toBe(true);
+    const waiting = new AbortController();
+    let admitted = false;
+    const admission = pool
+      .waitForAdbServerResetRecoveryMatchingName(original.name, waiting.signal)
+      .then(
+        () => {
+          admitted = true;
+        },
+        () => {},
+      );
+    await flush();
+    expect(admitted).toBe(false);
+    waiting.abort();
+    await admission;
+    manager.bootedDevices = [];
+    expect(
+      await pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(original.deviceId, captured),
+    ).toBe(true);
+    await pool.releaseAdbServerResetCohortReservations(cohort.devices);
+    expect(pool.isSessionRecoveryInFlight("session")).toBe(false);
+    await pool.waitForAdbServerResetRecoveryMatchingName(original.name);
+  } finally {
+    sessions.stopCleanupTimer();
+  }
+});
+
+test("ordinary session recovery preserves quarantined ownership after unconfirmed shutdown", async () => {
+  const { timer, sessions, manager, pool, captured } = await setup();
+  try {
+    const recovery = pool.recoverSessionBoundAndroidDeviceAfterLoss(
+      original.deviceId,
+      undefined,
+      captured,
+    );
+    await manager.killAccepted.promise;
+    await flush();
+    timer.advanceTime(30_000);
+    expect(await recovery).toBe("deferred");
+    expect(manager.startedDevices).toHaveLength(0);
+    expect(sessions.getSession("session")?.assignedDevice).toBe(original.deviceId);
+    expect(pool.getDevice(original.deviceId)).toBe(captured);
+    expect(pool.isSessionRecoveryInFlight("session")).toBe(true);
+  } finally {
+    sessions.stopCleanupTimer();
+  }
+});

--- a/test/processLifecycle.test.ts
+++ b/test/processLifecycle.test.ts
@@ -6,6 +6,7 @@ import {
   type ProcessLifecycleProcess,
 } from "../src/processLifecycle";
 import { FakeTimer } from "./fakes/FakeTimer";
+import { DAEMON_SHUTDOWN_TIMEOUT_MS } from "../src/daemon/constants";
 
 class FakeProcess implements ProcessLifecycleProcess {
   readonly listeners = new Map<keyof ProcessLifecycleEventMap, Array<(...args: any[]) => void>>();
@@ -301,33 +302,51 @@ describe("process lifecycle handlers", () => {
     }
   });
 
-  test("does not time out signal cleanup", async () => {
+  test.each(["SIGINT", "SIGTERM"] as const)(
+    "bounds %s cleanup even without stdin",
+    async (signal) => {
+      const fakeProcess = new FakeProcess();
+      const timer = new FakeTimer();
+      const lifecycle = new ProcessLifecycleHandlers(fakeProcess, timer, 50);
+      let finishShutdown!: () => void;
+
+      lifecycle.install();
+      lifecycle.setShutdownHandler(async () => {
+        await new Promise<void>((resolve) => {
+          finishShutdown = resolve;
+        });
+      });
+
+      fakeProcess.emit(signal);
+      await flushMicrotasks();
+      timer.advanceTime(50);
+      await flushMicrotasks();
+
+      expect(fakeProcess.exitCodes).toEqual([1]);
+
+      finishShutdown();
+      await flushMicrotasks();
+
+      expect(fakeProcess.exitCodes).toEqual([1]);
+    },
+  );
+
+  test("finishes the default watchdog before the daemon supervisor escalates", async () => {
     const fakeProcess = new FakeProcess();
     const timer = new FakeTimer();
-    const lifecycle = new ProcessLifecycleHandlers(fakeProcess, timer, 50);
-    let finishShutdown!: () => void;
-
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess, timer);
     lifecycle.install();
-    lifecycle.setShutdownHandler(async () => {
-      await new Promise<void>((resolve) => {
-        finishShutdown = resolve;
-      });
-    });
+    lifecycle.setShutdownHandler(async () => await new Promise<void>(() => {}));
 
     fakeProcess.emit("SIGTERM");
     await flushMicrotasks();
-    timer.advanceTime(50);
+    timer.advanceTime(DAEMON_SHUTDOWN_TIMEOUT_MS - 1);
     await flushMicrotasks();
 
-    expect(fakeProcess.exitCodes).toEqual([]);
-
-    finishShutdown();
-    await flushMicrotasks();
-
-    expect(fakeProcess.exitCodes).toEqual([0]);
+    expect(fakeProcess.exitCodes).toEqual([1]);
   });
 
-  test("uses the stdin timeout when stdin closes during signal cleanup", async () => {
+  test("does not restart the signal timeout when stdin closes during cleanup", async () => {
     const fakeProcess = new FakeProcess();
     const fakeStdin = new FakeStdin();
     const timer = new FakeTimer();
@@ -341,8 +360,9 @@ describe("process lifecycle handlers", () => {
 
       fakeProcess.emit("SIGTERM");
       await flushMicrotasks();
+      timer.advanceTime(25);
       fakeStdin.emit("close");
-      timer.advanceTime(50);
+      timer.advanceTime(25);
       await flushMicrotasks();
 
       expect(fakeProcess.exitCodes).toEqual([1]);

--- a/test/server/unissuedSessionBoundConnection.integration.test.ts
+++ b/test/server/unissuedSessionBoundConnection.integration.test.ts
@@ -70,7 +70,13 @@ describe("unissued sessionUuid on a bound connection (#6069)", () => {
     ToolRegistry.registerDeviceAware(
       "observeProbe",
       "observeProbe",
-      z.object({ sessionUuid: z.string().optional(), platform: z.string().optional() }).strict(),
+      z
+        .object({
+          sessionUuid: z.string().optional(),
+          platform: z.string().optional(),
+          device: z.string().optional(),
+        })
+        .strict(),
       async (device: BootedDevice) => {
         handlerDevices.push(device.deviceId);
         return {
@@ -217,6 +223,105 @@ describe("unissued sessionUuid on a bound connection (#6069)", () => {
       expect(rejected || result?.isError === true).toBe(true);
     } finally {
       delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+    }
+  });
+  test.each(["forwarded", "direct", "direct-spoof"] as const)(
+    "rejects a genuinely issued foreign session on an autolock %s connection",
+    async (route) => {
+      const previousAutolock = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+      process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+      try {
+        if (route !== "forwarded") {
+          await fixture!.teardown();
+          fixture = new McpTestFixture({
+            daemonMode: false,
+            sessionContext: { sessionId: "direct-conn-1" },
+          });
+          await fixture.setup();
+        }
+        const connectionId = route !== "forwarded" ? "direct-conn-1" : "forwarded-conn-1";
+        const { client } = fixture!.getContext();
+
+        // An autolock session is the connection's active session (implicit binding
+        // via the mcp session id), not an explicit SessionToolBinding.
+        const autolockSessionId = await pool.autolockDevice(
+          "emulator-5554",
+          "android",
+          connectionId,
+        );
+        expect(sessionManager.getSession(autolockSessionId)?.assignedDevice).toBe("emulator-5554");
+
+        await sessionManager.createSession("F1", "emulator-5556", "android");
+        let rejected = false;
+        let result: { isError?: boolean } | undefined;
+        try {
+          result = (await client.request(
+            {
+              method: "tools/call",
+              params: {
+                name: "observeProbe",
+                arguments: {
+                  sessionUuid: "F1",
+                  ...(route === "forwarded" ? { __mcpSessionId: connectionId } : {}),
+                  ...(route === "direct-spoof"
+                    ? { __mcpSessionId: "forged-unbound-connection" }
+                    : {}),
+                },
+              },
+            },
+            z.any(),
+          )) as { isError?: boolean };
+        } catch {
+          rejected = true;
+        }
+
+        expect(handlerDevices).not.toContain("emulator-5556");
+        expect(rejected || result?.isError === true).toBe(true);
+      } finally {
+        if (previousAutolock === undefined) {
+          delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+        } else {
+          process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = previousAutolock;
+        }
+      }
+    },
+  );
+  test("allows an autolock owner's explicit session and allocated second-device label", async () => {
+    const previousAutolock = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+    try {
+      const { client } = fixture!.getContext();
+      const ownSession = await pool.autolockDevice("emulator-5554", "android", "forwarded-conn-1");
+      expect(ownSession).toBeDefined();
+      const secondSession = `${ownSession}:B`;
+      await sessionManager.createSession(secondSession, "emulator-5556", "android");
+      sessionManager.setDeviceLabels(ownSession!, { A: ownSession!, B: secondSession });
+      for (const device of ["A", "B"]) {
+        const result = await client.request(
+          {
+            method: "tools/call",
+            params: {
+              name: "observeProbe",
+              arguments: {
+                sessionUuid: ownSession,
+                device,
+                __mcpSessionId: "forwarded-conn-1",
+              },
+            },
+          },
+          z.any(),
+        );
+        expect(result.isError ?? false).toBe(false);
+      }
+      expect(handlerDevices).toEqual(["emulator-5554", "emulator-5556"]);
+      expect(sessionManager.getSession(ownSession!)?.assignedDevice).toBe("emulator-5554");
+      expect(sessionManager.getSession(secondSession)?.assignedDevice).toBe("emulator-5556");
+    } finally {
+      if (previousAutolock === undefined) {
+        delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+      } else {
+        process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = previousAutolock;
+      }
     }
   });
 });

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-getBootedDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-getBootedDevices.test.ts
@@ -107,6 +107,7 @@ describe("AndroidEmulatorClient.getBootedDevicesChecked", () => {
 
   test("bypasses the device-list cache only when terminating", async () => {
     const adb = new RecordingAdbExecutor();
+    adb.setCommandResponse("emu avd name", execResult("Pixel 8\nOK\n"));
     adb.setDevices([
       {
         name: "Pixel 8",

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-killIdentity.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-killIdentity.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "bun:test";
+import { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
+import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
+import type { BootedDevice } from "../../../src/models";
+import { AndroidEmulatorClient } from "../../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+const original: BootedDevice = {
+  name: "Pixel_8",
+  platform: "android",
+  deviceId: "emulator-5554",
+  transportId: "1",
+};
+function fixture(observed: BootedDevice) {
+  const adb = new FakeAdbExecutor();
+  adb.setDevices([observed]);
+  const stdout = `${observed.name}\nOK\n`;
+  adb.setCommandResponse("emu avd name", {
+    stdout,
+    stderr: "",
+    toString: () => stdout,
+    trim: () => stdout.trim(),
+    includes: (search: string) => stdout.includes(search),
+  });
+  const factory = new FakeAdbClientFactory(adb);
+  const client = new AndroidEmulatorClient(null, null, new FakeTimer(), factory);
+  return { client, adb, factory };
+}
+
+for (const replacement of [
+  { ...original, name: "Pixel_9", transportId: "2" },
+  { ...original, transportId: "2" },
+  { ...original, name: "Pixel_9" },
+  { ...original, transportId: undefined },
+]) {
+  test(`refuses replacement ${replacement.name} transport ${replacement.transportId}`, async () => {
+    const { client, adb } = fixture(replacement);
+    await expect(client.killDevice(original)).rejects.toThrow("identity");
+    expect(adb.getExecutedCommands().some((command) => command.endsWith("emu kill"))).toBe(false);
+  });
+}
+
+test("pins termination to the checked transport rather than redispatching to its reusable serial", async () => {
+  const { client, adb, factory } = fixture(original);
+  await expect(client.killDevice(original)).resolves.toMatchObject(original);
+  expect(adb.getExecutedCommands()).toContain("-t 1 emu kill");
+  expect(factory.getCalls().at(-1)?.device).toBeNull();
+});
+
+test("unknown expected transport permits a matching cold-boot AVD and pins its discovered transport", async () => {
+  const { client, adb } = fixture(original);
+  await client.killDevice({ ...original, transportId: undefined });
+  expect(adb.getExecutedCommands()).toContain("-t 1 emu kill");
+});
+
+test("matching legacy discovery without transport still allows ordinary termination", async () => {
+  const legacy = { ...original, transportId: undefined };
+  const { client, adb, factory } = fixture(legacy);
+  await client.killDevice(legacy);
+  expect(adb.getExecutedCommands()).toContain("emu kill");
+  expect(factory.getCalls().at(-1)?.device?.deviceId).toBe(original.deviceId);
+});
+
+for (const replacedBeforeDispatch of [false, true]) {
+  test(`real ADB builder uses exactly one transport selector; replacement=${replacedBeforeDispatch}`, async () => {
+    const commands: string[][] = [];
+    let currentTransport = "1";
+    let replacementKilled = false;
+    const timer = new FakeTimer();
+    const factory: AdbClientFactory = {
+      create: (device) =>
+        new AdbClient(
+          device ?? null,
+          async (_file: string, args: string[], _maxBuffer?: number) => {
+            commands.push(args);
+            let stdout = "";
+            if (args.join(" ") === "devices -l") {
+              stdout = "List of devices attached\nemulator-5554 device transport_id:1\n";
+            } else if (args.slice(-3).join(" ") === "emu avd name") {
+              stdout = "Pixel_8\nOK\n";
+              if (replacedBeforeDispatch) {
+                currentTransport = "2";
+              }
+            } else if (args.slice(-2).join(" ") === "emu kill") {
+              if (args[0] === "-t" && args[1] !== currentTransport) {
+                throw new Error("transport 1 not found");
+              }
+              replacementKilled = replacedBeforeDispatch;
+            }
+            return {
+              stdout,
+              stderr: "",
+              toString: () => stdout,
+              trim: () => stdout.trim(),
+              includes: (part: string) => stdout.includes(part),
+            };
+          },
+          null,
+          undefined,
+          timer,
+        ),
+    };
+    const client = new AndroidEmulatorClient(null, null, timer, factory);
+    if (replacedBeforeDispatch) {
+      await expect(client.killDevice(original)).rejects.toThrow("transport 1 not found");
+    } else {
+      await expect(client.killDevice(original)).resolves.toMatchObject(original);
+    }
+    expect(commands.filter((args) => args.slice(-2).join(" ") === "emu kill")).toEqual([
+      ["-t", "1", "emu", "kill"],
+    ]);
+    expect(replacementKilled).toBe(false);
+  });
+}

--- a/test/utils/virtualDeviceLifecycleCoordinator.test.ts
+++ b/test/utils/virtualDeviceLifecycleCoordinator.test.ts
@@ -37,6 +37,101 @@ describe("InMemoryVirtualDeviceLifecycleCoordinator", () => {
     }
   });
 
+  test("explicit teardown rejects queued lifecycle work before granting stale ownership", async () => {
+    for (const ownerOperation of ["start", "teardown"] as const) {
+      const coordinator = new InMemoryVirtualDeviceLifecycleCoordinator(new FakeTimer());
+      const identity = { kind: "stable", platform: "android", stableId: "Pixel_8" } as const;
+      const owner = await coordinator.reserve(identity, {
+        operation: ownerOperation,
+        deadlineMs: 1_000,
+      });
+      const queued = (["start", "provision", "recovery", "shutdown"] as const).map((operation) =>
+        coordinator
+          .reserve(identity, {
+            operation,
+            deadlineMs: 1_000,
+          })
+          .then(
+            (lease) => {
+              lease.release();
+              return lease;
+            },
+            (error: unknown) => error,
+          ),
+      );
+      const teardownPromise = coordinator.reserve(identity, {
+        operation: "teardown",
+        deadlineMs: 1_000,
+      });
+      owner.release();
+      const teardown = await teardownPromise;
+      teardown.release();
+      for (const result of await Promise.all(queued)) {
+        expect(result).toBeInstanceOf(DeviceLifecyclePreemptedError);
+      }
+      const fresh = await coordinator.reserve(identity, {
+        operation: "provision",
+        deadlineMs: 1_000,
+      });
+      expect(fresh.signal.aborted).toBe(false);
+      fresh.release();
+    }
+  });
+
+  test("teardown rejects stale canonical binding while preserving queued teardown", async () => {
+    const coordinator = new InMemoryVirtualDeviceLifecycleCoordinator(new FakeTimer());
+    const identity = { kind: "stable", platform: "android", stableId: "Pixel_8" } as const;
+    const owner = await coordinator.reserve(identity, { operation: "start", deadlineMs: 1_000 });
+    const selector = await coordinator.reserve(
+      { kind: "selector", platform: "android", selector: "api-35" },
+      { operation: "start", deadlineMs: 1_000 },
+    );
+    const binding = selector.bindCanonicalIdentity(identity).catch((error: unknown) => error);
+    const firstTeardown = coordinator.reserve(identity, {
+      operation: "teardown",
+      deadlineMs: 1_000,
+    });
+    const secondTeardown = coordinator.reserve(identity, {
+      operation: "teardown",
+      deadlineMs: 1_000,
+    });
+    expect(await binding).toBeInstanceOf(DeviceLifecyclePreemptedError);
+    expect(selector.signal.aborted).toBe(true);
+    selector.release();
+    owner.release();
+    const first = await firstTeardown;
+    expect(first.signal.aborted).toBe(false);
+    first.release();
+    const second = await secondTeardown;
+    expect(second.signal.aborted).toBe(false);
+    second.release();
+  });
+
+  test("expired or cancelled teardown does not preempt existing lifecycle work", async () => {
+    for (const expired of [true, false]) {
+      const coordinator = new InMemoryVirtualDeviceLifecycleCoordinator(new FakeTimer());
+      const identity = { kind: "stable", platform: "android", stableId: "Pixel_8" } as const;
+      const owner = await coordinator.reserve(identity, { operation: "start", deadlineMs: 1_000 });
+      const queued = coordinator.reserve(identity, { operation: "start", deadlineMs: 1_000 });
+      const caller = new AbortController();
+      if (!expired) {
+        caller.abort(new Error("caller cancelled"));
+      }
+      await expect(
+        coordinator.reserve(identity, {
+          operation: "teardown",
+          deadlineMs: expired ? 0 : 1_000,
+          signal: caller.signal,
+        }),
+      ).rejects.toThrow(expired ? "Timed out waiting to teardown" : "caller cancelled");
+      expect(owner.signal.aborted).toBe(false);
+      owner.release();
+      const next = await queued;
+      expect(next.signal.aborted).toBe(false);
+      next.release();
+    }
+  });
+
   test("canonical binding retains exclusion while releasing the selector", async () => {
     const timer = new FakeTimer();
     const coordinator = new InMemoryVirtualDeviceLifecycleCoordinator(timer);


### PR DESCRIPTION
## Problem and behavior

An autolocked MCP connection could use a genuinely issued session from another device, and explicit acquisition could claim a device while its former session's cleanup was still running. This change enforces the connection's pool autolock at the public routing boundary and keeps release/cleanup ownership authoritative until cleanup settles. Legitimate allocated multi-device labels and reacquisition after cleanup remain supported.

Explicit teardown now invalidates older queued lifecycle work before it can resume against a destroyed device. Android recovery waits for checked emulator disappearance after kill acknowledgment and retains session quarantine plus the AVD reservation when shutdown is uncertain, including through the full detached-cohort path. The emulator client rechecks expected identity and targets the observed ADB transport so a reused serial cannot redirect termination to a replacement. SIGINT and SIGTERM now arm the same bounded shutdown path as stdin closure, with room for finalization before supervisor escalation.

- Fixes [#6729](https://github.com/kaeawc/auto-mobile/issues/6729)
- Fixes [#6398](https://github.com/kaeawc/auto-mobile/issues/6398)
- Fixes [#6365](https://github.com/kaeawc/auto-mobile/issues/6365)
- Fixes [#6549](https://github.com/kaeawc/auto-mobile/issues/6549)
- Fixes [#6541](https://github.com/kaeawc/auto-mobile/issues/6541)

Related: [Android shutdown acknowledgment gap](https://github.com/kaeawc/auto-mobile/issues/6409). This PR hardens the reachable pool recovery path; the low-level emulator kill API still returns its command acknowledgment, while recovery now verifies the effect.

## Validation

- Full `bun run turbo:validate`: 7/7 tasks, 15,249 unit tests, zero failures.
- `bun run typecheck`: no new type errors; existing baseline retained.
- Relevant ownership/lifecycle integrations: 43 tests, 150 assertions across eight files.
- Three independent review lenses completed; direct-identity spoofing, outer recovery ownership loss, and replacement termination findings were reproduced, fixed, and independently verified.
- Changed-file formatting checked; coordinator tests rerun after formatting: 10 pass. Regressions were observed failing before their fixes using existing fakes and FakeTimer. Coverage includes genuine foreign sessions, direct and forwarded connection identities, multi-device labels, four cleanup phases, expired/replacement sessions, queued teardown ordering, and shutdown deadlines.

TypeScript only. No native runner source, artifact, or pin changes. No Android devices or booted iOS simulators were available; fake-based and host integration proof must not be read as live-device verification.

## Remaining release gates

Existing PRs own the iOS fixes and were not duplicated or modified:

- [Bounded simulator boot-lease wait](https://github.com/kaeawc/auto-mobile/pull/6786)
- [Bounded runner termination](https://github.com/kaeawc/auto-mobile/pull/6787)
- [Runner ownership before force-stop](https://github.com/kaeawc/auto-mobile/pull/6788); its proposed ownership probe still authorizes termination on timeout/error and needs fail-closed review.
- [Manager/port eviction](https://github.com/kaeawc/auto-mobile/pull/6789)
- [Resident runner cancellation isolation](https://github.com/kaeawc/auto-mobile/pull/6778)
- [Health endpoint device identity](https://github.com/kaeawc/auto-mobile/pull/6779)

[Mid-boot duplicate launch](https://github.com/kaeawc/auto-mobile/issues/6407) remains unproven through the complete production path. [Shared readiness cancellation](https://github.com/kaeawc/auto-mobile/issues/6400) reproduced only with manually duplicated device bindings, not authorized production assignment. [Teardown service deadline](https://github.com/kaeawc/auto-mobile/issues/6568) has no outer watchdog, but production stop/destroy stages are bounded; no production hang was reproduced. [Sibling daemon persisted bookkeeping](https://github.com/kaeawc/auto-mobile/issues/6551) remains separate from live routing enforcement.

Secret-redaction work remains separate and unresolved by this PR. This PR does not establish that 0.0.70 is ready to release. Leave open; no automerge or release requested.
