### PR TITLE
fix(ios): force runner termination within shutdown budget

### DIFF
--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -465,8 +465,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     timer: Timer,
   ): Promise<unknown | null> {
     let timeout: NodeJS.Timeout | undefined;
-    let forceStopStarted = false;
-    const settled = instance.stop().then(
+    let forceStop: Promise<void> | undefined;
+    const settled = instance.stop(instance.timer.now() + SHUTDOWN_STOP_TIMEOUT_MS).then(
       () => null,
       (error) => error,
     );
@@ -474,15 +474,19 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       timeout = timer.setTimeout(() => {
         // stop() may be blocked on a remote runner call. Reserve a bounded
         // window to await direct termination before clearing the registry.
-        forceStopStarted = true;
-        void IOSCtrlProxyManager.forceStopWithinShutdownDeadline(instance, timer).then(() =>
+        forceStop = IOSCtrlProxyManager.forceStopWithinShutdownDeadline(instance, timer);
+        void forceStop.then(() =>
           resolve(new Error(`timed out after ${SHUTDOWN_STOP_TIMEOUT_MS}ms`)),
         );
       }, SHUTDOWN_STOP_TIMEOUT_MS);
     });
     try {
       const result = await Promise.race([settled, timedOut]);
-      if (result !== null && !forceStopStarted) {
+      if (forceStop) {
+        // The original stop can settle while force termination is in flight.
+        // Keep the registry until that bounded force stage has also settled.
+        await forceStop;
+      } else if (result !== null) {
         await IOSCtrlProxyManager.forceStopWithinShutdownDeadline(instance, timer);
       }
       return result;
@@ -502,7 +506,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       timeout = timer.setTimeout(resolve, SHUTDOWN_FORCE_STOP_TIMEOUT_MS);
     });
     try {
-      await Promise.race([instance.forceStopForShutdown(), deadline]);
+      await Promise.race([
+        instance.forceStopForShutdown(instance.timer.now() + SHUTDOWN_FORCE_STOP_TIMEOUT_MS),
+        deadline,
+      ]);
     } finally {
       if (timeout) {
         timer.clearTimeout(timeout);
@@ -510,7 +517,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
   }
 
-  private async forceStopForShutdown(): Promise<void> {
+  private async forceStopForShutdown(deadline: number): Promise<void> {
     this.isStopping = true;
     this.processSupervisor.stop();
     this.iproxySupervisor.stop();
@@ -547,9 +554,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       logger.debug(`[IOSCtrlProxy] Forced iproxy termination was already complete: ${error}`);
     }
     if (runnerPid) {
-      await this.processClient.terminateProcessTree(runnerPid).catch((error) => {
-        logger.warn(`[IOSCtrlProxy] Forced CtrlProxy runner termination failed: ${error}`);
-      });
+      await this.processClient
+        .terminateProcessTree(runnerPid, deadline, { skipGraceful: true })
+        .catch((error) => {
+          logger.warn(`[IOSCtrlProxy] Forced CtrlProxy runner termination failed: ${error}`);
+        });
     }
   }
 
@@ -1231,7 +1240,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   /**
    * Stop CtrlProxy
    */
-  public async stop(): Promise<void> {
+  public async stop(deadline?: number): Promise<void> {
     logger.info("[IOSCtrlProxy] Stopping CtrlProxy");
     this.isStopping = true;
 
@@ -1269,7 +1278,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     if (this.xcTestProcessId) {
       try {
         if (await this.isOwnRunnerProcessAlive()) {
-          await this.processClient.terminateProcessTree(this.xcTestProcessId);
+          await this.processClient.terminateProcessTree(this.xcTestProcessId, deadline);
         } else {
           logger.debug(
             `[IOSCtrlProxy] Tracked runner PID ${this.xcTestProcessId} is not an owned CtrlProxy runner; ` +

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -430,7 +430,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         new XcodebuildClient(
           async (file, args) => processExecutor.executeCommand(file, args),
           timer,
-          (command, args, options) => processExecutor.spawn(command, args, options),
+          processExecutor.spawn.bind(processExecutor),
         ),
       processClient ?? new IOSCtrlProxyProcessClient(processExecutor, timer),
     );

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -193,13 +193,19 @@ export class IOSCtrlProxyProcessClient {
     }
   }
 
-  async terminateProcessTree(pid: number, deadline?: number): Promise<void> {
+  async terminateProcessTree(
+    pid: number,
+    deadline?: number,
+    options: { skipGraceful?: boolean } = {},
+  ): Promise<void> {
     const descendants = await this.findDescendantProcessIds(pid, deadline);
     const targets = [...descendants].reverse().concat(pid);
-    await this.signalGroup(pid, "TERM", deadline);
-    await this.signalPids(targets, "TERM", deadline);
-    if (await this.waitForExit([pid, ...descendants], deadline)) {
-      return;
+    if (!options.skipGraceful) {
+      await this.signalGroup(pid, "TERM", deadline);
+      await this.signalPids(targets, "TERM", deadline);
+      if (await this.waitForExit([pid, ...descendants], deadline)) {
+        return;
+      }
     }
     await this.signalGroup(pid, "KILL", deadline);
     await this.signalPids(targets, "KILL", deadline);

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -286,6 +286,77 @@ describe("IOSCtrlProxyManager", function () {
   });
 
   describe("shutdownAll", function () {
+    test("awaits in-flight force termination when the original stop settles", async () => {
+      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+      const stop = deferred();
+      const force = deferred();
+      spyOn(manager, "stop").mockReturnValue(stop.promise);
+      spyOn(manager as any, "forceStopForShutdown").mockReturnValue(force.promise);
+      let settled = false;
+      const shutdown = IOSCtrlProxyManager.shutdownAll(fakeTimer).then(() => {
+        settled = true;
+      });
+      fakeTimer.advanceTime(1_200);
+      stop.resolve();
+      for (let i = 0; i < 20; i++) {
+        await Promise.resolve();
+      }
+      expect(settled).toBe(false);
+      force.resolve();
+      await shutdown;
+      expect(settled).toBe(true);
+    });
+
+    for (const ignoreTerm of [true, false]) {
+      test(`signals a shutdown runner tree within budget (ignoreTerm=${ignoreTerm})`, async () => {
+        const executor = new FakeProcessExecutor();
+        const processes: FakeListeningProcess[] = [42, 43].map((pid) => ({
+          pid,
+          ppid: pid === 42 ? 1 : 42,
+          port: 8765,
+          command: `xcodebuild CtrlProxy -destination id=${testDevice.deviceId}`,
+          alive: true,
+          ignoreTerm,
+        }));
+        installListeningProcessFakes(executor, processes);
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          testDevice,
+          fakeTimer,
+          createFakeBuilder(),
+          executor,
+        );
+        (manager as any).xcTestProcessId = 42;
+        (IOSCtrlProxyManager as any).instances.set(testDevice.deviceId, manager);
+        let settled = false;
+        const shutdown = IOSCtrlProxyManager.shutdownAll(fakeTimer).then(() => {
+          settled = true;
+        });
+        // Flush process discovery and signaling without advancing the grace sleeps.
+        for (let i = 0; i < 100; i++) {
+          await Promise.resolve();
+        }
+        if (ignoreTerm) {
+          expect(settled).toBe(false);
+          fakeTimer.advanceTime(1_200);
+          for (let i = 0; i < 100; i++) {
+            await Promise.resolve();
+          }
+          fakeTimer.advanceTime(250);
+          for (let i = 0; i < 100; i++) {
+            await Promise.resolve();
+          }
+        }
+        expect(settled).toBe(true);
+        expect(processes.every((process) => !process.alive)).toBe(true);
+        const kills = executor
+          .getExecutedCommands()
+          .filter((command) => command.includes("kill -KILL"));
+        expect(kills.length > 0).toBe(ignoreTerm);
+        expect(fakeTimer.now()).toBeLessThanOrEqual(1_500);
+        await shutdown;
+      });
+    }
+
     test("stops every instance and clears them when one stop fails", async function () {
       const first = IOSCtrlProxyManager.getInstance(testDevice);
       const otherDevice = {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -3114,6 +3114,12 @@ describe("IOSCtrlProxyManager", function () {
         alive: true,
       };
       installListeningProcessFakes(fakeExecutor, [staleListener, daemonXcodebuild, daemonShell]);
+      const originalSpawn = fakeExecutor.spawn.bind(fakeExecutor);
+      let portWasFreeAtSpawn = false;
+      fakeExecutor.spawn = (command, args, options) => {
+        portWasFreeAtSpawn = !staleListener.alive;
+        return originalSpawn(command, args, options);
+      };
       fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
       // The health-first direct-runner probe sees this candidate, but its
       // daemon-managed shell root must keep it out of adoption so port cleanup
@@ -3129,13 +3135,6 @@ describe("IOSCtrlProxyManager", function () {
         createFakeBuilder(),
         fakeExecutor,
       );
-      const originalSpawn = fakeExecutor.spawn.bind(fakeExecutor);
-      let portWasFreeAtSpawn = false;
-      fakeExecutor.spawn = (command, args, options) => {
-        portWasFreeAtSpawn = !staleListener.alive;
-        return originalSpawn(command, args, options);
-      };
-
       await manager.start();
 
       expect(fakeExecutor.wasCommandExecuted("ps -p 2226")).toBe(true);

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -18,6 +18,35 @@ function result(stdout = "", stderr = "") {
 }
 
 describe("IOSCtrlProxyProcessClient", () => {
+  test("force termination skips TERM and bounds commands and exit waiting by its deadline", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const commands: string[] = [];
+    const timeouts: Array<number | undefined> = [];
+    const host: HostCommandExecutor = {
+      async executeCommand(file, args, options) {
+        commands.push([file, ...args].join(" "));
+        timeouts.push(options?.timeoutMs);
+        return result(file === "ps" ? "42 1\n43 42\n" : "");
+      },
+    };
+    const client = new IOSCtrlProxyProcessClient(host, timer);
+
+    await expect(client.terminateProcessTree(42, 250, { skipGraceful: true })).rejects.toThrow(
+      "deadline elapsed",
+    );
+
+    expect(commands).toEqual([
+      "ps -axo pid=,ppid=",
+      "kill -KILL -- -42",
+      "kill -KILL 43",
+      "kill -KILL 42",
+      "kill -0 42",
+    ]);
+    expect(timeouts.every((timeout) => timeout === 250)).toBe(true);
+    expect(timer.now()).toBe(250);
+  });
+
   test("bounds startup candidate discovery by the supplied deadline", async () => {
     const timer = new FakeTimer();
     const options: Array<HostCommandOptions | undefined> = [];


### PR DESCRIPTION
## Summary

Ensure iOS CtrlProxy shutdown sends SIGKILL during the existing 250 ms force stage instead of restarting the TERM grace period. Pass shutdown deadlines into process-tree termination and await an in-flight force stage even if the original stop settles concurrently. Healthy trees still exit with TERM alone; shutdown budgets are unchanged.

Closes [#6578](https://github.com/kaeawc/auto-mobile/issues/6578).

## Bug / Regression Context

A runner tree that ignores TERM could outlive shutdown because forced cleanup repeated the graceful termination ladder. The regression test reproduced shutdown resolving with the tree alive before this fix. The existing process client and injected timer/executor seams cover the fix without new dependencies.

## Validation

- 134 targeted manager, process-client, XcodebuildClient, and daemon child-cleanup tests pass. Regression coverage includes TERM-resistant trees, healthy trees, force deadlines, and concurrent stop settlement.
- `bun run build` passes.
- `bun run typecheck` passes the baseline gate with no new errors.
- `bun run lint` passes, including all 13 boundary checks. The test factory passes the bound executor spawn method into XcodebuildClient; its stale-listener test installs the observer before constructing the client.
- Validation used a fresh checkout of current main. No device test was performed.
