### PR TITLE
fix(ios): reserve force-stop budget for discovery and signaling

### DIFF
--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -161,7 +161,11 @@ export class IOSCtrlProxyProcessClient {
     );
   }
 
-  async findDescendantProcessIds(rootPid: number, deadline?: number): Promise<number[]> {
+  async findDescendantProcessIds(
+    rootPid: number,
+    deadline?: number,
+    options: { throwOnError?: boolean } = {},
+  ): Promise<number[]> {
     try {
       const { stdout } = await this.executeCommand("ps", ["-axo", "pid=,ppid="], deadline);
       const children = new Map<number, number[]>();
@@ -189,6 +193,9 @@ export class IOSCtrlProxyProcessClient {
       return descendants;
     } catch (error) {
       logger.debug(`[IOSCtrlProxy] Failed to enumerate descendants of PID ${rootPid}: ${error}`);
+      if (options.throwOnError) {
+        throw error;
+      }
       return [];
     }
   }
@@ -198,13 +205,32 @@ export class IOSCtrlProxyProcessClient {
     deadline?: number,
     options: { skipGraceful?: boolean } = {},
   ): Promise<void> {
+    let descendants: number[];
     if (options.skipGraceful) {
-      // Discovery can consume the entire force budget. Signal the known group
-      // and root first, including roots that are not process group leaders.
+      // Snapshot before root exit can reparent children, but reserve at least
+      // half the remaining budget for signals. Never spend over 50ms discovering.
+      const discoveryBudgetMs = Math.min(50, (this.remainingTimeoutMs(deadline) ?? 100) / 2);
+      let discoveryError: unknown;
+      try {
+        descendants = await this.findDescendantProcessIds(
+          pid,
+          this.timer.now() + discoveryBudgetMs,
+          { throwOnError: true },
+        );
+      } catch (error) {
+        descendants = [];
+        discoveryError = error;
+      }
       await this.signalGroup(pid, "KILL", deadline);
       await this.signalPids([pid], "KILL", deadline);
+      if (discoveryError !== undefined) {
+        throw new Error(`CtrlProxy descendant discovery failed for PID ${pid}`, {
+          cause: discoveryError,
+        });
+      }
+    } else {
+      descendants = await this.findDescendantProcessIds(pid, deadline);
     }
-    const descendants = await this.findDescendantProcessIds(pid, deadline);
     const targets = [...descendants].reverse().concat(pid);
     if (!options.skipGraceful) {
       await this.signalGroup(pid, "TERM", deadline);

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -198,6 +198,12 @@ export class IOSCtrlProxyProcessClient {
     deadline?: number,
     options: { skipGraceful?: boolean } = {},
   ): Promise<void> {
+    if (options.skipGraceful) {
+      // Discovery can consume the entire force budget. Signal the known group
+      // and root first, including roots that are not process group leaders.
+      await this.signalGroup(pid, "KILL", deadline);
+      await this.signalPids([pid], "KILL", deadline);
+    }
     const descendants = await this.findDescendantProcessIds(pid, deadline);
     const targets = [...descendants].reverse().concat(pid);
     if (!options.skipGraceful) {
@@ -207,8 +213,12 @@ export class IOSCtrlProxyProcessClient {
         return;
       }
     }
-    await this.signalGroup(pid, "KILL", deadline);
-    await this.signalPids(targets, "KILL", deadline);
+    if (options.skipGraceful) {
+      await this.signalPids([...descendants].reverse(), "KILL", deadline);
+    } else {
+      await this.signalGroup(pid, "KILL", deadline);
+      await this.signalPids(targets, "KILL", deadline);
+    }
     if (!(await this.waitForExit([pid, ...descendants], deadline))) {
       throw new Error(`CtrlProxy process tree rooted at PID ${pid} remained alive after SIGKILL`);
     }

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -18,7 +18,34 @@ function result(stdout = "", stderr = "") {
 }
 
 describe("IOSCtrlProxyProcessClient", () => {
-  test("force termination signals the known group and root before discovery exhausts the deadline", async () => {
+  test("force termination retains a separate-group child after the root exits", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    let rootAlive = true;
+    let childAlive = true;
+    const host: HostCommandExecutor = {
+      async executeCommand(file, args) {
+        if (file === "ps") {return result(rootAlive ? "42 1\n43 42\n" : "43 1\n");}
+        if (args.includes("--")) {throw new Error("not a process group leader");}
+        if (args[0] === "-KILL") {
+          if (args[1] === "42") {rootAlive = false;}
+          if (args[1] === "43") {childAlive = false;}
+        }
+        if (args[0] === "-0" && !(args[1] === "42" ? rootAlive : childAlive)) {
+          throw new Error("No such process");
+        }
+        return result();
+      },
+    };
+    const client = new IOSCtrlProxyProcessClient(host, timer);
+
+    await client.terminateProcessTree(42, 250, { skipGraceful: true });
+
+    expect(rootAlive).toBe(false);
+    expect(childAlive).toBe(false);
+  });
+
+  test("force termination reserves signaling time when discovery times out", async () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
     const commands: string[] = [];
@@ -38,11 +65,11 @@ describe("IOSCtrlProxyProcessClient", () => {
     const client = new IOSCtrlProxyProcessClient(host, timer);
 
     await expect(client.terminateProcessTree(42, 250, { skipGraceful: true })).rejects.toThrow(
-      "deadline elapsed",
+      "descendant discovery failed",
     );
 
-    expect(commands).toEqual(["kill -KILL -- -42", "kill -KILL 42", "ps -axo pid=,ppid="]);
-    expect(timer.now()).toBe(250);
+    expect(commands).toEqual(["ps -axo pid=,ppid=", "kill -KILL -- -42", "kill -KILL 42"]);
+    expect(timer.now()).toBe(50);
   });
 
   test("force termination skips TERM and bounds commands and exit waiting by its deadline", async () => {
@@ -64,13 +91,13 @@ describe("IOSCtrlProxyProcessClient", () => {
     );
 
     expect(commands).toEqual([
+      "ps -axo pid=,ppid=",
       "kill -KILL -- -42",
       "kill -KILL 42",
-      "ps -axo pid=,ppid=",
       "kill -KILL 43",
       "kill -0 42",
     ]);
-    expect(timeouts.every((timeout) => timeout === 250)).toBe(true);
+    expect(timeouts).toEqual([50, 250, 250, 250, 250]);
     expect(timer.now()).toBe(250);
   });
 

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -25,11 +25,19 @@ describe("IOSCtrlProxyProcessClient", () => {
     let childAlive = true;
     const host: HostCommandExecutor = {
       async executeCommand(file, args) {
-        if (file === "ps") {return result(rootAlive ? "42 1\n43 42\n" : "43 1\n");}
-        if (args.includes("--")) {throw new Error("not a process group leader");}
+        if (file === "ps") {
+          return result(rootAlive ? "42 1\n43 42\n" : "43 1\n");
+        }
+        if (args.includes("--")) {
+          throw new Error("not a process group leader");
+        }
         if (args[0] === "-KILL") {
-          if (args[1] === "42") {rootAlive = false;}
-          if (args[1] === "43") {childAlive = false;}
+          if (args[1] === "42") {
+            rootAlive = false;
+          }
+          if (args[1] === "43") {
+            childAlive = false;
+          }
         }
         if (args[0] === "-0" && !(args[1] === "42" ? rootAlive : childAlive)) {
           throw new Error("No such process");

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -18,6 +18,33 @@ function result(stdout = "", stderr = "") {
 }
 
 describe("IOSCtrlProxyProcessClient", () => {
+  test("force termination signals the known group and root before discovery exhausts the deadline", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const commands: string[] = [];
+    const host: HostCommandExecutor = {
+      async executeCommand(file, args, options) {
+        commands.push([file, ...args].join(" "));
+        if (file === "ps") {
+          await timer.sleep(options!.timeoutMs!);
+          throw new Error("process discovery timed out");
+        }
+        if (args.includes("--")) {
+          throw new Error("root is not a process group leader");
+        }
+        return result();
+      },
+    };
+    const client = new IOSCtrlProxyProcessClient(host, timer);
+
+    await expect(client.terminateProcessTree(42, 250, { skipGraceful: true })).rejects.toThrow(
+      "deadline elapsed",
+    );
+
+    expect(commands).toEqual(["kill -KILL -- -42", "kill -KILL 42", "ps -axo pid=,ppid="]);
+    expect(timer.now()).toBe(250);
+  });
+
   test("force termination skips TERM and bounds commands and exit waiting by its deadline", async () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
@@ -37,10 +64,10 @@ describe("IOSCtrlProxyProcessClient", () => {
     );
 
     expect(commands).toEqual([
-      "ps -axo pid=,ppid=",
       "kill -KILL -- -42",
-      "kill -KILL 43",
       "kill -KILL 42",
+      "ps -axo pid=,ppid=",
+      "kill -KILL 43",
       "kill -0 42",
     ]);
     expect(timeouts.every((timeout) => timeout === 250)).toBe(true);


### PR DESCRIPTION
## Summary

Bound forced runner descendant discovery to at most 50 ms and half the remaining force budget before signaling the known group and root. This preserves child identities before root exit can reparent them while reserving time for SIGKILL if discovery stalls. Discovery failures still trigger known-target signaling, then report incomplete cleanup rather than successful tree termination.

Follow-up to [PR #6808](https://github.com/kaeawc/auto-mobile/pull/6808), addressing [discovery starvation](https://github.com/kaeawc/auto-mobile/pull/6808#discussion_r3978060865) and [child reparenting](https://github.com/kaeawc/auto-mobile/pull/6809#discussion_r3978214022) feedback.

## Bug / Regression Context

Waiting for discovery under the full force deadline could leave no time for signals. Killing the root before discovery could instead lose separate-group children through reparenting. A bounded snapshot precedes signals; captured descendants are then signaled and included in exit verification. Graceful shutdown and total shutdown budgets remain unchanged.

## Validation

- 126 targeted process-client, manager, and daemon cleanup tests pass.
- Regression tests reproduce stalled discovery and a non-group-leading root whose separate-group child is reparented on root exit.
- Full lint, build, formatting, and typecheck baseline gate pass.
- Reuses existing process signaling and FakeTimer seams; no new dependencies.
- No live device test performed.
