### PR TITLE
Fix device routing selectors

### DIFF
--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -309,6 +309,9 @@ export const DAEMON_TOOL_SELECTION_PROFILE_PARAM = "__autoMobileToolSelectionPro
  */
 export const DAEMON_BOUND_SESSION_PARAM = "__autoMobileBoundSessionUuid";
 
+/** Retained session capabilities restored on selector calls after a socket reconnect. */
+export const DAEMON_OWNED_SESSIONS_PARAM = "__autoMobileOwnedSessionUuids";
+
 /** Socket RPC field identifying a released session used only for inactive resource reads. */
 export const DAEMON_RELEASED_SESSION_PARAM = "__autoMobileReleasedSessionUuid";
 

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -20,6 +20,7 @@ import {
   DAEMON_BOUND_SESSION_REPLAY_TTL_MS,
   DAEMON_TOOL_SELECTION_PROFILE_PARAM,
   DAEMON_BOUND_SESSION_PARAM,
+  DAEMON_OWNED_SESSIONS_PARAM,
   DAEMON_RELEASED_SESSION_PARAM,
   DAEMON_SHUTDOWN_TIMEOUT_MS,
   DAEMON_RESTART_HANDOFF_TIMEOUT_MS,
@@ -1943,6 +1944,7 @@ export class DaemonMcpProxy {
     // values: only this proxy may add them after selecting its active binding.
     const callerArgs = { ...args };
     delete callerArgs[DAEMON_BOUND_SESSION_PARAM];
+    delete callerArgs[DAEMON_OWNED_SESSIONS_PARAM];
     delete callerArgs[DAEMON_RELEASED_SESSION_PARAM];
     delete callerArgs[DAEMON_TOOL_SELECTION_PROFILE_PARAM];
     // Device-session acquisition (including booted provisionDevice) mints a NEW
@@ -1954,11 +1956,11 @@ export class DaemonMcpProxy {
     // An omitted `sessionUuid` on the control tool means the connection profile,
     // not the proxy's retained device-routing session. Preserve that distinction
     // after a device has been bound.
-    const routingArgs =
-      name === SET_TOOL_ENABLED_TOOL_NAME || isSessionAcquisition
-        ? callerArgs
-        : this.withBoundSessionUuid(callerArgs, name === "setActiveDevice");
-    const forwardedArgs = this.withToolSelectionProfile(routingArgs);
+    const { forwardedArgs, allowReleasedSession } = this.prepareToolRoutingArgs(
+      name,
+      callerArgs,
+      isSessionAcquisition,
+    );
     const forwardedSessionUuid = this.sessionUuidFromArgs(forwardedArgs);
     this.retainReleaseEpochReference(forwardedSessionUuid);
     // Snapshot the release epoch at forward time. If a session-released signal for
@@ -1984,7 +1986,7 @@ export class DaemonMcpProxy {
         forwardedSessionUuid,
         // Acquisition is admitted while fenced; the terminal fence is cleared once
         // the result-minted session establishes a fresh binding.
-        isSessionAcquisition,
+        allowReleasedSession,
       );
       if (result?.isError) {
         // Provisioning retains its usable device session when optional resource
@@ -2043,6 +2045,58 @@ export class DaemonMcpProxy {
     }
   }
 
+  private prepareToolRoutingArgs(
+    name: string,
+    callerArgs: Record<string, unknown>,
+    isSessionAcquisition: boolean,
+  ): { forwardedArgs: Record<string, unknown>; allowReleasedSession: boolean } {
+    const usesDeviceSelector =
+      this.toolTargetsDevice(name) &&
+      this.hasImplicitDeviceSelector(callerArgs, name === "setActiveDevice");
+    const routingArgs =
+      name === SET_TOOL_ENABLED_TOOL_NAME || isSessionAcquisition
+        ? callerArgs
+        : this.withBoundSessionUuid(callerArgs, usesDeviceSelector);
+    const canUseSurvivingSession = this.canUseSurvivingSession(callerArgs, usesDeviceSelector);
+    const forwardedArgs = this.withToolSelectionProfile(
+      this.withOwnedSessionCapabilities(routingArgs, usesDeviceSelector && !isSessionAcquisition),
+    );
+    return { forwardedArgs, allowReleasedSession: isSessionAcquisition || canUseSurvivingSession };
+  }
+
+  private toolTargetsDevice(name: string): boolean {
+    if (name === "setActiveDevice") {
+      return true;
+    }
+    const schema =
+      this.cachedTools?.find((definition) => definition.name === name)?.inputSchema ??
+      this.staticToolDefinitionsProvider().find((definition) => definition.name === name)
+        ?.inputSchema;
+    // Device-targeting schemas expose the device-label contract. Plain
+    // platform filters do not have it and must retain their session policy.
+    return (
+      typeof schema?.properties === "object" &&
+      schema.properties !== null &&
+      "device" in schema.properties
+    );
+  }
+
+  private withOwnedSessionCapabilities(
+    args: Record<string, unknown>,
+    restore: boolean,
+  ): Record<string, unknown> {
+    if (!restore || this.sessionUuidFromArgs(args)) {
+      return args;
+    }
+    const retained = [...this.ownedDeviceSessions].filter(
+      (id) => id !== this.terminalBoundSession?.sessionUuid && id !== this.boundSessionUuid,
+    );
+    if (this.boundSessionUuid) {
+      retained.push(this.boundSessionUuid);
+    }
+    return retained.length ? { ...args, [DAEMON_OWNED_SESSIONS_PARAM]: retained } : args;
+  }
+
   private rememberActiveDeviceSession(name: string, result: unknown, releaseEpoch: number): void {
     if (name !== "setActiveDevice") {
       return;
@@ -2071,7 +2125,7 @@ export class DaemonMcpProxy {
 
   private withBoundSessionUuid(
     args: Record<string, unknown>,
-    selectingActiveDevice = false,
+    usesDeviceSelector = false,
   ): Record<string, unknown> {
     // A daemon session released by ordinary heartbeat/idle expiry leaves this
     // remembered binding dangling; replaying its UUID on a later sessionless call
@@ -2080,7 +2134,9 @@ export class DaemonMcpProxy {
     // no forwarded call (explicit or implicit) refreshing the binding, treat it
     // as retired.
     const explicitSessionUuid = this.sessionUuidFromArgs(args);
-    this.throwIfBoundSessionUnavailable(explicitSessionUuid);
+    if (!this.canUseSurvivingSession(args, usesDeviceSelector)) {
+      this.throwIfBoundSessionUnavailable(explicitSessionUuid);
+    }
     const normalizedArgs =
       explicitSessionUuid && explicitSessionUuid !== args.sessionUuid
         ? { ...args, sessionUuid: explicitSessionUuid }
@@ -2099,7 +2155,7 @@ export class DaemonMcpProxy {
     }
     // A caller's device selector must reach daemon autolock resolution without
     // being disguised as an explicitly supplied session UUID (#6807).
-    if (this.hasImplicitDeviceSelector(args, selectingActiveDevice)) {
+    if (usesDeviceSelector) {
       return normalizedArgs;
     }
     return {
@@ -2107,6 +2163,20 @@ export class DaemonMcpProxy {
       sessionUuid: this.boundSessionUuid,
       [DAEMON_BOUND_SESSION_PARAM]: this.boundSessionUuid,
     };
+  }
+
+  private canUseSurvivingSession(
+    args: Record<string, unknown>,
+    usesDeviceSelector: boolean,
+  ): boolean {
+    if (!this.terminalBoundSession || this.config.initialSessionUuid) {
+      return false;
+    }
+    const explicit = this.sessionUuidFromArgs(args);
+    const liveOwned = [...this.ownedDeviceSessions].filter(
+      (id) => id !== this.terminalBoundSession?.sessionUuid,
+    );
+    return explicit ? liveOwned.includes(explicit) : liveOwned.length > 0 && usesDeviceSelector;
   }
 
   private throwIfBoundSessionUnavailable(explicitSessionUuid?: string): void {
@@ -2623,6 +2693,13 @@ export class DaemonMcpProxy {
       rememberedSessionUuid &&
       (rememberedSessionUuid === this.boundSessionUuid || this.toolAcceptsSessionUuid(name))
     ) {
+      if (
+        this.terminalBoundSession &&
+        rememberedSessionUuid !== this.terminalBoundSession.sessionUuid &&
+        this.ownedDeviceSessions.has(rememberedSessionUuid)
+      ) {
+        this.terminalBoundSession = undefined;
+      }
       this.updateBoundSessionUuid(rememberedSessionUuid);
       this.startBoundSessionHeartbeat();
     }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -35,6 +35,7 @@ import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../server/sessionReleaseBr
 import {
   DEVICE_SESSION_RECOVERY_PROMPT,
   getDeviceSessionIdFromResult,
+  DEVICE_SESSION_ACQUISITION_TOOLS,
   isDeviceSessionAcquisitionTool,
 } from "../server/deviceSessionResult";
 import {
@@ -1956,7 +1957,7 @@ export class DaemonMcpProxy {
     const routingArgs =
       name === SET_TOOL_ENABLED_TOOL_NAME || isSessionAcquisition
         ? callerArgs
-        : this.withBoundSessionUuid(callerArgs);
+        : this.withBoundSessionUuid(callerArgs, name === "setActiveDevice");
     const forwardedArgs = this.withToolSelectionProfile(routingArgs);
     const forwardedSessionUuid = this.sessionUuidFromArgs(forwardedArgs);
     this.retainReleaseEpochReference(forwardedSessionUuid);
@@ -1967,7 +1968,10 @@ export class DaemonMcpProxy {
     // UNRELATED session bumps the global epoch but not the forwarded UUID's entry,
     // so it does not block remembering the session this call forwarded.
     const callReleaseEpoch = this.releaseEpoch;
-    this.retainAcquisitionReleaseEpoch(isSessionAcquisition, callReleaseEpoch);
+    const learnsResultSession = ["setActiveDevice", ...DEVICE_SESSION_ACQUISITION_TOOLS].includes(
+      name,
+    );
+    this.retainAcquisitionReleaseEpoch(learnsResultSession, callReleaseEpoch);
     if (progressToken !== undefined && onProgress) {
       this.progressListeners.set(progressToken, onProgress);
     }
@@ -2004,6 +2008,7 @@ export class DaemonMcpProxy {
       // being mistaken for idleness, so a later reconnect re-seeds the still-live
       // session instead of creating an unseeded transport (issue #4610).
       this.rememberSessionUuid(name, forwardedArgs, callReleaseEpoch);
+      this.rememberActiveDeviceSession(name, result, callReleaseEpoch);
       return result;
     } catch (error) {
       // The success-only rememberSessionUuid above never runs when the handler
@@ -2031,14 +2036,43 @@ export class DaemonMcpProxy {
       throw error;
     } finally {
       this.releaseReleaseEpochReference(forwardedSessionUuid);
-      this.releaseAcquisitionReleaseEpoch(isSessionAcquisition, callReleaseEpoch);
+      this.releaseAcquisitionReleaseEpoch(learnsResultSession, callReleaseEpoch);
       if (progressToken !== undefined) {
         this.progressListeners.delete(progressToken);
       }
     }
   }
 
-  private withBoundSessionUuid(args: Record<string, unknown>): Record<string, unknown> {
+  private rememberActiveDeviceSession(name: string, result: unknown, releaseEpoch: number): void {
+    if (name !== "setActiveDevice") {
+      return;
+    }
+    const sessionUuid = getDeviceSessionIdFromResult(result);
+    if (sessionUuid) {
+      this.throwIfSessionReleasedSince(sessionUuid, releaseEpoch);
+      this.rememberSessionUuid(name, { sessionUuid }, releaseEpoch);
+    }
+  }
+
+  private hasImplicitDeviceSelector(
+    args: Record<string, unknown>,
+    selectingActiveDevice: boolean,
+  ): boolean {
+    if (this.initialSessionBindingConfigured || args.device) {
+      return false;
+    }
+    if (selectingActiveDevice) {
+      return true;
+    }
+    return (
+      typeof args.deviceId === "string" || args.platform === "android" || args.platform === "ios"
+    );
+  }
+
+  private withBoundSessionUuid(
+    args: Record<string, unknown>,
+    selectingActiveDevice = false,
+  ): Record<string, unknown> {
     // A daemon session released by ordinary heartbeat/idle expiry leaves this
     // remembered binding dangling; replaying its UUID on a later sessionless call
     // would silently recreate the session and reacquire a device without the
@@ -2052,12 +2086,6 @@ export class DaemonMcpProxy {
         ? { ...args, sessionUuid: explicitSessionUuid }
         : args;
     if (!this.boundSessionUuid || explicitSessionUuid === this.boundSessionUuid) {
-      if (explicitSessionUuid === this.boundSessionUuid && this.boundSessionUuid) {
-        return {
-          ...normalizedArgs,
-          [DAEMON_BOUND_SESSION_PARAM]: this.boundSessionUuid,
-        };
-      }
       return normalizedArgs;
     }
     if (explicitSessionUuid && this.initialSessionBindingConfigured) {
@@ -2067,6 +2095,11 @@ export class DaemonMcpProxy {
       );
     }
     if (explicitSessionUuid) {
+      return normalizedArgs;
+    }
+    // A caller's device selector must reach daemon autolock resolution without
+    // being disguised as an explicitly supplied session UUID (#6807).
+    if (this.hasImplicitDeviceSelector(args, selectingActiveDevice)) {
       return normalizedArgs;
     }
     return {

--- a/src/daemon/daemonRequestHandlers.ts
+++ b/src/daemon/daemonRequestHandlers.ts
@@ -28,6 +28,10 @@ export interface DaemonStateAccess {
     releaseSession(sessionId: string): Promise<string | null>;
   };
   getDevicePool(): {
+    restoreAutolockSessionsForMcpSession?(
+      sessionIds: readonly string[],
+      mcpSessionId: string,
+    ): Promise<void>;
     refreshDevices(): Promise<number>;
     getStats(): DevicePoolStats;
     releaseDevice(deviceId: string, expectedSessionId: string): Promise<void>;

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -6199,6 +6199,15 @@ export class DevicePool {
     mcpSessionId: string,
   ): Promise<void> {
     for (const id of sessionIds) {
+      // Nothing left to restore for a session this connection already holds
+      // while it also already has a default. Re-checked each iteration rather
+      // than snapshotted, so an attachment cannot act on a stale reading.
+      if (
+        this.mcpSessionAcquiredAutolocks.get(mcpSessionId)?.has(id) &&
+        this.resolveAutolockSessionForMcpSession(mcpSessionId) !== undefined
+      ) {
+        continue;
+      }
       // "if-absent" defers the default decision to attach time, under the
       // assignment mutex. A pre-loop snapshot would be stale by the time the
       // second attachment runs, letting restoration clobber a `setActiveDevice`

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -378,6 +378,7 @@ export class DevicePool {
   private readonly idGenerator: IdGenerator;
   private lastUsedAtMarker = 0;
   private lastReleasedDeviceId: string | null = null;
+  private readonly mcpSessionAcquiredAutolocks = new Map<string, Set<string>>();
   private readonly mcpSessionAutolockMap: Map<string, string> = new Map();
   private readonly mcpSessionRecoveryDevices: Map<string, McpSessionRecoveryLease> = new Map();
   private readonly refreshMissingDeviceMisses: Map<string, number> = new Map();
@@ -5883,6 +5884,9 @@ export class DevicePool {
     this.sessionManager.setDeviceReadiness(sessionId, achievedReadiness);
     if (mcpSessionId) {
       this.mcpSessionAutolockMap.set(mcpSessionId, sessionId);
+      const acquired = this.mcpSessionAcquiredAutolocks.get(mcpSessionId) ?? new Set<string>();
+      acquired.add(sessionId);
+      this.mcpSessionAcquiredAutolocks.set(mcpSessionId, acquired);
     }
     await this.persistAcquiredAutolockSession(device, session, assignmentSnapshot, mcpSessionId);
 
@@ -6073,11 +6077,32 @@ export class DevicePool {
     mcpSessionId: string | undefined,
     platform?: Platform,
     execution?: SessionExecutionMetadata,
+    deviceId?: string,
   ): string | undefined {
     if (!mcpSessionId) {
       return undefined;
     }
 
+    if (platform || deviceId) {
+      const selected = this.resolveAutolockDeviceSelector(
+        mcpSessionId,
+        platform,
+        execution,
+        deviceId,
+      );
+      if (selected || deviceId) {
+        return selected;
+      }
+    }
+
+    return this.resolveLatestAutolockSession(mcpSessionId, platform, execution);
+  }
+
+  private resolveLatestAutolockSession(
+    mcpSessionId: string,
+    platform: Platform | undefined,
+    execution: SessionExecutionMetadata | undefined,
+  ): string | undefined {
     const sessionId = this.mcpSessionAutolockMap.get(mcpSessionId);
     if (!sessionId) {
       return undefined;
@@ -6103,6 +6128,41 @@ export class DevicePool {
     }
 
     return sessionId;
+  }
+
+  private resolveAutolockDeviceSelector(
+    mcpSessionId: string,
+    platform: Platform | undefined,
+    execution: SessionExecutionMetadata | undefined,
+    deviceId: string | undefined,
+  ): string | undefined {
+    const candidates = [...(this.mcpSessionAcquiredAutolocks.get(mcpSessionId) ?? [])].flatMap(
+      (id) => {
+        const session = this.sessionManager.getSessionForNewExecution(id, execution);
+        const device = session ? this.devices.get(session.assignedDevice) : undefined;
+        return session && device && device.autolockSessionId === id && device.sessionId === id
+          ? [{ sessionId: id, deviceId: device.id, platform: device.platform }]
+          : [];
+      },
+    );
+    const matches = candidates.filter(
+      (candidate) =>
+        (!platform || candidate.platform === platform) &&
+        (!deviceId || candidate.deviceId === deviceId),
+    );
+    if (matches.length === 1) {
+      return matches[0].sessionId;
+    }
+    if (candidates.length > 0 && !deviceId) {
+      throw new ActionableError(
+        `Cannot resolve requested platform/deviceId unambiguously. Candidate sessions: ${candidates
+          .map(
+            (candidate) => `${candidate.sessionId} (${candidate.deviceId}, ${candidate.platform})`,
+          )
+          .join(", ")}. Pass an explicit sessionUuid/deviceId.`,
+      );
+    }
+    return undefined;
   }
 
   /**
@@ -6134,6 +6194,9 @@ export class DevicePool {
         expiresAtMs: session.expiresAt,
       });
       this.mcpSessionAutolockMap.set(mcpSessionId, sessionId);
+      const acquired = this.mcpSessionAcquiredAutolocks.get(mcpSessionId) ?? new Set<string>();
+      acquired.add(sessionId);
+      this.mcpSessionAcquiredAutolocks.set(mcpSessionId, acquired);
     });
   }
 
@@ -6203,6 +6266,12 @@ export class DevicePool {
   }
 
   private clearMcpAutolockMappings(sessionId: string): void {
+    for (const [mcpSessionId, acquired] of this.mcpSessionAcquiredAutolocks) {
+      acquired.delete(sessionId);
+      if (acquired.size === 0) {
+        this.mcpSessionAcquiredAutolocks.delete(mcpSessionId);
+      }
+    }
     for (const [mcpSessionId, mappedSessionId] of this.mcpSessionAutolockMap) {
       if (mappedSessionId === sessionId) {
         this.mcpSessionAutolockMap.delete(mcpSessionId);

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5579,8 +5579,13 @@ export class DevicePool {
     }
 
     return async () => {
+      const wasAutolocked = this.devices.get(previousDeviceId)?.autolockSessionId === sessionId;
       const session = await this.sessionManager.rebindSession(sessionId, deviceId, platform);
       await this.releaseDevice(previousDeviceId, sessionId);
+      const replacement = this.devices.get(deviceId);
+      if (wasAutolocked && replacement?.sessionId === sessionId) {
+        replacement.autolockSessionId = sessionId;
+      }
       return session;
     };
   }
@@ -6165,12 +6170,26 @@ export class DevicePool {
     return undefined;
   }
 
+  /** Restore retained capabilities without letting an older queued request reset the default. */
+  async restoreAutolockSessionsForMcpSession(
+    sessionIds: readonly string[],
+    mcpSessionId: string,
+  ): Promise<void> {
+    const hadDefault = this.resolveAutolockSessionForMcpSession(mcpSessionId) !== undefined;
+    for (const id of sessionIds) {
+      if (!hadDefault || !this.mcpSessionAcquiredAutolocks.get(mcpSessionId)?.has(id)) {
+        await this.attachAutolockSessionToMcpSession(id, mcpSessionId, !hadDefault);
+      }
+    }
+  }
+
   /**
    * Associate a live autolock session with a reconnected MCP client session.
    */
   async attachAutolockSessionToMcpSession(
     sessionId: string,
     mcpSessionId: string | undefined,
+    makeDefault = true,
   ): Promise<void> {
     if (!mcpSessionId) {
       return;
@@ -6193,7 +6212,9 @@ export class DevicePool {
         lastUsedAtMs: session.lastUsedAt,
         expiresAtMs: session.expiresAt,
       });
-      this.mcpSessionAutolockMap.set(mcpSessionId, sessionId);
+      if (makeDefault) {
+        this.mcpSessionAutolockMap.set(mcpSessionId, sessionId);
+      }
       const acquired = this.mcpSessionAcquiredAutolocks.get(mcpSessionId) ?? new Set<string>();
       acquired.add(sessionId);
       this.mcpSessionAcquiredAutolocks.set(mcpSessionId, acquired);

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -6144,9 +6144,28 @@ export class DevicePool {
     const candidates = [...(this.mcpSessionAcquiredAutolocks.get(mcpSessionId) ?? [])].flatMap(
       (id) => {
         const session = this.sessionManager.getSessionForNewExecution(id, execution);
-        const device = session ? this.devices.get(session.assignedDevice) : undefined;
-        return session && device && device.autolockSessionId === id && device.sessionId === id
-          ? [{ sessionId: id, deviceId: device.id, platform: device.platform }]
+        if (!session) {
+          return [];
+        }
+        const device = this.devices.get(session.assignedDevice);
+        if (device && device.autolockSessionId === id && device.sessionId === id) {
+          return [
+            { sessionId: id, deviceId: device.id, platform: device.platform, recovering: false },
+          ];
+        }
+        // A session detached by a process-wide ADB reset is still owned by this
+        // MCP connection; its device is simply absent from the pool while the
+        // reset is recovered. Dropping it here would let an implicit selector
+        // silently route to the connection's *other* device (#6807).
+        return this.adbServerResetQuarantinedSessions.has(id)
+          ? [
+              {
+                sessionId: id,
+                deviceId: session.assignedDevice,
+                platform: session.platform,
+                recovering: true,
+              },
+            ]
           : [];
       },
     );
@@ -6156,13 +6175,17 @@ export class DevicePool {
         (!deviceId || candidate.deviceId === deviceId),
     );
     if (matches.length === 1) {
+      // A lone recovering match is not ambiguous: returning it lets the caller
+      // surface the recovery error for the device the client actually owns.
       return matches[0].sessionId;
     }
     if (candidates.length > 0 && !deviceId) {
       throw new ActionableError(
         `Cannot resolve requested platform/deviceId unambiguously. Candidate sessions: ${candidates
           .map(
-            (candidate) => `${candidate.sessionId} (${candidate.deviceId}, ${candidate.platform})`,
+            (candidate) =>
+              `${candidate.sessionId} (${candidate.deviceId}, ${candidate.platform}` +
+              `${candidate.recovering ? ", recovering" : ""})`,
           )
           .join(", ")}. Pass an explicit sessionUuid/deviceId.`,
       );
@@ -6175,11 +6198,12 @@ export class DevicePool {
     sessionIds: readonly string[],
     mcpSessionId: string,
   ): Promise<void> {
-    const hadDefault = this.resolveAutolockSessionForMcpSession(mcpSessionId) !== undefined;
     for (const id of sessionIds) {
-      if (!hadDefault || !this.mcpSessionAcquiredAutolocks.get(mcpSessionId)?.has(id)) {
-        await this.attachAutolockSessionToMcpSession(id, mcpSessionId, !hadDefault);
-      }
+      // "if-absent" defers the default decision to attach time, under the
+      // assignment mutex. A pre-loop snapshot would be stale by the time the
+      // second attachment runs, letting restoration clobber a `setActiveDevice`
+      // that landed in between (#6807).
+      await this.attachAutolockSessionToMcpSession(id, mcpSessionId, "if-absent");
     }
   }
 
@@ -6189,7 +6213,7 @@ export class DevicePool {
   async attachAutolockSessionToMcpSession(
     sessionId: string,
     mcpSessionId: string | undefined,
-    makeDefault = true,
+    makeDefault: boolean | "if-absent" = true,
   ): Promise<void> {
     if (!mcpSessionId) {
       return;
@@ -6212,7 +6236,11 @@ export class DevicePool {
         lastUsedAtMs: session.lastUsedAt,
         expiresAtMs: session.expiresAt,
       });
-      if (makeDefault) {
+      if (
+        makeDefault === true ||
+        (makeDefault === "if-absent" &&
+          this.resolveAutolockSessionForMcpSession(mcpSessionId) === undefined)
+      ) {
         this.mcpSessionAutolockMap.set(mcpSessionId, sessionId);
       }
       const acquired = this.mcpSessionAcquiredAutolocks.get(mcpSessionId) ?? new Set<string>();

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1434,6 +1434,15 @@ export class UnixSocketServer {
     const sessionUuid = this.getSessionUuid(args);
     const toolSelectionProfileUuid =
       this.getToolSelectionProfileUuid(args) ?? boundRoute?.toolSelectionProfileUuid;
+    if (this.hasImplicitDeviceSelector(args)) {
+      return this.selectorMcpForwardRoute(
+        socketSessionId,
+        args,
+        scopedKey,
+        toolSelectionProfileUuid,
+      );
+    }
+
     if (sessionUuid) {
       return this.sessionScopedForwardRoute(
         socketSessionId,
@@ -1469,6 +1478,40 @@ export class UnixSocketServer {
     // The daemon injects __mcpSessionId before forwarding. Use the socket session as the
     // pre-forward key so separate daemon clients can autolock and run independently.
     return this.sharedMcpForwardRoute(`socket:${socketSessionId}`);
+  }
+
+  private selectorMcpForwardRoute(
+    socketSessionId: string,
+    args: unknown,
+    scopedKey: string | undefined,
+    profileUuid: string | undefined,
+  ): McpForwardRoute {
+    const key =
+      scopedKey ??
+      this.getImplicitAutolockScopeKey(socketSessionId, args) ??
+      `socket:${socketSessionId}`;
+    return profileUuid
+      ? this.toolSelectionProfileScopedForwardRoute(socketSessionId, profileUuid, key)
+      : this.sharedMcpForwardRoute(key);
+  }
+
+  private hasImplicitDeviceSelector(args: unknown): boolean {
+    if (!args || typeof args !== "object" || Array.isArray(args)) {
+      return false;
+    }
+    const record = args as Record<string, unknown>;
+    if (record.device) {
+      return false;
+    }
+    const sessionUuid = this.getSessionUuid(args);
+    if (sessionUuid) {
+      return false;
+    }
+    return (
+      record.platform === "android" ||
+      record.platform === "ios" ||
+      typeof record.deviceId === "string"
+    );
   }
 
   private sharedMcpForwardRoute(key: string): McpForwardRoute {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -32,6 +32,7 @@ import {
   DAEMON_TOOL_SELECTION_PROFILE_HEADER,
   DAEMON_TOOL_SELECTION_PROFILE_PARAM,
   DAEMON_BOUND_SESSION_PARAM,
+  DAEMON_OWNED_SESSIONS_PARAM,
   DAEMON_RELEASED_SESSION_PARAM,
   DAEMON_VERSION,
   INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
@@ -1039,6 +1040,9 @@ export class UnixSocketServer {
           };
         }
 
+        if (request.method === "tools/call") {
+          await this.restoreSelectorSessions(request.params?.arguments, sessionId);
+        }
         const initialRoute = this.getMcpForwardRoute(request, sessionId);
 
         const result = await this.runMcpForwardForCurrentRoute(
@@ -1425,6 +1429,19 @@ export class UnixSocketServer {
     return this.sharedMcpForwardRoute(
       typeof uri === "string" ? `resource:${uri}` : "resource:unknown",
     );
+  }
+
+  private async restoreSelectorSessions(args: unknown, socketSessionId: string): Promise<void> {
+    if (!args || typeof args !== "object" || Array.isArray(args)) {
+      return;
+    }
+    const ids = (args as Record<string, unknown>)[DAEMON_OWNED_SESSIONS_PARAM];
+    if (!Array.isArray(ids) || !ids.every((id) => typeof id === "string" && id.length > 0)) {
+      return;
+    }
+    const pool = this.daemonState.getDevicePool();
+    // Restoration accepts only live autolocks and does not reallocate a released UUID.
+    await pool.restoreAutolockSessionsForMcpSession?.([...new Set<string>(ids)], socketSessionId);
   }
 
   private getToolsCallForwardRoute(args: unknown, socketSessionId: string): McpForwardRoute {
@@ -4608,6 +4625,7 @@ export class UnixSocketServer {
 
     const forwardedArgs = { ...args } as Record<string, unknown>;
     delete forwardedArgs[DAEMON_TOOL_SELECTION_PROFILE_PARAM];
+    delete forwardedArgs[DAEMON_OWNED_SESSIONS_PARAM];
     this.throwIfReleasedBoundSession(forwardedArgs);
     const boundSessionUuid = this.getSessionUuid(forwardedArgs);
     const usesBoundSession = forwardedArgs[DAEMON_BOUND_SESSION_PARAM] === boundSessionUuid;

--- a/src/server/SessionToolBinding.ts
+++ b/src/server/SessionToolBinding.ts
@@ -1,6 +1,7 @@
 import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 
 export class SessionToolBinding {
+  private readonly acquiredSessions = new Map<string | undefined, Set<string>>();
   private readonly boundDeviceSessions = new Map<string, string>();
   private readonly releasedDeviceSessions = new Map<string, string>();
   private initialSessionUuid?: string;
@@ -50,6 +51,71 @@ export class SessionToolBinding {
       );
     }
     return explicitSessionUuid ?? boundSessionUuid;
+  }
+
+  /** Resolve selectors only within sessions admitted on this connection. */
+  resolveDeviceSessionUuid(
+    mcpSessionId: string | undefined,
+    params: Record<string, unknown>,
+    lookup: (sessionUuid: string) => { deviceId: string; platform: string } | undefined,
+  ): string | undefined {
+    const fallback = this.effectiveSessionUuid(mcpSessionId, params);
+    const platform =
+      params.platform === "android" || params.platform === "ios" ? params.platform : undefined;
+    const deviceId = typeof params.deviceId === "string" ? params.deviceId : undefined;
+    if ((!platform && !deviceId) || params.device) {
+      return fallback;
+    }
+    const matches = (device: { deviceId: string; platform: string }) =>
+      (!platform || device.platform === platform) && (!deviceId || device.deviceId === deviceId);
+    if (params.sessionUuid) {
+      return fallback;
+    }
+    if (this.initialSessionUuid) {
+      const device = lookup(this.initialSessionUuid);
+      if (device && !matches(device)) {
+        throw new Error(
+          `Bound device session ${fallback} does not match the requested platform/deviceId. Pass an explicit sessionUuid.`,
+        );
+      }
+      return fallback;
+    }
+    return this.resolveAcquiredDeviceSession(mcpSessionId, lookup, matches);
+  }
+
+  private resolveAcquiredDeviceSession(
+    mcpSessionId: string | undefined,
+    lookup: (sessionUuid: string) => { deviceId: string; platform: string } | undefined,
+    matches: (device: { deviceId: string; platform: string }) => boolean,
+  ): string | undefined {
+    const candidates = [...(this.acquiredSessions.get(mcpSessionId) ?? [])].flatMap(
+      (sessionUuid) => {
+        const device = lookup(sessionUuid);
+        return device ? [{ sessionUuid, ...device }] : [];
+      },
+    );
+    if (candidates.length === 0) {
+      // With no live acquired device, let ordinary device discovery resolve the selector.
+      return undefined;
+    }
+    const selected = candidates.filter(matches);
+    if (selected.length === 1) {
+      return selected[0].sessionUuid;
+    }
+    throw new Error(
+      `Cannot resolve requested platform/deviceId unambiguously. Candidate sessions: ${candidates
+        .map(
+          (candidate) => `${candidate.sessionUuid} (${candidate.deviceId}, ${candidate.platform})`,
+        )
+        .join(", ")}. Pass an explicit sessionUuid/deviceId.`,
+    );
+  }
+
+  ownsSession(mcpSessionId: string | undefined, sessionUuid: string): boolean {
+    return (
+      this.initialSessionUuid === sessionUuid ||
+      this.acquiredSessions.get(mcpSessionId)?.has(sessionUuid) === true
+    );
   }
 
   /**
@@ -111,6 +177,12 @@ export class SessionToolBinding {
     if (this.initialSessionUuid && sessionUuid !== this.initialSessionUuid) {
       return false;
     }
+    let acquired = this.acquiredSessions.get(mcpSessionId);
+    if (!acquired) {
+      acquired = new Set<string>();
+      this.acquiredSessions.set(mcpSessionId, acquired);
+    }
+    acquired.add(sessionUuid);
     if (!mcpSessionId) {
       if (this.directDeviceSessionUuid === sessionUuid) {
         return false;
@@ -174,6 +246,9 @@ export class SessionToolBinding {
       return false;
     }
     let removed = false;
+    for (const acquired of this.acquiredSessions.values()) {
+      removed = acquired.delete(sessionUuid) || removed;
+    }
     for (const [mcpSessionId, boundSessionUuid] of this.boundDeviceSessions) {
       if (boundSessionUuid === sessionUuid) {
         this.boundDeviceSessions.delete(mcpSessionId);

--- a/src/server/SessionToolBinding.ts
+++ b/src/server/SessionToolBinding.ts
@@ -58,6 +58,7 @@ export class SessionToolBinding {
     mcpSessionId: string | undefined,
     params: Record<string, unknown>,
     lookup: (sessionUuid: string) => { deviceId: string; platform: string } | undefined,
+    selectingActiveDevice = false,
   ): string | undefined {
     const fallback = this.effectiveSessionUuid(mcpSessionId, params);
     const platform =
@@ -80,13 +81,21 @@ export class SessionToolBinding {
       }
       return fallback;
     }
-    return this.resolveAcquiredDeviceSession(mcpSessionId, lookup, matches);
+    return this.resolveAcquiredDeviceSession(
+      mcpSessionId,
+      lookup,
+      matches,
+      fallback,
+      selectingActiveDevice,
+    );
   }
 
   private resolveAcquiredDeviceSession(
     mcpSessionId: string | undefined,
     lookup: (sessionUuid: string) => { deviceId: string; platform: string } | undefined,
     matches: (device: { deviceId: string; platform: string }) => boolean,
+    rebindFallback?: string,
+    selectingActiveDevice = false,
   ): string | undefined {
     const candidates = [...(this.acquiredSessions.get(mcpSessionId) ?? [])].flatMap(
       (sessionUuid) => {
@@ -99,6 +108,14 @@ export class SessionToolBinding {
       return undefined;
     }
     const selected = candidates.filter(matches);
+    if (
+      selected.length === 0 &&
+      selectingActiveDevice &&
+      rebindFallback &&
+      candidates.some((candidate) => candidate.sessionUuid === rebindFallback)
+    ) {
+      return rebindFallback;
+    }
     if (selected.length === 1) {
       return selected[0].sessionUuid;
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1097,10 +1097,16 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
           ? sessionForBinding !== null &&
             sessionForBinding !== undefined &&
             daemonSessionManager.isAdmittedForAutomation(sessionForBinding)
-          : resolveDirectSessionDevice(providedSessionUuid) !== undefined) &&
-        sessionToolBinding.bind(sessionId, providedSessionUuid)
+          : resolveDirectSessionDevice(providedSessionUuid) !== undefined)
       ) {
-        ToolRegistry.notifyToolListChanged();
+        if (sessionToolBinding.bind(sessionId, providedSessionUuid)) {
+          ToolRegistry.notifyToolListChanged();
+        }
+        if (tool.requiresDevice && daemonSessionManager && implicitAutolockMcpSessionId) {
+          await DaemonState.getInstance()
+            .getDevicePool()
+            .attachAutolockSessionToMcpSession(providedSessionUuid, implicitAutolockMcpSessionId);
+        }
       }
       // Wire-boundary output policy: strip the duplicated `structuredContent`
       // tree for no-schema tools unconditionally (issue #2759) and for schema

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -638,6 +638,11 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
             undefined,
             deviceId,
           );
+        if (!routingSessionUuid && name === "setActiveDevice") {
+          routingSessionUuid = daemonState
+            .getDevicePool()
+            .resolveAutolockSessionForMcpSession(implicitAutolockMcpSessionId);
+        }
         resolvedImplicitAutolockSessionUuid = routingSessionUuid;
       } else {
         routingSessionUuid = sessionToolBinding.resolveDeviceSessionUuid(
@@ -657,6 +662,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
               .getDevice(session.assignedDevice);
             return device ? { deviceId: device.id, platform: device.platform } : undefined;
           },
+          name === "setActiveDevice",
         );
       }
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -594,7 +594,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     const requestMcpSessionId = daemonMode ? extractInternalMcpSessionId(toolParams) : undefined;
     const implicitAutolockMcpSessionId =
       requestMcpSessionId ?? (!daemonMode ? sessionId : undefined);
-    const routingSessionUuid = sessionToolBinding.effectiveSessionUuid(sessionId, toolParams);
+    let routingSessionUuid = sessionToolBinding.effectiveSessionUuid(sessionId, toolParams);
     let connectionProfileUuid = sessionToolBinding.connectionToolSelectionProfileUuid(sessionId);
     const rawRequestedToolSelectionProfileUuid = (toolParams as Record<string, unknown>)
       .sessionUuid;
@@ -607,6 +607,56 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     const tool = ToolRegistry.getTool(name);
     if (!tool) {
       throw new ActionableError(`Unknown tool: ${name}`);
+    }
+
+    if (
+      (tool.requiresDevice && !isDeviceSessionAcquisitionTool(name)) ||
+      name === "setActiveDevice"
+    ) {
+      const daemonState = DaemonState.getInstance();
+      const rawArgs = toolParams as Record<string, unknown>;
+      if (
+        daemonState.isInitialized() &&
+        implicitAutolockMcpSessionId &&
+        !options.sessionContext?.initialSessionToolBinding &&
+        !rawArgs.sessionUuid &&
+        !rawArgs.device
+      ) {
+        // Loopback MCP clients are reused by execution scope, not by socket.
+        // Their local bindings are partial; only the pool owns all acquisitions.
+        const platform =
+          rawArgs.platform === "android" || rawArgs.platform === "ios"
+            ? rawArgs.platform
+            : undefined;
+        const deviceId = typeof rawArgs.deviceId === "string" ? rawArgs.deviceId : undefined;
+        routingSessionUuid = daemonState
+          .getDevicePool()
+          .resolveAutolockSessionForMcpSession(
+            implicitAutolockMcpSessionId,
+            platform,
+            undefined,
+            deviceId,
+          );
+      } else {
+        routingSessionUuid = sessionToolBinding.resolveDeviceSessionUuid(
+          sessionId,
+          toolParams,
+          (id) => {
+            if (!DaemonState.getInstance().isInitialized()) {
+              return resolveDirectSessionDevice(id)?.device;
+            }
+            const manager = DaemonState.getInstance().getSessionManager();
+            const session = manager.getSession(id);
+            if (!session || !manager.isAdmittedForAutomation(session) || !session.assignedDevice) {
+              return undefined;
+            }
+            const device = DaemonState.getInstance()
+              .getDevicePool()
+              .getDevice(session.assignedDevice);
+            return device ? { deviceId: device.id, platform: device.platform } : undefined;
+          },
+        );
+      }
     }
 
     // #6069: enforce connection ownership on the DEVICE-routing path. If this
@@ -639,7 +689,8 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       if (
         boundDeviceSessionUuid &&
         explicitSessionUuid &&
-        explicitSessionUuid !== boundDeviceSessionUuid
+        explicitSessionUuid !== boundDeviceSessionUuid &&
+        !sessionToolBinding.ownsSession(sessionId, explicitSessionUuid)
       ) {
         throw new ActionableError(
           `MCP connection is bound to device session ${boundDeviceSessionUuid}; ` +
@@ -781,6 +832,9 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       parsedParams && typeof parsedParams === "object"
         ? {
             ...parsedParams,
+            ...(name === "setActiveDevice" && routingSessionUuid
+              ? { sessionUuid: routingSessionUuid }
+              : {}),
             ...(implicitAutolockMcpSessionId
               ? { [INTERNAL_MCP_SESSION_PARAM]: implicitAutolockMcpSessionId }
               : {}),
@@ -990,6 +1044,16 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         if (acquisitionEnrichmentCancelled || requestSignal?.aborted) {
           failCancelledAcquisition(acquiredSessionUuid);
         }
+      }
+      if (
+        name === "setActiveDevice" &&
+        !result?.isError &&
+        sessionToolBinding.bind(
+          sessionId,
+          getDeviceSessionIdFromResult(result) ?? routingSessionUuid,
+        )
+      ) {
+        ToolRegistry.notifyToolListChanged();
       }
       const isRecordingIdCleanup =
         name === "videoRecording" &&

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -595,6 +595,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     const implicitAutolockMcpSessionId =
       requestMcpSessionId ?? (!daemonMode ? sessionId : undefined);
     let routingSessionUuid = sessionToolBinding.effectiveSessionUuid(sessionId, toolParams);
+    let resolvedImplicitAutolockSessionUuid: string | undefined;
     let connectionProfileUuid = sessionToolBinding.connectionToolSelectionProfileUuid(sessionId);
     const rawRequestedToolSelectionProfileUuid = (toolParams as Record<string, unknown>)
       .sessionUuid;
@@ -637,6 +638,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
             undefined,
             deviceId,
           );
+        resolvedImplicitAutolockSessionUuid = routingSessionUuid;
       } else {
         routingSessionUuid = sessionToolBinding.resolveDeviceSessionUuid(
           sessionId,
@@ -827,6 +829,14 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       executionSessionUuid,
       sessionId,
     );
+    if (resolvedImplicitAutolockSessionUuid) {
+      // Routing resolved before ToolRegistry, so retain its implicit-session
+      // tracking here without following later changes to the socket's default.
+      executionTracker.setResolvedAutolockSessionUuid(
+        execution.id,
+        resolvedImplicitAutolockSessionUuid,
+      );
+    }
     const requestSignal = combineAbortSignals(execution.abortController.signal, extra.signal);
     const handlerParams =
       parsedParams && typeof parsedParams === "object"

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -616,7 +616,7 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
         providedDeviceId = context.deviceId;
         logger.info(`[ToolRegistry] Resolved device from session: ${providedDeviceId}`);
       }
-      if (platform === "either" && context.devicePlatform) {
+      if (context.devicePlatform) {
         platform = context.devicePlatform;
       }
     } else if (shouldResolveDevice && sessionUuid) {
@@ -640,9 +640,7 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
         // narrowing to the session's platform here would send an explicit
         // cross-platform deviceId to the wrong platform's search and fail
         // (mirrors the #5870 deviceId-resolves-platform rule).
-        if (platform === "either") {
-          platform = directSession.device.platform;
-        }
+        platform = directSession.device.platform;
       }
     } else if (sessionUuid) {
       logger.warn(`[ToolRegistry] SessionUuid provided but DaemonState not initialized!`);
@@ -767,7 +765,12 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
     const platformFilter = platform === "android" || platform === "ios" ? platform : undefined;
     const sessionId = DaemonState.getInstance()
       .getDevicePool()
-      .resolveAutolockSessionForMcpSession(mcpSessionId, platformFilter, execution);
+      .resolveAutolockSessionForMcpSession(
+        mcpSessionId,
+        platformFilter,
+        execution,
+        providedDeviceId,
+      );
     if (!sessionId) {
       return undefined;
     }

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -496,7 +496,23 @@ async function captureBiometricEnrollment(
 export function registerUtilityTools() {
   // Set active device handler
   const setActiveDeviceHandler = async (args: SetActiveDeviceArgs & { sessionUuid?: string }) => {
+    const mcpSessionId = (args as SetActiveDeviceArgs & { __mcpSessionId?: string }).__mcpSessionId;
+    let selectedAutolockSession: string | undefined;
     try {
+      if (mcpSessionId && DaemonState.getInstance().isInitialized()) {
+        const ownedSession = DaemonState.getInstance()
+          .getDevicePool()
+          .resolveAutolockSessionForMcpSession(
+            mcpSessionId,
+            args.platform,
+            undefined,
+            args.deviceId,
+          );
+        args.sessionUuid ??= ownedSession;
+        if (ownedSession === args.sessionUuid) {
+          selectedAutolockSession = ownedSession;
+        }
+      }
       if (args.sessionUuid && DaemonState.getInstance().isInitialized()) {
         // Session-scoped: bind the specific requested device to this session
         const sessionManager = DaemonState.getInstance().getSessionManager();
@@ -567,9 +583,15 @@ export function registerUtilityTools() {
         }
       }
 
+      if (selectedAutolockSession) {
+        await DaemonState.getInstance()
+          .getDevicePool()
+          .attachAutolockSessionToMcpSession(selectedAutolockSession, mcpSessionId);
+      }
       return createJSONToolResponse({
         message: `Active device set to '${args.deviceId}'`,
         deviceId: args.deviceId,
+        ...(args.sessionUuid ? { sessionUuid: args.sessionUuid } : {}),
       });
     } catch (error) {
       logger.error("Failed to set active device:", error);

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -29,6 +29,10 @@ import {
   withJsonSchemaOverride,
 } from "./toolSchemaHelpers";
 import { DaemonState } from "../daemon/daemonState";
+import {
+  registerDirectSessionDevice,
+  resolveDirectSessionDevice,
+} from "./directSessionDeviceRegistry";
 import type { SessionManager } from "../daemon/sessionManager";
 import {
   applyStateAfterBiometricCaptureFailure,
@@ -508,9 +512,14 @@ export function registerUtilityTools() {
             undefined,
             args.deviceId,
           );
-        args.sessionUuid ??= ownedSession;
-        if (ownedSession === args.sessionUuid) {
-          selectedAutolockSession = ownedSession;
+        const targetSession =
+          ownedSession ??
+          DaemonState.getInstance()
+            .getDevicePool()
+            .resolveAutolockSessionForMcpSession(mcpSessionId);
+        args.sessionUuid ??= targetSession;
+        if (targetSession === args.sessionUuid) {
+          selectedAutolockSession = targetSession;
         }
       }
       if (args.sessionUuid && DaemonState.getInstance().isInitialized()) {
@@ -571,6 +580,9 @@ export function registerUtilityTools() {
           args.deviceId,
         );
         const resolvedPlatform = args.platform ?? readyDevice.platform;
+        if (args.sessionUuid && resolveDirectSessionDevice(args.sessionUuid)) {
+          registerDirectSessionDevice(args.sessionUuid, readyDevice);
+        }
 
         // When switching platforms, clear observation caches to prevent stale
         // data from the previous platform contaminating subsequent observe calls.

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -341,24 +341,22 @@ describe("DaemonMcpProxy", () => {
       try {
         await proxy.callTool("observe", {
           sessionUuid: "session-a",
-          deviceId: "device-a",
         });
         timer.advanceTime(2_000);
         await heartbeatStarted.promise;
 
         await proxy.callTool("observe", {
           sessionUuid: "session-b",
-          deviceId: "device-b",
         });
         releaseFirstHeartbeat.resolve();
         await retryHeartbeatCalled.promise;
         await Promise.resolve();
         await Promise.resolve();
 
-        await expect(proxy.callTool("observe", { deviceId: "device-b" })).resolves.toBeDefined();
+        await expect(proxy.callTool("observe", {})).resolves.toBeDefined();
         expect(freshClient.callToolCalls.at(-1)).toEqual({
           toolName: "observe",
-          params: { deviceId: "device-b", sessionUuid: "session-b" },
+          params: { sessionUuid: "session-b" },
         });
       } finally {
         isAvailableSpy.mockRestore();
@@ -390,14 +388,13 @@ describe("DaemonMcpProxy", () => {
       try {
         await proxy.callTool("observe", {
           sessionUuid: "  session-a  ",
-          deviceId: "device-a",
         });
         expect(firstClient.callToolCalls[0]).toEqual({
           toolName: "observe",
-          params: { sessionUuid: "session-a", deviceId: "device-a" },
+          params: { sessionUuid: "session-a" },
         });
 
-        await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toMatchObject({
+        await expect(proxy.callTool("observe", {})).rejects.toMatchObject({
           sessionUuid: "session-a",
           reason: "session-not-found",
         });
@@ -2410,12 +2407,10 @@ describe("DaemonMcpProxy", () => {
 
       try {
         await proxy.callTool("observe", {
-          deviceId: "ios-simulator-a",
           sessionUuid: "ios-session-a",
         });
         await expect(
           proxy.callTool("observe", {
-            deviceId: "ios-simulator-b",
             sessionUuid: "ios-session-b",
             __autoMobileBoundSessionUuid: "ios-session-b",
           }),
@@ -2424,14 +2419,13 @@ describe("DaemonMcpProxy", () => {
           reason: "session-not-found",
         });
         expect(failedRequestParams).toEqual({
-          deviceId: "ios-simulator-b",
           sessionUuid: "ios-session-b",
         });
 
-        await proxy.callTool("observe", { deviceId: "ios-simulator-a" });
+        await proxy.callTool("observe", {});
         expect(client.callToolCalls.at(-1)).toEqual({
           toolName: "observe",
-          params: { deviceId: "ios-simulator-a", sessionUuid: "ios-session-a" },
+          params: { sessionUuid: "ios-session-a" },
         });
       } finally {
         isAvailableSpy.mockRestore();
@@ -2496,21 +2490,19 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
         const result = await proxy.callTool("videoRecording", {
           action: "stop",
-          deviceId: "device-a",
           recordingId: "recording-a",
         });
 
         expect(result).toEqual({ content: [{ type: "text", text: "recovered" }] });
         expect(staleClient.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
           {
             toolName: "videoRecording",
             params: {
               action: "stop",
-              deviceId: "device-a",
               recordingId: "recording-a",
               sessionUuid: "session-a",
             },
@@ -2521,7 +2513,6 @@ describe("DaemonMcpProxy", () => {
             toolName: "videoRecording",
             params: {
               action: "stop",
-              deviceId: "device-a",
               recordingId: "recording-a",
               sessionUuid: "session-a",
             },
@@ -2589,11 +2580,11 @@ describe("DaemonMcpProxy", () => {
 
       try {
         await proxy.callTool("executePlan", { sessionUuid: "session-a", deviceId: "device-a" });
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
 
         expect(client.callToolCalls).toEqual([
           { toolName: "executePlan", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { deviceId: "device-a" } },
+          { toolName: "observe", params: {} },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -2622,18 +2613,16 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
-        await expect(proxy.callTool("executePlan", { deviceId: "device-a" })).rejects.toThrow(
-          "plan boom",
-        );
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
+        await expect(proxy.callTool("executePlan", {})).rejects.toThrow("plan boom");
+        await proxy.callTool("observe", {});
 
         // The third call is still rewritten to session-a: the binding survived the
         // rejection because nothing proved the session was released.
         expect(client.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "executePlan", params: { deviceId: "device-a", sessionUuid: "session-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "executePlan", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -2691,13 +2680,13 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
         timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
 
         expect(client.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -2715,14 +2704,14 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
-        await proxy.callTool("observe", { sessionUuid: "session-b", deviceId: "device-b" });
-        await proxy.callTool("observe", { deviceId: "device-b" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-b" });
+        await proxy.callTool("observe", {});
 
         expect(client.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { sessionUuid: "session-b", deviceId: "device-b" } },
-          { toolName: "observe", params: { sessionUuid: "session-b", deviceId: "device-b" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-b" } },
+          { toolName: "observe", params: { sessionUuid: "session-b" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -2750,18 +2739,18 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
         // Two implicit calls, each within the TTL, but cumulatively past it. Each
         // forwarded implicit call must renew the lease so the binding survives.
         timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
         timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
 
         expect(client.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -2791,22 +2780,20 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
         // An admitted-then-rejected implicit call within the TTL. It must renew the
         // lease off the injected UUID even though it throws.
         timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
-        await expect(proxy.callTool("tapOn", { deviceId: "device-a" })).rejects.toThrow(
-          "tap failed after admission",
-        );
+        await expect(proxy.callTool("tapOn", {})).rejects.toThrow("tap failed after admission");
         // Cumulatively past one TTL from the initial bind; only the refreshed lease
         // keeps the binding alive for this final implicit call.
         timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
 
         expect(client.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "tapOn", params: { deviceId: "device-a", sessionUuid: "session-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "tapOn", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -2836,18 +2823,18 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
         timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
-        await expect(proxy.callTool("tapOn", { deviceId: "device-a" })).resolves.toMatchObject({
+        await expect(proxy.callTool("tapOn", {})).resolves.toMatchObject({
           isError: true,
         });
         timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
 
         expect(client.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "tapOn", params: { deviceId: "device-a", sessionUuid: "session-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "tapOn", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -2869,14 +2856,14 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
         await proxy.callTool("listDevices", { sessionUuid: "unissued-session" });
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
 
         expect(client.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
           { toolName: "listDevices", params: { sessionUuid: "unissued-session" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -2899,16 +2886,16 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
         timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
         await proxy.callTool("listDevices", {});
         timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
 
         expect(client.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
           { toolName: "listDevices", params: { sessionUuid: "session-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -2937,16 +2924,16 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
-        await expect(
-          proxy.callTool("tapOn", { sessionUuid: "session-b", deviceId: "device-b" }),
-        ).rejects.toThrow("is not an active daemon session");
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
+        await expect(proxy.callTool("tapOn", { sessionUuid: "session-b" })).rejects.toThrow(
+          "is not an active daemon session",
+        );
+        await proxy.callTool("observe", {});
 
         expect(client.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "tapOn", params: { sessionUuid: "session-b", deviceId: "device-b" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "tapOn", params: { sessionUuid: "session-b" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -2973,18 +2960,17 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
         const rejected = await proxy.callTool("tapOn", {
           sessionUuid: "session-b",
-          deviceId: "device-b",
         });
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
 
         expect(rejected.isError).toBe(true);
         expect(client.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "tapOn", params: { sessionUuid: "session-b", deviceId: "device-b" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "tapOn", params: { sessionUuid: "session-b" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -3012,20 +2998,18 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
         timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
-        await expect(proxy.callTool("tapOn", { deviceId: "device-a" })).rejects.toBeInstanceOf(
-          DaemonUnavailableError,
-        );
+        await expect(proxy.callTool("tapOn", {})).rejects.toBeInstanceOf(DaemonUnavailableError);
         timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
 
         // The final implicit observe remains bound because heartbeat activity,
         // not the failed tool attempt, refreshed the live session.
         const lastCall = client.callToolCalls[client.callToolCalls.length - 1];
         expect(lastCall).toEqual({
           toolName: "observe",
-          params: { deviceId: "device-a", sessionUuid: "session-a" },
+          params: { sessionUuid: "session-a" },
         });
       } finally {
         isAvailableSpy.mockRestore();
@@ -3048,20 +3032,18 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
         await proxy.callTool("observe", {
-          deviceId: "device-a",
           sessionUuid: null as unknown as string,
         });
         await proxy.callTool("observe", {
-          deviceId: "device-a",
           sessionUuid: 42 as unknown as string,
         });
 
         expect(client.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -3346,16 +3328,16 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
         // A derived-only release (`${base}:${label}`) or an unrelated session key
         // must NOT clear a base binding matched by exact equality.
         fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-a:device-a");
         fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-b");
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
 
         expect(fakeClient.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -3388,17 +3370,17 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
         // Call 2 injects session-a, then the release lands mid-flight.
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
         // Call 3 must fail terminally without reaching the daemon.
-        await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toThrow(
+        await expect(proxy.callTool("observe", {})).rejects.toThrow(
           /session-a.*(?:expired|released)/i,
         );
 
         expect(fakeClient.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -3489,18 +3471,18 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
-        await expect(proxy.callTool("tapOn", { deviceId: "device-a" })).rejects.toThrow(
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
+        await expect(proxy.callTool("tapOn", {})).rejects.toThrow(
           /session-a.*(?:expired|released)/i,
         );
         // The admitted-failure refresh must not resurrect the released UUID's lease.
-        await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toThrow(
+        await expect(proxy.callTool("observe", {})).rejects.toThrow(
           /session-a.*(?:expired|released)/i,
         );
 
         expect(fakeClient.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "tapOn", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "tapOn", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -3544,11 +3526,11 @@ describe("DaemonMcpProxy", () => {
         await expect(
           proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" }),
         ).rejects.toBe(transportError);
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
 
         expect(fakeClient.callToolCalls).toEqual([
           { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { deviceId: "device-a" } },
+          { toolName: "observe", params: {} },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -3594,11 +3576,11 @@ describe("DaemonMcpProxy", () => {
         await expect(
           proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" }),
         ).rejects.toBe(transportError);
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
 
         expect(fakeClient.callToolCalls).toEqual([
           { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { deviceId: "device-a" } },
+          { toolName: "observe", params: {} },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -3615,7 +3597,6 @@ describe("DaemonMcpProxy", () => {
           code: "device_control_transport_failure",
           transport: "daemon_loopback_http",
           toolName: "observe",
-          deviceId: "device-a",
           deviceSessionUuid: "device-epoch-a",
           sessionUuid: "session-a",
           sessionValid: true,
@@ -3649,20 +3630,18 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
         await Promise.resolve();
         await Promise.resolve();
         timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
-        await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toBe(
-          responseError,
-        );
+        await expect(proxy.callTool("observe", {})).rejects.toBe(responseError);
         timer.advanceTime(2);
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
 
         expect(fakeClient.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -3689,12 +3668,12 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
+        await proxy.callTool("observe", {});
 
         expect(fakeClient.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
         expect(observed).toBe(2);
       } finally {
@@ -3921,14 +3900,14 @@ describe("DaemonMcpProxy", () => {
       });
 
       try {
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-a" });
         // A future notification family must not touch the binding.
         expect(() => fakeClient.emitNotification("notifications/some/future_thing")).not.toThrow();
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await proxy.callTool("observe", {});
 
         expect(fakeClient.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -344,7 +344,9 @@ describe("DevicePool autolock", () => {
       const sessionId = await pool.autolockDevice("emulator-5554", "android", "mcp-session-1");
 
       expect(pool.resolveAutolockSessionForMcpSession("mcp-session-1", "android")).toBe(sessionId);
-      expect(pool.resolveAutolockSessionForMcpSession("mcp-session-1", "ios")).toBeUndefined();
+      expect(() => pool.resolveAutolockSessionForMcpSession("mcp-session-1", "ios")).toThrow(
+        "Candidate sessions:",
+      );
       expect(
         pool.resolveAutolockSessionForMcpSession("other-mcp-session", "android"),
       ).toBeUndefined();

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -352,6 +352,111 @@ describe("DevicePool autolock", () => {
       ).toBeUndefined();
     });
 
+    it("keeps a recovering owned session in the ambiguity candidate set", async () => {
+      // Two Android devices autolocked by the same MCP connection. When one is
+      // detached by a process-wide ADB reset, its session is still owned by the
+      // connection - it is merely recovering. An implicit `platform: "android"`
+      // selector must report ambiguity rather than silently routing every call
+      // to the one device that happens to still be attached.
+      const first = {
+        name: "Pixel_8_API_35",
+        platform: "android" as const,
+        deviceId: "emulator-5554",
+      };
+      const second = {
+        name: "Pixel_9_API_36",
+        platform: "android" as const,
+        deviceId: "emulator-5556",
+      };
+      const firstImage = {
+        name: first.name,
+        platform: "android" as const,
+        isRunning: true,
+        source: "local" as const,
+      };
+      const secondImage = { ...firstImage, name: second.name };
+      fakeDeviceUtils.setBootedDevices("android", [first, second]);
+      await pool.addDevice(first, firstImage);
+      await pool.addDevice(second, secondImage);
+      const firstSession = await pool.autolockDevice(
+        first.deviceId,
+        "android",
+        "mcp-session-1",
+        firstImage,
+      );
+      const secondSession = await pool.autolockDevice(
+        second.deviceId,
+        "android",
+        "mcp-session-1",
+        secondImage,
+      );
+
+      const detached = await pool.detachAdbServerResetCohort([pool.getDevice(first.deviceId)!]);
+      try {
+        expect(pool.isSessionRecoveryInFlight(firstSession!)).toBe(true);
+        expect(() => pool.resolveAutolockSessionForMcpSession("mcp-session-1", "android")).toThrow(
+          new RegExp(`Candidate sessions:.*${firstSession}.*${secondSession}`, "s"),
+        );
+      } finally {
+        await pool.releaseAdbServerResetCohortReservations(detached.devices);
+      }
+    });
+
+    it("does not let a queued restoration overwrite a default set after its snapshot", async () => {
+      // `setActiveDevice` can land between the moment restoration reads "this
+      // connection has no default" and the moment it actually attaches. The
+      // conditional default must therefore be evaluated at attach time, under
+      // the assignment mutex, not from the stale pre-loop snapshot.
+      const first = {
+        name: "Pixel_8_API_35",
+        platform: "android" as const,
+        deviceId: "emulator-5554",
+      };
+      const second = {
+        name: "Pixel_9_API_36",
+        platform: "android" as const,
+        deviceId: "emulator-5556",
+      };
+      const gate = Promise.withResolvers<void>();
+      const entered = Promise.withResolvers<void>();
+      let gatedSessionId: string | undefined;
+      const repository = {
+        markAutolockSession: async (sessionId: string): Promise<void> => {
+          if (gatedSessionId === sessionId) {
+            gatedSessionId = undefined;
+            entered.resolve();
+            await gate.promise;
+          }
+        },
+      };
+      const gatedPool = new DevicePool(
+        sessionManager,
+        "daemon-session-1",
+        timer,
+        undefined,
+        fakeDeviceUtils,
+        undefined,
+        repository,
+      );
+      fakeDeviceUtils.setBootedDevices("android", [first, second]);
+      await gatedPool.initializeWithDevices([first, second]);
+      const firstSession = await gatedPool.autolockDevice(first.deviceId, "android");
+      const secondSession = await gatedPool.autolockDevice(second.deviceId, "android");
+
+      gatedSessionId = firstSession;
+      const explicit = gatedPool.attachAutolockSessionToMcpSession(firstSession!, "mcp-session-1");
+      await entered.promise;
+      const restore = gatedPool.restoreAutolockSessionsForMcpSession(
+        [secondSession!],
+        "mcp-session-1",
+      );
+      gate.resolve();
+      await explicit;
+      await restore;
+
+      expect(gatedPool.resolveAutolockSessionForMcpSession("mcp-session-1")).toBe(firstSession);
+    });
+
     it("records achieved readiness before publishing the MCP session route (#6227 round 9)", async () => {
       await initializeLiveAndroidDevice();
 

--- a/test/daemon/proxyResultMintedSession.test.ts
+++ b/test/daemon/proxyResultMintedSession.test.ts
@@ -143,25 +143,59 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
     try {
       await proxy.callTool("getAndroid", {});
       await proxy.callTool("getApple", {});
-      await proxy.callTool("observe", { platform: "android" });
-      expect(client.callToolCalls.at(-1)?.params).toEqual({ platform: "android" });
+      await proxy.callTool("observe", {
+        platform: "android",
+        __autoMobileOwnedSessionUuids: ["forged"],
+      });
+      expect(client.callToolCalls.at(-1)?.params).toMatchObject({
+        platform: "android",
+        __autoMobileOwnedSessionUuids: ["android-session", "ios-session"],
+      });
+      expect(client.callToolCalls.at(-1)?.params).not.toHaveProperty("sessionUuid");
       await proxy.callTool("observe", { platform: "ios", sessionUuid: "android-session" });
-      expect(client.callToolCalls.at(-1)?.params).toEqual({
+      expect(client.callToolCalls.at(-1)?.params).toMatchObject({
         platform: "ios",
         sessionUuid: "android-session",
       });
       await proxy.callTool("getApple", {});
       await proxy.callTool("setActiveDevice", { platform: "android", deviceId: "emulator-5554" });
-      expect(client.callToolCalls.at(-1)?.params).toEqual({
+      expect(client.callToolCalls.at(-1)?.params).toMatchObject({
         platform: "android",
         deviceId: "emulator-5554",
       });
+      expect(client.callToolCalls.at(-1)?.params).not.toHaveProperty("sessionUuid");
       await proxy.callTool("observe", {});
       expect(client.callToolCalls.at(-1)?.params).toEqual({ sessionUuid: "android-session" });
     } finally {
       await proxy.close();
     }
   });
+
+  test.each(["listDevices", "listDeviceImages"])(
+    "platform filters retain bound policy for %s",
+    async (name) => {
+      const client = new FakeDaemonClient({
+        toolResultFor: (tool) =>
+          tool === "getAndroid" ? deviceStartResult("android-session") : undefined,
+      });
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+      });
+      try {
+        await proxy.callTool("getAndroid", {});
+        await proxy.callTool(name, { platform: "android" });
+        expect(client.callToolCalls.at(-1)?.params).toEqual({
+          platform: "android",
+          sessionUuid: "android-session",
+        });
+      } finally {
+        await proxy.close();
+      }
+    },
+  );
 
   test("does not resurrect a session released during setActiveDevice", async () => {
     const client = new FakeDaemonClient({
@@ -304,10 +338,11 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
       const observe = await proxy.callTool("observe", { platform: "android", project: "skeleton" });
       expect(observe).toEqual({ content: [{ type: "text", text: "success" }] });
       // Preserve the selector for the daemon; do not turn the retained session into an explicit override.
-      expect(client.callToolCalls.at(-1)).toEqual({
+      expect(client.callToolCalls.at(-1)).toMatchObject({
         toolName: "observe",
         params: { platform: "android", project: "skeleton" },
       });
+      expect(client.callToolCalls.at(-1)?.params).not.toHaveProperty("sessionUuid");
     } finally {
       await proxy.close();
     }
@@ -339,7 +374,7 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
 
       // The fence is cleared: a subsequent sessionless call routes to M2.
       await proxy.callTool("observe", {});
-      expect(client.callToolCalls.at(-1)).toEqual({
+      expect(client.callToolCalls.at(-1)).toMatchObject({
         toolName: "observe",
         params: { sessionUuid: M2 },
       });

--- a/test/daemon/proxyResultMintedSession.test.ts
+++ b/test/daemon/proxyResultMintedSession.test.ts
@@ -122,6 +122,87 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
     clearHeartbeatEnv();
   });
 
+  test("keeps platform selectors implicit and adopts the session selected by setActiveDevice", async () => {
+    const client = new FakeDaemonClient({
+      toolResultFor: (name) => {
+        if (name === "getAndroid" || name === "setActiveDevice") {
+          return deviceStartResult("android-session");
+        }
+        if (name === "getApple") {
+          return deviceStartResult("ios-session");
+        }
+        return undefined;
+      },
+    });
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => client,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+    try {
+      await proxy.callTool("getAndroid", {});
+      await proxy.callTool("getApple", {});
+      await proxy.callTool("observe", { platform: "android" });
+      expect(client.callToolCalls.at(-1)?.params).toEqual({ platform: "android" });
+      await proxy.callTool("observe", { platform: "ios", sessionUuid: "android-session" });
+      expect(client.callToolCalls.at(-1)?.params).toEqual({
+        platform: "ios",
+        sessionUuid: "android-session",
+      });
+      await proxy.callTool("getApple", {});
+      await proxy.callTool("setActiveDevice", { platform: "android", deviceId: "emulator-5554" });
+      expect(client.callToolCalls.at(-1)?.params).toEqual({
+        platform: "android",
+        deviceId: "emulator-5554",
+      });
+      await proxy.callTool("observe", {});
+      expect(client.callToolCalls.at(-1)?.params).toEqual({ sessionUuid: "android-session" });
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  test("does not resurrect a session released during setActiveDevice", async () => {
+    const client = new FakeDaemonClient({
+      onCallTool: (name) => {
+        if (name === "setActiveDevice") {
+          client.emitNotification(
+            SESSION_RELEASED_NOTIFICATION_METHOD,
+            "android-session",
+            "heartbeat-timeout",
+          );
+        }
+      },
+      toolResultFor: (name) => {
+        if (name === "getAndroid" || name === "setActiveDevice") {
+          return deviceStartResult("android-session");
+        }
+        if (name === "getApple") {
+          return deviceStartResult("ios-session");
+        }
+        return undefined;
+      },
+    });
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => client,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+    try {
+      await proxy.callTool("getAndroid", {});
+      await proxy.callTool("getApple", {});
+      await expect(
+        proxy.callTool("setActiveDevice", { deviceId: "emulator-5554" }),
+      ).rejects.toMatchObject({ sessionUuid: "android-session" });
+      await proxy.callTool("observe", {});
+      expect(client.callToolCalls.at(-1)?.params.sessionUuid).toBe("ios-session");
+    } finally {
+      await proxy.close();
+    }
+  });
+
   // AC1: a getAndroid RESULT-minted session is bound AND heartbeated by the proxy
   // (as src/server/index.ts does on the direct path), so the daemon has recorded
   // ownership and never reaps it under the pre-first-heartbeat grace.
@@ -222,10 +303,10 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
 
       const observe = await proxy.callTool("observe", { platform: "android", project: "skeleton" });
       expect(observe).toEqual({ content: [{ type: "text", text: "success" }] });
-      // The sessionless call routed to the minted session, not a released id.
+      // Preserve the selector for the daemon; do not turn the retained session into an explicit override.
       expect(client.callToolCalls.at(-1)).toEqual({
         toolName: "observe",
-        params: { platform: "android", project: "skeleton", sessionUuid: MINTED },
+        params: { platform: "android", project: "skeleton" },
       });
     } finally {
       await proxy.close();
@@ -257,10 +338,10 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
       expect(sessionManager.getSession(M2)?.hasReceivedHeartbeat).toBe(true);
 
       // The fence is cleared: a subsequent sessionless call routes to M2.
-      await proxy.callTool("observe", { deviceId: "device-a" });
+      await proxy.callTool("observe", {});
       expect(client.callToolCalls.at(-1)).toEqual({
         toolName: "observe",
-        params: { deviceId: "device-a", sessionUuid: M2 },
+        params: { sessionUuid: M2 },
       });
     } finally {
       await proxy.close();
@@ -385,12 +466,12 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
       );
 
       await Promise.all([
-        expect(
-          firstProxy.callTool("observe", { deviceId: "ios-simulator-a" }),
-        ).rejects.toMatchObject({ reason: "daemon-shutdown" }),
-        expect(
-          secondProxy.callTool("observe", { deviceId: "ios-simulator-b" }),
-        ).rejects.toMatchObject({ reason: "daemon-shutdown" }),
+        expect(firstProxy.callTool("observe", {})).rejects.toMatchObject({
+          reason: "daemon-shutdown",
+        }),
+        expect(secondProxy.callTool("observe", {})).rejects.toMatchObject({
+          reason: "daemon-shutdown",
+        }),
       ]);
       expect(firstApple.client.callToolCalls).toEqual([{ toolName: "getApple", params: {} }]);
       expect(secondApple.client.callToolCalls).toEqual([{ toolName: "getApple", params: {} }]);
@@ -401,23 +482,20 @@ describe("proxy binds and heartbeats a result-minted device session (issue #5689
         firstProxy.callTool("getApple", {}),
         secondProxy.callTool("getApple", {}),
       ]);
-      await Promise.all([
-        firstProxy.callTool("observe", { deviceId: "ios-simulator-a" }),
-        secondProxy.callTool("observe", { deviceId: "ios-simulator-b" }),
-      ]);
+      await Promise.all([firstProxy.callTool("observe", {}), secondProxy.callTool("observe", {})]);
 
       expect(replacementApple.client.callToolCalls).toEqual([
         { toolName: "getApple", params: {} },
         {
           toolName: "observe",
-          params: { deviceId: "ios-simulator-a", sessionUuid: "ios-replacement-a" },
+          params: { sessionUuid: "ios-replacement-a" },
         },
       ]);
       expect(replacementSecondApple.client.callToolCalls).toEqual([
         { toolName: "getApple", params: {} },
         {
           toolName: "observe",
-          params: { deviceId: "ios-simulator-b", sessionUuid: "ios-replacement-b" },
+          params: { sessionUuid: "ios-replacement-b" },
         },
       ]);
     } finally {

--- a/test/daemon/socketServerIdeForwardRoute.integration.test.ts
+++ b/test/daemon/socketServerIdeForwardRoute.integration.test.ts
@@ -1,3 +1,5 @@
+import { DAEMON_BOUND_SESSION_PARAM } from "../../src/daemon/constants";
+import { SessionToolBinding } from "../../src/server/SessionToolBinding";
 import { describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
@@ -150,5 +152,69 @@ describe("UnixSocketServer ide/getNavigationGraph cross-session routing", () => 
 
     expect(resolved.clientKey).toBe(`socket:${socketSessionId}:session:session-a`);
     expect(resolved.sessionUuid).toBe("session-a");
+  });
+});
+
+describe("tools/call selector forwarding", () => {
+  test.each([{ platform: "ios" }, { platform: "ios", deviceId: "iphone" }])(
+    "does not seed an implicit selector from the socket's previous binding: %j",
+    (args) => {
+      const server = createServer();
+      bindSocketToSessionA(server, "socket-A");
+      const resolved = route(
+        server,
+        { id: "selector", method: "tools/call", params: { name: "observe", arguments: args } },
+        "socket-A",
+      );
+      expect(resolved.sessionUuid).toBeUndefined();
+      const forwarded = (server as any).withSocketSessionAutolockKey(args, "socket-A", 1000);
+      expect(forwarded.sessionUuid).toBeUndefined();
+      expect(forwarded.__mcpSessionId).toBe("socket-A");
+    },
+  );
+
+  test("a pinned proxy's injected UUID keeps the bound transport", () => {
+    const server = createServer();
+    bindSocketToSessionA(server, "socket-A");
+    const args = {
+      platform: "ios",
+      deviceId: "iphone",
+      sessionUuid: "session-a",
+      [DAEMON_BOUND_SESSION_PARAM]: "session-a",
+    };
+    const resolved = route(
+      server,
+      { id: "pinned", method: "tools/call", params: { name: "observe", arguments: args } },
+      "socket-A",
+    );
+    expect(resolved.sessionUuid).toBe("session-a");
+    const forwarded = (server as any).withSocketSessionAutolockKey(args, "socket-A", 1000);
+    const binding = new SessionToolBinding(resolved.sessionUuid);
+    expect(() =>
+      binding.resolveDeviceSessionUuid(undefined, forwarded, () => ({
+        deviceId: "device-1",
+        platform: "android",
+      })),
+    ).toThrow("does not match");
+  });
+
+  test("preserves an explicit UUID matching the prior binding over a conflicting platform", () => {
+    const server = createServer();
+    bindSocketToSessionA(server, "socket-A");
+    const args = { sessionUuid: "session-a", platform: "ios" };
+    const resolved = route(
+      server,
+      { id: "explicit", method: "tools/call", params: { name: "observe", arguments: args } },
+      "socket-A",
+    );
+    const forwarded = (server as any).withSocketSessionAutolockKey(args, "socket-A", 1000);
+    const binding = new SessionToolBinding(resolved.sessionUuid);
+    expect(forwarded.sessionUuid).toBe("session-a");
+    expect(
+      binding.resolveDeviceSessionUuid(undefined, forwarded, () => ({
+        deviceId: "device-1",
+        platform: "android",
+      })),
+    ).toBe("session-a");
   });
 });

--- a/test/daemon/socketServerMcpForwardSerialization.integration.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.integration.test.ts
@@ -637,7 +637,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
       });
       const sessionlessCall = await client.request("tools/call", {
         name: "videoRecording",
-        arguments: { action: "stop", recordingId: "recording-1", deviceId: "device-a" },
+        arguments: { action: "stop", recordingId: "recording-1" },
       });
       const navigationGraph = await client.request("ide/getNavigationGraph", {
         deviceId: "device-a",
@@ -739,7 +739,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
       // queued behind socket A's op (same executionKey device:device-a).
       const queuedCall = socketB.request("tools/call", {
         name: "videoRecording",
-        arguments: { action: "stop", recordingId: "recording-1", deviceId: "device-a" },
+        arguments: { action: "stop", recordingId: "recording-1" },
       });
       // Let socket B read the frame and compute its initial (bound) route while
       // the binding still exists.
@@ -756,6 +756,9 @@ describe("UnixSocketServer MCP forward serialization", () => {
       ).boundMcpClientKeysBySocketSession;
       const socketSessionId = boundClientKeysBySocketSession.keys().next().value as string;
       expect(socketSessionId).toBeDefined();
+      // Disconnect drops the transport binding, while the pool still owns the
+      // live session. Keep its device scope so this exercises client retention.
+      mcpAutolockSessions.set(socketSessionId, "session-a");
       (
         server as unknown as {
           clearBoundMcpClientKey(socketSessionId: string): void;
@@ -856,7 +859,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
       // queued behind socket A's op (same executionKey device:device-a).
       const queuedCall = socketB.request("tools/call", {
         name: "videoRecording",
-        arguments: { action: "stop", recordingId: "recording-1", deviceId: "device-a" },
+        arguments: { action: "stop", recordingId: "recording-1" },
       });
       // Let socket B read the frame and compute its initial (bound) route while
       // session-a is still active.
@@ -876,8 +879,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
       const queued = forwardedCalls.find((call) => call.toolName === "videoRecording");
       expect(queued).toBeDefined();
       // The released session must NOT be replayed: the call re-resolves to the
-      // shared unbound client socket A created for device:device-a (created with
-      // undefined), never B's session-a bound client.
+      // unbound client (created with undefined), never B's session-a bound client.
       expect(queued?.createdWith).toBeUndefined();
     } finally {
       releaseBlocker();

--- a/test/server/mcpSessionAutolockRouting.integration.test.ts
+++ b/test/server/mcpSessionAutolockRouting.integration.test.ts
@@ -95,61 +95,72 @@ describe("MCP session autolock routing", () => {
   test.each([{}, { platform: "android" }, { deviceId: "emulator-5554" }])(
     "binds an implicit execution with %j to its resolved autolock before an MCP remap",
     async (selectors) => {
-      process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
-      process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT = "60";
-      const timer = new FakeTimer();
-      const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-      const fakeDeviceUtils = new FakeDeviceUtils();
-      const devices = [
-        {
-          name: "Pixel 7",
-          platform: "android" as const,
-          deviceId: "emulator-5554",
-        },
-        {
-          name: "Pixel 8",
-          platform: "android" as const,
-          deviceId: "emulator-5556",
-        },
-      ];
-      fakeDeviceUtils.setBootedDevices("android", devices);
-      const pool = new DevicePool(sessionManager, "daemon-test", timer, undefined, fakeDeviceUtils);
-      await pool.initializeWithDevices(devices);
-      DaemonState.getInstance().initialize(sessionManager, pool);
-      const originalSessionId = await pool.autolockDevice(
-        "emulator-5554",
-        "android",
-        "mcp-session",
-      );
-      const handlerStarted = Promise.withResolvers<void>();
-      const releaseHandler = Promise.withResolvers<void>();
-
-      // #6227: `pool.autolockDevice` creates its session directly (bypassing the
-      // `deviceTools.ts` acquisition recorder), so routing the `tools/call`
-      // request below through `captureAutolockOwnership` drives real per-session
-      // accessibility-service setup against a fake device. The shared test
-      // preload (test/setup/testPreload.ts) installs a no-op readiness driver so
-      // that setup cannot block on real `adb`/network.
-      ToolRegistry.clearTools();
-      ToolRegistry.registerDeviceAware(
-        "captureAutolockOwnership",
-        "captureAutolockOwnership",
-        captureSchema.extend({
-          platform: z.string().optional(),
-          deviceId: z.string().optional(),
-        }),
-        async () => {
-          handlerStarted.resolve();
-          await releaseHandler.promise;
-          return { content: [{ type: "text", text: "ok" }] };
-        },
-      );
-      fixture = new McpTestFixture({
-        sessionContext: { sessionId: "mcp-session" },
-      });
-      await fixture.setup();
-
+      // Everything that allocates a cleanup timer, a pool, or an MCP fixture is
+      // constructed inside the try, so the finally below still tears it down if
+      // any setup step throws part-way through.
+      let sessionManager: SessionManager | undefined;
       try {
+        process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+        process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT = "60";
+        const timer = new FakeTimer();
+        sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+        const fakeDeviceUtils = new FakeDeviceUtils();
+        const devices = [
+          {
+            name: "Pixel 7",
+            platform: "android" as const,
+            deviceId: "emulator-5554",
+          },
+          {
+            name: "Pixel 8",
+            platform: "android" as const,
+            deviceId: "emulator-5556",
+          },
+        ];
+        fakeDeviceUtils.setBootedDevices("android", devices);
+        const pool = new DevicePool(
+          sessionManager,
+          "daemon-test",
+          timer,
+          undefined,
+          fakeDeviceUtils,
+        );
+        await pool.initializeWithDevices(devices);
+        DaemonState.getInstance().initialize(sessionManager, pool);
+        const originalSessionId = await pool.autolockDevice(
+          "emulator-5554",
+          "android",
+          "mcp-session",
+        );
+        const handlerStarted = Promise.withResolvers<void>();
+        const releaseHandler = Promise.withResolvers<void>();
+
+        // [#6227](https://github.com/kaeawc/auto-mobile/issues/6227):
+        // `pool.autolockDevice` creates its session directly (bypassing the
+        // `deviceTools.ts` acquisition recorder), so routing the `tools/call`
+        // request below through `captureAutolockOwnership` drives real per-session
+        // accessibility-service setup against a fake device. The shared test
+        // preload (test/setup/testPreload.ts) installs a no-op readiness driver so
+        // that setup cannot block on real `adb`/network.
+        ToolRegistry.clearTools();
+        ToolRegistry.registerDeviceAware(
+          "captureAutolockOwnership",
+          "captureAutolockOwnership",
+          captureSchema.extend({
+            platform: z.string().optional(),
+            deviceId: z.string().optional(),
+          }),
+          async () => {
+            handlerStarted.resolve();
+            await releaseHandler.promise;
+            return { content: [{ type: "text", text: "ok" }] };
+          },
+        );
+        fixture = new McpTestFixture({
+          sessionContext: { sessionId: "mcp-session" },
+        });
+        await fixture.setup();
+
         const { client } = fixture.getContext();
         const request = client.request(
           {
@@ -182,7 +193,7 @@ describe("MCP session autolock routing", () => {
         releaseHandler.resolve();
         await request;
       } finally {
-        sessionManager.stopCleanupTimer();
+        sessionManager?.stopCleanupTimer();
         DaemonState.getInstance().reset();
         delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
         delete process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT;

--- a/test/server/mcpSessionAutolockRouting.integration.test.ts
+++ b/test/server/mcpSessionAutolockRouting.integration.test.ts
@@ -92,83 +92,103 @@ describe("MCP session autolock routing", () => {
     });
   });
 
-  test("binds an implicit execution to its resolved autolock before an MCP remap", async () => {
-    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
-    process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT = "60";
-    const timer = new FakeTimer();
-    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const fakeDeviceUtils = new FakeDeviceUtils();
-    const devices = [
-      { name: "Pixel 7", platform: "android" as const, deviceId: "emulator-5554" },
-      { name: "Pixel 8", platform: "android" as const, deviceId: "emulator-5556" },
-    ];
-    fakeDeviceUtils.setBootedDevices("android", devices);
-    const pool = new DevicePool(sessionManager, "daemon-test", timer, undefined, fakeDeviceUtils);
-    await pool.initializeWithDevices(devices);
-    DaemonState.getInstance().initialize(sessionManager, pool);
-    const originalSessionId = await pool.autolockDevice("emulator-5554", "android", "mcp-session");
-    const handlerStarted = Promise.withResolvers<void>();
-    const releaseHandler = Promise.withResolvers<void>();
-
-    // #6227: `pool.autolockDevice` creates its session directly (bypassing the
-    // `deviceTools.ts` acquisition recorder), so routing the `tools/call`
-    // request below through `captureAutolockOwnership` drives real per-session
-    // accessibility-service setup against a fake device. The shared test
-    // preload (test/setup/testPreload.ts) installs a no-op readiness driver so
-    // that setup cannot block on real `adb`/network.
-    ToolRegistry.clearTools();
-    ToolRegistry.registerDeviceAware(
-      "captureAutolockOwnership",
-      "captureAutolockOwnership",
-      captureSchema,
-      async () => {
-        handlerStarted.resolve();
-        await releaseHandler.promise;
-        return { content: [{ type: "text", text: "ok" }] };
-      },
-    );
-    fixture = new McpTestFixture({ sessionContext: { sessionId: "mcp-session" } });
-    await fixture.setup();
-
-    try {
-      const { client } = fixture.getContext();
-      const request = client.request(
+  test.each([{}, { platform: "android" }, { deviceId: "emulator-5554" }])(
+    "binds an implicit execution with %j to its resolved autolock before an MCP remap",
+    async (selectors) => {
+      process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+      process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT = "60";
+      const timer = new FakeTimer();
+      const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+      const fakeDeviceUtils = new FakeDeviceUtils();
+      const devices = [
         {
-          method: "tools/call",
-          params: { name: "captureAutolockOwnership", arguments: {} },
+          name: "Pixel 7",
+          platform: "android" as const,
+          deviceId: "emulator-5554",
         },
-        z.any(),
-      );
-      await handlerStarted.promise;
-
-      const replacementSessionId = await pool.autolockDevice(
-        "emulator-5556",
+        {
+          name: "Pixel 8",
+          platform: "android" as const,
+          deviceId: "emulator-5556",
+        },
+      ];
+      fakeDeviceUtils.setBootedDevices("android", devices);
+      const pool = new DevicePool(sessionManager, "daemon-test", timer, undefined, fakeDeviceUtils);
+      await pool.initializeWithDevices(devices);
+      DaemonState.getInstance().initialize(sessionManager, pool);
+      const originalSessionId = await pool.autolockDevice(
+        "emulator-5554",
         "android",
         "mcp-session",
       );
-      expect(executionTracker.hasActiveAutolockSessionExecutions(originalSessionId!)).toBe(true);
-      expect(executionTracker.hasActiveAutolockSessionExecutions(replacementSessionId!)).toBe(
-        false,
-      );
+      const handlerStarted = Promise.withResolvers<void>();
+      const releaseHandler = Promise.withResolvers<void>();
 
-      sessionManager.setActiveSessionExecutionChecker(
-        (sessionUuid) =>
-          executionTracker.hasActiveSessionUuidExecutions(sessionUuid) ||
-          executionTracker.hasActiveAutolockSessionExecutions(sessionUuid),
+      // #6227: `pool.autolockDevice` creates its session directly (bypassing the
+      // `deviceTools.ts` acquisition recorder), so routing the `tools/call`
+      // request below through `captureAutolockOwnership` drives real per-session
+      // accessibility-service setup against a fake device. The shared test
+      // preload (test/setup/testPreload.ts) installs a no-op readiness driver so
+      // that setup cannot block on real `adb`/network.
+      ToolRegistry.clearTools();
+      ToolRegistry.registerDeviceAware(
+        "captureAutolockOwnership",
+        "captureAutolockOwnership",
+        captureSchema.extend({
+          platform: z.string().optional(),
+          deviceId: z.string().optional(),
+        }),
+        async () => {
+          handlerStarted.resolve();
+          await releaseHandler.promise;
+          return { content: [{ type: "text", text: "ok" }] };
+        },
       );
-      timer.advanceTime(60_001);
-      expect(sessionManager.getSession(originalSessionId!)).not.toBeNull();
-      expect(sessionManager.getSession(replacementSessionId!)).toBeNull();
+      fixture = new McpTestFixture({
+        sessionContext: { sessionId: "mcp-session" },
+      });
+      await fixture.setup();
 
-      releaseHandler.resolve();
-      await request;
-    } finally {
-      sessionManager.stopCleanupTimer();
-      DaemonState.getInstance().reset();
-      delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
-      delete process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT;
-    }
-  });
+      try {
+        const { client } = fixture.getContext();
+        const request = client.request(
+          {
+            method: "tools/call",
+            params: { name: "captureAutolockOwnership", arguments: selectors },
+          },
+          z.any(),
+        );
+        await handlerStarted.promise;
+
+        const replacementSessionId = await pool.autolockDevice(
+          "emulator-5556",
+          "android",
+          "mcp-session",
+        );
+        expect(executionTracker.hasActiveAutolockSessionExecutions(originalSessionId!)).toBe(true);
+        expect(executionTracker.hasActiveAutolockSessionExecutions(replacementSessionId!)).toBe(
+          false,
+        );
+
+        sessionManager.setActiveSessionExecutionChecker(
+          (sessionUuid) =>
+            executionTracker.hasActiveSessionUuidExecutions(sessionUuid) ||
+            executionTracker.hasActiveAutolockSessionExecutions(sessionUuid),
+        );
+        timer.advanceTime(60_001);
+        expect(sessionManager.getSession(originalSessionId!)).not.toBeNull();
+        expect(sessionManager.getSession(replacementSessionId!)).toBeNull();
+
+        releaseHandler.resolve();
+        await request;
+      } finally {
+        sessionManager.stopCleanupTimer();
+        DaemonState.getInstance().reset();
+        delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+        delete process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT;
+      }
+    },
+  );
 
   test("does not use the shared daemon loopback MCP session as an implicit autolock key", async () => {
     fixture = new McpTestFixture({
@@ -184,7 +204,9 @@ describe("MCP session autolock routing", () => {
   });
 
   test("keeps direct MCP sessions available as implicit autolock keys", async () => {
-    fixture = new McpTestFixture({ sessionContext: { sessionId: "direct-mcp-session" } });
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "direct-mcp-session" },
+    });
     await fixture.setup();
 
     const capturedArgs = await callCaptureTool(fixture, { value: "ok" });

--- a/test/server/proxyServerSessionOwnership.test.ts
+++ b/test/server/proxyServerSessionOwnership.test.ts
@@ -240,7 +240,7 @@ describe("proxy server session ownership errors", () => {
       await client.callTool({ name: "getApple", arguments: {} });
       await client.callTool({
         name: "observe",
-        arguments: { deviceId: "ios-simulator-1" },
+        arguments: {},
       });
 
       expect(originalClient.callToolCalls).toEqual([{ toolName: "getApple", params: {} }]);
@@ -248,7 +248,7 @@ describe("proxy server session ownership errors", () => {
         { toolName: "getApple", params: {} },
         {
           toolName: "observe",
-          params: { deviceId: "ios-simulator-1", sessionUuid: "replacement-session" },
+          params: { sessionUuid: "replacement-session" },
         },
       ]);
     } finally {

--- a/test/server/sessionPlatformRouting.daemon.integration.test.ts
+++ b/test/server/sessionPlatformRouting.daemon.integration.test.ts
@@ -245,6 +245,12 @@ test("proxy and socket route through reused MCP clients using the socket-owned p
       platform: "ios",
       keepScreenAwake: false,
     });
+    expect(pool.resolveAutolockSessionForMcpSession(socketSessionId)).toBe(android);
+    const appleBeforeSwitch = pool.resolveAutolockSessionForMcpSession(socketSessionId, "ios");
+    await proxy.callTool("setActiveDevice", { deviceId: devices[2].deviceId, platform: "android" });
+    expect(manager.getSession(android!)?.assignedDevice).toBe(devices[2].deviceId);
+    expect(manager.getSession(appleBeforeSwitch!)?.assignedDevice).toBe(devices[1].deviceId);
+    await proxy.callTool("setActiveDevice", { deviceId: devices[0].deviceId, platform: "android" });
     await proxy.callTool("routingProbe", {
       sessionUuid: android,
       platform: "ios",

--- a/test/server/sessionPlatformRouting.daemon.integration.test.ts
+++ b/test/server/sessionPlatformRouting.daemon.integration.test.ts
@@ -1,0 +1,267 @@
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { DaemonMcpProxy } from "../../src/daemon/daemonMcpProxy";
+import { DaemonClient } from "../../src/daemon/client";
+import { DAEMON_VERSION } from "../../src/daemon/constants";
+import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
+import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
+import { McpTestFixture } from "../fixtures/mcpTestFixture";
+import { FeatureFlagService } from "../../src/features/featureFlags/FeatureFlagService";
+import { FakeFeatureFlagRepository } from "../fakes/FakeFeatureFlagRepository";
+import { FakeFeatureFlagApplier } from "../fakes/FakeFeatureFlagApplier";
+import { afterEach, beforeEach, expect, test, spyOn } from "bun:test";
+import { Database as Sqlite } from "bun:sqlite";
+import { Kysely } from "kysely";
+import { z } from "zod/v4";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { up } from "../../src/db/migrations/2026_04_02_000_device_sessions";
+import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
+import type { Database } from "../../src/db/types";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { registerUtilityTools } from "../../src/server/utilityTools";
+import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import type { BootedDevice } from "../../src/models";
+
+const devices: BootedDevice[] = [
+  { name: "Pixel", deviceId: "emulator-5554", platform: "android" },
+  { name: "iPhone", deviceId: "iphone", platform: "ios" },
+  { name: "Pixel 2", deviceId: "emulator-5556", platform: "android" },
+];
+let db: Kysely<Database>;
+let manager: SessionManager;
+let pool: DevicePool;
+let androidSession: string | undefined;
+let iosSession: string | undefined;
+let previousAutolock: string | undefined;
+let originalRepository: unknown;
+
+beforeEach(async () => {
+  previousAutolock = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+  process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+  db = new Kysely<Database>({
+    dialect: new BunSqliteDialect({ database: new Sqlite(":memory:") }),
+  });
+  await up(db as Kysely<unknown>);
+  const repository = new DeviceSessionRepository(db);
+  const timer = new FakeTimer();
+  manager = new SessionManager(timer, repository);
+  const utils = new FakeDeviceUtils();
+  utils.setBootedDevices("android", [devices[0], devices[2]]);
+  utils.setBootedDevices("ios", [devices[1]]);
+  pool = new DevicePool(
+    manager,
+    "daemon",
+    timer,
+    new FakeInstalledAppsRepository(),
+    utils,
+    new DefaultRetryExecutor(timer),
+    repository,
+  );
+  await pool.initializeWithDevices(devices);
+  DaemonState.getInstance().initialize(manager, pool);
+  ToolRegistry.clearTools();
+  originalRepository = (ToolRegistry as any).toolCallRepository;
+  (ToolRegistry as any).toolCallRepository = { recordToolCall: async () => {} };
+});
+
+afterEach(async () => {
+  (ToolRegistry as any).toolCallRepository = originalRepository;
+  ToolRegistry.clearTools();
+  DaemonState.getInstance().reset();
+  manager.stopCleanupTimer();
+  await db.destroy();
+  if (previousAutolock === undefined) {
+    delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+  } else {
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = previousAutolock;
+  }
+});
+
+async function acquireBoth(): Promise<void> {
+  androidSession = await pool.autolockDevice(devices[0].deviceId, "android", "client");
+  iosSession = await pool.autolockDevice(devices[1].deviceId, "ios", "client");
+}
+
+test("daemon routes both platforms and explicit session wins over platform", async () => {
+  await acquireBoth();
+  const received: string[] = [];
+  ToolRegistry.registerDeviceAware(
+    "platformProbe",
+    "platformProbe",
+    z.object({}),
+    async (device) => {
+      received.push(device.deviceId);
+      return { success: true };
+    },
+    { deviceReadiness: "booted" },
+  );
+  const tool = ToolRegistry.getTool("platformProbe")!;
+  await tool.handler({ platform: "android", __mcpSessionId: "client", keepScreenAwake: false });
+  await tool.handler({ platform: "ios", __mcpSessionId: "client", keepScreenAwake: false });
+  await tool.handler({ platform: "ios", sessionUuid: androidSession, keepScreenAwake: false });
+  expect(received).toEqual([devices[0].deviceId, devices[1].deviceId, devices[0].deviceId]);
+}, 30000);
+
+test("ambiguous platform names candidates and deviceId selects the matching owned session", async () => {
+  await acquireBoth();
+  expect(pool.resolveAutolockSessionForMcpSession("client", "android")).toBe(androidSession);
+  expect(pool.resolveAutolockSessionForMcpSession("client", "ios")).toBe(iosSession);
+  expect(pool.resolveAutolockSessionForMcpSession("other", "android")).toBeUndefined();
+  const second = await pool.autolockDevice(devices[2].deviceId, "android", "client");
+  expect(() => pool.resolveAutolockSessionForMcpSession("client", "android")).toThrow(
+    `Candidate sessions: ${androidSession}`,
+  );
+  expect(
+    pool.resolveAutolockSessionForMcpSession("client", "android", undefined, devices[2].deviceId),
+  ).toBe(second);
+}, 30000);
+
+test("setActiveDevice selects an acquired session without an explicit UUID", async () => {
+  await acquireBoth();
+  registerUtilityTools();
+  const result = await ToolRegistry.getTool("setActiveDevice")!.handler({
+    deviceId: devices[0].deviceId,
+    platform: "android",
+    __mcpSessionId: "client",
+  });
+  expect(JSON.parse(result.content[0].text).sessionUuid).toBe(androidSession);
+  expect(pool.resolveAutolockSessionForMcpSession("client")).toBe(androidSession);
+}, 30000);
+
+test("proxy and socket route through reused MCP clients using the socket-owned pool", async () => {
+  const flags = spyOn(FeatureFlagService, "getInstance").mockReturnValue(
+    new FeatureFlagService(new FakeFeatureFlagRepository(), new FakeFeatureFlagApplier()),
+  );
+  const available = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+  const timer = new FakeTimer();
+  const socket = new UnixSocketServer(
+    "/private/tmp/unused-6807.sock",
+    "http://localhost:0/mcp",
+    DaemonState.getInstance(),
+    timer,
+  );
+  const fixtures = new Map<string, McpTestFixture>();
+  const received: string[] = [];
+  const routes: string[] = [];
+  const dispatch = async (name: string, args: Record<string, unknown>) => {
+    const request = { id: "routing", method: "tools/call", params: { name, arguments: args } };
+    const route = (socket as any).getMcpForwardRoute(request, "client");
+    routes.push(route.clientKey);
+    let fixture = fixtures.get(route.clientKey);
+    if (!fixture) {
+      fixture = new McpTestFixture({
+        daemonMode: true,
+        sessionContext: {
+          sessionId: route.clientKey,
+          initialSessionToolBinding: route.sessionUuid,
+        },
+      });
+      await fixture.setup();
+      fixtures.set(route.clientKey, fixture);
+      for (const [toolName, device] of [
+        ["getAndroid", devices[0]],
+        ["getApple", devices[1]],
+      ] as const) {
+        ToolRegistry.register(toolName, toolName, z.object({}), async () => {
+          const sessionUuid = await pool.autolockDevice(device.deviceId, device.platform, "client");
+          return { content: [{ type: "text" as const, text: JSON.stringify({ sessionUuid }) }] };
+        });
+      }
+      ToolRegistry.registerDeviceAware(
+        "routingProbe",
+        "routingProbe",
+        z.object({
+          platform: z.enum(["android", "ios"]).optional(),
+          deviceId: z.string().optional(),
+          sessionUuid: z.string().optional(),
+          keepScreenAwake: z.boolean().optional(),
+        }),
+        async (device) => {
+          received.push(device.deviceId);
+          return { content: [{ type: "text" as const, text: device.deviceId }] };
+        },
+        { deviceReadiness: "booted" },
+      );
+    }
+    const forwarded = (socket as any).withSocketSessionAutolockKey(args, "client", 10000);
+    const result = await fixture.client.callTool({ name, arguments: forwarded });
+    (socket as any).recordBoundMcpClientKey(request, "client", route, true, result);
+    return result;
+  };
+  const daemon = new FakeDaemonManager();
+  daemon.statusResult = { ...daemon.statusResult, version: DAEMON_VERSION };
+  const client = new FakeDaemonClient({ toolResultFor: dispatch });
+  const proxy = new DaemonMcpProxy({
+    clientFactory: () => client,
+    daemonManager: daemon,
+    autoStartDaemon: false,
+    timer,
+  });
+  try {
+    await proxy.callTool("getAndroid", {});
+    await proxy.callTool("getApple", {});
+    // Acquisition and execution intentionally share different internal MCP clients.
+    expect(routes[0]).not.toBe(routes[1]);
+    for (const args of [
+      { platform: "android" },
+      { platform: "ios" },
+      { platform: "android", deviceId: devices[0].deviceId },
+      { deviceId: devices[0].deviceId },
+    ]) {
+      await proxy.callTool("routingProbe", { ...args, keepScreenAwake: false });
+    }
+    const android = pool.resolveAutolockSessionForMcpSession("client", "android");
+    await proxy.callTool("routingProbe", {
+      sessionUuid: android,
+      platform: "ios",
+      keepScreenAwake: false,
+    });
+    await proxy.callTool("routingProbe", {
+      sessionUuid: android,
+      platform: "ios",
+      keepScreenAwake: false,
+    });
+    await proxy.callTool("setActiveDevice", { deviceId: devices[0].deviceId, platform: "android" });
+    expect(pool.resolveAutolockSessionForMcpSession("client")).toBe(android);
+    await proxy.callTool("routingProbe", { keepScreenAwake: false });
+    expect(received).toEqual([
+      devices[0].deviceId,
+      devices[1].deviceId,
+      devices[0].deviceId,
+      devices[0].deviceId,
+      devices[0].deviceId,
+      devices[0].deviceId,
+      devices[0].deviceId,
+    ]);
+    const pinned = new DaemonMcpProxy({
+      clientFactory: () => client,
+      daemonManager: daemon,
+      autoStartDaemon: false,
+      timer,
+      initialSessionUuid: pool.resolveAutolockSessionForMcpSession("client", "ios"),
+    });
+    try {
+      await expect(
+        pinned.callTool("routingProbe", {
+          platform: "android",
+          deviceId: devices[0].deviceId,
+          keepScreenAwake: false,
+        }),
+      ).rejects.toThrow("does not match");
+    } finally {
+      await pinned.close();
+    }
+  } finally {
+    await proxy.close();
+    for (const fixture of fixtures.values()) {
+      await fixture.teardown();
+    }
+    available.mockRestore();
+    flags.mockRestore();
+  }
+}, 30000);

--- a/test/server/sessionPlatformRouting.daemon.integration.test.ts
+++ b/test/server/sessionPlatformRouting.daemon.integration.test.ts
@@ -1,6 +1,8 @@
 import { UnixSocketServer } from "../../src/daemon/socketServer";
 import { DaemonMcpProxy } from "../../src/daemon/daemonMcpProxy";
+import { getStaticToolDefinitions } from "../../src/daemon/staticToolDefinitions";
 import { DaemonClient } from "../../src/daemon/client";
+import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../../src/server/sessionReleaseBroadcast";
 import { DAEMON_VERSION } from "../../src/daemon/constants";
 import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
 import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
@@ -148,14 +150,22 @@ test("proxy and socket route through reused MCP clients using the socket-owned p
   const fixtures = new Map<string, McpTestFixture>();
   const received: string[] = [];
   const routes: string[] = [];
+  let socketSessionId = "client";
   const dispatch = async (name: string, args: Record<string, unknown>) => {
     const request = { id: "routing", method: "tools/call", params: { name, arguments: args } };
-    const route = (socket as any).getMcpForwardRoute(request, "client");
+    await (socket as any).restoreSelectorSessions(args, socketSessionId);
+    const route = (socket as any).getMcpForwardRoute(request, socketSessionId);
     routes.push(route.clientKey);
     let fixture = fixtures.get(route.clientKey);
     if (!fixture) {
       fixture = new McpTestFixture({
         daemonMode: true,
+        sessionToolSelectionService: {
+          isEnabled: async (id, name, fallback) =>
+            id && ["listDevices", "listDeviceImages"].includes(name) ? false : fallback,
+          getOverride: async (id, name) =>
+            id && ["listDevices", "listDeviceImages"].includes(name) ? false : undefined,
+        },
         sessionContext: {
           sessionId: route.clientKey,
           initialSessionToolBinding: route.sessionUuid,
@@ -176,6 +186,7 @@ test("proxy and socket route through reused MCP clients using the socket-owned p
         "routingProbe",
         "routingProbe",
         z.object({
+          device: z.string().optional(),
           platform: z.enum(["android", "ios"]).optional(),
           deviceId: z.string().optional(),
           sessionUuid: z.string().optional(),
@@ -188,9 +199,9 @@ test("proxy and socket route through reused MCP clients using the socket-owned p
         { deviceReadiness: "booted" },
       );
     }
-    const forwarded = (socket as any).withSocketSessionAutolockKey(args, "client", 10000);
+    const forwarded = (socket as any).withSocketSessionAutolockKey(args, socketSessionId, 10000);
     const result = await fixture.client.callTool({ name, arguments: forwarded });
-    (socket as any).recordBoundMcpClientKey(request, "client", route, true, result);
+    (socket as any).recordBoundMcpClientKey(request, socketSessionId, route, true, result);
     return result;
   };
   const daemon = new FakeDaemonManager();
@@ -201,10 +212,17 @@ test("proxy and socket route through reused MCP clients using the socket-owned p
     daemonManager: daemon,
     autoStartDaemon: false,
     timer,
+    staticToolDefinitionsProvider: () => [
+      ...getStaticToolDefinitions(),
+      { name: "routingProbe", inputSchema: { properties: { device: {}, sessionUuid: {} } } },
+    ],
   });
   try {
     await proxy.callTool("getAndroid", {});
     await proxy.callTool("getApple", {});
+    for (const name of ["listDevices", "listDeviceImages"]) {
+      await expect(proxy.callTool(name, { platform: "android" })).rejects.toThrow("disabled");
+    }
     // Acquisition and execution intentionally share different internal MCP clients.
     expect(routes[0]).not.toBe(routes[1]);
     for (const args of [
@@ -215,7 +233,13 @@ test("proxy and socket route through reused MCP clients using the socket-owned p
     ]) {
       await proxy.callTool("routingProbe", { ...args, keepScreenAwake: false });
     }
-    const android = pool.resolveAutolockSessionForMcpSession("client", "android");
+    // A replacement socket must recover both acquisitions before selector routing.
+    socketSessionId = "replacement-client";
+    client.emitConnectionClosed();
+
+    await proxy.callTool("routingProbe", { platform: "android", keepScreenAwake: false });
+    await proxy.callTool("routingProbe", { platform: "ios", keepScreenAwake: false });
+    const android = pool.resolveAutolockSessionForMcpSession(socketSessionId, "android");
     await proxy.callTool("routingProbe", {
       sessionUuid: android,
       platform: "ios",
@@ -227,13 +251,15 @@ test("proxy and socket route through reused MCP clients using the socket-owned p
       keepScreenAwake: false,
     });
     await proxy.callTool("setActiveDevice", { deviceId: devices[0].deviceId, platform: "android" });
-    expect(pool.resolveAutolockSessionForMcpSession("client")).toBe(android);
+    expect(pool.resolveAutolockSessionForMcpSession(socketSessionId)).toBe(android);
     await proxy.callTool("routingProbe", { keepScreenAwake: false });
     expect(received).toEqual([
       devices[0].deviceId,
       devices[1].deviceId,
       devices[0].deviceId,
       devices[0].deviceId,
+      devices[0].deviceId,
+      devices[1].deviceId,
       devices[0].deviceId,
       devices[0].deviceId,
       devices[0].deviceId,
@@ -256,6 +282,31 @@ test("proxy and socket route through reused MCP clients using the socket-owned p
     } finally {
       await pinned.close();
     }
+    const apple = pool.resolveAutolockSessionForMcpSession(socketSessionId, "ios")!;
+    // Releasing the default must not fence a different, still-owned session.
+    await proxy.callTool("setActiveDevice", { deviceId: devices[1].deviceId, platform: "ios" });
+    await manager.releaseSession(apple, "heartbeat-timeout");
+    await pool.releaseDevice(devices[1].deviceId, apple);
+    client.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, apple, "heartbeat-timeout");
+    await expect(
+      proxy.callTool("routingProbe", { platform: "ios", keepScreenAwake: false }),
+    ).rejects.toThrow();
+    await expect(proxy.callTool("routingProbe", {})).rejects.toThrow();
+    await expect(proxy.callTool("routingProbe", { sessionUuid: apple })).rejects.toThrow();
+    await proxy.callTool("routingProbe", { platform: "android", keepScreenAwake: false });
+    await proxy.callTool("routingProbe", { sessionUuid: android, keepScreenAwake: false });
+
+    expect(received.slice(-2)).toEqual([devices[0].deviceId, devices[0].deviceId]);
+    const staleResult = await proxy.callTool("routingProbe", {
+      sessionUuid: apple,
+      keepScreenAwake: false,
+    });
+    expect(staleResult.isError).toBe(true);
+    expect(received.slice(-2)).toEqual([devices[0].deviceId, devices[0].deviceId]);
+    expect(manager.getSession(apple)).toBeNull();
+    await proxy.callTool("setActiveDevice", { deviceId: devices[2].deviceId, platform: "android" });
+    await proxy.callTool("routingProbe", { keepScreenAwake: false });
+    expect(received.at(-1)).toBe(devices[2].deviceId);
   } finally {
     await proxy.close();
     for (const fixture of fixtures.values()) {
@@ -265,3 +316,23 @@ test("proxy and socket route through reused MCP clients using the socket-owned p
     flags.mockRestore();
   }
 }, 30000);
+
+test("setActiveDevice rebinds the current session to an unacquired free device", async () => {
+  await acquireBoth();
+  registerUtilityTools();
+  const result = await ToolRegistry.getTool("setActiveDevice")!.handler({
+    deviceId: devices[2].deviceId,
+    platform: "android",
+    __mcpSessionId: "client",
+  });
+  expect(JSON.parse(result.content[0].text).sessionUuid).toBe(iosSession);
+  expect(manager.getSession(iosSession!)?.assignedDevice).toBe(devices[2].deviceId);
+  expect(pool.resolveAutolockSessionForMcpSession("client")).toBe(iosSession);
+}, 30000);
+
+test("restoring retained sessions preserves an already changed default", async () => {
+  await acquireBoth();
+  await pool.attachAutolockSessionToMcpSession(androidSession!, "client");
+  await pool.restoreAutolockSessionsForMcpSession([androidSession!, iosSession!], "client");
+  expect(pool.resolveAutolockSessionForMcpSession("client")).toBe(androidSession);
+});

--- a/test/server/sessionPlatformRouting.integration.test.ts
+++ b/test/server/sessionPlatformRouting.integration.test.ts
@@ -3,6 +3,8 @@ import { FakeFeatureFlagRepository } from "../fakes/FakeFeatureFlagRepository";
 import { FakeFeatureFlagApplier } from "../fakes/FakeFeatureFlagApplier";
 import { afterEach, beforeEach, expect, test, spyOn } from "bun:test";
 import { z } from "zod/v4";
+import { DeviceSessionManager } from "../../src/utils/DeviceSessionManager";
+import { registerUtilityTools } from "../../src/server/utilityTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import {
   clearDirectSessionDevices,
@@ -95,4 +97,24 @@ test("explicit session takes precedence over platform", async () => {
     arguments: { sessionUuid: "android-session", platform: "ios" },
   });
   expect(received).toEqual([android.deviceId]);
+});
+
+test("direct setActiveDevice rebinds the default to a free device", async () => {
+  const other: BootedDevice = { deviceId: "emulator-5556", platform: "android", name: "Other" };
+  const manager = new FakeDeviceSessionManager();
+  manager.setConnectedDevices([android, ios, other]);
+  const instance = spyOn(DeviceSessionManager, "getInstance").mockReturnValue(manager);
+  (ToolRegistry as any).deviceSessionManager = manager;
+  registerUtilityTools();
+  try {
+    const result = await fixture.client.callTool({
+      name: "setActiveDevice",
+      arguments: { deviceId: other.deviceId, platform: "android" },
+    });
+    expect(result.isError).not.toBe(true);
+    await fixture.client.callTool({ name: "routingProbe", arguments: {} });
+    expect(received).toEqual([other.deviceId]);
+  } finally {
+    instance.mockRestore();
+  }
 });

--- a/test/server/sessionPlatformRouting.integration.test.ts
+++ b/test/server/sessionPlatformRouting.integration.test.ts
@@ -1,0 +1,98 @@
+import { FeatureFlagService } from "../../src/features/featureFlags/FeatureFlagService";
+import { FakeFeatureFlagRepository } from "../fakes/FakeFeatureFlagRepository";
+import { FakeFeatureFlagApplier } from "../fakes/FakeFeatureFlagApplier";
+import { afterEach, beforeEach, expect, test, spyOn } from "bun:test";
+import { z } from "zod/v4";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import {
+  clearDirectSessionDevices,
+  registerDirectSessionDevice,
+} from "../../src/server/directSessionDeviceRegistry";
+import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
+import { McpTestFixture } from "../fixtures/mcpTestFixture";
+import type { BootedDevice } from "../../src/models";
+
+const android: BootedDevice = { deviceId: "emulator-5554", platform: "android", name: "Pixel" };
+const ios: BootedDevice = { deviceId: "iphone", platform: "ios", name: "iPhone" };
+let fixture: McpTestFixture;
+let originalManager: unknown;
+let originalRepository: unknown;
+let featureFlags: ReturnType<typeof spyOn>;
+
+const received: string[] = [];
+
+beforeEach(async () => {
+  featureFlags = spyOn(FeatureFlagService, "getInstance").mockReturnValue(
+    new FeatureFlagService(new FakeFeatureFlagRepository(), new FakeFeatureFlagApplier()),
+  );
+  originalRepository = (ToolRegistry as any).toolCallRepository;
+  (ToolRegistry as any).toolCallRepository = { recordToolCall: async () => {} };
+  ToolRegistry.clearTools();
+  clearDirectSessionDevices();
+  received.length = 0;
+  originalManager = (ToolRegistry as any).deviceSessionManager;
+  const manager = new FakeDeviceSessionManager();
+  manager.setConnectedDevices([android, ios]);
+  (ToolRegistry as any).deviceSessionManager = manager;
+  fixture = new McpTestFixture();
+  await fixture.setup();
+  for (const [name, sessionUuid, device] of [
+    ["getAndroid", "android-session", android],
+    ["getApple", "ios-session", ios],
+  ] as const) {
+    ToolRegistry.register(name, name, z.object({}), async () => {
+      registerDirectSessionDevice(sessionUuid, device);
+      return { content: [{ type: "text" as const, text: JSON.stringify({ sessionUuid }) }] };
+    });
+  }
+  const schema = z.object({
+    platform: z.enum(["android", "ios"]).optional(),
+    deviceId: z.string().optional(),
+    sessionUuid: z.string().optional(),
+  });
+  ToolRegistry.registerDeviceAware("routingProbe", "routingProbe", schema, async (device) => {
+    received.push(device.deviceId);
+    return { content: [{ type: "text" as const, text: device.deviceId }] };
+  });
+  ToolRegistry.register("setActiveDevice", "setActiveDevice", schema, async () => ({
+    content: [],
+  }));
+  await fixture.client.callTool({ name: "getAndroid", arguments: {} });
+  await fixture.client.callTool({ name: "getApple", arguments: {} });
+});
+afterEach(async () => {
+  await fixture?.teardown();
+  featureFlags.mockRestore();
+  (ToolRegistry as any).toolCallRepository = originalRepository;
+  (ToolRegistry as any).deviceSessionManager = originalManager;
+  ToolRegistry.clearTools();
+  clearDirectSessionDevices();
+});
+
+test("MCP platform and explicit sessions reach the correct device after two acquisitions", async () => {
+  for (const args of [
+    { platform: "android" },
+    { platform: "ios" },
+    { sessionUuid: "android-session" },
+  ]) {
+    await fixture.client.callTool({ name: "routingProbe", arguments: args });
+  }
+  expect(received).toEqual([android.deviceId, ios.deviceId, android.deviceId]);
+});
+
+test("successful setActiveDevice changes subsequent sessionless routing", async () => {
+  await fixture.client.callTool({
+    name: "setActiveDevice",
+    arguments: { deviceId: android.deviceId, platform: "android" },
+  });
+  await fixture.client.callTool({ name: "routingProbe", arguments: {} });
+  expect(received).toEqual([android.deviceId]);
+});
+
+test("explicit session takes precedence over platform", async () => {
+  await fixture.client.callTool({
+    name: "routingProbe",
+    arguments: { sessionUuid: "android-session", platform: "ios" },
+  });
+  expect(received).toEqual([android.deviceId]);
+});

--- a/test/server/sessionPlatformRouting.test.ts
+++ b/test/server/sessionPlatformRouting.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { SessionToolBinding } from "../../src/server/SessionToolBinding";
+
+const devices = new Map([
+  ["android-a", { deviceId: "emulator-5554", platform: "android" }],
+  ["android-b", { deviceId: "emulator-5556", platform: "android" }],
+  ["ios-a", { deviceId: "iphone", platform: "ios" }],
+]);
+const lookup = (id: string) => devices.get(id);
+
+function acquired() {
+  const binding = new SessionToolBinding();
+  binding.bind(undefined, "android-a");
+  binding.bind(undefined, "ios-a");
+  return binding;
+}
+
+describe("connection device selectors", () => {
+  test("routes each platform among acquired sessions regardless of acquisition order", () => {
+    const binding = acquired();
+    expect(binding.resolveDeviceSessionUuid(undefined, { platform: "android" }, lookup)).toBe(
+      "android-a",
+    );
+    expect(binding.resolveDeviceSessionUuid(undefined, { platform: "ios" }, lookup)).toBe("ios-a");
+    binding.bind(undefined, "android-a");
+    expect(binding.resolveDeviceSessionUuid(undefined, { platform: "ios" }, lookup)).toBe("ios-a");
+  });
+
+  test("rejects ambiguous platform with actionable candidates", () => {
+    const binding = acquired();
+    binding.bind(undefined, "android-b");
+    expect(() =>
+      binding.resolveDeviceSessionUuid(undefined, { platform: "android" }, lookup),
+    ).toThrow(/android-a.*emulator-5554.*android-b.*emulator-5556.*sessionUuid.*deviceId/);
+    expect(
+      binding.resolveDeviceSessionUuid(
+        undefined,
+        { platform: "android", deviceId: "emulator-5554" },
+        lookup,
+      ),
+    ).toBe("android-a");
+  });
+
+  test("does not route to another platform or another connection's session", () => {
+    const binding = new SessionToolBinding();
+    binding.bind("one", "ios-a");
+    binding.bind("two", "android-a");
+    expect(() => binding.resolveDeviceSessionUuid("one", { platform: "android" }, lookup)).toThrow(
+      /sessionUuid/,
+    );
+  });
+
+  test("explicit session remains authoritative over platform", () => {
+    const binding = acquired();
+    expect(binding.resolveDeviceSessionUuid(undefined, { sessionUuid: "android-a" }, lookup)).toBe(
+      "android-a",
+    );
+    expect(
+      binding.resolveDeviceSessionUuid(
+        undefined,
+        { sessionUuid: "android-a", platform: "ios" },
+        lookup,
+      ),
+    ).toBe("android-a");
+    expect(binding.resolveDeviceSessionUuid(undefined, { sessionUuid: "stale" }, lookup)).toBe(
+      "stale",
+    );
+  });
+
+  test("released sessions are removed from candidates", () => {
+    const binding = acquired();
+    binding.unbindSession("android-a");
+    expect(() =>
+      binding.resolveDeviceSessionUuid(undefined, { platform: "android" }, lookup),
+    ).toThrow(/sessionUuid/);
+  });
+
+  test("seeded connection cannot switch device", () => {
+    const binding = new SessionToolBinding("ios-a");
+    expect(() =>
+      binding.resolveDeviceSessionUuid(undefined, { platform: "android" }, lookup),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

After acquiring Android and iOS on one connection, an implicit session could override `platform` and send reads or input to the wrong device. Resolve device selectors against the connection’s live acquired sessions, preserve explicit UUID precedence and pinned bindings, and list candidates when the choice is ambiguous.

- Restore retained live session capabilities after a socket reconnect before resolving device selectors.
- Make `setActiveDevice` select an acquired session or rebind the current session to a free device; subsequent calls use that default in daemon and direct modes.
- Synchronize the pool default after a successful explicit device-session call, so a later free-device switch rebinds the same session without disturbing another acquired session.
- Allow access to surviving owned sessions after the current session is released. Terminally released UUIDs remain denied; existing nonterminal explicit-release recovery behavior is preserved.
- Keep session tool-selection restrictions on plain platform-filtered tools such as `listDevices` and `listDeviceImages`.

Closes [#6807](https://github.com/kaeawc/auto-mobile/issues/6807).

## Validation

- `bun run turbo:validate`: lint, build, unit tests, and repository boundaries.
- `bun run typecheck`: no new errors.
- Full host integration and stress lanes.
- Proxy, socket forwarding, reused MCP clients, real device pool with fake devices, and direct-mode regression coverage: both platforms, ambiguity, active selection, free-device rebind, reconnect, terminal release, surviving sessions, pinned mismatch, and bound-policy enforcement.
- Existing interfaces, fakes, FakeTimer, and in-memory SQLite; no new dependency.

Live device replay was not performed.
