### PR TITLE
fix: device provisioning readiness, deadlines, and inventory

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
@@ -14,7 +14,10 @@ data class BootedDevicesResponse(
   val lastUpdated: String,
   val devices: List<BootedDeviceInfo>,
   val observationComplete: Boolean = true,
+  val platformObservations: Map<String, DevicePlatformObservation> = emptyMap(),
 )
+
+@Serializable data class DevicePlatformObservation(val observationComplete: Boolean = false)
 
 @Serializable
 data class DeviceIdentity(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
@@ -15,6 +15,7 @@ data class BootedDevicesResponse(
   val devices: List<BootedDeviceInfo>,
   val observationComplete: Boolean = true,
   val platformObservations: Map<String, DevicePlatformObservation> = emptyMap(),
+  val sourceObservations: Map<String, DevicePlatformObservation> = emptyMap(),
 )
 
 @Serializable data class DevicePlatformObservation(val observationComplete: Boolean = false)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
@@ -13,6 +13,14 @@ data class BootedDevicesResponse(
   val physicalCount: Int,
   val lastUpdated: String,
   val devices: List<BootedDeviceInfo>,
+  val observationComplete: Boolean = true,
+)
+
+@Serializable
+data class DeviceIdentity(
+  val stableId: String,
+  val connectionId: String,
+  val transportId: String? = null,
 )
 
 @Serializable
@@ -45,6 +53,7 @@ data class BootedDeviceInfo(
   // Daemon-minted identity for this live device epoch. Older daemons omit it, so it must remain
   // optional while UUID-scoped consumers fail closed.
   val deviceSessionUuid: String? = null,
+  val identity: DeviceIdentity? = null,
 )
 
 @Serializable

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePicker.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePicker.kt
@@ -176,7 +176,7 @@ private fun Content(
       ActiveChips(content.filters, onAction)
       content.inventoryError?.let { message ->
         Text(
-          text = "Showing previous device status. $message",
+          text = message,
           modifier = Modifier.padding(16.dp),
           color = MaterialTheme.colorScheme.error,
         )
@@ -339,21 +339,22 @@ private fun DeviceGrid(
     horizontalArrangement = Arrangement.spacedBy(12.dp),
     verticalItemSpacing = 12.dp,
   ) {
-    items(devices, key = { it.id }) { device ->
+    items(devices, key = { it.uiKey }) { device ->
       DeviceCard(
         device = device,
-        selected = device.id in content.selectedIds,
-        booting = device.id in content.bootingIds,
-        error = content.bootErrors[device.id],
+        selected = device.uiKey in content.selectedIds,
+        booting = device.uiKey in content.bootingIds,
+        error = content.bootErrors[device.uiKey],
         thumbnail = thumbnail,
         onClick = { multiSelect ->
           when {
             // A shut-down card boots on click; the boot auto-observes once it completes.
-            device.state != DeviceState.Booted -> onAction(DevicePickerAction.BootDevice(device.id))
+            device.state != DeviceState.Booted ->
+              onAction(DevicePickerAction.BootDevice(device.uiKey))
             // Cmd/Shift-click builds a multi-device selection to observe together.
-            multiSelect -> onAction(DevicePickerAction.ToggleSelect(device.id))
+            multiSelect -> onAction(DevicePickerAction.ToggleSelect(device.uiKey))
             // Plain click observes this device immediately.
-            else -> onAction(DevicePickerAction.ObserveOne(device.id))
+            else -> onAction(DevicePickerAction.ObserveOne(device.uiKey))
           }
         },
       )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePicker.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePicker.kt
@@ -174,6 +174,13 @@ private fun Content(
     Column(Modifier.weight(1f).fillMaxHeight()) {
       HeaderRow(content, onAction, onClose, canClose)
       ActiveChips(content.filters, onAction)
+      content.inventoryError?.let { message ->
+        Text(
+          text = "Showing previous device status. $message",
+          modifier = Modifier.padding(16.dp),
+          color = MaterialTheme.colorScheme.error,
+        )
+      }
       DeviceGrid(content, onAction, thumbnail)
     }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -25,6 +25,8 @@ private val LOG = LoggerFactory.getLogger("DevicePickerViewModel")
 private const val BOOTED_URI = "automobile:devices/booted"
 private const val IMAGES_URI = "automobile:devices/images"
 
+private data class PickerInventory(val devices: List<PickerDevice>, val warning: String?)
+
 private fun discoverySource(platform: Platform, isVirtual: Boolean): String =
   when {
     platform == Platform.Android -> "android"
@@ -45,7 +47,7 @@ sealed interface DevicePickerUiState {
     val bootingIds: Set<String> = emptySet(),
     /** Per-device boot failure message; presence marks a card as retryable. */
     val bootErrors: Map<String, String> = emptyMap(),
-    /** Last discovery failed: these rows are the previous snapshot, not shutdown evidence. */
+    /** Nonblocking discovery warning: devices may be missing or retained from an older snapshot. */
     val inventoryError: String? = null,
   ) : DevicePickerUiState
 
@@ -199,8 +201,8 @@ class DevicePickerViewModel(
     activeLoads++
     scope.launch {
       try {
-        val devices = fetchDevices()
-        emitIfCurrent(generation, devices)
+        val inventory = fetchDevices()
+        emitIfCurrent(generation, inventory)
       } catch (c: CancellationException) {
         throw c // don't turn cancellation into a load error
       } catch (e: Exception) {
@@ -217,16 +219,18 @@ class DevicePickerViewModel(
   // throws rather than degrading to an empty list: a partial/garbled read must NOT reconstruct a
   // just-booted device as Shutdown (which would permit a duplicate start), and a total failure must
   // not empty the picker and prune live boot state — callers retain the prior snapshot.
-  private suspend fun fetchDevices(): List<PickerDevice> =
+  private suspend fun fetchDevices(): PickerInventory =
     withContext(ioDispatcher) {
       val observation = readBootedDevices()
       val booted = observation.devices
-      val completeSources =
+      val sourcePlatforms =
         mapOf(
-            "android" to Platform.Android,
-            "ios-simulator" to Platform.Ios,
-            "ios-physical" to Platform.Ios,
-          )
+          "android" to Platform.Android,
+          "ios-simulator" to Platform.Ios,
+          "ios-physical" to Platform.Ios,
+        )
+      val completeSources =
+        sourcePlatforms
           .filter { (source, platform) ->
             observation.sourceObservations[source]?.observationComplete
               ?: observation.platformObservations[platform.name.lowercase()]?.observationComplete
@@ -301,7 +305,12 @@ class DevicePickerViewModel(
       check(devices.isNotEmpty() || retained.isNotEmpty() || completeSources.isNotEmpty()) {
         "Device discovery is incomplete; no authoritative inventory is available"
       }
-      devices + retained
+      PickerInventory(
+        devices + retained,
+        if (completeSources.size < sourcePlatforms.size)
+          "Some device discovery is incomplete; devices may be missing or show previous status"
+        else null,
+      )
     }
 
   private suspend fun readBootedDevices(): BootedDevicesResponse =
@@ -336,11 +345,11 @@ class DevicePickerViewModel(
    * still the newest. A stale success is dropped: its persistent selection/boot state was already
    * recorded and a newer emission carries it, so dropping the stale LIST cannot lose it.
    */
-  private fun emitIfCurrent(generation: Long, devices: List<PickerDevice>) {
+  private fun emitIfCurrent(generation: Long, inventory: PickerInventory) {
     if (generation != loadGeneration) return
-    lastInventory = devices
-    LOG.info("Picker loaded ${devices.size} devices")
-    emitContent(devices)
+    lastInventory = inventory.devices
+    LOG.info("Picker loaded ${inventory.devices.size} devices")
+    emitContent(inventory.devices, inventory.warning)
   }
 
   /**
@@ -468,7 +477,7 @@ class DevicePickerViewModel(
           (bootedImageRuntimeIds[bootedDevice.platform].orEmpty() +
             (bootedDevice.id to runtimeDeviceId)))
     val generation = ++loadGeneration
-    val devices =
+    val inventory =
       try {
         fetchDevices()
       } catch (c: CancellationException) {
@@ -480,6 +489,7 @@ class DevicePickerViewModel(
         resolveFetchFailure(generation, e)
         return
       }
+    val devices = inventory.devices
     val bootedRuntime = devices.firstOrNull {
       it.id == runtimeDeviceId &&
         it.platform == bootedDevice.platform &&
@@ -501,7 +511,7 @@ class DevicePickerViewModel(
     // as
     // stale below.
     syncState()
-    emitIfCurrent(generation, devices)
+    emitIfCurrent(generation, inventory)
     // Boot then auto-observe — but observe from the CURRENT (winning) state, not this reload's own
     // (possibly stale) list. If a newer refresh superseded this stalled reload, emitIfCurrent
     // dropped

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -1,7 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.workspace.picker
 
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
-import dev.jasonpearson.automobile.desktop.core.mcp.BootedDeviceInfo
+import dev.jasonpearson.automobile.desktop.core.mcp.BootedDevicesResponse
 import dev.jasonpearson.automobile.desktop.core.mcp.DeviceImageInfo
 import dev.jasonpearson.automobile.desktop.core.mcp.DeviceResourceParser
 import dev.jasonpearson.automobile.desktop.core.mcp.McpResourceClient
@@ -120,7 +120,7 @@ class DevicePickerViewModel(
   // Lets the merge hide a re-keyed booted device's EXACT source image (not a positional same-named
   // guess). Pruned to devices still booted; devices booted outside this session fall back to the
   // name heuristic in buildPickerDevices.
-  private var bootedImageRuntimeIds: Map<String, String> = emptyMap()
+  private var bootedImageRuntimeIds: Map<Platform, Map<String, String>> = emptyMap()
 
   // Source ids whose boot coroutine is still running (bootController.boot has not returned). The
   // serialization guard in bootingIds must survive against THIS set, not only the live device list:
@@ -136,6 +136,7 @@ class DevicePickerViewModel(
   // guard), nor the rule that the newest generation ends terminal (Content or Error) — a failure is
   // never dropped into a stranded Loading.
   private var loadGeneration: Long = 0
+  private var lastInventory: List<PickerDevice> = emptyList()
 
   // Count of load() coroutines currently in flight — ALL of them, not just the newest: overlapping
   // explicit Refreshes are not cancelled, so a newer one can finish while an older read is still
@@ -211,8 +212,18 @@ class DevicePickerViewModel(
   // not empty the picker and prune live boot state — callers retain the prior snapshot.
   private suspend fun fetchDevices(): List<PickerDevice> =
     withContext(ioDispatcher) {
-      val booted = readBootedDevices()
-      val images = readDeviceImages()
+      val observation = readBootedDevices()
+      val booted = observation.devices
+      val completePlatforms =
+        Platform.entries
+          .filter { platform ->
+            observation.platformObservations[platform.name.lowercase()]?.observationComplete
+              ?: observation.observationComplete
+          }
+          .toSet()
+      // Positive observations stay usable even if a sibling platform cannot be queried.
+      // Only complete platforms may infer Shutdown from absence in this snapshot.
+      val images = readDeviceImages().filter { platformOf(it.platform) in completePlatforms }
       // Separate resource reads can straddle a boot. Absence from the earlier booted snapshot
       // cannot turn an image explicitly observed as Booting/Booted into a bootable Shutdown row.
       check(
@@ -227,7 +238,14 @@ class DevicePickerViewModel(
       ) {
         "Device inventory changed during discovery; refresh to get its current state"
       }
-      val devices = buildPickerDevices(booted, images, bootedImageRuntimeIds)
+      val devices =
+        Platform.entries.flatMap { platform ->
+          buildPickerDevices(
+            booted.filter { platformOf(it.platform) == platform },
+            images.filter { platformOf(it.platform) == platform },
+            bootedImageRuntimeIds[platform].orEmpty(),
+          )
+        }
       // A runtime whose AVD name probe failed may be one of these saved images. Neither
       // row order nor an unknown name proves which image is shut down; preserve the previous
       // snapshot until discovery resolves the identity or a successful boot supplies attribution.
@@ -238,25 +256,42 @@ class DevicePickerViewModel(
               it.isVirtual &&
               it.knownSourceImageId() == null &&
               (it.name == it.deviceId || it.name == "Unknown (${it.deviceId})") &&
-              it.deviceId !in bootedImageRuntimeIds.values
+              it.deviceId !in bootedImageRuntimeIds[Platform.Android].orEmpty().values
           }
       ) {
         "Android emulator identity is unavailable; refresh after its AVD name can be discovered"
       }
-      devices
+      val present = devices.map { it.platform to it.id }.toSet()
+      val sourceIds =
+        booted
+          .mapNotNull { device ->
+            device.knownSourceImageId()?.let { platformOf(device.platform) to it }
+          }
+          .toSet()
+      val retained =
+        lastInventory
+          .filter {
+            it.platform !in completePlatforms &&
+              (it.platform to it.id) !in present &&
+              (it.platform to it.id) !in sourceIds
+          }
+          .map { it.copy(inventoryUncertain = true) }
+      check(devices.isNotEmpty() || retained.isNotEmpty() || completePlatforms.isNotEmpty()) {
+        "Device discovery is incomplete; no authoritative inventory is available"
+      }
+      devices + retained
     }
 
-  private suspend fun readBootedDevices(): List<BootedDeviceInfo> =
+  private suspend fun readBootedDevices(): BootedDevicesResponse =
     when (val result = resourceClient.readResource(BOOTED_URI)) {
       is ResourceReadResult.Success ->
         (DeviceResourceParser.parseBootedDevices(result.content)
             ?: throw IllegalStateException("Malformed booted-devices payload"))
           .also {
-            check(it.observationComplete) {
+            check(it.observationComplete || it.platformObservations.isNotEmpty()) {
               "Device discovery is incomplete; retaining the previous inventory"
             }
           }
-          .devices
       is ResourceReadResult.Error ->
         throw IllegalStateException("Failed to read booted devices: ${result.message}")
     }
@@ -277,6 +312,7 @@ class DevicePickerViewModel(
    */
   private fun emitIfCurrent(generation: Long, devices: List<PickerDevice>) {
     if (generation != loadGeneration) return
+    lastInventory = devices
     LOG.info("Picker loaded ${devices.size} devices")
     emitContent(devices)
   }
@@ -294,6 +330,7 @@ class DevicePickerViewModel(
       when (val current = _state.value) {
         is DevicePickerUiState.Content ->
           current.copy(
+            devices = current.devices.map { it.copy(inventoryUncertain = true) },
             filters = filters,
             selectedIds = selectedIds,
             bootingIds = bootingIds,
@@ -314,6 +351,10 @@ class DevicePickerViewModel(
         selectedIds = selectedIds,
         bootingIds = bootingIds,
         bootErrors = bootErrors,
+        inventoryError =
+          if (devices.any { it.inventoryUncertain })
+            "Some device discovery is incomplete; retained devices cannot be booted"
+          else null,
       )
   }
 
@@ -323,8 +364,8 @@ class DevicePickerViewModel(
    * device is still present and booted.
    */
   private fun pruneState(devices: List<PickerDevice>) {
-    val shutdownIds = devices.filter { it.state == DeviceState.Shutdown }.map { it.id }.toSet()
-    val bootedIds = devices.filter { it.state == DeviceState.Booted }.map { it.id }.toSet()
+    val shutdownIds = devices.filter { it.state == DeviceState.Shutdown }.map { it.uiKey }.toSet()
+    val bootedIds = devices.filter { it.state == DeviceState.Booted }.map { it.uiKey }.toSet()
     // A boot guard survives while its boot coroutine is still in flight even when the live list no
     // longer shows the source as Shutdown: once the daemon exposes the started runtime device its
     // same-named card hides the source image, so the guard must not be dropped mid-boot (#4881).
@@ -332,7 +373,9 @@ class DevicePickerViewModel(
     bootErrors = bootErrors.filterKeys { it in shutdownIds }
     selectedIds = selectedIds intersect bootedIds
     // Keep only attributions whose runtime device is still booted (drop killed/replaced ids).
-    bootedImageRuntimeIds = bootedImageRuntimeIds.filterValues { it in bootedIds }
+    bootedImageRuntimeIds = bootedImageRuntimeIds.mapValues { (platform, mappings) ->
+      mappings.filterValues { "${platform.name.lowercase()}:$it" in bootedIds }
+    }
   }
 
   /** Reflect the persistent state onto the live Content (no device reload). */
@@ -347,16 +390,20 @@ class DevicePickerViewModel(
     }
   }
 
-  private fun bootDevice(deviceId: String) {
+  private fun bootDevice(selector: String) {
     // Boots are serialized: at most one in flight. A click on any shut-down card while a boot is
     // running is a no-op. This structurally removes overlapping reloads (and their generation
     // reordering hazards); the next card can boot once this one finishes. A failed boot leaves
     // bootingIds empty, so retrying (clicking the same card again) is still allowed.
     if (bootingIds.isNotEmpty()) return
     val content = _state.value as? DevicePickerUiState.Content ?: return
-    if (content.inventoryError != null) return
-    val device = content.devices.firstOrNull { it.id == deviceId } ?: return
-    if (device.state != DeviceState.Shutdown) return // only shut-down cards boot
+    val device =
+      content.devices.singleOrNull { it.uiKey == selector }
+        ?: content.devices.singleOrNull { it.id == selector }
+        ?: return
+    val deviceId = device.uiKey
+    if (device.state != DeviceState.Shutdown || device.inventoryUncertain)
+      return // only confirmed shut-down cards boot
     bootingIds = bootingIds + deviceId
     bootErrors = bootErrors - deviceId
     // Guard against a concurrent Refresh pruning the boot guard while the boot is still running.
@@ -393,7 +440,11 @@ class DevicePickerViewModel(
   private suspend fun reloadAfterBoot(bootedDevice: PickerDevice, runtimeDeviceId: String) {
     // Record the exact source-image -> runtime-id attribution BEFORE the reload, so this very fetch
     // hides the started device's own source image by id (not a positional same-name guess).
-    bootedImageRuntimeIds = bootedImageRuntimeIds + (bootedDevice.id to runtimeDeviceId)
+    bootedImageRuntimeIds =
+      bootedImageRuntimeIds +
+        (bootedDevice.platform to
+          (bootedImageRuntimeIds[bootedDevice.platform].orEmpty() +
+            (bootedDevice.id to runtimeDeviceId)))
     val generation = ++loadGeneration
     val devices =
       try {
@@ -402,24 +453,26 @@ class DevicePickerViewModel(
         throw c // don't turn cancellation into a boot failure
       } catch (e: Exception) {
         LOG.warn("Reload after boot failed for ${bootedDevice.name}: ${e.message}", e)
-        bootingIds = bootingIds - bootedDevice.id
-        bootErrors = bootErrors + (bootedDevice.id to (e.message ?: "Reload after boot failed"))
+        bootingIds = bootingIds - bootedDevice.uiKey
+        bootErrors = bootErrors + (bootedDevice.uiKey to (e.message ?: "Reload after boot failed"))
         resolveFetchFailure(generation, e)
         return
       }
     val bootedRuntime = devices.firstOrNull {
-      it.id == runtimeDeviceId && it.state == DeviceState.Booted
+      it.id == runtimeDeviceId &&
+        it.platform == bootedDevice.platform &&
+        it.state == DeviceState.Booted
     }
-    bootingIds = bootingIds - bootedDevice.id
+    bootingIds = bootingIds - bootedDevice.uiKey
     if (bootedRuntime != null) {
       // A completed boot AUTO-OBSERVES the device (below); it deliberately does NOT auto-select it.
       // The runtime id is daemon-assigned on boot and can't have been selected earlier (you can't
       // select a shut-down card), so there is nothing to retain, and leaving it selected would show
       // a stale "Observe (1)" when the grid reopens (#5220). Both the observed and the
       // superseded/killed branches therefore leave the selection untouched.
-      bootErrors = bootErrors - bootedDevice.id
+      bootErrors = bootErrors - bootedDevice.uiKey
     } else {
-      bootErrors = bootErrors + (bootedDevice.id to "Boot did not complete")
+      bootErrors = bootErrors + (bootedDevice.uiKey to "Boot did not complete")
     }
     // Persistent state is reflected onto the CURRENT Content unconditionally, so it never diverges
     // from what observeSelected() reads — even when this reload's device-LIST emission is dropped
@@ -437,17 +490,23 @@ class DevicePickerViewModel(
     // present-and-booted, with its fresh lock/virtual state (Codex).
     val stillBooted =
       (_state.value as? DevicePickerUiState.Content)?.devices?.firstOrNull {
-        it.id == runtimeDeviceId && it.state == DeviceState.Booted
+        it.id == runtimeDeviceId &&
+          it.platform == bootedDevice.platform &&
+          it.state == DeviceState.Booted
       }
     if (stillBooted != null) {
       _effect.send(DevicePickerEffect.Observe(listOf(columnOf(stillBooted))))
     }
   }
 
-  private fun toggleSelect(deviceId: String) {
+  private fun toggleSelect(selector: String) {
     val content = _state.value as? DevicePickerUiState.Content ?: return
     // Booted-only: ignore selection of non-booted devices.
-    val device = content.devices.firstOrNull { it.id == deviceId } ?: return
+    val device =
+      content.devices.singleOrNull { it.uiKey == selector }
+        ?: content.devices.singleOrNull { it.id == selector }
+        ?: return
+    val deviceId = device.uiKey
     if (device.state != DeviceState.Booted) return
     selectedIds = selectedIds.toggle(deviceId)
     syncState()
@@ -462,13 +521,14 @@ class DevicePickerViewModel(
     val content = _state.value as? DevicePickerUiState.Content ?: return
     val columns =
       content.devices
-        .filter { it.id in selectedIds && it.state == DeviceState.Booted }
+        .filter { it.uiKey in selectedIds && it.state == DeviceState.Booted }
         .map(::columnOf)
     if (columns.isNotEmpty()) {
       // Observed devices leave the selection: otherwise reopening the grid shows them still
       // selected as a stale "Observe (N)" (#5220). Selection is a transient staging area for the
       // multi-select gesture, not a record of what's observed.
-      selectedIds = selectedIds - columns.map { it.deviceId }.toSet()
+      selectedIds =
+        selectedIds - columns.map { "${it.platform.name.lowercase()}:${it.deviceId}" }.toSet()
       syncState()
       scope.launch { _effect.send(DevicePickerEffect.Observe(columns)) }
     }
@@ -478,9 +538,13 @@ class DevicePickerViewModel(
    * Observe a single booted device immediately — the plain-click path. A non-booted or unknown id
    * is a no-op (shut-down cards boot instead, and a boot auto-observes on completion).
    */
-  private fun observeDevice(deviceId: String) {
+  private fun observeDevice(selector: String) {
     val content = _state.value as? DevicePickerUiState.Content ?: return
-    val device = content.devices.firstOrNull { it.id == deviceId } ?: return
+    val device =
+      content.devices.singleOrNull { it.uiKey == selector }
+        ?: content.devices.singleOrNull { it.id == selector }
+        ?: return
+    val deviceId = device.uiKey
     if (device.state != DeviceState.Booted) return
     // A plain click doesn't select, but a modifier-selected device can also be plain-clicked; clear
     // it either way so an observed device never lingers selected (#5220).

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -143,7 +143,7 @@ class DevicePickerViewModel(
   // guard), nor the rule that the newest generation ends terminal (Content or Error) — a failure is
   // never dropped into a stranded Loading.
   private var loadGeneration: Long = 0
-  private var lastInventory: List<PickerDevice> = emptyList()
+  private var lastInventory: List<PickerDevice>? = null
 
   // Count of load() coroutines currently in flight — ALL of them, not just the newest: overlapping
   // explicit Refreshes are not cancelled, so a newer one can finish while an older read is still
@@ -291,6 +291,7 @@ class DevicePickerViewModel(
           .toSet()
       val retained =
         lastInventory
+          .orEmpty()
           .filter {
             discoverySource(it.platform, it.isVirtual) !in completeSources &&
               (it.platform to it.id) !in present &&
@@ -351,23 +352,18 @@ class DevicePickerViewModel(
    */
   private fun resolveFetchFailure(generation: Long, error: Throwable) {
     if (generation != loadGeneration) return
-    _state.value =
-      when (val current = _state.value) {
-        is DevicePickerUiState.Content ->
-          current.copy(
-            devices = current.devices.map { it.copy(inventoryUncertain = true) },
-            filters = filters,
-            selectedIds = selectedIds,
-            bootingIds = bootingIds,
-            bootErrors = bootErrors,
-            inventoryError = error.message ?: "Device discovery is unavailable",
-          )
-        else -> DevicePickerUiState.Error(error.message ?: "Failed to load devices")
-      }
+    val previous = lastInventory
+    if (previous == null) {
+      _state.value = DevicePickerUiState.Error(error.message ?: "Failed to load devices")
+      return
+    }
+    val retained = previous.map { it.copy(inventoryUncertain = true) }
+    lastInventory = retained
+    emitContent(retained, error.message ?: "Device discovery is unavailable")
   }
 
   /** Rebuild Content from a device list, merging the pruned persistent state. */
-  private fun emitContent(devices: List<PickerDevice>) {
+  private fun emitContent(devices: List<PickerDevice>, inventoryError: String? = null) {
     pruneState(devices)
     _state.value =
       DevicePickerUiState.Content(
@@ -377,9 +373,10 @@ class DevicePickerViewModel(
         bootingIds = bootingIds,
         bootErrors = bootErrors,
         inventoryError =
-          if (devices.any { it.inventoryUncertain })
-            "Some device discovery is incomplete; retained devices cannot be booted"
-          else null,
+          inventoryError
+            ?: if (devices.any { it.inventoryUncertain })
+              "Some device discovery is incomplete; retained devices cannot be booted"
+            else null,
       )
   }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -38,6 +38,8 @@ sealed interface DevicePickerUiState {
     val bootingIds: Set<String> = emptySet(),
     /** Per-device boot failure message; presence marks a card as retryable. */
     val bootErrors: Map<String, String> = emptyMap(),
+    /** Last discovery failed: these rows are the previous snapshot, not shutdown evidence. */
+    val inventoryError: String? = null,
   ) : DevicePickerUiState
 
   data class Error(val message: String) : DevicePickerUiState
@@ -209,14 +211,52 @@ class DevicePickerViewModel(
   // not empty the picker and prune live boot state — callers retain the prior snapshot.
   private suspend fun fetchDevices(): List<PickerDevice> =
     withContext(ioDispatcher) {
-      buildPickerDevices(readBootedDevices(), readDeviceImages(), bootedImageRuntimeIds)
+      val booted = readBootedDevices()
+      val images = readDeviceImages()
+      // Separate resource reads can straddle a boot. Absence from the earlier booted snapshot
+      // cannot turn an image explicitly observed as Booting/Booted into a bootable Shutdown row.
+      check(
+        images.none { image ->
+          image.platform.equals("ios", ignoreCase = true) &&
+            image.state != null &&
+            !image.state.equals("Shutdown", ignoreCase = true) &&
+            booted.none {
+              it.platform.equals(image.platform, ignoreCase = true) && it.deviceId == image.deviceId
+            }
+        }
+      ) {
+        "Device inventory changed during discovery; refresh to get its current state"
+      }
+      val devices = buildPickerDevices(booted, images, bootedImageRuntimeIds)
+      // A runtime whose AVD name probe failed may be one of these saved images. Neither
+      // row order nor an unknown name proves which image is shut down; preserve the previous
+      // snapshot until discovery resolves the identity or a successful boot supplies attribution.
+      check(
+        devices.none { it.platform == Platform.Android && it.state == DeviceState.Shutdown } ||
+          booted.none {
+            it.platform.equals("android", ignoreCase = true) &&
+              it.isVirtual &&
+              it.knownSourceImageId() == null &&
+              (it.name == it.deviceId || it.name == "Unknown (${it.deviceId})") &&
+              it.deviceId !in bootedImageRuntimeIds.values
+          }
+      ) {
+        "Android emulator identity is unavailable; refresh after its AVD name can be discovered"
+      }
+      devices
     }
 
   private suspend fun readBootedDevices(): List<BootedDeviceInfo> =
     when (val result = resourceClient.readResource(BOOTED_URI)) {
       is ResourceReadResult.Success ->
-        DeviceResourceParser.parseBootedDevices(result.content)?.devices
-          ?: throw IllegalStateException("Malformed booted-devices payload")
+        (DeviceResourceParser.parseBootedDevices(result.content)
+            ?: throw IllegalStateException("Malformed booted-devices payload"))
+          .also {
+            check(it.observationComplete) {
+              "Device discovery is incomplete; retaining the previous inventory"
+            }
+          }
+          .devices
       is ResourceReadResult.Error ->
         throw IllegalStateException("Failed to read booted devices: ${result.message}")
     }
@@ -258,6 +298,7 @@ class DevicePickerViewModel(
             selectedIds = selectedIds,
             bootingIds = bootingIds,
             bootErrors = bootErrors,
+            inventoryError = error.message ?: "Device discovery is unavailable",
           )
         else -> DevicePickerUiState.Error(error.message ?: "Failed to load devices")
       }
@@ -313,6 +354,7 @@ class DevicePickerViewModel(
     // bootingIds empty, so retrying (clicking the same card again) is still allowed.
     if (bootingIds.isNotEmpty()) return
     val content = _state.value as? DevicePickerUiState.Content ?: return
+    if (content.inventoryError != null) return
     val device = content.devices.firstOrNull { it.id == deviceId } ?: return
     if (device.state != DeviceState.Shutdown) return // only shut-down cards boot
     bootingIds = bootingIds + deviceId

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -25,6 +25,13 @@ private val LOG = LoggerFactory.getLogger("DevicePickerViewModel")
 private const val BOOTED_URI = "automobile:devices/booted"
 private const val IMAGES_URI = "automobile:devices/images"
 
+private fun discoverySource(platform: Platform, isVirtual: Boolean): String =
+  when {
+    platform == Platform.Android -> "android"
+    isVirtual -> "ios-simulator"
+    else -> "ios-physical"
+  }
+
 sealed interface DevicePickerUiState {
   data object Loading : DevicePickerUiState
 
@@ -214,16 +221,24 @@ class DevicePickerViewModel(
     withContext(ioDispatcher) {
       val observation = readBootedDevices()
       val booted = observation.devices
-      val completePlatforms =
-        Platform.entries
-          .filter { platform ->
-            observation.platformObservations[platform.name.lowercase()]?.observationComplete
+      val completeSources =
+        mapOf(
+            "android" to Platform.Android,
+            "ios-simulator" to Platform.Ios,
+            "ios-physical" to Platform.Ios,
+          )
+          .filter { (source, platform) ->
+            observation.sourceObservations[source]?.observationComplete
+              ?: observation.platformObservations[platform.name.lowercase()]?.observationComplete
               ?: observation.observationComplete
           }
-          .toSet()
-      // Positive observations stay usable even if a sibling platform cannot be queried.
-      // Only complete platforms may infer Shutdown from absence in this snapshot.
-      val images = readDeviceImages().filter { platformOf(it.platform) in completePlatforms }
+          .keys
+      // Simulator definitions depend only on simctl, not the independent devicectl sweep.
+      // Older daemons fall back to their platform-level completeness contract.
+      val images =
+        readDeviceImages().filter {
+          discoverySource(platformOf(it.platform), isVirtual = true) in completeSources
+        }
       // Separate resource reads can straddle a boot. Absence from the earlier booted snapshot
       // cannot turn an image explicitly observed as Booting/Booted into a bootable Shutdown row.
       check(
@@ -239,13 +254,19 @@ class DevicePickerViewModel(
         "Device inventory changed during discovery; refresh to get its current state"
       }
       val devices =
-        Platform.entries.flatMap { platform ->
-          buildPickerDevices(
-            booted.filter { platformOf(it.platform) == platform },
-            images.filter { platformOf(it.platform) == platform },
-            bootedImageRuntimeIds[platform].orEmpty(),
-          )
-        }
+        Platform.entries
+          .flatMap { platform ->
+            buildPickerDevices(
+              booted.filter { platformOf(it.platform) == platform },
+              images.filter { platformOf(it.platform) == platform },
+              bootedImageRuntimeIds[platform].orEmpty(),
+            )
+          }
+          .map {
+            it.copy(
+              inventoryUncertain = discoverySource(it.platform, it.isVirtual) !in completeSources
+            )
+          }
       // A runtime whose AVD name probe failed may be one of these saved images. Neither
       // row order nor an unknown name proves which image is shut down; preserve the previous
       // snapshot until discovery resolves the identity or a successful boot supplies attribution.
@@ -271,12 +292,12 @@ class DevicePickerViewModel(
       val retained =
         lastInventory
           .filter {
-            it.platform !in completePlatforms &&
+            discoverySource(it.platform, it.isVirtual) !in completeSources &&
               (it.platform to it.id) !in present &&
               (it.platform to it.id) !in sourceIds
           }
           .map { it.copy(inventoryUncertain = true) }
-      check(devices.isNotEmpty() || retained.isNotEmpty() || completePlatforms.isNotEmpty()) {
+      check(devices.isNotEmpty() || retained.isNotEmpty() || completeSources.isNotEmpty()) {
         "Device discovery is incomplete; no authoritative inventory is available"
       }
       devices + retained
@@ -288,7 +309,11 @@ class DevicePickerViewModel(
         (DeviceResourceParser.parseBootedDevices(result.content)
             ?: throw IllegalStateException("Malformed booted-devices payload"))
           .also {
-            check(it.observationComplete || it.platformObservations.isNotEmpty()) {
+            check(
+              it.observationComplete ||
+                it.platformObservations.isNotEmpty() ||
+                it.sourceObservations.isNotEmpty()
+            ) {
               "Device discovery is incomplete; retaining the previous inventory"
             }
           }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
@@ -36,6 +36,12 @@ data class PickerDevice(
   val deviceSessionUuid: String? = null,
 )
 
+/** An unresolved Android AVD probe reports a runtime label, not a source-image identity. */
+internal fun BootedDeviceInfo.knownSourceImageId(): String? =
+  identity?.stableId?.takeUnless {
+    platform.equals("android", ignoreCase = true) && (it == deviceId || it == "Unknown ($deviceId)")
+  }
+
 private val ANDROID_TARGET = Regex("android-(\\d+)")
 private val API_IN_NAME = Regex("API (\\d+)")
 
@@ -66,10 +72,11 @@ private fun osOfImage(image: DeviceImageInfo): Pair<String?, String?> =
  *   across boot); or
  * - when [sourceImageToRuntimeId] attributes a booted runtime id to that exact source image (an
  *   in-session boot: `BootDevice(sourceImageId)` -> `StartDeviceResult.deviceId`), so re-keyed
- *   devices hide their EXACT source, never a positional same-name guess; or
+ *   devices hide their EXACT source, never a positional same-name guess (the daemon's stable
+ *   identity takes precedence when available); or
  * - as a FALLBACK for a booted VIRTUAL device not attributed in-session (already-running /
  *   externally booted) that the daemon re-keyed off its image id — one same-named image per such
- *   device, not all same-named images.
+ *   device, only when exactly one same-platform image matches.
  *
  * Physical devices are not re-keyed, so they dedup by exact id only and never hide a distinct
  * same-named shut-down image. This keeps devices that merely share a display name (common for
@@ -81,8 +88,8 @@ fun buildPickerDevices(
   images: List<DeviceImageInfo>,
   sourceImageToRuntimeId: Map<String, String> = emptyMap(),
 ): List<PickerDevice> {
-  val bootedIds = booted.map { it.deviceId }.toSet()
-  val imageIds = images.map { it.deviceId ?: it.name }.toSet()
+  val bootedIds = booted.map { platformOf(it.platform) to it.deviceId }.toSet()
+  val imageIds = images.map { platformOf(it.platform) to (it.deviceId ?: it.name) }.toSet()
   val runtimeToSourceImage =
     sourceImageToRuntimeId.entries.associate { (source, rt) -> rt to source }
 
@@ -104,26 +111,42 @@ fun buildPickerDevices(
     )
   }
 
-  // Exact source images hidden via in-session boot attribution (runtime id -> its source image id).
-  val attributedSourceIds = booted.mapNotNull { runtimeToSourceImage[it.deviceId] }.toSet()
+  // The daemon's stable identity wins over a previous boot attribution: a runtime serial may
+  // have been reused by a different AVD. Older daemons fall back to in-session attribution.
+  val attributedSourceIds =
+    booted
+      .filter { it.isVirtual }
+      .mapNotNull { device ->
+        // The daemon can still carry its unresolved AVD-name sentinel as stableId. It is
+        // not a new identity and must not replace an attribution from a successful boot.
+        val stableId = device.knownSourceImageId()
+        (stableId ?: runtimeToSourceImage[device.deviceId])?.let {
+          platformOf(device.platform) to it
+        }
+      }
+      .toSet()
 
-  // Fallback name heuristic ONLY for re-keyed VIRTUAL devices with no in-session attribution
-  // (already-running / externally booted): each hides exactly one same-named image, not all.
-  // Physical devices are excluded — they are not re-keyed and must not hide a distinct sibling.
+  // Legacy resources carry no stable identity. A name can only reconcile an unambiguous
+  // same-platform image; never hide an arbitrary sibling with the same display name.
+  val imageNameCounts = images.groupingBy { platformOf(it.platform) to it.name }.eachCount()
   val hideByName =
     booted
       .filter {
-        it.isVirtual && it.deviceId !in imageIds && it.deviceId !in runtimeToSourceImage
+        it.isVirtual &&
+          it.identity == null &&
+          (platformOf(it.platform) to it.deviceId) !in imageIds &&
+          it.deviceId !in runtimeToSourceImage
       }
-      .groupingBy { it.name }
+      .groupingBy { platformOf(it.platform) to it.name }
       .eachCount()
+      .filter { (key, count) -> count == 1 && imageNameCounts[key] == 1 }
+      .keys
 
   val shutdownDevices =
     images
-      .filter { (it.deviceId ?: it.name) !in bootedIds } // exact identity already booted
-      .filter { (it.deviceId ?: it.name) !in attributedSourceIds } // exact in-session source
-      .groupBy { it.name }
-      .flatMap { (name, sameName) -> sameName.drop(hideByName[name] ?: 0) }
+      .filter { (platformOf(it.platform) to (it.deviceId ?: it.name)) !in bootedIds }
+      .filter { (platformOf(it.platform) to (it.deviceId ?: it.name)) !in attributedSourceIds }
+      .filter { (platformOf(it.platform) to it.name) !in hideByName }
       .map { image ->
         val (osKey, osLabel) = osOfImage(image)
         PickerDevice(
@@ -137,5 +160,5 @@ fun buildPickerDevices(
         )
       }
 
-  return (bootedDevices + shutdownDevices).distinctBy { it.id }
+  return (bootedDevices + shutdownDevices).distinctBy { it.platform to it.id }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
@@ -34,7 +34,13 @@ data class PickerDevice(
   val isVirtual: Boolean = true,
   /** Daemon-minted identity for the booted device epoch; absent on older daemon resources. */
   val deviceSessionUuid: String? = null,
-)
+  /** Retained after an incomplete sweep; absence is not evidence of shutdown. */
+  val inventoryUncertain: Boolean = false,
+) {
+  /** UI identity is platform scoped; id remains the raw daemon command target. */
+  val uiKey: String
+    get() = "${platform.name.lowercase()}:$id"
+}
 
 /** An unresolved Android AVD probe reports a runtime label, not a source-image identity. */
 internal fun BootedDeviceInfo.knownSourceImageId(): String? =

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceResourceParserTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceResourceParserTest.kt
@@ -21,6 +21,7 @@ class DeviceResourceParserTest {
           "virtualCount": 1,
           "physicalCount": 0,
           "lastUpdated": "2024-01-24T23:00:00Z",
+          "observationComplete": false,
           "devices": [
               {
                   "name": "Pixel 8 API 35",
@@ -28,7 +29,8 @@ class DeviceResourceParserTest {
                   "deviceId": "emulator-5554",
                   "source": "local",
                   "isVirtual": true,
-                  "status": "booted"
+                  "status": "booted",
+                  "identity": { "stableId": "Pixel_8", "connectionId": "transport-1" }
               }
           ]
       }
@@ -37,6 +39,8 @@ class DeviceResourceParserTest {
 
     val result = DeviceResourceParser.parseBootedDevices(json)
     assertNotNull(result)
+    assertEquals(false, result.observationComplete)
+    assertEquals("Pixel_8", result.devices.single().identity?.stableId)
     assertEquals(1, result.totalCount)
     assertEquals(1, result.androidCount)
     assertEquals(0, result.iosCount)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceResourceParserTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceResourceParserTest.kt
@@ -22,6 +22,10 @@ class DeviceResourceParserTest {
           "physicalCount": 0,
           "lastUpdated": "2024-01-24T23:00:00Z",
           "observationComplete": false,
+          "sourceObservations": {
+            "ios-simulator": { "observationComplete": true },
+            "ios-physical": { "observationComplete": false, "discoveryError": { "code": "failed" } }
+          },
           "devices": [
               {
                   "name": "Pixel 8 API 35",
@@ -40,6 +44,8 @@ class DeviceResourceParserTest {
     val result = DeviceResourceParser.parseBootedDevices(json)
     assertNotNull(result)
     assertEquals(false, result.observationComplete)
+    assertEquals(true, result.sourceObservations["ios-simulator"]?.observationComplete)
+    assertEquals(false, result.sourceObservations["ios-physical"]?.observationComplete)
     assertEquals("Pixel_8", result.devices.single().identity?.stableId)
     assertEquals(1, result.totalCount)
     assertEquals(1, result.androidCount)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerUiTest.kt
@@ -48,6 +48,23 @@ class DevicePickerUiTest {
   }
 
   @Test
+  fun `renders same-id devices on both platforms with distinct click targets`() = runComposeUiTest {
+    var action: DevicePickerAction? = null
+    picker(
+      DevicePickerUiState.Content(
+        listOf(
+          PickerDevice("shared", "Android twin", Platform.Android, DeviceState.Booted),
+          PickerDevice("shared", "iOS twin", Platform.Ios, DeviceState.Booted),
+        )
+      ),
+      onAction = { action = it },
+    )
+    onNodeWithContentDescription("Observe Android twin").assertIsDisplayed()
+    onNodeWithContentDescription("Observe iOS twin").performClick()
+    assertEquals(DevicePickerAction.ObserveOne("ios:shared"), action)
+  }
+
+  @Test
   fun `renders rail options and device cards`() = runComposeUiTest {
     picker()
     onNodeWithContentDescription("Select filter Booted").assertIsDisplayed()
@@ -63,7 +80,7 @@ class DevicePickerUiTest {
     var action: DevicePickerAction? = null
     picker(onAction = { action = it })
     onNodeWithContentDescription("Observe Pixel 8").performClick()
-    assertEquals(DevicePickerAction.ObserveOne("p8"), action)
+    assertEquals(DevicePickerAction.ObserveOne("android:p8"), action)
   }
 
   @Test
@@ -71,12 +88,12 @@ class DevicePickerUiTest {
     var action: DevicePickerAction? = null
     picker(onAction = { action = it })
     onNodeWithContentDescription("Boot iPhone 15").performClick()
-    assertEquals(DevicePickerAction.BootDevice("i15"), action)
+    assertEquals(DevicePickerAction.BootDevice("ios:i15"), action)
   }
 
   @Test
   fun `a booting card shows Booting and offers no boot affordance`() = runComposeUiTest {
-    picker(content(bootingIds = setOf("i15")))
+    picker(content(bootingIds = setOf("ios:i15")))
     // No boot/retry affordance while a boot is in flight — the card is a passive "Booting…".
     onNodeWithText("Booting…").assertIsDisplayed()
     onNodeWithText("Click to boot").assertDoesNotExist()
@@ -87,10 +104,10 @@ class DevicePickerUiTest {
   @Test
   fun `a failed card offers a retry that dispatches BootDevice`() = runComposeUiTest {
     var action: DevicePickerAction? = null
-    picker(content(bootErrors = mapOf("i15" to "boom")), onAction = { action = it })
+    picker(content(bootErrors = mapOf("ios:i15" to "boom")), onAction = { action = it })
     onNodeWithText("Boot failed · Click to retry").assertIsDisplayed()
     onNodeWithContentDescription("Retry boot iPhone 15").performClick()
-    assertEquals(DevicePickerAction.BootDevice("i15"), action)
+    assertEquals(DevicePickerAction.BootDevice("ios:i15"), action)
   }
 
   @Test
@@ -105,7 +122,7 @@ class DevicePickerUiTest {
   fun `the observe-selected button appears only once a selection exists and dispatches`() =
     runComposeUiTest {
       var action: DevicePickerAction? = null
-      picker(content(selected = setOf("p8")), onAction = { action = it })
+      picker(content(selected = setOf("android:p8")), onAction = { action = it })
       onNodeWithContentDescription("Observe selected").assertIsEnabled().performClick()
       assertEquals(DevicePickerAction.ObserveSelected, action)
     }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -104,6 +104,49 @@ class DevicePickerViewModelTest {
     }
 
   @Test
+  fun `failed physical discovery still permits a simulator boot on first load`() =
+    testScope.runTest {
+      val client = fake()
+      client.bootedDevicesResponse =
+        client.bootedDevicesResponse.replace(
+          "\"lastUpdated\":\"x\"",
+          "\"lastUpdated\":\"x\",\"observationComplete\":false,\"platformObservations\":{\"android\":{\"observationComplete\":true},\"ios\":{\"observationComplete\":false}},\"sourceObservations\":{\"android\":{\"observationComplete\":true},\"ios-simulator\":{\"observationComplete\":true},\"ios-physical\":{\"observationComplete\":false}}",
+        )
+      val boot = FakeDeviceBootController()
+      val viewModel = vm(client, boot)
+      assertTrue(content(viewModel).devices.any { it.id == "iphone-15" && !it.inventoryUncertain })
+      viewModel.onAction(DevicePickerAction.BootDevice("ios:iphone-15"))
+      assertEquals(Platform.Ios, boot.bootRequests.single().platform)
+      assertEquals("iphone-15", boot.bootRequests.single().id)
+    }
+
+  @Test
+  fun `source failure retains only affected physical rows and keeps simulator images current`() =
+    testScope.runTest {
+      val client = fake()
+      client.bootedDevicesResponse =
+        """{"totalCount":1,"androidCount":0,"iosCount":1,"virtualCount":0,"physicalCount":1,"lastUpdated":"x","devices":[{"name":"USB iPhone","platform":"ios","deviceId":"physical-ios","source":"local","isVirtual":false,"status":"booted"}]}"""
+      val viewModel = vm(client)
+      client.bootedDevicesResponse =
+        """{"totalCount":0,"androidCount":0,"iosCount":0,"virtualCount":0,"physicalCount":0,"lastUpdated":"x","observationComplete":false,"platformObservations":{"android":{"observationComplete":true},"ios":{"observationComplete":false}},"sourceObservations":{"ios-simulator":{"observationComplete":true},"ios-physical":{"observationComplete":false}},"devices":[]}"""
+      viewModel.onAction(DevicePickerAction.SilentRefresh)
+      assertTrue(
+        content(viewModel).devices.any { it.id == "physical-ios" && it.inventoryUncertain }
+      )
+      assertTrue(content(viewModel).devices.any { it.id == "iphone-15" && !it.inventoryUncertain })
+      // Reversing the failed source authoritatively removes the physical device, but cannot
+      // reinterpret the retained simulator definition as a newly bootable shutdown device.
+      client.bootedDevicesResponse =
+        client.bootedDevicesResponse.replace(
+          "\"ios-simulator\":{\"observationComplete\":true},\"ios-physical\":{\"observationComplete\":false}",
+          "\"ios-simulator\":{\"observationComplete\":false},\"ios-physical\":{\"observationComplete\":true}",
+        )
+      viewModel.onAction(DevicePickerAction.SilentRefresh)
+      assertTrue(content(viewModel).devices.none { it.id == "physical-ios" })
+      assertTrue(content(viewModel).devices.any { it.id == "iphone-15" && it.inventoryUncertain })
+    }
+
+  @Test
   fun `partial iOS discovery retains only missing iOS rows while accepting fresh Android inventory`() =
     testScope.runTest {
       val client = fake()
@@ -114,7 +157,7 @@ class DevicePickerViewModelTest {
       viewModel.onAction(DevicePickerAction.SilentRefresh)
       val devices = content(viewModel).devices
       assertTrue(devices.none { it.id == "emulator-5554" })
-      assertTrue(devices.any { it.id == "fresh-ios" && !it.inventoryUncertain })
+      assertTrue(devices.any { it.id == "fresh-ios" && it.state == DeviceState.Booted })
       assertTrue(devices.any { it.id == "iphone-15" && it.inventoryUncertain })
       viewModel.onAction(DevicePickerAction.BootDevice("iphone-15"))
       assertTrue(boot.bootRequests.isEmpty())

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -50,6 +50,79 @@ class DevicePickerViewModelTest {
   ) = DevicePickerViewModel(resourceClient, bootController, testScope, UnconfinedTestDispatcher())
 
   @Test
+  fun `identical raw runtime ids have distinct grid keys and selection targets`() =
+    testScope.runTest {
+      val client = fake()
+      client.bootedDevicesResponse =
+        """{"totalCount":2,"androidCount":1,"iosCount":1,"virtualCount":0,"physicalCount":2,"lastUpdated":"x","devices":[{"name":"Android","platform":"android","deviceId":"shared","source":"local","isVirtual":false,"status":"booted"},{"name":"iPhone","platform":"ios","deviceId":"shared","source":"local","isVirtual":false,"status":"booted"}]}"""
+      val viewModel = vm(client)
+      val twins = content(viewModel).devices.filter { it.id == "shared" }
+      assertEquals(setOf("android:shared", "ios:shared"), twins.map { it.uiKey }.toSet())
+      viewModel.onAction(DevicePickerAction.ToggleSelect("shared"))
+      assertTrue(
+        content(viewModel).selectedIds.isEmpty()
+      ) // ambiguous legacy input cannot target a sibling
+      viewModel.onAction(DevicePickerAction.ToggleSelect("ios:shared"))
+      assertEquals(setOf("ios:shared"), content(viewModel).selectedIds)
+      viewModel.effect.test {
+        viewModel.onAction(DevicePickerAction.ObserveSelected)
+        val column = (awaitItem() as DevicePickerEffect.Observe).columns.single()
+        assertEquals("shared", column.deviceId)
+        assertEquals(Platform.Ios, column.platform)
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+
+  @Test
+  fun `identical image ids boot the selected platform using the raw daemon target`() =
+    testScope.runTest {
+      val client = fake()
+      client.deviceImagesResponse =
+        """{"totalCount":2,"androidCount":1,"iosCount":1,"lastUpdated":"x","images":[{"name":"Android image","platform":"android","deviceId":"shared"},{"name":"iOS image","platform":"ios","deviceId":"shared","state":"Shutdown"}]}"""
+      val boot = FakeDeviceBootController()
+      val viewModel = vm(client, boot)
+      viewModel.onAction(DevicePickerAction.BootDevice("ios:shared"))
+      assertEquals("shared", boot.bootRequests.single().id)
+      assertEquals(Platform.Ios, boot.bootRequests.single().platform)
+    }
+
+  @Test
+  fun `unavailable iOS does not block Android inventory or Android boots on Linux and Windows`() =
+    testScope.runTest {
+      val client = fake()
+      client.bootedDevicesResponse =
+        client.bootedDevicesResponse.replace(
+          "\"lastUpdated\":\"x\"",
+          "\"lastUpdated\":\"x\",\"observationComplete\":false,\"platformObservations\":{\"android\":{\"observationComplete\":true},\"ios\":{\"observationComplete\":false,\"discoveryError\":{\"code\":\"unavailable\"}}}",
+        )
+      val boot = FakeDeviceBootController()
+      val viewModel = vm(client, boot)
+      assertTrue(content(viewModel).devices.isNotEmpty())
+      assertTrue(content(viewModel).devices.all { it.platform == Platform.Android })
+      viewModel.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
+      assertEquals(1, boot.bootRequests.size)
+    }
+
+  @Test
+  fun `partial iOS discovery retains only missing iOS rows while accepting fresh Android inventory`() =
+    testScope.runTest {
+      val client = fake()
+      val boot = FakeDeviceBootController()
+      val viewModel = vm(client, boot)
+      client.bootedDevicesResponse =
+        """{"totalCount":1,"androidCount":0,"iosCount":1,"virtualCount":1,"physicalCount":0,"lastUpdated":"x","observationComplete":false,"platformObservations":{"android":{"observationComplete":true},"ios":{"observationComplete":false}},"devices":[{"name":"New iPhone","platform":"ios","deviceId":"fresh-ios","source":"local","isVirtual":true,"status":"booted"}]}"""
+      viewModel.onAction(DevicePickerAction.SilentRefresh)
+      val devices = content(viewModel).devices
+      assertTrue(devices.none { it.id == "emulator-5554" })
+      assertTrue(devices.any { it.id == "fresh-ios" && !it.inventoryUncertain })
+      assertTrue(devices.any { it.id == "iphone-15" && it.inventoryUncertain })
+      viewModel.onAction(DevicePickerAction.BootDevice("iphone-15"))
+      assertTrue(boot.bootRequests.isEmpty())
+      viewModel.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
+      assertEquals(1, boot.bootRequests.size)
+    }
+
+  @Test
   fun `an external emulator with unresolved identity does not create shutdown candidates on first load`() =
     testScope.runTest {
       val client = fake()
@@ -70,7 +143,10 @@ class DevicePickerViewModelTest {
       client.bootedDevicesResponse =
         client.bootedDevicesResponse.replace("Pixel 8 API 35", "Unknown (emulator-5554)")
       viewModel.onAction(DevicePickerAction.SilentRefresh)
-      assertEquals(before, content(viewModel).devices)
+      assertEquals(
+        before.map { it.id to it.state },
+        content(viewModel).devices.map { it.id to it.state },
+      )
       assertTrue(content(viewModel).inventoryError?.contains("identity is unavailable") == true)
       viewModel.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
       assertTrue(bootController.bootRequests.isEmpty())
@@ -86,7 +162,10 @@ class DevicePickerViewModelTest {
       client.bootedDevicesResponse =
         """{"totalCount":0,"androidCount":0,"iosCount":0,"virtualCount":0,"physicalCount":0,"lastUpdated":"x","observationComplete":false,"devices":[]}"""
       viewModel.onAction(DevicePickerAction.SilentRefresh)
-      assertEquals(before, content(viewModel).devices)
+      assertEquals(
+        before.map { it.id to it.state },
+        content(viewModel).devices.map { it.id to it.state },
+      )
       assertTrue(content(viewModel).inventoryError != null)
       viewModel.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
       assertTrue(bootController.bootRequests.isEmpty())
@@ -114,7 +193,10 @@ class DevicePickerViewModelTest {
       val before = content(viewModel).devices
       client.deviceImagesResponse = client.deviceImagesResponse.replace("Shutdown", "Booting")
       viewModel.onAction(DevicePickerAction.SilentRefresh)
-      assertEquals(before, content(viewModel).devices)
+      assertEquals(
+        before.map { it.id to it.state },
+        content(viewModel).devices.map { it.id to it.state },
+      )
     }
 
   @Test
@@ -149,7 +231,7 @@ class DevicePickerViewModelTest {
     vm.onAction(DevicePickerAction.ToggleSelect("iphone-15")) // shutdown — ignored
     assertTrue(content(vm).selectedIds.isEmpty())
     vm.onAction(DevicePickerAction.ToggleSelect("emulator-5554")) // booted
-    assertEquals(setOf("emulator-5554"), content(vm).selectedIds)
+    assertEquals(setOf("android:emulator-5554"), content(vm).selectedIds)
   }
 
   @Test
@@ -219,7 +301,7 @@ class DevicePickerViewModelTest {
       assertEquals(listOf("emulator-5556"), columns.map { it.deviceId })
       // Auto-observed, so the device must NOT linger in the selection (no stale "Observe (1)" when
       // the grid reopens) — issue #5220.
-      assertTrue("emulator-5556" !in content(v).selectedIds)
+      assertTrue("android:emulator-5556" !in content(v).selectedIds)
       cancelAndIgnoreRemainingEvents()
     }
   }
@@ -229,10 +311,10 @@ class DevicePickerViewModelTest {
     val vm =
       DevicePickerViewModel(fake(), FakeDeviceBootController(), this, UnconfinedTestDispatcher())
     vm.onAction(DevicePickerAction.ToggleSelect("emulator-5554"))
-    assertEquals(setOf("emulator-5554"), content(vm).selectedIds)
+    assertEquals(setOf("android:emulator-5554"), content(vm).selectedIds)
     vm.onAction(DevicePickerAction.ObserveSelected)
     // Once observed, the device is no longer selected — reopening the grid shows a clean selection.
-    assertTrue("emulator-5554" !in content(vm).selectedIds)
+    assertTrue("android:emulator-5554" !in content(vm).selectedIds)
   }
 
   @Test
@@ -241,7 +323,7 @@ class DevicePickerViewModelTest {
       DevicePickerViewModel(fake(), FakeDeviceBootController(), this, UnconfinedTestDispatcher())
     vm.onAction(DevicePickerAction.ToggleSelect("emulator-5554"))
     vm.onAction(DevicePickerAction.ObserveOne("emulator-5554"))
-    assertTrue("emulator-5554" !in content(vm).selectedIds)
+    assertTrue("android:emulator-5554" !in content(vm).selectedIds)
   }
 
   @Test
@@ -313,7 +395,7 @@ class DevicePickerViewModelTest {
         reloadGate.complete(Unit) // stale reload resumes: auto-observe must see the device is gone
         expectNoEvents() // no Observe effect for the now-dead device
         // ...and the gone device is not left lingering in the selection either (#5220).
-        assertTrue("emulator-5556" !in content(v).selectedIds)
+        assertTrue("android:emulator-5556" !in content(v).selectedIds)
         cancelAndIgnoreRemainingEvents()
       }
     }
@@ -387,7 +469,7 @@ class DevicePickerViewModelTest {
     val boot = FakeDeviceBootController().apply { autoComplete = false }
     val v = vm(bootController = boot)
     v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
-    assertEquals(setOf("Pixel_6_API_33"), content(v).bootingIds)
+    assertEquals(setOf("android:Pixel_6_API_33"), content(v).bootingIds)
     assertEquals(listOf("Pixel_6_API_33"), boot.bootRequests.map { it.id })
     boot.complete() // let the held boot resolve so runTest can finish
   }
@@ -417,7 +499,9 @@ class DevicePickerViewModelTest {
       val v = vm(resourceClient = resources, bootController = boot)
       v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
       val c = content(v)
-      assertTrue("emulator-5556" !in c.selectedIds) // auto-observed, not auto-selected (#5220)
+      assertTrue(
+        "android:emulator-5556" !in c.selectedIds
+      ) // auto-observed, not auto-selected (#5220)
       assertTrue(c.bootingIds.isEmpty())
       assertTrue(c.devices.any { it.id == "emulator-5556" && it.state == DeviceState.Booted })
       assertTrue(c.devices.none { it.id == "Pixel_6_API_33" }) // shut-down entry replaced by booted
@@ -431,7 +515,7 @@ class DevicePickerViewModelTest {
     v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
     val c = content(v)
     assertTrue(c.bootingIds.isEmpty())
-    assertEquals("boom", c.bootErrors["Pixel_6_API_33"])
+    assertEquals("boom", c.bootErrors["android:Pixel_6_API_33"])
   }
 
   @Test
@@ -459,10 +543,13 @@ class DevicePickerViewModelTest {
       val boot = FakeDeviceBootController().apply { autoComplete = false } // hold the boot open
       val v = vm(bootController = boot)
       v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
-      assertEquals(setOf("Pixel_6_API_33"), content(v).bootingIds)
+      assertEquals(setOf("android:Pixel_6_API_33"), content(v).bootingIds)
       // Reopen/refresh while the boot is still in flight — load() swaps Content out and back.
       v.onAction(DevicePickerAction.Refresh)
-      assertEquals(setOf("Pixel_6_API_33"), content(v).bootingIds) // guard survived the reload
+      assertEquals(
+        setOf("android:Pixel_6_API_33"),
+        content(v).bootingIds,
+      ) // guard survived the reload
       v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33")) // clicking again must not re-boot
       assertEquals(1, boot.bootRequests.size)
       boot.complete() // release; device still shut down on reload -> boot did not complete
@@ -480,7 +567,7 @@ class DevicePickerViewModelTest {
       val v = vm(resourceClient = resources, bootController = boot)
       v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
       v.onAction(DevicePickerAction.Refresh) // state cycled Loading -> Content, guard preserved
-      assertEquals(setOf("Pixel_6_API_33"), content(v).bootingIds)
+      assertEquals(setOf("android:Pixel_6_API_33"), content(v).bootingIds)
       // The daemon finished the boot; it now reports the device booted under a runtime serial.
       resources.bootedDevicesResponse =
         """
@@ -494,7 +581,9 @@ class DevicePickerViewModelTest {
           .trimIndent()
       boot.complete() // reloadAfterBoot fetches -> device booted -> auto-observe by runtime id
       val c = content(v)
-      assertTrue("emulator-5556" !in c.selectedIds) // auto-observed, not auto-selected (#5220)
+      assertTrue(
+        "android:emulator-5556" !in c.selectedIds
+      ) // auto-observed, not auto-selected (#5220)
       assertTrue(c.bootingIds.isEmpty())
       assertTrue(c.devices.any { it.id == "emulator-5556" && it.state == DeviceState.Booted })
     }
@@ -509,7 +598,7 @@ class DevicePickerViewModelTest {
       v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33")) // in flight (held)
       v.onAction(DevicePickerAction.BootDevice("iphone-15")) // ignored — a boot is already running
       assertEquals(listOf("Pixel_6_API_33"), boot.bootRequests.map { it.id })
-      assertEquals(setOf("Pixel_6_API_33"), content(v).bootingIds)
+      assertEquals(setOf("android:Pixel_6_API_33"), content(v).bootingIds)
       boot.complete() // release so runTest can finish
     }
 
@@ -534,11 +623,13 @@ class DevicePickerViewModelTest {
       client.imagesGate = null // the post-boot reload must not be gated
 
       boot.complete() // reloadAfterBoot fetches fresh, emits + auto-observes the booted device
-      assertTrue("emulator-5556" !in content(v).selectedIds) // auto-observed, not selected (#5220)
+      assertTrue(
+        "android:emulator-5556" !in content(v).selectedIds
+      ) // auto-observed, not selected (#5220)
 
       staleGate.complete(Unit) // stale Refresh resumes with the OLD (shut-down) list — dropped
       val c = content(v)
-      assertTrue("emulator-5556" !in c.selectedIds) // fresh post-boot state survived
+      assertTrue("android:emulator-5556" !in c.selectedIds) // fresh post-boot state survived
       assertTrue(c.devices.any { it.id == "emulator-5556" && it.state == DeviceState.Booted })
       assertTrue(c.devices.none { it.id == "Pixel_6_API_33" }) // stale shut-down card not restored
 
@@ -569,7 +660,7 @@ class DevicePickerViewModelTest {
       // still-booted Pixel 8 as shut down). Previous snapshot retained; a retry is surfaced.
       assertTrue(c.devices.any { it.id == "emulator-5554" && it.state == DeviceState.Booted })
       assertTrue(c.bootingIds.isEmpty())
-      assertTrue(c.bootErrors.containsKey("Pixel_6_API_33"))
+      assertTrue(c.bootErrors.containsKey("android:Pixel_6_API_33"))
     }
 
   @Test
@@ -680,7 +771,9 @@ class DevicePickerViewModelTest {
         reloadGate.complete(Unit) // reload resumes: auto-observes from the winning Content
         val columns = (awaitItem() as DevicePickerEffect.Observe).columns
         assertEquals(listOf("emulator-5556"), columns.map { it.deviceId })
-        assertTrue("emulator-5556" !in content(v).selectedIds) // observed, not left selected
+        assertTrue(
+          "android:emulator-5556" !in content(v).selectedIds
+        ) // observed, not left selected
         cancelAndIgnoreRemainingEvents()
       }
     }
@@ -730,7 +823,7 @@ class DevicePickerViewModelTest {
       // NOT
       // a fabricated shut-down card that would permit a duplicate start.
       assertTrue(c.devices.any { it.id == "emulator-5554" && it.state == DeviceState.Booted })
-      assertTrue(c.bootErrors.containsKey("Pixel_6_API_33"))
+      assertTrue(c.bootErrors.containsKey("android:Pixel_6_API_33"))
     }
 
   @Test
@@ -765,7 +858,7 @@ class DevicePickerViewModelTest {
         }
       val v = DevicePickerViewModel(client, boot, testScope, UnconfinedTestDispatcher())
       v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33")) // boot in flight (held)
-      assertEquals(setOf("Pixel_6_API_33"), content(v).bootingIds)
+      assertEquals(setOf("android:Pixel_6_API_33"), content(v).bootingIds)
 
       // The daemon exposes the started device under its runtime serial BEFORE boot() returns. Its
       // same-named card hides the Pixel_6_API_33 source image, so a refresh's list shows that
@@ -775,7 +868,7 @@ class DevicePickerViewModelTest {
       v.onAction(DevicePickerAction.Refresh)
       // The guard must survive on the in-flight boot job even though the source vanished from the
       // list — otherwise a second startDevice could fire while this boot is still running (#4881).
-      assertEquals(setOf("Pixel_6_API_33"), content(v).bootingIds)
+      assertEquals(setOf("android:Pixel_6_API_33"), content(v).bootingIds)
 
       // A click on a DIFFERENT shut-down card must still be a no-op: boots stay serialized.
       v.onAction(DevicePickerAction.BootDevice("iphone-15"))

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -50,6 +50,74 @@ class DevicePickerViewModelTest {
   ) = DevicePickerViewModel(resourceClient, bootController, testScope, UnconfinedTestDispatcher())
 
   @Test
+  fun `an external emulator with unresolved identity does not create shutdown candidates on first load`() =
+    testScope.runTest {
+      val client = fake()
+      client.bootedDevicesResponse =
+        client.bootedDevicesResponse.replace("Pixel 8 API 35", "Unknown (emulator-5554)")
+      val state = vm(client).state.value
+      assertTrue(state is DevicePickerUiState.Error)
+      assertTrue((state as DevicePickerUiState.Error).message.contains("identity is unavailable"))
+    }
+
+  @Test
+  fun `an unresolved external emulator retains prior inventory and disables new boots`() =
+    testScope.runTest {
+      val client = fake()
+      val bootController = FakeDeviceBootController()
+      val viewModel = vm(client, bootController)
+      val before = content(viewModel).devices
+      client.bootedDevicesResponse =
+        client.bootedDevicesResponse.replace("Pixel 8 API 35", "Unknown (emulator-5554)")
+      viewModel.onAction(DevicePickerAction.SilentRefresh)
+      assertEquals(before, content(viewModel).devices)
+      assertTrue(content(viewModel).inventoryError?.contains("identity is unavailable") == true)
+      viewModel.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
+      assertTrue(bootController.bootRequests.isEmpty())
+    }
+
+  @Test
+  fun `an incomplete observation retains the previous booted row instead of reporting shutdown`() =
+    testScope.runTest {
+      val client = fake()
+      val bootController = FakeDeviceBootController()
+      val viewModel = vm(client, bootController)
+      val before = content(viewModel).devices
+      client.bootedDevicesResponse =
+        """{"totalCount":0,"androidCount":0,"iosCount":0,"virtualCount":0,"physicalCount":0,"lastUpdated":"x","observationComplete":false,"devices":[]}"""
+      viewModel.onAction(DevicePickerAction.SilentRefresh)
+      assertEquals(before, content(viewModel).devices)
+      assertTrue(content(viewModel).inventoryError != null)
+      viewModel.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
+      assertTrue(bootController.bootRequests.isEmpty())
+      assertTrue(
+        content(viewModel).devices.any {
+          it.id == "emulator-5554" && it.state == DeviceState.Booted
+        }
+      )
+    }
+
+  @Test
+  fun `a first incomplete observation produces an error rather than bootable shutdown images`() =
+    testScope.runTest {
+      val client = fake()
+      client.bootedDevicesResponse =
+        """{"totalCount":0,"androidCount":0,"iosCount":0,"virtualCount":0,"physicalCount":0,"lastUpdated":"x","observationComplete":false,"devices":[]}"""
+      assertTrue(vm(client).state.value is DevicePickerUiState.Error)
+    }
+
+  @Test
+  fun `a simulator transitioning between resource reads does not become a shutdown row`() =
+    testScope.runTest {
+      val client = fake()
+      val viewModel = vm(client)
+      val before = content(viewModel).devices
+      client.deviceImagesResponse = client.deviceImagesResponse.replace("Shutdown", "Booting")
+      viewModel.onAction(DevicePickerAction.SilentRefresh)
+      assertEquals(before, content(viewModel).devices)
+    }
+
+  @Test
   fun `loads and unifies booted + images with dedupe and iOS architecture`() = testScope.runTest {
     val vm =
       DevicePickerViewModel(fake(), FakeDeviceBootController(), this, UnconfinedTestDispatcher())

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -727,28 +727,67 @@ class DevicePickerViewModelTest {
   // closes the picker, so a boot never accumulates a persistent selection to survive a refresh.
 
   @Test
-  fun `a refresh during boot whose post-boot read fails ends in Error, not stuck Loading`() =
+  fun `a refresh during boot whose post-boot read fails retains uncertain inventory`() =
     testScope.runTest {
       val client =
-        ScriptableResourceClient(bootedJson = SINGLE_BOOTED_PIXEL8, imagesJson = TWO_IMAGES_8_6)
+        ScriptableResourceClient(
+          bootedJson = SINGLE_BOOTED_PIXEL8,
+          imagesJson = TWO_IMAGES_8_6,
+        )
       val boot = FakeDeviceBootController().apply { autoComplete = false }
       val v = DevicePickerViewModel(client, boot, testScope, UnconfinedTestDispatcher())
       v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33")) // boot in flight (gated)
 
-      // A Refresh sets Loading and stalls mid-read, so state is Loading when the boot resolves.
+      // A Refresh sets Loading and stalls mid-read, so state is Loading when the boot
+      // resolves.
       val staleGate = CompletableDeferred<Unit>()
       client.imagesGate = staleGate
       v.onAction(DevicePickerAction.Refresh)
       client.imagesGate = null
 
-      // The post-boot reload's booted read now fails: the newest generation must still resolve to a
-      // terminal Error (retryable) — never leave the Refresh's Loading stranded.
+      // The post-boot reload's booted read now fails: the newest generation must still
+      // resolve to a
+      // retained inventory — never leave the Refresh's Loading stranded.
       client.failBooted = true
       boot.complete()
-      assertTrue(v.state.value is DevicePickerUiState.Error)
+      assertTrue(content(v).devices.all { it.inventoryUncertain })
+      assertTrue(content(v).inventoryError != null)
 
-      staleGate.complete(Unit) // stale Refresh resumes; its emission is dropped, Error stands
-      assertTrue(v.state.value is DevicePickerUiState.Error)
+      staleGate.complete(Unit) // stale Refresh cannot replace the uncertain snapshot
+      assertTrue(content(v).devices.all { it.inventoryUncertain })
+      assertTrue(content(v).inventoryError != null)
+    }
+
+  @Test
+  fun `explicit refresh failures retain the grid and selection until recovery`() =
+    testScope.runTest {
+      val client = ScriptableResourceClient(SINGLE_BOOTED_PIXEL8, TWO_IMAGES_8_6)
+      val boot = FakeDeviceBootController()
+      val viewModel = DevicePickerViewModel(client, boot, testScope, UnconfinedTestDispatcher())
+      val ids = content(viewModel).devices.map { it.uiKey }
+      viewModel.onAction(DevicePickerAction.ToggleSelect("android:emulator-5554"))
+      viewModel.onAction(DevicePickerAction.SetQuery("Pixel"))
+
+      client.failBooted = true
+      viewModel.onAction(DevicePickerAction.Refresh)
+      assertEquals(ids, content(viewModel).devices.map { it.uiKey })
+      assertTrue(content(viewModel).devices.all { it.inventoryUncertain })
+      assertEquals(setOf("android:emulator-5554"), content(viewModel).selectedIds)
+      assertEquals("Pixel", content(viewModel).filters.query)
+      viewModel.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
+      assertTrue(boot.bootRequests.isEmpty())
+
+      client.failBooted = false
+      client.bootedJson = "{ malformed"
+      viewModel.onAction(DevicePickerAction.Refresh)
+      assertEquals(ids, content(viewModel).devices.map { it.uiKey })
+      assertTrue(content(viewModel).inventoryError != null)
+
+      client.bootedJson = SINGLE_BOOTED_PIXEL8
+      viewModel.onAction(DevicePickerAction.Refresh)
+      assertEquals(ids, content(viewModel).devices.map { it.uiKey })
+      assertTrue(content(viewModel).devices.none { it.inventoryUncertain })
+      assertNull(content(viewModel).inventoryError)
     }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -99,6 +99,8 @@ class DevicePickerViewModelTest {
       val viewModel = vm(client, boot)
       assertTrue(content(viewModel).devices.isNotEmpty())
       assertTrue(content(viewModel).devices.all { it.platform == Platform.Android })
+      assertTrue(content(viewModel).devices.none { it.inventoryUncertain })
+      assertTrue(content(viewModel).inventoryError?.contains("incomplete") == true)
       viewModel.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
       assertEquals(1, boot.bootRequests.size)
     }
@@ -644,6 +646,36 @@ class DevicePickerViewModelTest {
       assertEquals(setOf("android:Pixel_6_API_33"), content(v).bootingIds)
       boot.complete() // release so runTest can finish
     }
+
+  @Test
+  fun `observation warnings belong to the winning refresh generation`() = testScope.runTest {
+    val partial =
+      SINGLE_BOOTED_PIXEL8.replace(
+        "\"lastUpdated\":\"x\"",
+        "\"lastUpdated\":\"x\",\"observationComplete\":false,\"platformObservations\":{\"android\":{\"observationComplete\":true},\"ios\":{\"observationComplete\":false}}",
+      )
+    for (staleIncomplete in listOf(true, false)) {
+      val client = ScriptableResourceClient(SINGLE_BOOTED_PIXEL8, THREE_IMAGES)
+      val viewModel =
+        DevicePickerViewModel(
+          client,
+          FakeDeviceBootController(),
+          testScope,
+          UnconfinedTestDispatcher(),
+        )
+      val staleGate = CompletableDeferred<Unit>()
+      client.bootedJson = if (staleIncomplete) partial else SINGLE_BOOTED_PIXEL8
+      client.imagesGate = staleGate
+      viewModel.onAction(DevicePickerAction.Refresh)
+      client.imagesGate = null
+      client.bootedJson = if (staleIncomplete) SINGLE_BOOTED_PIXEL8 else partial
+      viewModel.onAction(DevicePickerAction.Refresh)
+      val winningWarning = content(viewModel).inventoryError
+      assertEquals(!staleIncomplete, winningWarning != null)
+      staleGate.complete(Unit)
+      assertEquals(winningWarning, content(viewModel).inventoryError)
+    }
+  }
 
   @Test
   fun `a stale load resuming after a boot completion cannot clobber the fresh state`() =

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModelsTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModelsTest.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.workspace.picker
 
 import dev.jasonpearson.automobile.desktop.core.mcp.BootedDeviceInfo
+import dev.jasonpearson.automobile.desktop.core.mcp.DeviceIdentity
 import dev.jasonpearson.automobile.desktop.core.mcp.DeviceImageInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -22,15 +23,59 @@ class PickerModelsTest {
     DeviceImageInfo(name = name, platform = "android", deviceId = deviceId)
 
   @Test
-  fun `a re-keyed virtual device hides exactly one same-named image, not both`() {
+  fun `an unresolved AVD probe preserves the successful boot attribution`() {
+    val devices =
+      buildPickerDevices(
+        booted =
+          listOf(
+            booted("Unknown (emulator-5554)", "emulator-5554", true)
+              .copy(identity = DeviceIdentity("Unknown (emulator-5554)", "emulator-5554"))
+          ),
+        images = listOf(image("Pixel", "avd_a")),
+        sourceImageToRuntimeId = mapOf("avd_a" to "emulator-5554"),
+      )
+    assertEquals(listOf("emulator-5554"), devices.map { it.id })
+  }
+
+  @Test
+  fun `stable source identity joins an unresolved name and overrides a recycled serial attribution`() {
+    val devices =
+      buildPickerDevices(
+        booted =
+          listOf(
+            booted("Unknown (emulator-5554)", "emulator-5554", true)
+              .copy(
+                identity = DeviceIdentity("avd_b", "transport-new"),
+                deviceSessionUuid = "epoch-new",
+              )
+          ),
+        images = listOf(image("Pixel", "avd_a"), image("Pixel", "avd_b")),
+        sourceImageToRuntimeId = mapOf("avd_a" to "emulator-5554"),
+      )
+    assertEquals(listOf("emulator-5554", "avd_a"), devices.map { it.id })
+    assertEquals("epoch-new", devices.first().deviceSessionUuid)
+  }
+
+  @Test
+  fun `a legacy name match never hides a device on a different platform`() {
+    val devices =
+      buildPickerDevices(
+        booted = listOf(booted("Shared name", "emulator-5554", true)),
+        images = listOf(image("Shared name", "ios-udid").copy(platform = "ios")),
+      )
+    assertEquals(listOf("emulator-5554", "ios-udid"), devices.map { it.id })
+  }
+
+  @Test
+  fun `an ambiguous legacy name preserves both distinct source images`() {
     val devices =
       buildPickerDevices(
         booted = listOf(booted("Pixel 8", "emulator-5554", isVirtual = true)),
         images = listOf(image("Pixel 8", "avd_a"), image("Pixel 8", "avd_b")),
       )
     assertTrue(devices.any { it.id == "emulator-5554" && it.state == DeviceState.Booted })
-    // Virtual re-key hides one same-named image; the distinct sibling remains bootable.
-    assertEquals(1, devices.count { it.state == DeviceState.Shutdown && it.name == "Pixel 8" })
+    // No stable identity is available: a positional guess would hide a distinct device.
+    assertEquals(2, devices.count { it.state == DeviceState.Shutdown && it.name == "Pixel 8" })
   }
 
   @Test

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1600,13 +1600,13 @@
       "type": "object",
       "properties": {
         "bootTimeoutMs": {
-          "description": "Maximum time to find, recover, or boot the device operating system",
+          "description": "Maximum time in ms to find, recover, or boot the device operating system (default 180000). bootTimeoutMs + automationReadyTimeoutMs must be <= 890000, including defaults for omitted fields.",
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 890000
         },
         "automationReadyTimeoutMs": {
-          "description": "Maximum time to install, update, start, and verify the automation runner",
+          "description": "Maximum time in ms to install, update, start, and verify the automation runner (default 180000). bootTimeoutMs + automationReadyTimeoutMs must be <= 890000, including defaults for omitted fields; when bootTimeoutMs is omitted, this must be <= 710000.",
           "type": "integer",
           "minimum": 1000,
           "maximum": 890000
@@ -1633,13 +1633,13 @@
       "type": "object",
       "properties": {
         "bootTimeoutMs": {
-          "description": "Maximum time to find, recover, or boot the device operating system",
+          "description": "Maximum time in ms to find, recover, or boot the device operating system (default 180000). bootTimeoutMs + automationReadyTimeoutMs must be <= 890000, including defaults for omitted fields.",
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 890000
         },
         "automationReadyTimeoutMs": {
-          "description": "Maximum time to install, update, start, and verify the automation runner",
+          "description": "Maximum time in ms to install, update, start, and verify the automation runner (default 180000). bootTimeoutMs + automationReadyTimeoutMs must be <= 890000, including defaults for omitted fields; when bootTimeoutMs is omitted, this must be <= 710000.",
           "type": "integer",
           "minimum": 1000,
           "maximum": 890000

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1609,7 +1609,7 @@
           "description": "Maximum time to install, update, start, and verify the automation runner",
           "type": "integer",
           "minimum": 1000,
-          "maximum": 120000
+          "maximum": 890000
         },
         "avdName": {
           "description": "Configured Android Virtual Device name (the `name` field of automobile:devices/images/android)",
@@ -1642,7 +1642,7 @@
           "description": "Maximum time to install, update, start, and verify the automation runner",
           "type": "integer",
           "minimum": 1000,
-          "maximum": 120000
+          "maximum": 890000
         },
         "udid": {
           "description": "iOS Simulator UDID (the `deviceId` field of automobile:devices/booted/ios or automobile:devices/images/ios)",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,7 +3,12 @@ import { ToolRegistry } from "../server/toolRegistry";
 import { logger } from "../utils/logger";
 import { ActionableError } from "../models";
 import { DaemonClient, DaemonUnavailableError } from "../daemon/client";
-import { DaemonMcpProxy } from "../daemon/daemonMcpProxy";
+import {
+  DaemonMcpProxy,
+  DaemonVersionMismatchError,
+  DaemonBuildMismatchError,
+  DaemonAssetVersionMismatchError,
+} from "../daemon/daemonMcpProxy";
 import type { DaemonMcpProxyConfig } from "../daemon/daemonMcpProxy";
 import type { DaemonOptions } from "../daemon/types";
 import { resolveDaemonInstallSpecifier } from "../constants/release";
@@ -402,6 +407,15 @@ async function runToolViaDaemon(
     }
     return result;
   } catch (error) {
+    if (
+      error instanceof DaemonVersionMismatchError ||
+      error instanceof DaemonBuildMismatchError ||
+      error instanceof DaemonAssetVersionMismatchError
+    ) {
+      throw new ActionableError(
+        `Daemon preflight failed; no device operation started. ${error.message}`,
+      );
+    }
     if (error instanceof DaemonUnavailableError) {
       throw new ActionableError(
         `Daemon became unavailable during tool execution: ${error.message}. ` +

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -37,6 +37,7 @@ import { isDaemonHandshakeFailure, type DaemonHandshakeFailure } from "./daemonH
 import type { DaemonStatus } from "./types";
 
 const socketStatusSchema = z.object({
+  pid: z.number().int().positive().optional(),
   version: z.string().trim().min(1),
   buildId: z.string().optional(),
   entryScript: z.string().optional(),

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -1,6 +1,7 @@
 import { createConnection, Socket } from "node:net";
 import { existsSync, statSync } from "node:fs";
 import { platform } from "node:os";
+import { z } from "zod";
 import { logger } from "../utils/logger";
 import { encodeNonFinite } from "../utils/nonFiniteJson";
 import { ActionableError } from "../models";
@@ -32,6 +33,27 @@ import {
   sanitizeDeviceControlTransportFailure,
 } from "./deviceControlTransportFailure";
 import { readPidFileDataSync, isProcessRunning } from "./daemonFiles";
+import { isDaemonHandshakeFailure, type DaemonHandshakeFailure } from "./daemonHandshake";
+import type { DaemonStatus } from "./types";
+
+const socketStatusSchema = z.object({
+  version: z.string().trim().min(1),
+  buildId: z.string().optional(),
+  entryScript: z.string().optional(),
+  releaseVersion: z.string().optional(),
+  startedAt: z.number().finite().optional(),
+});
+
+/** The server rejected this request before dispatch; retry cannot duplicate work. */
+export class DaemonHandshakeMismatchError extends ActionableError {
+  constructor(
+    readonly failure: DaemonHandshakeFailure,
+    message: string,
+  ) {
+    super(`Daemon preflight failed; no device operation started. ${message}`);
+    this.name = "DaemonHandshakeMismatchError";
+  }
+}
 
 /**
  * Custom error thrown when daemon is unavailable
@@ -624,17 +646,54 @@ export class DaemonClient {
       const transportFailure = sanitizeDeviceControlTransportFailure(response.transportFailure);
       const boundSessionLoss = sanitizeBoundSessionLoss(response.boundSessionLoss);
       pending.reject(
-        boundSessionLoss
-          ? new DaemonBoundSessionLostError(boundSessionLoss)
-          : transportFailure
-            ? new DeviceControlTransportError(
-                response.error || "Device-control transport failure",
-                transportFailure,
-              )
-            : response.error === DAEMON_SHUTTING_DOWN_ERROR_MESSAGE
-              ? new DaemonShuttingDownError()
-              : new ActionableError(response.error || "Unknown error from daemon"),
+        isDaemonHandshakeFailure(response.handshakeFailure)
+          ? new DaemonHandshakeMismatchError(
+              response.handshakeFailure,
+              response.error || "Daemon identity mismatch",
+            )
+          : boundSessionLoss
+            ? new DaemonBoundSessionLostError(boundSessionLoss)
+            : transportFailure
+              ? new DeviceControlTransportError(
+                  response.error || "Device-control transport failure",
+                  transportFailure,
+                )
+              : response.error === DAEMON_SHUTTING_DOWN_ERROR_MESSAGE
+                ? new DaemonShuttingDownError()
+                : new ActionableError(response.error || "Unknown error from daemon"),
       );
+    }
+  }
+
+  /** Read the actual socket owner's identity, including older version-only daemons. */
+  async getDaemonStatus(): Promise<DaemonStatus> {
+    // ide/status is side-effect-free and existed before structured handshake
+    // errors. Like doctor, this diagnostic request deliberately omits identity.
+    const diagnostic = new DaemonClient(
+      this.socketPath,
+      this.connectionTimeout,
+      this.timer,
+      {},
+      null,
+    );
+    try {
+      const parsed = socketStatusSchema.safeParse(
+        await diagnostic.callDaemonMethod("ide/status", {}),
+      );
+      if (!parsed.success) {
+        throw new ActionableError(
+          "Daemon preflight failed: the socket owner returned no version identity; no device operation started. Restart the daemon from this client installation.",
+        );
+      }
+      const { releaseVersion, ...identity } = parsed.data;
+      return {
+        running: true,
+        ...identity,
+        socketPath: this.socketPath,
+        ...(releaseVersion ? { assetVersion: releaseVersion } : {}),
+      };
+    } finally {
+      await diagnostic.close();
     }
   }
 

--- a/src/daemon/daemonHandshake.ts
+++ b/src/daemon/daemonHandshake.ts
@@ -1,4 +1,5 @@
 import { releaseVersion } from "../utils/mcpVersion";
+import { z } from "zod";
 import { type BuildIdentity, buildIdentitiesMatch, describeBuildIdentity } from "./buildIdentity";
 
 /**
@@ -21,6 +22,35 @@ import { type BuildIdentity, buildIdentitiesMatch, describeBuildIdentity } from 
  */
 
 export type HandshakeMismatchReason = "version" | "build";
+
+export interface DaemonHandshakeFailure {
+  code: "daemon_identity_mismatch";
+  phase: "daemon-preflight";
+  executionStarted: false;
+  reason: HandshakeMismatchReason;
+  daemon: DaemonSelfIdentity;
+  client: ClientHandshake;
+}
+
+const handshakeFailureSchema = z.object({
+  code: z.literal("daemon_identity_mismatch"),
+  phase: z.literal("daemon-preflight"),
+  executionStarted: z.literal(false),
+  reason: z.enum(["version", "build"]),
+  daemon: z.object({
+    version: z.string(),
+    build: z.object({ buildId: z.string(), entryScript: z.string() }),
+  }),
+  client: z.object({
+    clientVersion: z.string().optional(),
+    clientBuildId: z.string().optional(),
+    clientEntryScript: z.string().optional(),
+  }),
+});
+
+export function isDaemonHandshakeFailure(value: unknown): value is DaemonHandshakeFailure {
+  return handshakeFailureSchema.safeParse(value).success;
+}
 
 /**
  * The identity fields a client declares on connect. All optional so a legacy

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -69,6 +69,25 @@ export type BuildMismatchReason = "autoStartDisabled" | "cooldown" | "restartMis
 const DAEMON_MCP_HEARTBEAT_INTERVAL_MS = 2_000;
 const COLD_RESOURCE_CONNECT_RETRY_DELAYS_MS = [250, 1_000, 4_000] as const;
 
+/** A transport failed before dispatch, rather than a reconciliation policy gate. */
+class DaemonPreflightConnectionError extends DaemonUnavailableError {
+  constructor(readonly cause: DaemonUnavailableError) {
+    super(cause.message);
+    this.name = "DaemonPreflightConnectionError";
+  }
+}
+
+async function runPreflightTransport<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof DaemonUnavailableError) {
+      throw new DaemonPreflightConnectionError(error);
+    }
+    throw error;
+  }
+}
+
 function isFreshSessionScreenshotUri(uri: string, sessionUuid: string): boolean {
   return uri === `automobile:device-session/${sessionUuid}/screenshot`;
 }
@@ -912,7 +931,7 @@ export class DaemonMcpProxy {
       );
     }
     this.subscribeToClientConnectionClosed(client);
-    await client.connect();
+    await runPreflightTransport(() => client.connect());
     if (this.closing) {
       await client.close();
       throw new DaemonUnavailableError("MCP proxy is closing");
@@ -1228,7 +1247,7 @@ export class DaemonMcpProxy {
 
   private async readSocketReconciliationStatus(): Promise<DaemonStatus> {
     const recorded = await this.daemonManager.status();
-    const actual = await this.daemonStatusProbe!();
+    const actual = await runPreflightTransport(() => this.daemonStatusProbe!());
     // Compatibility allows legacy missing build fields, but missing identity is not
     // evidence that a PID record belongs to this socket. Only enrich a known matching
     // process, build and entry script; never manufacture live build/options from a legacy probe.
@@ -1599,10 +1618,15 @@ export class DaemonMcpProxy {
       throw new DaemonUnavailableError("MCP proxy is closing");
     }
     this.throwIfBoundSessionFenced(allowReleasedSession);
-    await this.ensureConnected();
-    this.throwIfBoundSessionFenced(allowReleasedSession);
+    let established = false;
 
     try {
+      // Socket identity discovery can race a daemon handoff before any tool
+      // has been dispatched. Give establishment the same single reconnect
+      // attempt as a recoverable transport failure, preserving the fences.
+      await this.ensureConnected();
+      this.throwIfBoundSessionFenced(allowReleasedSession);
+      established = true;
       return await operation();
     } catch (error) {
       if (this.closing) {
@@ -1624,7 +1648,7 @@ export class DaemonMcpProxy {
         );
         throw this.boundSessionExpiredError();
       }
-      if (!this.isRecoverableDaemonSessionError(error)) {
+      if (!this.isRecoverableDaemonSessionError(error, established)) {
         throw error;
       }
 
@@ -1655,7 +1679,19 @@ export class DaemonMcpProxy {
     }
   }
 
-  private isRecoverableDaemonSessionError(error: unknown): boolean {
+  private isRecoverableDaemonSessionError(error: unknown, established = true): boolean {
+    if (!established) {
+      return error instanceof DaemonPreflightConnectionError;
+    }
+    // Compatibility policy failures cannot be healed by another connection
+    // attempt (and repeating a failed reconciliation could restart twice).
+    if (
+      error instanceof DaemonVersionMismatchError ||
+      error instanceof DaemonBuildMismatchError ||
+      error instanceof DaemonAssetVersionMismatchError
+    ) {
+      return false;
+    }
     // Structured server evidence proves rejection happened before dispatch.
     // Legacy message-only errors remain non-retryable rather than guessing.
     if (error instanceof DaemonHandshakeMismatchError) {

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1229,12 +1229,20 @@ export class DaemonMcpProxy {
   private async readSocketReconciliationStatus(): Promise<DaemonStatus> {
     const recorded = await this.daemonManager.status();
     const actual = await this.daemonStatusProbe!();
-    // PID files are discovery hints, not proof of who serves the socket. Retain
-    // startup configuration only when the record agrees with that live identity.
+    // Compatibility allows legacy missing build fields, but missing identity is not
+    // evidence that a PID record belongs to this socket. Only enrich a known matching
+    // process, build and entry script; never manufacture live build/options from a legacy probe.
+    const actualBuild = buildIdentityFromStatus(actual);
     const matchesRecord =
       recorded.running &&
+      actual.pid !== undefined &&
+      actual.pid === recorded.pid &&
       recorded.version === actual.version &&
-      buildIdentitiesMatch(buildIdentityFromStatus(recorded), buildIdentityFromStatus(actual));
+      actualBuild.buildId !== "unknown" &&
+      actualBuild.buildId.length > 0 &&
+      actualBuild.entryScript.length > 0 &&
+      recorded.buildId === actualBuild.buildId &&
+      recorded.entryScript === actualBuild.entryScript;
     return matchesRecord ? { ...recorded, ...actual } : actual;
   }
 

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -3,6 +3,7 @@ import { shellQuote } from "../utils/shellQuote";
 import {
   DaemonBoundSessionLostError,
   DaemonClient,
+  DaemonHandshakeMismatchError,
   DaemonShuttingDownError,
   DaemonUnavailableError,
   type DaemonClientLike,
@@ -23,7 +24,12 @@ import {
   DAEMON_SHUTDOWN_TIMEOUT_MS,
   DAEMON_RESTART_HANDOFF_TIMEOUT_MS,
 } from "./constants";
-import { PROGRESS_NOTIFICATION_METHOD, type DaemonNotification, type DaemonOptions } from "./types";
+import {
+  PROGRESS_NOTIFICATION_METHOD,
+  type DaemonNotification,
+  type DaemonOptions,
+  type DaemonStatus,
+} from "./types";
 import { listChangedKindForMethod, type ListChangedKind } from "../server/listChangedBroadcast";
 import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../server/sessionReleaseBroadcast";
 import {
@@ -304,6 +310,8 @@ export interface DaemonMcpProxyConfig {
   connectionTimeoutMs?: number;
   /** Factory for creating daemon clients (for testing) */
   clientFactory?: DaemonClientFactory;
+  /** Socket-owner identity probe; custom client factories inject this separately. */
+  daemonStatusProbe?: () => Promise<DaemonStatus>;
   /** Custom daemon manager (for testing) */
   daemonManager?: DaemonManagerLike;
   /** Options to pass when auto-starting the daemon */
@@ -641,6 +649,8 @@ export class DaemonMcpProxy {
   private config: DaemonMcpProxyConfig;
   private daemonManager: DaemonManagerLike;
   private clientFactory: DaemonClientFactory;
+  private readonly daemonStatusProbe?: () => Promise<DaemonStatus>;
+  private reconciliationSnapshot?: Promise<DaemonStatus>;
   private readonly timer: Timer;
   private readonly heartbeatKeeper: SingleFlightInterval;
   /**
@@ -783,6 +793,7 @@ export class DaemonMcpProxy {
     this.clientFactory =
       config.clientFactory ??
       (() => new DaemonClient(this.config.socketPath, this.config.connectionTimeoutMs));
+    this.daemonStatusProbe = this.createStatusProbe(config);
     this.timer = config.timer ?? defaultTimer;
     this.heartbeatKeeper = new SingleFlightInterval(
       this.timer,
@@ -858,6 +869,7 @@ export class DaemonMcpProxy {
 
   private async doConnect(): Promise<void> {
     this.throwIfClosing();
+    this.reconciliationSnapshot = undefined;
     // Check if daemon is available
     const socketPath = this.config.socketPath ?? SOCKET_PATH;
     // This is an observation-only probe (issue #6140: isAvailable never touches
@@ -1191,12 +1203,44 @@ export class DaemonMcpProxy {
     }
   }
 
-  /**
-   * Ensure the client never attaches to a daemon running a different package version.
-   * Newer clients may restart older daemons, but every mismatch remains a hard gate.
-   */
+  private createStatusProbe(
+    config: DaemonMcpProxyConfig,
+  ): (() => Promise<DaemonStatus>) | undefined {
+    // Custom transports supply their matching probe separately; constructing a
+    // default socket client here would escape an injected transport/test seam.
+    if (config.daemonStatusProbe) {
+      return config.daemonStatusProbe;
+    }
+    if (config.clientFactory) {
+      return undefined;
+    }
+    return () =>
+      new DaemonClient(this.config.socketPath, this.config.connectionTimeoutMs).getDaemonStatus();
+  }
+
+  private reconciliationStatus(): Promise<DaemonStatus> {
+    if (!this.daemonStatusProbe) {
+      return this.daemonManager.status();
+    }
+    this.reconciliationSnapshot ??= this.readSocketReconciliationStatus();
+    return this.reconciliationSnapshot;
+  }
+
+  private async readSocketReconciliationStatus(): Promise<DaemonStatus> {
+    const recorded = await this.daemonManager.status();
+    const actual = await this.daemonStatusProbe!();
+    // PID files are discovery hints, not proof of who serves the socket. Retain
+    // startup configuration only when the record agrees with that live identity.
+    const matchesRecord =
+      recorded.running &&
+      recorded.version === actual.version &&
+      buildIdentitiesMatch(buildIdentityFromStatus(recorded), buildIdentityFromStatus(actual));
+    return matchesRecord ? { ...recorded, ...actual } : actual;
+  }
+
+  /** Newer clients may replace older daemons; mismatches remain a pre-dispatch gate. */
   private async ensureVersionMatches(): Promise<void> {
-    const status = await this.daemonManager.status();
+    const status = await this.reconciliationStatus();
     if (!status.running) {
       return;
     }
@@ -1287,6 +1331,7 @@ export class DaemonMcpProxy {
     // than resetting to this client's config, which would strip flags the
     // daemon was launched with when the connecting client is bare (issue #3846).
     await this.daemonManager.restart(mergeDaemonOptions(status.options, this.config.daemonOptions));
+    this.reconciliationSnapshot = undefined;
     // The replacement daemon may expose a different tool set; drop the cache so we
     // never advertise the old daemon's tools against the new build.
     this.invalidateCache();
@@ -1297,7 +1342,7 @@ export class DaemonMcpProxy {
       );
     }
 
-    const restartedStatus = await this.daemonManager.status();
+    const restartedStatus = await this.reconciliationStatus();
     const restartedVersion = restartedStatus.version?.trim() ?? "";
     if (!restartedStatus.running || restartedVersion !== this.clientVersion) {
       throw this.versionMismatchError(
@@ -1334,7 +1379,7 @@ export class DaemonMcpProxy {
     if (!this.clientAssetVersion) {
       return;
     }
-    const status = await this.daemonManager.status();
+    const status = await this.reconciliationStatus();
     if (!status.running) {
       return;
     }
@@ -1357,7 +1402,7 @@ export class DaemonMcpProxy {
    * {@link ensureVersionMatches}.
    */
   private async ensureBuildMatches(): Promise<void> {
-    const status = await this.daemonManager.status();
+    const status = await this.reconciliationStatus();
     if (!status.running) {
       return;
     }
@@ -1393,6 +1438,7 @@ export class DaemonMcpProxy {
     // than resetting to this client's config, which would strip flags the
     // daemon was launched with when the connecting client is bare (issue #3846).
     await this.daemonManager.restart(mergeDaemonOptions(status.options, this.config.daemonOptions));
+    this.reconciliationSnapshot = undefined;
     // The replacement daemon may expose a different tool set; drop the cache so we
     // never advertise the old daemon's tools against the new build.
     this.invalidateCache();
@@ -1403,7 +1449,7 @@ export class DaemonMcpProxy {
       );
     }
 
-    const restartedStatus = await this.daemonManager.status();
+    const restartedStatus = await this.reconciliationStatus();
     const restartedIdentity = buildIdentityFromStatus(restartedStatus);
     if (!restartedStatus.running || !buildIdentitiesMatch(this.buildIdentity, restartedIdentity)) {
       throw this.buildMismatchError(
@@ -1430,7 +1476,7 @@ export class DaemonMcpProxy {
   }
 
   private async ensureStartupOptionsMatch(): Promise<void> {
-    const status = await this.daemonManager.status();
+    const status = await this.reconciliationStatus();
     if (!status.running) {
       return;
     }
@@ -1454,6 +1500,7 @@ export class DaemonMcpProxy {
     // so the restart gains the missing flag without stripping any the daemon
     // already had (issue #3846).
     await this.daemonManager.restart(mergeDaemonOptions(status.options, requested));
+    this.reconciliationSnapshot = undefined;
     const ready = await this.daemonManager.waitForReady(DAEMON_STARTUP_TIMEOUT_MS);
     if (!ready) {
       throw new DaemonUnavailableError(
@@ -1461,7 +1508,7 @@ export class DaemonMcpProxy {
       );
     }
 
-    const restartedStatus = await this.daemonManager.status();
+    const restartedStatus = await this.reconciliationStatus();
     const remaining = startupOptionDeficits(requested, restartedStatus.options);
     if (!restartedStatus.running || remaining.length > 0) {
       throw new DaemonUnavailableError(
@@ -1601,6 +1648,11 @@ export class DaemonMcpProxy {
   }
 
   private isRecoverableDaemonSessionError(error: unknown): boolean {
+    // Structured server evidence proves rejection happened before dispatch.
+    // Legacy message-only errors remain non-retryable rather than guessing.
+    if (error instanceof DaemonHandshakeMismatchError) {
+      return true;
+    }
     if (error instanceof DaemonUnavailableError) {
       return true;
     }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -34,7 +34,7 @@ import { didSourceSucceedForDevice, type DiscoverySource } from "../utils/discov
 import { consolePortFromSerial } from "../utils/android-cmdline-tools/EmulatorConsoleClient";
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
-import { getAbortSignal, runWithAbortSignal } from "../utils/AbortContext";
+import { getAbortSignal, runWithAbortSignal, throwIfRequestAborted } from "../utils/AbortContext";
 import { AndroidCommandOutputStreamRedactor } from "../utils/android-cmdline-tools/redactAndroidCommandOutput";
 import { boundedEmulatorOutputTail } from "../utils/android-cmdline-tools/AndroidEmulatorClient";
 import {
@@ -5018,6 +5018,7 @@ export class DevicePool {
     const owner = Symbol("readiness-reservation");
     let trackStableName = false;
     await this.assignmentMutex.runExclusive(async () => {
+      throwIfRequestAborted();
       const pooled = this.devices.get(deviceId);
       if (pooled) {
         // Acquisition may reboot a device during readiness recovery. Prove
@@ -5029,6 +5030,7 @@ export class DevicePool {
           this.assertRuntimeIdentity(pooled, expectedIdentity);
         }
       }
+      throwIfRequestAborted();
       const current = this.devices.get(deviceId);
       trackStableName =
         current?.platform === "android" &&
@@ -5387,6 +5389,7 @@ export class DevicePool {
     expectedExistingSessionDeviceId?: string,
   ): Promise<string> {
     return await this.assignmentMutex.runExclusive(async () => {
+      throwIfRequestAborted();
       const androidAvdIdentity = verifiedAndroidAvdIdentity ?? sourceImage;
       const alreadyPooled = this.devices.has(deviceId);
       if (!alreadyPooled) {
@@ -5397,6 +5400,7 @@ export class DevicePool {
         }
       }
 
+      throwIfRequestAborted();
       let device = this.devices.get(deviceId);
       if (!device) {
         throw new ActionableError(`Device '${deviceId}' is not available in the device pool.`);
@@ -5435,6 +5439,7 @@ export class DevicePool {
         readinessReservationOwners,
       );
 
+      throwIfRequestAborted();
       this.assertDeviceCleanupComplete(deviceId);
       if (device.sessionId) {
         const existingSession = this.sessionManager.getSession(device.sessionId);
@@ -5769,6 +5774,7 @@ export class DevicePool {
     verifiedAndroidAvdIdentity?: DeviceInfo,
     achievedReadiness: DeviceReadinessLevel = "automationReady",
   ): Promise<string> {
+    throwIfRequestAborted();
     const androidAvdIdentity = verifiedAndroidAvdIdentity ?? sourceImage;
 
     // Ensure device is in the pool (it may have been freshly booted)
@@ -5782,6 +5788,7 @@ export class DevicePool {
     }
 
     // Assign the device to the generated session
+    throwIfRequestAborted();
     let device = this.devices.get(deviceId);
     if (!device) {
       throw new ActionableError(
@@ -5834,6 +5841,7 @@ export class DevicePool {
       readinessReservationOwners,
     );
 
+    throwIfRequestAborted();
     const reusedSessionId = await this.reuseOwnedAutolockSession(
       device,
       mcpSessionId,
@@ -5873,16 +5881,51 @@ export class DevicePool {
     if (mcpSessionId) {
       this.mcpSessionAutolockMap.set(mcpSessionId, sessionId);
     }
-    await this.deviceSessionRepository.markAutolockSession(sessionId, {
-      mcpSessionId: mcpSessionId ?? null,
-      daemonSessionId: this.daemonSessionId,
-      lastUsedAtMs: session.lastUsedAt,
-      expiresAtMs: session.expiresAt,
-    });
+    await this.persistAcquiredAutolockSession(device, session, assignmentSnapshot, mcpSessionId);
+
     logger.info(
       `Autolocked device ${deviceId} with session ${sessionId} (timeout: ${timeoutMs}ms)`,
     );
     return sessionId;
+  }
+
+  private async persistAcquiredAutolockSession(
+    device: PooledDevice,
+    session: Session,
+    snapshot: SessionAssignmentSnapshot,
+    mcpSessionId?: string,
+  ): Promise<void> {
+    const signal = getAbortSignal();
+    const cancelPublishedSession = async () => {
+      // Only this newly minted session may be compensated; never a replacement.
+      if (this.sessionManager.getSession(session.sessionId) === session) {
+        await this.sessionManager.releaseSession(session.sessionId, "session-creation-cancelled");
+      }
+    };
+    const abort = () => {
+      void cancelPublishedSession().catch((error) =>
+        logger.warn(`Cancelled autolock release failed: ${error}`),
+      );
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+    try {
+      signal?.throwIfAborted();
+      await this.deviceSessionRepository.markAutolockSession(session.sessionId, {
+        mcpSessionId: mcpSessionId ?? null,
+        daemonSessionId: this.daemonSessionId,
+        lastUsedAtMs: session.lastUsedAt,
+        expiresAtMs: session.expiresAt,
+      });
+      signal?.throwIfAborted();
+    } catch (error) {
+      await cancelPublishedSession();
+      if (this.devices.get(device.id) === device && device.sessionId === session.sessionId) {
+        this.restoreSessionAssignment(device, snapshot);
+      }
+      throw error;
+    } finally {
+      signal?.removeEventListener("abort", abort);
+    }
   }
 
   private assertMcpSessionCanAutolockDevice(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5898,33 +5898,66 @@ export class DevicePool {
     const signal = getAbortSignal();
     const cancelPublishedSession = async () => {
       // Only this newly minted session may be compensated; never a replacement.
-      if (this.sessionManager.getSession(session.sessionId) === session) {
-        await this.sessionManager.releaseSession(session.sessionId, "session-creation-cancelled");
-      }
-    };
-    const abort = () => {
-      void cancelPublishedSession().catch((error) =>
-        logger.warn(`Cancelled autolock release failed: ${error}`),
+      await this.sessionManager.releaseSessionIfOwned(
+        session.sessionId,
+        session,
+        device.id,
+        "session-creation-cancelled",
       );
     };
-    signal?.addEventListener("abort", abort, { once: true });
+    let abort: (() => void) | undefined;
+    const cancelled = signal
+      ? new Promise<never>((_resolve, reject) => {
+          abort = () => reject(signal.reason);
+          signal.addEventListener("abort", abort, { once: true });
+        })
+      : undefined;
     try {
       signal?.throwIfAborted();
-      await this.deviceSessionRepository.markAutolockSession(session.sessionId, {
+      const persistence = this.deviceSessionRepository.markAutolockSession(session.sessionId, {
         mcpSessionId: mcpSessionId ?? null,
         daemonSessionId: this.daemonSessionId,
         lastUsedAtMs: session.lastUsedAt,
         expiresAtMs: session.expiresAt,
       });
+      await Promise.race([persistence, ...(cancelled ? [cancelled] : [])]);
       signal?.throwIfAborted();
     } catch (error) {
-      await cancelPublishedSession();
-      if (this.devices.get(device.id) === device && device.sessionId === session.sessionId) {
-        this.restoreSessionAssignment(device, snapshot);
-      }
+      // Session release fences automation admission synchronously, then may
+      // wait for teardown/durable persistence. Neither that wait nor the late
+      // metadata write may hold the global assignment mutex after cancellation.
+      // The repository's active-row guard prevents the late metadata write from
+      // overwriting a completed terminal release.
+      void cancelPublishedSession().catch((releaseError) =>
+        logger.warn(`Cancelled autolock release failed: ${releaseError}`),
+      );
+      this.restoreCancelledAutolockAssignment(device, session, snapshot);
       throw error;
     } finally {
-      signal?.removeEventListener("abort", abort);
+      if (abort) {
+        signal?.removeEventListener("abort", abort);
+      }
+    }
+  }
+
+  private restoreCancelledAutolockAssignment(
+    device: PooledDevice,
+    session: Session,
+    snapshot: SessionAssignmentSnapshot,
+  ): void {
+    if (
+      session.assignedDevice === device.id &&
+      this.sessionManager.isLatestSessionIdentity(session)
+    ) {
+      this.clearMcpAutolockMappings(session.sessionId);
+    }
+    if (
+      this.devices.get(device.id) === device &&
+      device.sessionId === session.sessionId &&
+      device.assignmentCount === snapshot.assignmentCount + 1 &&
+      this.pooledSessionIdentities.get(device) === session
+    ) {
+      this.restoreSessionAssignment(device, snapshot);
     }
   }
 

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -387,7 +387,7 @@ export class DevicePool {
   private installedAppsRepository: InstalledAppsStore;
   private deviceManager: PlatformDeviceManager;
   private readonly retryExecutor: RetryExecutor;
-  private readonly deviceSessionRepository: DeviceSessionRepository;
+  private readonly deviceSessionRepository: Pick<DeviceSessionRepository, "markAutolockSession">;
   private readonly criteriaMatcher: DeviceCriteriaMatcher;
   private readonly releaseSessionForDisconnectedDevice: DeviceDisconnectSessionReleaser;
   private readonly onDeviceReady: DeviceReadyListener | undefined;
@@ -490,7 +490,10 @@ export class DevicePool {
     installedAppsRepository?: InstalledAppsStore,
     deviceManager: PlatformDeviceManager = new MultiPlatformDeviceManager(),
     retryExecutor: RetryExecutor = defaultRetryExecutor,
-    deviceSessionRepository: DeviceSessionRepository = new DeviceSessionRepository(),
+    deviceSessionRepository: Pick<
+      DeviceSessionRepository,
+      "markAutolockSession"
+    > = new DeviceSessionRepository(),
     criteriaMatcher: DeviceCriteriaMatcher = new DeviceCriteriaMatcher(),
     releaseSessionForDisconnectedDevice?: DeviceDisconnectSessionReleaser,
     onDeviceReady?: DeviceReadyListener,

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -2,13 +2,14 @@ import type { DaemonRequest } from "./types";
 import {
   DEFAULT_DEVICE_TEARDOWN_TIMEOUT_MS,
   DEFAULT_DEVICE_READY_TIMEOUT_MS,
+  DEFAULT_START_DEVICE_TIMEOUT_MS,
   DEFAULT_DEVICE_RESOURCE_TIMEOUT_MS,
   DEFAULT_PROVISION_DEVICE_TIMEOUT_MS,
   MAX_PROVISION_DEVICE_TIMEOUT_MS,
   MAX_DEVICE_READY_TIMEOUT_MS,
   START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS,
 } from "../utils/deviceTimeouts";
-import { DEFAULT_RUNNER_READINESS_TIMEOUT_MS } from "../utils/runnerReadinessConfig";
+import { DEFAULT_RUNNER_PROVISION_TIMEOUT_MS } from "../utils/runnerReadinessConfig";
 import {
   TAP_ANY_SEARCH_UNTIL_DEFAULT_MS,
   TAP_ANY_LONG_PRESS_DEFAULT_DURATION_MS_IOS,
@@ -250,7 +251,7 @@ function resolveNamedDevicePreparationBudgetMs(argumentsRecord: Record<string, u
     positiveFiniteNumber(argumentsRecord.bootTimeoutMs) ?? DEFAULT_DEVICE_READY_TIMEOUT_MS;
   const automationReadyTimeoutMs =
     positiveFiniteNumber(argumentsRecord.automationReadyTimeoutMs) ??
-    DEFAULT_RUNNER_READINESS_TIMEOUT_MS;
+    DEFAULT_RUNNER_PROVISION_TIMEOUT_MS;
   return (
     Math.min(bootTimeoutMs + automationReadyTimeoutMs, MAX_DEVICE_READY_TIMEOUT_MS) +
     START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS
@@ -264,10 +265,10 @@ function resolveLegacyStartDeviceBudgetMs(
   // Match startDeviceSchema's legacy normalization: an explicit top-level value
   // wins over the nested device payload.
   const timeoutMs = positiveFiniteNumber(argumentsRecord.timeoutMs ?? legacyTimeoutMs);
-  if (timeoutMs === undefined) {
-    return undefined;
-  }
-  return Math.min(timeoutMs, MAX_DEVICE_READY_TIMEOUT_MS) + START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS;
+  return (
+    Math.min(timeoutMs ?? DEFAULT_START_DEVICE_TIMEOUT_MS, MAX_DEVICE_READY_TIMEOUT_MS) +
+    START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS
+  );
 }
 
 function resolveDevicePreparationToolBudgetMs(request: DaemonRequest): number | undefined {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -1,3 +1,4 @@
+import { getAbortSignal } from "../utils/AbortContext";
 import { defaultTimer, Timer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 import { BootedDevice, Platform } from "../models";
@@ -273,6 +274,7 @@ function isTerminalReleaseReason(releaseReason: string): boolean {
     releaseReason === "missing-first-heartbeat" ||
     releaseReason === "heartbeat-timeout" ||
     releaseReason === "device-killed" ||
+    releaseReason === "session-creation-cancelled" ||
     releaseReason.startsWith("device-disconnected:")
   );
 }
@@ -527,6 +529,7 @@ export class SessionManager {
     timeoutMs?: number,
     heartbeatTimeoutMs?: number,
   ): Promise<Session> {
+    getAbortSignal()?.throwIfAborted();
     if (!this.acceptingSessionCreations) {
       throw new ActionableError(
         `Cannot create device session ${sessionId}: the daemon is shutting down.`,
@@ -624,14 +627,15 @@ export class SessionManager {
   }
 
   private async rejectCreationAfterShutdownFence(session: Session): Promise<void> {
-    if (this.acceptingSessionCreations) {
+    const cancellation = getAbortSignal();
+    if (this.acceptingSessionCreations && !cancellation?.aborted) {
       return;
     }
     const releasedAtMs = this.timer.now();
     const snapshot: SessionReleaseSnapshot = {
       sessionId: session.sessionId,
       deviceId: session.assignedDevice,
-      releaseReason: "daemon-shutdown",
+      releaseReason: cancellation?.aborted ? "session-creation-cancelled" : "daemon-shutdown",
       releasedAtMs,
       terminal: true,
       heartbeat: {
@@ -643,6 +647,7 @@ export class SessionManager {
     };
     await this.persistTerminalReleaseIfNeeded(snapshot);
     this.notifySessionRelease(snapshot);
+    cancellation?.throwIfAborted();
     throw new TerminalSessionError(session.sessionId, snapshot);
   }
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -2751,6 +2751,7 @@ export class UnixSocketServer {
           // floating "latest" tag — external consumers must see exactly what the
           // daemon will fetch (#2746).
           version: this.daemonIdentity.version,
+          pid: process.pid,
           buildId: this.daemonIdentity.build.buildId,
           entryScript: this.daemonIdentity.build.entryScript,
           startedAt: this.identityStartedAt,

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -88,7 +88,6 @@ import {
   setAndroidKeyValueDirect,
   withAndroidSharedPreferencesInspectionFallback,
 } from "../features/storage/AndroidSharedPreferencesKeyValueFile";
-import { getMcpServerVersion } from "../utils/mcpVersion";
 import {
   IOS_CTRL_PROXY_APP_HASH,
   resolveApkChecksum,
@@ -519,6 +518,7 @@ export class UnixSocketServer {
   private featureFlagService: FeatureFlagService | null;
   private readonly handshakeEnforced: boolean;
   private readonly daemonIdentity: DaemonSelfIdentity;
+  private readonly identityStartedAt: number;
   private readonly sessionToolSelectionService?: Pick<
     SessionToolSelectionService,
     "isEnabled" | "setEnabled"
@@ -615,6 +615,7 @@ export class UnixSocketServer {
       version: DAEMON_VERSION,
       build: getCurrentBuildIdentity(),
     };
+    this.identityStartedAt = this.timer.now();
     logger.info(`UnixSocketServer initialized with endpoint: "${mcpEndpoint}"`);
     if (!mcpEndpoint) {
       logger.error("ERROR: mcpEndpoint is empty or undefined!");
@@ -1174,6 +1175,14 @@ export class UnixSocketServer {
       type: "mcp_response",
       success: false,
       error: evaluation.message,
+      handshakeFailure: {
+        code: "daemon_identity_mismatch",
+        phase: "daemon-preflight",
+        executionStarted: false,
+        reason: evaluation.reason,
+        daemon: this.daemonIdentity,
+        client: extractClientHandshake(request),
+      },
     };
   }
 
@@ -2741,7 +2750,10 @@ export class UnixSocketServer {
           // Concrete pinned version (honors AUTOMOBILE_VERSION), never the
           // floating "latest" tag — external consumers must see exactly what the
           // daemon will fetch (#2746).
-          version: getMcpServerVersion(),
+          version: this.daemonIdentity.version,
+          buildId: this.daemonIdentity.build.buildId,
+          entryScript: this.daemonIdentity.build.entryScript,
+          startedAt: this.identityStartedAt,
           releaseVersion: resolveAssetVersion(resolvePinnedVersion()),
           android: {
             ctrlProxy: {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -1,5 +1,6 @@
 import type { DeviceControlTransportFailure } from "./deviceControlTransportFailure";
 import type { SessionReleaseSnapshot } from "./sessionManager";
+import type { DaemonHandshakeFailure } from "./daemonHandshake";
 
 /**
  * Request sent from CLI client to daemon
@@ -52,6 +53,8 @@ export interface DaemonResponse {
   result?: any;
   /** Error message if unsuccessful */
   error?: string;
+  /** Rejected before any device operation was admitted. */
+  handshakeFailure?: DaemonHandshakeFailure;
   /**
    * Safe, machine-readable details for a loopback device-control transport
    * failure. Optional so older Kotlin, Swift, and TypeScript clients keep using

--- a/src/db/deviceSessionRepository.ts
+++ b/src/db/deviceSessionRepository.ts
@@ -156,6 +156,9 @@ export class DeviceSessionRepository {
           updated_at: new Date().toISOString(),
         })
         .where("session_uuid", "=", sessionUuid)
+        // Like activity refresh, delayed autolock metadata may only update a
+        // live row. Cancellation can durably retire it while this write waits.
+        .where("status", "=", "active")
         .execute();
     } catch (error) {
       logger.warn(

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -22,7 +22,7 @@ import {
   getRequiredIosRunnerFeatureFlags,
 } from "../features/observe/ios/IOSCtrlProxyClient";
 import { resolveApkChecksum, resolveIpaChecksum } from "../constants/release";
-import { sourcesForPlatform } from "../utils/discoverySource";
+import { type DiscoverySource, sourcesForPlatform } from "../utils/discoverySource";
 import { defaultTimer } from "../utils/SystemTimer";
 
 // Resource URIs
@@ -129,6 +129,7 @@ export interface BootedDevicesResourceContent {
   lastUpdated: string; // ISO 8601
   observationComplete: boolean;
   platformObservations: Partial<Record<Platform, PlatformObservation>>;
+  sourceObservations: Partial<Record<DiscoverySource, PlatformObservation>>;
   poolStatus?: PoolStatusSummary;
   devices: BootedDeviceInfo[];
 }
@@ -484,6 +485,7 @@ interface PlatformDiscoveryResult {
   devices: BootedDeviceInfo[];
   succeededPlatforms: Set<Platform>;
   observation: PlatformObservation;
+  sourceObservations: Partial<Record<DiscoverySource, PlatformObservation>>;
 }
 
 async function discoverBootedDevicesForPlatform(
@@ -508,6 +510,16 @@ async function discoverBootedDevicesForPlatform(
         ),
       ),
       succeededPlatforms: discovery.succeededPlatforms,
+      sourceObservations: Object.fromEntries(
+        sourcesForPlatform(platform).map((source) => [
+          source,
+          {
+            observationComplete: discovery.succeededSources
+              ? discovery.succeededSources.has(source)
+              : discovery.succeededPlatforms.has(platform),
+          },
+        ]),
+      ),
       observation: complete
         ? { observationComplete: true }
         : {
@@ -524,6 +536,9 @@ async function discoverBootedDevicesForPlatform(
     return {
       devices: [],
       succeededPlatforms: new Set(),
+      sourceObservations: Object.fromEntries(
+        sourcesForPlatform(platform).map((source) => [source, { observationComplete: false }]),
+      ),
       observation: {
         observationComplete: false,
         discoveryError: {
@@ -693,6 +708,7 @@ async function getBootedDevicesForPlatforms(
 
   const succeededPlatforms = new Set<Platform>();
   const platformObservations: Partial<Record<Platform, PlatformObservation>> = {};
+  const sourceObservations: Partial<Record<DiscoverySource, PlatformObservation>> = {};
 
   for (const platform of platforms) {
     const discovery = await discoverBootedDevicesForPlatform(
@@ -703,6 +719,7 @@ async function getBootedDevicesForPlatforms(
     );
     devices.push(...discovery.devices);
     platformObservations[platform] = discovery.observation;
+    Object.assign(sourceObservations, discovery.sourceObservations);
     for (const discoveredPlatform of discovery.succeededPlatforms) {
       succeededPlatforms.add(discoveredPlatform);
     }
@@ -729,6 +746,7 @@ async function getBootedDevicesForPlatforms(
       (platform) => platformObservations[platform]?.observationComplete === true,
     ),
     platformObservations,
+    sourceObservations,
     poolStatus,
     devices,
   };

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -12,6 +12,7 @@ import type {
   DeviceRecoveryPolicy,
 } from "../daemon/devicePool";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
+import { AndroidCtrlProxyClient } from "../features/observe/android/AndroidCtrlProxyClient";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
 import { IOSCtrlProxyBuilder } from "../utils/IOSCtrlProxyBuilder";
@@ -21,6 +22,7 @@ import {
   getRequiredIosRunnerFeatureFlags,
 } from "../features/observe/ios/IOSCtrlProxyClient";
 import { resolveApkChecksum, resolveIpaChecksum } from "../constants/release";
+import { sourcesForPlatform } from "../utils/discoverySource";
 import { defaultTimer } from "../utils/SystemTimer";
 
 // Resource URIs
@@ -493,7 +495,9 @@ async function discoverBootedDevicesForPlatform(
   try {
     const discovery =
       await PlatformDeviceManagerFactory.getInstance().getBootedDevicesDetailed(platform);
-    const complete = discovery.succeededPlatforms.has(platform);
+    const complete = discovery.succeededSources
+      ? sourcesForPlatform(platform).every((source) => discovery.succeededSources!.has(source))
+      : discovery.succeededPlatforms.has(platform);
     return {
       devices: discovery.devices.map((device) =>
         toBootedDeviceInfo(
@@ -650,9 +654,9 @@ export function readinessFromServiceStatus(
     return { state: "not_ready" };
   }
   if (platform === "android") {
-    // Android's service status only proves the APK is installed and enabled.
-    // Resource reads do not open the CtrlProxy connection, so liveness remains unknown.
-    return { state: "unknown" };
+    // A resource read observes an existing connection without opening one. No connection
+    // is inconclusive; an installed/enabled service can still be usable on its next call.
+    return { state: serviceStatus.running ? "ready" : "unknown" };
   }
   return { state: serviceStatus.running ? "ready" : "not_ready" };
 }
@@ -731,8 +735,8 @@ async function getBootedDevicesForPlatforms(
 }
 
 // Query service status for a single booted device
-async function queryDeviceServiceStatus(
-  device: BootedDeviceInfo,
+export async function queryDeviceServiceStatus(
+  device: Pick<BootedDeviceInfo, "name" | "platform" | "deviceId" | "source">,
 ): Promise<DeviceServiceStatus | undefined> {
   const bootedDevice: BootedDevice = {
     name: device.name,
@@ -760,7 +764,8 @@ async function queryDeviceServiceStatus(
       return {
         installed,
         enabled,
-        running: installed && enabled,
+        running:
+          AndroidCtrlProxyClient.getExistingInstance(device.deviceId)?.isConnected() ?? false,
         installedSha256,
         expectedSha256,
         isCompatible,

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -509,7 +509,7 @@ async function discoverBootedDevicesForPlatform(
           resolveDeviceSessionUuid(device.deviceId),
         ),
       ),
-      succeededPlatforms: discovery.succeededPlatforms,
+      succeededPlatforms: complete ? new Set([platform]) : new Set(),
       sourceObservations: Object.fromEntries(
         sourcesForPlatform(platform).map((source) => [
           source,
@@ -752,9 +752,23 @@ async function getBootedDevicesForPlatforms(
   };
 }
 
+export interface AndroidServiceStatusLookup {
+  getManager(
+    device: BootedDevice,
+  ): Pick<AndroidCtrlProxyManager, "isInstalled" | "isEnabled" | "getInstalledApkSha256">;
+  isConnected(deviceId: string): boolean;
+}
+
+const defaultAndroidServiceStatusLookup: AndroidServiceStatusLookup = {
+  getManager: (device) => AndroidCtrlProxyManager.getInstance(device),
+  isConnected: (deviceId) =>
+    AndroidCtrlProxyClient.getExistingInstance(deviceId)?.isConnected() ?? false,
+};
+
 // Query service status for a single booted device
 export async function queryDeviceServiceStatus(
   device: Pick<BootedDeviceInfo, "name" | "platform" | "deviceId" | "source">,
+  androidLookup: AndroidServiceStatusLookup = defaultAndroidServiceStatusLookup,
 ): Promise<DeviceServiceStatus | undefined> {
   const bootedDevice: BootedDevice = {
     name: device.name,
@@ -765,7 +779,7 @@ export async function queryDeviceServiceStatus(
 
   try {
     if (device.platform === "android") {
-      const manager = AndroidCtrlProxyManager.getInstance(bootedDevice);
+      const manager = androidLookup.getManager(bootedDevice);
       const [installed, enabled, installedSha256] = await Promise.all([
         manager.isInstalled(),
         manager.isEnabled(),
@@ -782,8 +796,7 @@ export async function queryDeviceServiceStatus(
       return {
         installed,
         enabled,
-        running:
-          AndroidCtrlProxyClient.getExistingInstance(device.deviceId)?.isConnected() ?? false,
+        running: androidLookup.isConnected(device.deviceId),
         installedSha256,
         expectedSha256,
         isCompatible,

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -5478,6 +5478,7 @@ export function registerDeviceTools() {
     state.boot = await bootService.boot(
       {
         ...args,
+        operationName: budgets.operationName,
         timeoutMs: budgets.bootTimeoutMs,
         totalDeadlineMs: bootDeadlineMs,
         signal,

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -225,28 +225,39 @@ const devicePreparationTimeoutSchema = z
       .positive()
       .max(MAX_DEVICE_READY_TIMEOUT_MS)
       .optional()
-      .describe("Maximum time to find, recover, or boot the device operating system"),
+      .describe(
+        `Maximum time in ms to find, recover, or boot the device operating system (default ${DEFAULT_DEVICE_READY_TIMEOUT_MS}). ` +
+          `bootTimeoutMs + automationReadyTimeoutMs must be <= ${MAX_DEVICE_READY_TIMEOUT_MS}, including defaults for omitted fields.`,
+      ),
     automationReadyTimeoutMs: z
       .number()
       .int()
       .min(MIN_RUNNER_READINESS_TIMEOUT_MS)
       .max(MAX_DEVICE_READY_TIMEOUT_MS)
       .optional()
-      .describe("Maximum time to install, update, start, and verify the automation runner"),
+      .describe(
+        `Maximum time in ms to install, update, start, and verify the automation runner (default ${DEFAULT_RUNNER_PROVISION_TIMEOUT_MS}). ` +
+          `bootTimeoutMs + automationReadyTimeoutMs must be <= ${MAX_DEVICE_READY_TIMEOUT_MS}, including defaults for omitted fields; ` +
+          `when bootTimeoutMs is omitted, this must be <= ${MAX_DEVICE_READY_TIMEOUT_MS - DEFAULT_DEVICE_READY_TIMEOUT_MS}.`,
+      ),
   })
-  .strict()
-  .superRefine((value, context) => {
-    const totalTimeoutMs =
-      (value.bootTimeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS) +
-      (value.automationReadyTimeoutMs ?? DEFAULT_RUNNER_PROVISION_TIMEOUT_MS);
-    if (totalTimeoutMs > MAX_DEVICE_READY_TIMEOUT_MS) {
-      context.addIssue({
-        code: "custom",
-        message: `bootTimeoutMs + automationReadyTimeoutMs must be <= ${MAX_DEVICE_READY_TIMEOUT_MS}`,
-        path: ["bootTimeoutMs"],
-      });
-    }
-  });
+  .strict();
+
+function validateDevicePreparationTimeout(
+  value: { bootTimeoutMs?: number; automationReadyTimeoutMs?: number },
+  context: z.RefinementCtx,
+): void {
+  const totalTimeoutMs =
+    (value.bootTimeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS) +
+    (value.automationReadyTimeoutMs ?? DEFAULT_RUNNER_PROVISION_TIMEOUT_MS);
+  if (totalTimeoutMs > MAX_DEVICE_READY_TIMEOUT_MS) {
+    context.addIssue({
+      code: "custom",
+      message: `bootTimeoutMs + automationReadyTimeoutMs must be <= ${MAX_DEVICE_READY_TIMEOUT_MS}`,
+      path: ["bootTimeoutMs"],
+    });
+  }
+}
 
 // #5870: `deviceId` — the identifier every device resource leads with — is
 // accepted alongside the platform-native identifier. Either is sufficient; the
@@ -273,6 +284,7 @@ export const getAndroidSchema = devicePreparationTimeoutSchema
         "Booted device serial, e.g. emulator-5554 (the `deviceId` field of automobile:devices/booted/android), or a defined AVD image name, which is cold-booted by name. Prefer avdName to boot or coordinate a named AVD.",
       ),
   })
+  .superRefine(validateDevicePreparationTimeout)
   .superRefine((value, ctx) => {
     if (!value.avdName && !value.deviceId) {
       ctx.addIssue({
@@ -301,6 +313,7 @@ export const getAppleSchema = devicePreparationTimeoutSchema
         "Booted device identifier (the `deviceId` field of automobile:devices/booted/ios); alias for udid",
       ),
   })
+  .superRefine(validateDevicePreparationTimeout)
   .superRefine((value, ctx) => {
     if (!value.udid && !value.deviceId) {
       ctx.addIssue({

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -69,7 +69,11 @@ import type { DeviceReadinessLevel } from "../utils/DeviceSessionManager";
 import type { DevicePool, DeviceReadinessReservation, PooledDevice } from "../daemon/devicePool";
 import { McpSessionRecoveryInProgressError } from "../daemon/devicePool";
 import type { Session, SessionManager } from "../daemon/sessionManager";
-import { DeviceBootService, type DeviceBootResult } from "../utils/deviceBootService";
+import {
+  DeviceBootService,
+  DeviceBootTimeoutError,
+  type DeviceBootResult,
+} from "../utils/deviceBootService";
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
 import { isAdbMissingDeviceError } from "../utils/android-cmdline-tools/AdbDeviceHealth";
@@ -94,7 +98,7 @@ import {
   trackDeviceAcquisitionReadiness,
 } from "../utils/deviceReadinessLock";
 import {
-  DEFAULT_RUNNER_READINESS_TIMEOUT_MS,
+  DEFAULT_RUNNER_PROVISION_TIMEOUT_MS,
   MAX_RUNNER_READINESS_TIMEOUT_MS,
   MIN_RUNNER_READINESS_TIMEOUT_MS,
 } from "../utils/runnerReadinessConfig";
@@ -102,6 +106,7 @@ import { serverConfig } from "../utils/ServerConfig";
 import {
   DEFAULT_DEVICE_TEARDOWN_TIMEOUT_MS,
   DEFAULT_DEVICE_READY_TIMEOUT_MS,
+  DEFAULT_START_DEVICE_TIMEOUT_MS,
   DEFAULT_PROVISION_DEVICE_TIMEOUT_MS,
   MAX_PROVISION_DEVICE_TIMEOUT_MS,
   MAX_DEVICE_READY_TIMEOUT_MS,
@@ -225,7 +230,7 @@ const devicePreparationTimeoutSchema = z
       .number()
       .int()
       .min(MIN_RUNNER_READINESS_TIMEOUT_MS)
-      .max(MAX_RUNNER_READINESS_TIMEOUT_MS)
+      .max(MAX_DEVICE_READY_TIMEOUT_MS)
       .optional()
       .describe("Maximum time to install, update, start, and verify the automation runner"),
   })
@@ -233,7 +238,7 @@ const devicePreparationTimeoutSchema = z
   .superRefine((value, context) => {
     const totalTimeoutMs =
       (value.bootTimeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS) +
-      (value.automationReadyTimeoutMs ?? DEFAULT_RUNNER_READINESS_TIMEOUT_MS);
+      (value.automationReadyTimeoutMs ?? DEFAULT_RUNNER_PROVISION_TIMEOUT_MS);
     if (totalTimeoutMs > MAX_DEVICE_READY_TIMEOUT_MS) {
       context.addIssue({
         code: "custom",
@@ -3181,7 +3186,7 @@ async function runProvisionDeviceWithinDeadline<T>(
     : controller.signal;
   let timeoutHandle: NodeJS.Timeout | undefined;
   let removeAbortListener: (() => void) | undefined;
-  const operationPromise = operation(signal);
+  const operationPromise = runWithAbortSignal(signal, () => operation(signal));
   void operationPromise.catch(() => {});
 
   try {
@@ -4560,7 +4565,7 @@ export function registerDeviceTools() {
       return error;
     }
     return new ProvisionDeviceError(
-      "platform_command_failed",
+      error instanceof DeviceBootTimeoutError ? "timeout" : "platform_command_failed",
       `Failed to provision ${args.device.platform} device '${args.device.name}': ${errorMessage(error)}`,
     );
   }
@@ -5021,6 +5026,7 @@ export function registerDeviceTools() {
       }
       perf.startOperation("bootDevice");
       boot = await bootService.boot({
+        operationName: "provisionDevice",
         platform: args.device.platform,
         deviceId:
           exactBootedDevice?.deviceId ?? provisioned.device.deviceId ?? provisioned.device.name,
@@ -5036,7 +5042,22 @@ export function registerDeviceTools() {
         );
       }
       validatePooledDeviceMapping(boot.device, requestedIdentity);
-      releaseReadinessReservation = await reserveProvisionDeviceReadiness(boot.device);
+      releaseReadinessReservation = await runProvisionDeviceWithinDeadline(
+        deps.timer,
+        totalDeadlineMs,
+        operationSignal,
+        "reserving device readiness",
+        async (reservationSignal) => {
+          const release = await reserveProvisionDeviceReadiness(boot!.device);
+          if (reservationSignal.aborted) {
+            void release?.().catch((error) =>
+              logger.warn(`Late provision reservation release failed: ${error}`),
+            );
+            reservationSignal.throwIfAborted();
+          }
+          return release;
+        },
+      );
       clearColdBootShutdownMarker(boot.source, boot.device.deviceId);
       const sessionId = await trackDeviceAcquisitionReadiness(
         deviceReadinessLockKey(boot.device.platform, boot.device.deviceId),
@@ -5062,19 +5083,26 @@ export function registerDeviceTools() {
           operationSignal.throwIfAborted();
           validatePooledDeviceMapping(boot!.device, requestedIdentity);
           publishWarmDeviceReady(boot!.source, boot!.device.deviceId);
-          return await bindBootedDeviceSession(
-            boot!.device,
-            {
-              platform: args.device.platform,
-              name: args.device.name,
-              timeoutMs: args.timeoutMs,
-              __mcpSessionId: args.__mcpSessionId,
-            },
-            provisioned.device,
-            boot!.processHandle,
-            undefined,
-            undefined,
-            resolveProvisionDeviceAchievedReadiness(args.readiness),
+          return await runProvisionDeviceWithinDeadline(
+            deps.timer,
+            totalDeadlineMs,
+            operationSignal,
+            "binding the device session",
+            async () =>
+              await bindBootedDeviceSession(
+                boot!.device,
+                {
+                  platform: args.device.platform,
+                  name: args.device.name,
+                  timeoutMs: args.timeoutMs,
+                  __mcpSessionId: args.__mcpSessionId,
+                },
+                provisioned.device,
+                boot!.processHandle,
+                undefined,
+                undefined,
+                resolveProvisionDeviceAchievedReadiness(args.readiness),
+              ),
           );
         },
       );
@@ -5091,8 +5119,17 @@ export function registerDeviceTools() {
       }
       throw error;
     } finally {
-      await releaseReadinessReservation?.();
+      releaseProvisionReadiness(releaseReadinessReservation);
     }
+  }
+
+  function releaseProvisionReadiness(releaseReservation: (() => Promise<void>) | undefined): void {
+    // Session ownership is already committed on success. A delayed mutex-backed
+    // reservation release must neither turn that success into destructive rollback
+    // nor replace the original failure. Keep the balanced release queued.
+    void releaseReservation?.().catch((error) =>
+      logger.warn(`Provision readiness release failed: ${error}`),
+    );
   }
 
   /**
@@ -5679,7 +5716,7 @@ export function registerDeviceTools() {
       ...startDeviceSchema.parse(stripInternalAcquisitionParams(rawArgs)),
       __mcpSessionId: internalSessionId,
     };
-    const totalTimeoutMs = args.timeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS;
+    const totalTimeoutMs = args.timeoutMs ?? DEFAULT_START_DEVICE_TIMEOUT_MS;
     return await prepareDevice(
       args,
       {
@@ -5709,7 +5746,7 @@ export function registerDeviceTools() {
     const args = getAndroidSchema.parse(externalArgs);
     const bootTimeoutMs = args.bootTimeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS;
     const automationReadyTimeoutMs =
-      args.automationReadyTimeoutMs ?? DEFAULT_RUNNER_READINESS_TIMEOUT_MS;
+      args.automationReadyTimeoutMs ?? DEFAULT_RUNNER_PROVISION_TIMEOUT_MS;
     const startedAtMs = getDeviceToolsDependencies().timer.now();
     const mcpSessionId = typeof __mcpSessionId === "string" ? __mcpSessionId : undefined;
     // Prefer the AVD name (exact virtual-device identity); otherwise target the
@@ -5762,7 +5799,7 @@ export function registerDeviceTools() {
     const udid = args.udid ?? args.deviceId!;
     const bootTimeoutMs = args.bootTimeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS;
     const automationReadyTimeoutMs =
-      args.automationReadyTimeoutMs ?? DEFAULT_RUNNER_READINESS_TIMEOUT_MS;
+      args.automationReadyTimeoutMs ?? DEFAULT_RUNNER_PROVISION_TIMEOUT_MS;
     const startedAtMs = getDeviceToolsDependencies().timer.now();
     return await prepareDevice(
       {

--- a/src/utils/AbortContext.ts
+++ b/src/utils/AbortContext.ts
@@ -54,3 +54,8 @@ export const combineWithAmbientAbort = (signal?: AbortSignal): AbortSignal | und
   }
   return combineAbortSignals(signal, ambient);
 };
+
+/** Fence side effects after asynchronous acquisition work returns to its caller. */
+export function throwIfRequestAborted(): void {
+  getAbortSignal()?.throwIfAborted();
+}

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -752,7 +752,7 @@ export class RunnerReadinessService {
     }
 
     if (context.skipCtrlProxyDownload) {
-      await this.ensureIosReadyWithoutDownloads(context, manager, client);
+      await this.ensureIosReadyWithoutDownloads(context, manager);
       return;
     }
 
@@ -763,13 +763,15 @@ export class RunnerReadinessService {
     if (!setup.success) {
       this.fail(context, "runner-setup", 1, setup.error ?? setup.message);
     }
+    // Setup can reallocate a busy port or adopt the runner's actual listener.
+    // Resolve the client after launch, just as the force-restart path does.
+    client = this.dependencies.getIosClient(context.device, manager.getServicePort());
     await this.waitForResponsiveClient(context, client);
   }
 
   private async ensureIosReadyWithoutDownloads(
     context: ReadinessAttemptContext,
     manager: ReadinessIosManager,
-    client: ReadinessClient,
   ): Promise<void> {
     const installed = await this.runPhase(context, "runner-setup", 1, () => manager.isInstalled());
     if (!installed) {
@@ -786,6 +788,7 @@ export class RunnerReadinessService {
         minimumHealthPollDurationMs: this.remainingForPhase(context, "runner-setup"),
       }),
     );
+    const client = this.dependencies.getIosClient(context.device, manager.getServicePort());
     await this.waitForResponsiveClient(context, client);
   }
 

--- a/src/utils/deviceBootService.ts
+++ b/src/utils/deviceBootService.ts
@@ -28,6 +28,22 @@ import { stableStringify } from "./stableStringify";
 
 const ABORT_SETTLEMENT_GRACE_MS = 1_000;
 
+/** A boot deadline failure, kept distinct from platform command failures. */
+export class DeviceBootTimeoutError extends ActionableError {
+  readonly code = "timeout";
+
+  constructor(
+    readonly operation: string,
+    readonly phase: string,
+    readonly elapsedMs: number,
+    readonly budgetMs: number,
+  ) {
+    super(
+      `${operation} timeout exhausted while ${phase}; remainingBudgetMs=0; elapsedMs=${elapsedMs}; budgetMs=${budgetMs}; origin=DeviceBootService`,
+    );
+  }
+}
+
 /**
  * True for an `AbortSignal.reason` that carries no caller-supplied context: a
  * literal `undefined` (used by synthetic/fake signals in tests), or the
@@ -50,6 +66,7 @@ function isDefaultAbortReason(reason: unknown): boolean {
 
 /** Inputs which affect device discovery, creation, and readiness, but not MCP sessions or automation setup. */
 export interface DeviceBootRequest {
+  operationName?: string;
   platform: "android" | "ios";
   minOsVersion?: string;
   maxOsVersion?: string;
@@ -99,6 +116,8 @@ export interface DeviceBootServiceDependencies {
 }
 
 interface BootDeadlineContext {
+  operationName: string;
+  startedAtMs: number;
   deadlineMs: number;
   signal?: AbortSignal;
   lifecycleLease?: VirtualDeviceLifecycleLease;
@@ -164,6 +183,8 @@ export class DeviceBootService {
   async boot(request: DeviceBootRequest, progress?: DeviceBootProgress): Promise<DeviceBootResult> {
     const timeoutMs = request.timeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS;
     const context: BootDeadlineContext = {
+      operationName: request.operationName ?? "startDevice",
+      startedAtMs: this.timer.now(),
       deadlineMs: request.totalDeadlineMs ?? this.timer.now() + timeoutMs,
       signal: request.signal,
       lifecycleLease: this.dependencies.lifecycleLease,
@@ -423,7 +444,7 @@ export class DeviceBootService {
         const ready = await this.runPhase(context, "waiting for a running device", (signal) =>
           this.dependencies.deviceManager.waitForDeviceReady(
             { ...device, isRunning: true },
-            this.remaining(context.deadlineMs, "waiting for a running device"),
+            this.remaining(context, "waiting for a running device"),
             undefined,
             signal,
           ),
@@ -464,7 +485,7 @@ export class DeviceBootService {
     const handle = await this.runPhase(context, "starting the device", async (signal) => {
       const started = await this.dependencies.deviceManager.startDevice(
         image,
-        this.remaining(context.deadlineMs, "starting the device"),
+        this.remaining(context, "starting the device"),
       );
       const cancelStarted = () => {
         started?.kill();
@@ -493,10 +514,11 @@ export class DeviceBootService {
           this.dependencies.deviceManager,
           image,
           handle,
-          this.remaining(context.deadlineMs, "waiting for device boot readiness"),
+          this.remaining(context, "waiting for device boot readiness"),
           signal,
           this.timer,
           cancelHandle,
+          () => this.timeoutError(context, "waiting for device boot readiness"),
         ),
       );
       await this.reportProgress(context, progress, 100, "Device is ready for use");
@@ -533,12 +555,10 @@ export class DeviceBootService {
     );
   }
 
-  private remaining(deadlineMs: number, phase: string): number {
-    const remainingMs = Math.floor(deadlineMs - this.timer.now());
+  private remaining(context: BootDeadlineContext, phase: string): number {
+    const remainingMs = Math.floor(context.deadlineMs - this.timer.now());
     if (remainingMs <= 0) {
-      throw new ActionableError(
-        `startDevice timeout exhausted while ${phase}; remainingBudgetMs=0`,
-      );
+      throw this.timeoutError(context, phase);
     }
     return remainingMs;
   }
@@ -549,7 +569,7 @@ export class DeviceBootService {
     operation: (signal: AbortSignal) => Promise<T>,
     awaitAbortSettlement = true,
   ): Promise<T> {
-    const remainingMs = this.remaining(context.deadlineMs, phase);
+    const remainingMs = this.remaining(context, phase);
     const cancellation = createPhaseCancellation(context.signal, phase);
     cancellation.throwIfCancelled();
     const controller = new AbortController();
@@ -591,12 +611,9 @@ export class DeviceBootService {
         ...(externalAbortPromise ? [externalAbortPromise] : []),
         new Promise<never>((_resolve, reject) => {
           timeoutHandle = this.timer.setTimeout(() => {
-            controller.abort(new Error(`startDevice timeout exhausted while ${phase}`));
-            reject(
-              new ActionableError(
-                `startDevice timeout exhausted while ${phase}; remainingBudgetMs=0`,
-              ),
-            );
+            const error = this.timeoutError(context, phase);
+            controller.abort(error);
+            reject(error);
           }, remainingMs);
         }),
         cancellation.promise,
@@ -610,6 +627,7 @@ export class DeviceBootService {
       cancellation.throwIfCancelled();
       if (controller.signal.aborted) {
         throw this.phaseTimeoutFailure(
+          context,
           controller,
           operationFailureRecorded,
           operationFailure,
@@ -626,7 +644,17 @@ export class DeviceBootService {
     }
   }
 
+  private timeoutError(context: BootDeadlineContext, phase: string): DeviceBootTimeoutError {
+    return new DeviceBootTimeoutError(
+      context.operationName,
+      phase,
+      this.timer.now() - context.startedAtMs,
+      Math.max(0, context.deadlineMs - context.startedAtMs),
+    );
+  }
+
   private phaseTimeoutFailure(
+    context: BootDeadlineContext,
     controller: AbortController,
     operationFailureRecorded: boolean,
     operationFailure: unknown,
@@ -635,7 +663,7 @@ export class DeviceBootService {
     if (operationFailureRecorded && operationFailure !== controller.signal.reason) {
       return operationFailure;
     }
-    return new ActionableError(`startDevice timeout exhausted while ${phase}; remainingBudgetMs=0`);
+    return this.timeoutError(context, phase);
   }
 
   private throwExternalAbortReason(signal: AbortSignal | undefined, phase: string): void {

--- a/src/utils/deviceTimeouts.ts
+++ b/src/utils/deviceTimeouts.ts
@@ -1,4 +1,10 @@
-export const DEFAULT_DEVICE_READY_TIMEOUT_MS = 120000;
+import { DEFAULT_RUNNER_PROVISION_TIMEOUT_MS } from "./runnerReadinessConfig";
+
+// Cold virtual devices can legitimately need three minutes before OS readiness.
+export const DEFAULT_DEVICE_READY_TIMEOUT_MS = 180_000;
+// Legacy startDevice shares one budget across boot and automation readiness.
+export const DEFAULT_START_DEVICE_TIMEOUT_MS =
+  DEFAULT_DEVICE_READY_TIMEOUT_MS + DEFAULT_RUNNER_PROVISION_TIMEOUT_MS;
 // A full resource request may verify dozens of native services sequentially.
 export const DEFAULT_DEVICE_RESOURCE_TIMEOUT_MS = 300_000;
 export const DEFAULT_DEVICE_TEARDOWN_TIMEOUT_MS = 60_000;

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -251,6 +251,7 @@ export async function waitForDeviceReadyOrCancel(
   signal: AbortSignal | undefined = getAbortSignal(),
   timer: Pick<Timer, "setTimeout" | "clearTimeout"> = defaultTimer,
   cancelOwnedBoot?: () => void | Promise<void>,
+  createTimeoutError?: () => Error,
 ): Promise<BootedDevice> {
   const timeoutError = new ActionableError(
     `Device readiness timed out after ${timeoutMs}ms for ${device.deviceId ?? device.name}`,
@@ -290,7 +291,7 @@ export async function waitForDeviceReadyOrCancel(
       readinessSignal.addEventListener("abort", abortListener, { once: true });
     });
     timeoutHandle = timer.setTimeout(() => {
-      controller.abort(timeoutError);
+      controller.abort(createTimeoutError?.() ?? timeoutError);
     }, timeoutMs);
     return await Promise.race([readinessPromise, abortPromise]);
   } catch (error) {

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -907,7 +907,10 @@ export class SimCtlClient implements SimCtl {
     deadlineMs: number,
     signal: AbortSignal | undefined,
   ): Promise<void> {
-    const remainingMs = this.remainingBootTimeoutMs(udid, deadlineMs);
+    // Focusing the optional GUI must not consume the boot/readiness budget of
+    // an already booted simulator. A wedged LaunchServices/AppleScript call is
+    // cancelled promptly; automation continues without the window.
+    const remainingMs = Math.min(1_000, this.remainingBootTimeoutMs(udid, deadlineMs));
     if (signal?.aborted) {
       throw signal.reason ?? new ActionableError(`iOS simulator start aborted for ${udid}`);
     }

--- a/test/cli/toolResultFailure.test.ts
+++ b/test/cli/toolResultFailure.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { DaemonVersionMismatchError } from "../../src/daemon/daemonMcpProxy";
 import {
   isCliToolFailure,
   resetDaemonProxyFactoryForTesting,
@@ -14,6 +15,29 @@ describe("isCliToolFailure (issue #6017)", () => {
     process.exit = originalProcessExit;
     console.error = originalConsoleError;
     resetDaemonProxyFactoryForTesting();
+  });
+
+  test("reports version skew as preflight rather than an interrupted tool", async () => {
+    const messages: string[] = [];
+    process.exit = (() => {}) as typeof process.exit;
+    console.error = (...args: unknown[]) => {
+      messages.push(args.join(" "));
+    };
+    setDaemonProxyFactoryForTesting((): any => ({
+      callTool: async () => {
+        throw new DaemonVersionMismatchError({
+          clientVersion: "0.0.70",
+          daemonVersion: "0.0.68",
+          reason: "autoStartDisabled",
+          detail: "auto-start is disabled",
+        });
+      },
+      close: async () => {},
+    }));
+    await runCliCommand(["listDevices"]);
+    expect(messages.join("\n")).toContain("Daemon preflight failed; no device operation started");
+    expect(messages.join("\n")).toContain("daemon=0.0.68, client=0.0.70");
+    expect(messages.join("\n")).not.toContain("became unavailable during tool execution");
   });
 
   test("recognizes an in-band session ownership error envelope", () => {

--- a/test/daemon/clientRequestTimeout.test.ts
+++ b/test/daemon/clientRequestTimeout.test.ts
@@ -4,10 +4,13 @@ import { DaemonClient } from "../../src/daemon/client";
 import { McpTimeoutError } from "../../src/daemon/McpTimeoutError";
 import {
   DEFAULT_MCP_REQUEST_TIMEOUT_MS,
-  MIN_START_DEVICE_MCP_TIMEOUT_MS,
   MIN_UNINSTALL_APP_MCP_TIMEOUT_MS,
   MAX_PROGRESS_EXTENDED_MCP_REQUEST_TIMEOUT_MS,
 } from "../../src/daemon/mcpRequestTimeout";
+import {
+  DEFAULT_START_DEVICE_TIMEOUT_MS,
+  START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS,
+} from "../../src/utils/deviceTimeouts";
 import { PROGRESS_NOTIFICATION_METHOD } from "../../src/daemon/types";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -34,11 +37,12 @@ describe("DaemonClient per-request timeout", () => {
     fakeTimer = new FakeTimer();
   });
 
-  test("startDevice uses MIN_START_DEVICE_MCP_TIMEOUT_MS", async () => {
+  test("startDevice allows the full default acquisition budget plus response overhead", async () => {
     const client = createConnectedClient(fakeTimer);
+    const timeoutMs = DEFAULT_START_DEVICE_TIMEOUT_MS + START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS;
 
     const promise = client.callTool("startDevice", {});
-    fakeTimer.advanceTime(MIN_START_DEVICE_MCP_TIMEOUT_MS);
+    fakeTimer.advanceTime(timeoutMs);
 
     try {
       await promise;
@@ -47,7 +51,7 @@ describe("DaemonClient per-request timeout", () => {
       expect(err).toBeInstanceOf(McpTimeoutError);
       const timeoutErr = err as McpTimeoutError;
       expect(timeoutErr.toolName).toBe("startDevice");
-      expect(timeoutErr.timeoutMs).toBe(MIN_START_DEVICE_MCP_TIMEOUT_MS);
+      expect(timeoutErr.timeoutMs).toBe(timeoutMs);
       expect(timeoutErr.origin).toBe("DaemonClient.sendRequest");
     } finally {
       await client.close();
@@ -137,10 +141,12 @@ describe("DaemonClient per-request timeout", () => {
   });
 
   test("connectionTimeout overrides per-tool floor when larger", async () => {
-    const client = createConnectedClient(fakeTimer, 300_000);
+    const timeoutMs =
+      DEFAULT_START_DEVICE_TIMEOUT_MS + START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS + 60_000;
+    const client = createConnectedClient(fakeTimer, timeoutMs);
 
     const promise = client.callTool("startDevice", {});
-    fakeTimer.advanceTime(300_000);
+    fakeTimer.advanceTime(timeoutMs);
 
     try {
       await promise;
@@ -149,7 +155,7 @@ describe("DaemonClient per-request timeout", () => {
       expect(err).toBeInstanceOf(McpTimeoutError);
       const timeoutErr = err as McpTimeoutError;
       expect(timeoutErr.toolName).toBe("startDevice");
-      expect(timeoutErr.timeoutMs).toBe(300_000);
+      expect(timeoutErr.timeoutMs).toBe(timeoutMs);
     } finally {
       await client.close();
     }

--- a/test/daemon/daemonSocketIdentity.test.ts
+++ b/test/daemon/daemonSocketIdentity.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import { Duplex } from "node:stream";
-import { DaemonClient, DaemonHandshakeMismatchError } from "../../src/daemon/client";
+import {
+  DaemonClient,
+  DaemonHandshakeMismatchError,
+  DaemonUnavailableError,
+} from "../../src/daemon/client";
 import { DaemonMcpProxy, DaemonVersionMismatchError } from "../../src/daemon/daemonMcpProxy";
 import type { DaemonStatus, DaemonResponse } from "../../src/daemon/types";
 import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
@@ -8,6 +12,104 @@ import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 describe("socket-owner daemon preflight", () => {
+  for (const actualIdentity of [
+    {},
+    { pid: 101, buildId: "unknown", entryScript: "/current" },
+    { pid: 101, buildId: "current" },
+    { pid: 101, buildId: "current", entryScript: "/different" },
+    { buildId: "current", entryScript: "/current" },
+    { pid: 202, buildId: "current", entryScript: "/current" },
+  ]) {
+    test(`does not trust PID startup flags without verified socket identity ${JSON.stringify(actualIdentity)}`, async () => {
+      const manager = new FakeDaemonManager();
+      manager.statusResult = {
+        running: true,
+        pid: 101,
+        version: "0.0.70",
+        buildId: "current",
+        entryScript: "/current",
+        options: { debug: true },
+      };
+      const client = new FakeDaemonClient();
+      const available = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: manager,
+        clientVersion: "0.0.70",
+        buildIdentity: { buildId: "current", entryScript: "/current" },
+        autoStartDaemon: false,
+        daemonOptions: { debug: true },
+        timer: new FakeTimer(),
+        daemonStatusProbe: async () => ({ running: true, version: "0.0.70", ...actualIdentity }),
+      });
+      try {
+        await expect(proxy.callTool("provisionDevice", {})).rejects.toBeInstanceOf(
+          DaemonUnavailableError,
+        );
+        expect(client.callToolCalls).toHaveLength(0);
+        expect(manager.restartCallCount).toBe(0);
+      } finally {
+        available.mockRestore();
+        await proxy.close();
+      }
+    });
+  }
+
+  test("a version-only socket does not borrow a conflicting PID build", async () => {
+    const manager = new FakeDaemonManager();
+    manager.statusResult = {
+      running: true,
+      version: "0.0.70",
+      buildId: "unrelated",
+      entryScript: "/other",
+    };
+    const client = new FakeDaemonClient();
+    const available = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => client,
+      daemonManager: manager,
+      clientVersion: "0.0.70",
+      buildIdentity: { buildId: "current", entryScript: "/current" },
+      autoStartDaemon: false,
+      timer: new FakeTimer(),
+      daemonStatusProbe: async () => ({ running: true, version: "0.0.70" }),
+    });
+    try {
+      await proxy.callTool("provisionDevice", {});
+      expect(client.callToolCalls).toHaveLength(1);
+      expect(manager.restartCallCount).toBe(0);
+    } finally {
+      available.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  test("retains startup flags when the socket identifies the recorded process and build", async () => {
+    const manager = new FakeDaemonManager();
+    const identity = { pid: 101, version: "0.0.70", buildId: "current", entryScript: "/current" };
+    manager.statusResult = { running: true, ...identity, options: { debug: true } };
+    const client = new FakeDaemonClient();
+    const available = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => client,
+      daemonManager: manager,
+      clientVersion: "0.0.70",
+      buildIdentity: identity,
+      autoStartDaemon: false,
+      daemonOptions: { debug: true },
+      timer: new FakeTimer(),
+      daemonStatusProbe: async () => ({ running: true, ...identity }),
+    });
+    try {
+      await proxy.callTool("provisionDevice", {});
+      expect(client.callToolCalls).toHaveLength(1);
+      expect(manager.restartCallCount).toBe(0);
+    } finally {
+      available.mockRestore();
+      await proxy.close();
+    }
+  });
+
   test("a structured pre-dispatch rejection reconciles once without duplicating execution", async () => {
     const manager = new FakeDaemonManager();
     manager.statusResult = { running: false };
@@ -175,6 +277,28 @@ describe("socket-owner daemon preflight", () => {
       closed.mockRestore();
     }
   });
+
+  for (const pid of [101, 0, -1, 1.5, "101"]) {
+    test(`socket status validates process identity ${JSON.stringify(pid)}`, async () => {
+      const closed = spyOn(DaemonClient.prototype, "close").mockResolvedValue();
+      const method = spyOn(DaemonClient.prototype, "callDaemonMethod").mockResolvedValue({
+        version: "0.0.70",
+        pid,
+      });
+      try {
+        const result = new DaemonClient("/fake.sock").getDaemonStatus();
+        if (pid === 101) {
+          expect((await result).pid).toBe(101);
+        } else {
+          await expect(result).rejects.toThrow("Daemon preflight failed");
+        }
+        expect(closed).toHaveBeenCalledTimes(1);
+      } finally {
+        method.mockRestore();
+        closed.mockRestore();
+      }
+    });
+  }
 
   test("wire mismatch decodes into a typed preflight rejection", async () => {
     const failure = {

--- a/test/daemon/daemonSocketIdentity.test.ts
+++ b/test/daemon/daemonSocketIdentity.test.ts
@@ -12,6 +12,44 @@ import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 describe("socket-owner daemon preflight", () => {
+  for (const persistentFailure of [false, true]) {
+    test(`identity handoff retries establishment once before dispatch (persistent=${persistentFailure})`, async () => {
+      const manager = new FakeDaemonManager();
+      manager.statusResult = { running: false };
+      const client = new FakeDaemonClient();
+      const available = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      let probes = 0;
+      const failure = new DaemonUnavailableError("Socket owner exited during identity discovery");
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: manager,
+        clientVersion: "0.0.70",
+        timer: new FakeTimer(),
+        daemonStatusProbe: async () => {
+          probes++;
+          if (probes === 1 || persistentFailure) {
+            throw failure;
+          }
+          return { running: true, version: "0.0.70" };
+        },
+      });
+      try {
+        if (persistentFailure) {
+          await expect(proxy.callTool("provisionDevice", {})).rejects.toMatchObject({
+            cause: failure,
+          });
+        } else {
+          await proxy.callTool("provisionDevice", {});
+        }
+        expect(probes).toBe(2);
+        expect(client.callToolCalls).toHaveLength(persistentFailure ? 0 : 1);
+        expect(manager.restartCallCount).toBe(0);
+      } finally {
+        available.mockRestore();
+        await proxy.close();
+      }
+    });
+  }
   for (const actualIdentity of [
     {},
     { pid: 101, buildId: "unknown", entryScript: "/current" },

--- a/test/daemon/daemonSocketIdentity.test.ts
+++ b/test/daemon/daemonSocketIdentity.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { Duplex } from "node:stream";
+import { DaemonClient, DaemonHandshakeMismatchError } from "../../src/daemon/client";
+import { DaemonMcpProxy, DaemonVersionMismatchError } from "../../src/daemon/daemonMcpProxy";
+import type { DaemonStatus, DaemonResponse } from "../../src/daemon/types";
+import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
+import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+describe("socket-owner daemon preflight", () => {
+  test("a structured pre-dispatch rejection reconciles once without duplicating execution", async () => {
+    const manager = new FakeDaemonManager();
+    manager.statusResult = { running: false };
+    let rejected = false;
+    let executions = 0;
+    const client = new FakeDaemonClient({
+      onCallTool: () => {
+        if (!rejected) {
+          rejected = true;
+          throw new DaemonHandshakeMismatchError(
+            {
+              code: "daemon_identity_mismatch",
+              phase: "daemon-preflight",
+              executionStarted: false,
+              reason: "version",
+              daemon: { version: "0.0.68", build: { buildId: "old", entryScript: "/old" } },
+              client: { clientVersion: "0.0.70" },
+            },
+            "daemon changed before dispatch",
+          );
+        }
+        executions++;
+      },
+    });
+    const available = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => client,
+      daemonManager: manager,
+      clientVersion: "0.0.70",
+      timer: new FakeTimer(),
+      daemonStatusProbe: async () => ({
+        running: true,
+        version: rejected && !manager.restartCalled ? "0.0.68" : "0.0.70",
+      }),
+    });
+    try {
+      await proxy.callTool("provisionDevice", {});
+      expect(manager.restartCallCount).toBe(1);
+      expect(executions).toBe(1);
+      expect(client.callToolCalls).toHaveLength(2);
+    } finally {
+      available.mockRestore();
+      await proxy.close();
+    }
+  });
+  test("socket build identity overrides a matching-version PID record", async () => {
+    const manager = new FakeDaemonManager();
+    manager.statusResult = { running: true, version: "0.0.70", buildId: "current" };
+    const client = new FakeDaemonClient();
+    const available = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => client,
+      daemonManager: manager,
+      clientVersion: "0.0.70",
+      buildIdentity: { buildId: "current", entryScript: "/new" },
+      timer: new FakeTimer(),
+      daemonStatusProbe: async () => ({
+        running: true,
+        version: "0.0.70",
+        buildId: manager.restartCalled ? "current" : "old",
+        entryScript: manager.restartCalled ? "/new" : "/old",
+      }),
+    });
+    try {
+      await proxy.callTool("provisionDevice", {});
+      expect(manager.restartCallCount).toBe(1);
+      expect(client.callToolCalls).toHaveLength(1);
+    } finally {
+      available.mockRestore();
+      await proxy.close();
+    }
+  });
+  for (const recorded of [
+    { running: false },
+    { running: true, version: "0.0.70", buildId: "current" },
+  ]) {
+    test(`reconciles old socket owner despite PID record ${JSON.stringify(recorded)}`, async () => {
+      const manager = new FakeDaemonManager();
+      manager.statusResult = recorded;
+      const client = new FakeDaemonClient();
+      let probes = 0;
+      const available = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: manager,
+        clientVersion: "0.0.70",
+        buildIdentity: { buildId: "current", entryScript: "/new/index.js" },
+        timer: new FakeTimer(),
+        daemonStatusProbe: async () => {
+          probes++;
+          return {
+            running: true,
+            version: manager.restartCalled ? "0.0.70" : "0.0.68",
+          };
+        },
+      });
+      try {
+        await proxy.callTool("provisionDevice", {});
+        expect(manager.restartCallCount).toBe(1);
+        expect(client.callToolCalls).toHaveLength(1);
+        expect(probes).toBe(2);
+      } finally {
+        available.mockRestore();
+        await proxy.close();
+      }
+    });
+  }
+
+  for (const scenario of ["newer", "disabled", "cooldown", "replacement-mismatch"] as const) {
+    test(`${scenario} rejects before device dispatch`, async () => {
+      const manager = new FakeDaemonManager();
+      manager.statusResult = { running: false };
+      const client = new FakeDaemonClient();
+      const timer = new FakeTimer();
+      timer.advanceTime(100_000);
+      const available = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const actual: DaemonStatus = {
+        running: true,
+        version: scenario === "newer" ? "0.0.71" : "0.0.68",
+        ...(scenario === "cooldown" ? { startedAt: timer.now() } : {}),
+      };
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: manager,
+        daemonStatusProbe: async () => actual,
+        clientVersion: "0.0.70",
+        timer,
+        autoStartDaemon: scenario !== "disabled",
+      });
+      try {
+        await expect(proxy.callTool("provisionDevice", {})).rejects.toBeInstanceOf(
+          DaemonVersionMismatchError,
+        );
+        expect(client.callToolCalls).toHaveLength(0);
+        expect(manager.restartCallCount).toBe(scenario === "replacement-mismatch" ? 1 : 0);
+      } finally {
+        available.mockRestore();
+        await proxy.close();
+      }
+    });
+  }
+
+  test("legacy status probe is ungated and closes its diagnostic connection", async () => {
+    const closed = spyOn(DaemonClient.prototype, "close").mockResolvedValue();
+    let declaredIdentity: unknown = "unset";
+    const method = spyOn(DaemonClient.prototype, "callDaemonMethod").mockImplementation(
+      async function (name) {
+        expect(name).toBe("ide/status");
+        declaredIdentity = (this as unknown as { clientIdentity: unknown }).clientIdentity;
+        return { version: "0.0.68", releaseVersion: "0.0.68" };
+      },
+    );
+    try {
+      const status = await new DaemonClient("/fake.sock").getDaemonStatus();
+      expect(status).toEqual({
+        running: true,
+        version: "0.0.68",
+        assetVersion: "0.0.68",
+        socketPath: "/fake.sock",
+      });
+      expect(declaredIdentity).toBeNull();
+      expect(closed).toHaveBeenCalledTimes(1);
+    } finally {
+      method.mockRestore();
+      closed.mockRestore();
+    }
+  });
+
+  test("wire mismatch decodes into a typed preflight rejection", async () => {
+    const failure = {
+      code: "daemon_identity_mismatch",
+      phase: "daemon-preflight",
+      executionStarted: false,
+      reason: "version",
+      daemon: { version: "0.0.68", build: { buildId: "old", entryScript: "/old" } },
+      client: { clientVersion: "0.0.70" },
+    } as const;
+    const client = new DaemonClient("/fake.sock", 1000, new FakeTimer());
+    const internals = client as unknown as {
+      connected: boolean;
+      socket: Duplex;
+      handleResponse(response: DaemonResponse): void;
+    };
+    internals.connected = true;
+    internals.socket = new Duplex({
+      read() {},
+      write(chunk, _encoding, done) {
+        const request = JSON.parse(chunk.toString());
+        internals.handleResponse({
+          id: request.id,
+          type: "mcp_response",
+          success: false,
+          error: "daemon=0.0.68, client=0.0.70",
+          handshakeFailure: failure,
+        });
+        done();
+      },
+    });
+    try {
+      await client.callTool("provisionDevice", {});
+      expect.unreachable("Expected rejection");
+    } catch (error) {
+      expect(error).toBeInstanceOf(DaemonHandshakeMismatchError);
+      expect((error as DaemonHandshakeMismatchError).failure).toEqual(failure);
+      expect((error as Error).message).toContain("no device operation started");
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -9,10 +9,7 @@ import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
-import {
-  DeviceSessionRepository,
-  type DeviceSessionPersistence,
-} from "../../src/db/deviceSessionRepository";
+import { type DeviceSessionPersistence } from "../../src/db/deviceSessionRepository";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 import { BootedDevice, DeviceInfo, Platform, SomePlatform } from "../../src/models";
 import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
@@ -2108,12 +2105,13 @@ describe("DevicePool", () => {
 
     test("retires only its new autolock when metadata persistence outlives cancellation", async () => {
       const originalAutolock = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
-      const repository = new DeviceSessionRepository();
       const started = Promise.withResolvers<void>();
       const finished = Promise.withResolvers<void>();
-      repository.markAutolockSession = async () => {
-        started.resolve();
-        await finished.promise;
+      const repository = {
+        markAutolockSession: async () => {
+          started.resolve();
+          await finished.promise;
+        },
       };
       devicePool = new DevicePool(
         sessionManager,
@@ -2171,13 +2169,14 @@ describe("DevicePool", () => {
       };
       sessionManager.stopCleanupTimer();
       sessionManager = new SessionManager(fakeTimer, persistence);
-      const repository = new DeviceSessionRepository();
       let metadataCalls = 0;
-      repository.markAutolockSession = async () => {
-        if (metadataCalls++ === 0) {
-          metadataStarted.resolve();
-          await metadataFinished.promise;
-        }
+      const repository = {
+        markAutolockSession: async () => {
+          if (metadataCalls++ === 0) {
+            metadataStarted.resolve();
+            await metadataFinished.promise;
+          }
+        },
       };
       devicePool = new DevicePool(
         sessionManager,

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1,3 +1,4 @@
+import { runWithAbortSignal } from "../../src/utils/AbortContext";
 import { afterEach, describe, expect, test, beforeEach } from "bun:test";
 import { EventEmitter } from "node:events";
 import type { ChildProcess } from "node:child_process";
@@ -8,7 +9,10 @@ import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
-import type { DeviceSessionPersistence } from "../../src/db/deviceSessionRepository";
+import {
+  DeviceSessionRepository,
+  type DeviceSessionPersistence,
+} from "../../src/db/deviceSessionRepository";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 import { BootedDevice, DeviceInfo, Platform, SomePlatform } from "../../src/models";
 import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
@@ -725,6 +729,49 @@ describe("DevicePool", () => {
       } finally {
         await reservation?.release();
       }
+    });
+
+    test("rejects cancelled binding and readiness reservation after the assignment mutex opens", async () => {
+      const persistence = new DeferredDeviceSessionPersistence();
+      sessionManager.stopCleanupTimer();
+      sessionManager = new SessionManager(fakeTimer, persistence);
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+      const owner = devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        device.deviceId,
+        "android",
+        sourceImage,
+      );
+      await persistence.waitForUpsert();
+      const controller = new AbortController();
+      const lateBinding = runWithAbortSignal(controller.signal, () =>
+        devicePool.bindOrReuseDeviceSession(
+          "expired-session",
+          device.deviceId,
+          "android",
+          sourceImage,
+        ),
+      ).catch((error: unknown) => error);
+      const lateReservation = runWithAbortSignal(controller.signal, () =>
+        devicePool.reserveDeviceForReadiness(device.deviceId, device),
+      ).catch((error: unknown) => error);
+      controller.abort(new Error("provision deadline exhausted"));
+      persistence.finishUpsert();
+      await owner;
+      expect(await lateBinding).toBe(controller.signal.reason);
+      expect(await lateReservation).toBe(controller.signal.reason);
+      expect(devicePool.getDevice(device.deviceId)?.sessionId).toBe("owner-session");
+      expect(sessionManager.getSession("expired-session")).toBeNull();
     });
 
     test("captures session identity after an in-flight assignment publishes", async () => {
@@ -2057,6 +2104,49 @@ describe("DevicePool", () => {
       }
 
       expect(connectedDeviceIds).toEqual(["emulator-5554"]);
+    });
+
+    test("retires only its new autolock when metadata persistence outlives cancellation", async () => {
+      const originalAutolock = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+      const repository = new DeviceSessionRepository();
+      const started = Promise.withResolvers<void>();
+      const finished = Promise.withResolvers<void>();
+      repository.markAutolockSession = async () => {
+        started.resolve();
+        await finished.promise;
+      };
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+        repository,
+      );
+      const device = createBootedDevice("emulator-5554");
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+      process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+      const controller = new AbortController();
+      try {
+        const binding = runWithAbortSignal(controller.signal, () =>
+          devicePool.autolockDevice(device.deviceId, "android", "mcp-expired"),
+        ).catch((error: unknown) => error);
+        await started.promise;
+        controller.abort(new Error("binding deadline exhausted"));
+        finished.resolve();
+        expect(await binding).toBe(controller.signal.reason);
+        expect(sessionManager.getSessionForDevice(device.deviceId)).toBeNull();
+        expect(devicePool.getDevice(device.deviceId)?.sessionId).toBeNull();
+      } finally {
+        finished.resolve();
+        if (originalAutolock === undefined) {
+          delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+        } else {
+          process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = originalAutolock;
+        }
+      }
     });
 
     test("notifies before autolock validates an existing serial", async () => {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -2134,13 +2134,97 @@ describe("DevicePool", () => {
           devicePool.autolockDevice(device.deviceId, "android", "mcp-expired"),
         ).catch((error: unknown) => error);
         await started.promise;
+        const cancelledSessionId = devicePool.getDevice(device.deviceId)!.sessionId!;
         controller.abort(new Error("binding deadline exhausted"));
-        finished.resolve();
         expect(await binding).toBe(controller.signal.reason);
+        await sessionManager.waitForSessionRelease(cancelledSessionId);
         expect(sessionManager.getSessionForDevice(device.deviceId)).toBeNull();
         expect(devicePool.getDevice(device.deviceId)?.sessionId).toBeNull();
+        expect(devicePool.captureAutolockSessionForMcpSession("mcp-expired")).toBeUndefined();
+        repository.markAutolockSession = async () => {};
+        const replacement = await devicePool.autolockDevice(device.deviceId, "android", "mcp-new");
+        expect(replacement).not.toBe(cancelledSessionId);
+        finished.resolve();
+        await Promise.resolve();
+        expect(devicePool.getDevice(device.deviceId)?.sessionId).toBe(replacement);
+        expect(devicePool.captureAutolockSessionForMcpSession("mcp-new")).toBe(replacement);
       } finally {
         finished.resolve();
+        if (originalAutolock === undefined) {
+          delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+        } else {
+          process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = originalAutolock;
+        }
+      }
+    });
+
+    test("cancelled metadata and release persistence cannot hold the global assignment mutex", async () => {
+      const originalAutolock = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+      const metadataStarted = Promise.withResolvers<void>();
+      const metadataFinished = Promise.withResolvers<void>();
+      const releaseStarted = Promise.withResolvers<void>();
+      const releaseFinished = Promise.withResolvers<void>();
+      const persistence = new FakeDeviceSessionPersistence();
+      persistence.markReleased = async () => {
+        releaseStarted.resolve();
+        await releaseFinished.promise;
+      };
+      sessionManager.stopCleanupTimer();
+      sessionManager = new SessionManager(fakeTimer, persistence);
+      const repository = new DeviceSessionRepository();
+      let metadataCalls = 0;
+      repository.markAutolockSession = async () => {
+        if (metadataCalls++ === 0) {
+          metadataStarted.resolve();
+          await metadataFinished.promise;
+        }
+      };
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+        repository,
+      );
+      const first = createBootedDevice("emulator-5554");
+      const second = createBootedDevice("emulator-5556");
+      fakeDeviceManager.bootedDevices = [first, second];
+      await devicePool.initializeWithDevices([first, second]);
+      process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+      const controller = new AbortController();
+      try {
+        const binding = runWithAbortSignal(controller.signal, () =>
+          devicePool.autolockDevice(first.deviceId, "android", "mcp-cancelled"),
+        ).catch((error: unknown) => error);
+        await metadataStarted.promise;
+        const cancelledSessionId = devicePool.getDevice(first.deviceId)!.sessionId!;
+        controller.abort(new Error("binding deadline exhausted"));
+        expect(await binding).toBe(controller.signal.reason);
+        await releaseStarted.promise;
+        expect(devicePool.getDevice(first.deviceId)?.sessionId).toBeNull();
+        expect(devicePool.captureAutolockSessionForMcpSession("mcp-cancelled")).toBeUndefined();
+        expect(sessionManager.getSession(cancelledSessionId)).toBeNull();
+        // The first device stays quarantined for cleanup, but an unrelated
+        // reservation and assignment must succeed before either write settles.
+        expect(sessionManager.hasDeviceCleanupInProgress(first.deviceId)).toBe(true);
+        const reservation = await devicePool.reserveDeviceForReadiness(second.deviceId, second);
+        await reservation();
+        const secondSession = await devicePool.autolockDevice(
+          second.deviceId,
+          "android",
+          "mcp-second",
+        );
+        expect(devicePool.getDevice(second.deviceId)?.sessionId).toBe(secondSession);
+        metadataFinished.resolve();
+        releaseFinished.resolve();
+        await sessionManager.waitForSessionRelease(cancelledSessionId);
+        expect(devicePool.getDevice(second.deviceId)?.sessionId).toBe(secondSession);
+        expect(devicePool.captureAutolockSessionForMcpSession("mcp-second")).toBe(secondSession);
+      } finally {
+        metadataFinished.resolve();
+        releaseFinished.resolve();
         if (originalAutolock === undefined) {
           delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
         } else {

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -10,7 +10,6 @@ import {
   MIN_LAUNCH_APP_MCP_TIMEOUT_MS,
   MIN_PREFERENCE_MCP_TIMEOUT_MS,
   MIN_PROVISION_DEVICE_MCP_TIMEOUT_MS,
-  MIN_START_DEVICE_MCP_TIMEOUT_MS,
   MIN_TEARDOWN_DEVICE_MCP_TIMEOUT_MS,
   MIN_UNINSTALL_APP_MCP_TIMEOUT_MS,
   MIN_VIDEO_RECORDING_MCP_TIMEOUT_MS,
@@ -110,9 +109,9 @@ describe("resolveMcpRequestTimeoutMs", () => {
       expected: MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS,
     },
     {
-      name: "startDevice floor when timeoutMs omitted",
+      name: "startDevice default includes cold boot and runner setup",
       tool: "startDevice",
-      expected: MIN_START_DEVICE_MCP_TIMEOUT_MS,
+      expected: 365_000,
     },
     {
       name: "provisionDevice floor when timeoutMs omitted",
@@ -173,10 +172,10 @@ describe("resolveMcpRequestTimeoutMs", () => {
       expected: MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS,
     },
     {
-      name: "raises short startDevice to floor",
+      name: "raises short startDevice transport to default lifecycle budget",
       tool: "startDevice",
       timeoutMs: 60_000,
-      expected: MIN_START_DEVICE_MCP_TIMEOUT_MS,
+      expected: 365_000,
     },
     {
       name: "raises short provisionDevice to floor",
@@ -247,10 +246,10 @@ describe("resolveMcpRequestTimeoutMs", () => {
       expected: 900_000,
     },
     {
-      name: "preserves startDevice above floor",
+      name: "preserves startDevice above default lifecycle budget",
       tool: "startDevice",
-      timeoutMs: 300_000,
-      expected: 300_000,
+      timeoutMs: 400_000,
+      expected: 400_000,
     },
     {
       name: "preserves provisionDevice outer request timeout above the floor",

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -1,3 +1,4 @@
+import { runWithAbortSignal } from "../../src/utils/AbortContext";
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import {
   SessionManager,
@@ -229,6 +230,31 @@ describe("SessionManager", () => {
         repository.finishUpsert();
         await creating;
       } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("fences session publication when persistence outlives acquisition cancellation", async () => {
+      const repository = new DeferredDeviceSessionPersistence();
+      const manager = new SessionManager(fakeTimer, repository);
+      const controller = new AbortController();
+      try {
+        repository.deferNextUpsert();
+        const creating = runWithAbortSignal(controller.signal, () =>
+          manager.createSession("expired-acquisition", "emulator-5554", "android"),
+        );
+        await repository.waitForUpsert();
+        controller.abort(new Error("provision deadline exhausted"));
+        repository.finishUpsert();
+        await expect(creating).rejects.toThrow("provision deadline exhausted");
+        expect(manager.getSession("expired-acquisition")).toBeNull();
+        expect(manager.getSessionForDevice("emulator-5554")).toBeNull();
+        expect(manager.getTerminalReleaseSnapshot("expired-acquisition")).toMatchObject({
+          releaseReason: "session-creation-cancelled",
+          terminal: true,
+        });
+      } finally {
+        repository.finishUpsert();
         manager.stopCleanupTimer();
       }
     });

--- a/test/daemon/socketServerHandshake.integration.test.ts
+++ b/test/daemon/socketServerHandshake.integration.test.ts
@@ -78,6 +78,7 @@ describe("UnixSocketServer version/build-identity handshake gate", () => {
       expect(status.buildId).toBe(daemonIdentity.build.buildId);
       expect(status.entryScript).toBe(daemonIdentity.build.entryScript);
       expect(status.startedAt).toBe(0);
+      expect(status.pid).toBe(process.pid);
     } finally {
       await client.close();
     }

--- a/test/daemon/socketServerHandshake.integration.test.ts
+++ b/test/daemon/socketServerHandshake.integration.test.ts
@@ -9,6 +9,7 @@ import { sendRawSocketRequest } from "./helpers/socketRequest";
 import { FakeTimer } from "../fakes/FakeTimer";
 import type { DaemonResponse } from "../../src/daemon/types";
 import type { DaemonSelfIdentity } from "../../src/daemon/daemonHandshake";
+import { DaemonClient } from "../../src/daemon/client";
 
 function createFakeDaemonState() {
   return {
@@ -68,6 +69,20 @@ describe("UnixSocketServer version/build-identity handshake gate", () => {
     expect(response.success).toBe(true);
   });
 
+  test("identity diagnostics reach a different-build socket owner without executing a tool", async () => {
+    await startServer();
+    const client = new DaemonClient(socketPath);
+    try {
+      const status = await client.getDaemonStatus();
+      expect(status.version).toBe(daemonIdentity.version);
+      expect(status.buildId).toBe(daemonIdentity.build.buildId);
+      expect(status.entryScript).toBe(daemonIdentity.build.entryScript);
+      expect(status.startedAt).toBe(0);
+    } finally {
+      await client.close();
+    }
+  });
+
   test("allows a client whose release version matches (ignoring git stamp)", async () => {
     await startServer();
     const response = await sendRequest(socketPath, { ...PING, clientVersion: "0.0.40" });
@@ -80,6 +95,14 @@ describe("UnixSocketServer version/build-identity handshake gate", () => {
     expect(response.success).toBe(false);
     expect(response.error).toContain("version mismatch");
     expect(response.error).toContain("0.0.39");
+    expect(response.handshakeFailure).toEqual({
+      code: "daemon_identity_mismatch",
+      phase: "daemon-preflight",
+      executionStarted: false,
+      reason: "version",
+      daemon: daemonIdentity,
+      client: { clientVersion: "0.0.39", clientBuildId: undefined, clientEntryScript: undefined },
+    });
   });
 
   test("rejects a same-release client with a different build id", async () => {

--- a/test/db/deviceSessionRepository.integration.test.ts
+++ b/test/db/deviceSessionRepository.integration.test.ts
@@ -137,6 +137,40 @@ describe("DeviceSessionRepository", () => {
     expect(currentRow!.released_at_ms).toBeNull();
   });
 
+  test.each(["released", "expired"] as const)(
+    "delayed autolock metadata cannot reactivate a %s session",
+    async (status) => {
+      await repo.upsertActiveSession({
+        sessionUuid: "cancelled-autolock",
+        deviceId: "emulator-5554",
+        platform: "android",
+        source: "session-manager",
+        createdAtMs: 1000,
+        lastUsedAtMs: 1000,
+        expiresAtMs: 61_000,
+        sessionTimeoutMs: 60_000,
+        heartbeatTimeoutMs: 60_000,
+        hasReceivedHeartbeat: false,
+      });
+      const pendingMetadata = Promise.withResolvers<void>();
+      const lateWrite = pendingMetadata.promise.then(() =>
+        repo.markAutolockSession("cancelled-autolock", {
+          mcpSessionId: "late-mcp",
+          daemonSessionId: "daemon-1",
+          lastUsedAtMs: 3000,
+          expiresAtMs: 63_000,
+        }),
+      );
+      await repo.markReleased("cancelled-autolock", status, 2000, "session-creation-cancelled");
+      const released = await repo.getSession("cancelled-autolock");
+      pendingMetadata.resolve();
+      await lateWrite;
+      expect(await repo.getSession("cancelled-autolock")).toEqual(released);
+      expect(released?.status).toBe(status);
+      expect(released?.release_reason).toBe("session-creation-cancelled");
+    },
+  );
+
   test("late activity does not reactivate released sessions", async () => {
     await repo.upsertActiveSession({
       sessionUuid: "session-1",

--- a/test/features/observe/Window.deadlineAbort.test.ts
+++ b/test/features/observe/Window.deadlineAbort.test.ts
@@ -86,6 +86,7 @@ describe("Window.getActive deadline + abort plumbing (#6289)", () => {
   });
 
   test("applies the default read deadline when the caller supplies none", async () => {
+    window = new Window(device, new FakeAdbClientFactory(fakeAdb), scriptedClock([0]));
     fakeAdb.setDefaultResponse(
       execResult("imeControlTarget in display# 0 Window{1 u0 com.example.app/.Main}"),
     );

--- a/test/scripts/spmRootToolchainWorkflow.test.ts
+++ b/test/scripts/spmRootToolchainWorkflow.test.ts
@@ -82,7 +82,9 @@ describe("root SPM toolchain floor workflow", () => {
             expect(spawnSync("bash", ["-e", "-c", prepare], { cwd: root, env }).status).not.toBe(0);
           }
           expect(spawnSync("bash", ["-e", "-c", cleanup], { cwd: root, env }).status).toBe(0);
-          if (target) expect(existsSync(join(root, target))).toBe(false);
+          if (target) {
+            expect(existsSync(join(root, target))).toBe(false);
+          }
           expect(existsSync(join(root, "unrelated"))).toBe(true);
         } finally {
           rmSync(root, { recursive: true, force: true });

--- a/test/server/deviceTools.platformPreparation.test.ts
+++ b/test/server/deviceTools.platformPreparation.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../../src/utils/deviceTimeouts";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   getAndroidSchema,
@@ -99,7 +100,9 @@ describe("platform device preparation tools", () => {
       simulatorUdid: simulator.deviceId,
       simulatorName: simulator.name,
     });
-    expect(deviceUtils.getExecutedOperations()).toContain(`startDevice:${simulator.name}:120000`);
+    expect(deviceUtils.getExecutedOperations()).toContain(
+      `startDevice:${simulator.name}:${DEFAULT_DEVICE_READY_TIMEOUT_MS}`,
+    );
   });
 
   test("uses explicit boot and automation readiness budgets without accepting matcher inputs", async () => {
@@ -300,7 +303,9 @@ describe("platform device preparation tools", () => {
     await Promise.resolve();
 
     expect(settled).toBe(false);
-    expect(deviceUtils.getExecutedOperations()).not.toContain(`startDevice:${stale.name}:120000`);
+    expect(deviceUtils.getExecutedOperations()).not.toContain(
+      `startDevice:${stale.name}:${DEFAULT_DEVICE_READY_TIMEOUT_MS}`,
+    );
 
     await pool.releaseAdbServerResetCohortReservations(detached.devices);
     await expect(preparation).resolves.toMatchObject({
@@ -383,7 +388,9 @@ describe("platform device preparation tools", () => {
     try {
       await Promise.resolve();
       expect(settled).toBe(false);
-      expect(deviceUtils.getExecutedOperations()).not.toContain(`startDevice:${stale.name}:120000`);
+      expect(deviceUtils.getExecutedOperations()).not.toContain(
+        `startDevice:${stale.name}:${DEFAULT_DEVICE_READY_TIMEOUT_MS}`,
+      );
 
       deviceUtils.setBootedDevices("android", [stale]);
       await pool.releaseAdbServerResetCohortReservations(detached.devices);

--- a/test/server/deviceTools.platformPreparation.test.ts
+++ b/test/server/deviceTools.platformPreparation.test.ts
@@ -21,6 +21,7 @@ import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersiste
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { DeviceBootTimeoutError } from "../../src/utils/deviceBootService";
 
 describe("platform device preparation tools", () => {
   let deviceUtils: FakeDeviceUtils;
@@ -60,6 +61,33 @@ describe("platform device preparation tools", () => {
     return JSON.parse(
       typeof result === "string" ? result : ((result as any).content?.[0]?.text ?? "{}"),
     );
+  }
+
+  for (const [operation, platform, target] of [
+    ["getAndroid", "android", { avdName: "Pixel" }],
+    ["getApple", "ios", { udid: "sim-udid" }],
+  ] as const) {
+    test(`${operation} attributes boot deadlines to the requested acquisition`, async () => {
+      class SlowDiscovery extends FakeDeviceUtils {
+        override async listDeviceImages(selectedPlatform: "android" | "ios") {
+          const images = await super.listDeviceImages(selectedPlatform);
+          timer.advanceTime(11);
+          return images;
+        }
+      }
+      const slow = new SlowDiscovery();
+      slow.setDeviceImages(platform, [
+        { platform, name: "Pixel", deviceId: "sim-udid", isRunning: false },
+      ]);
+      setDeviceToolsDependencies({ deviceManagerFactory: () => slow });
+      const failure = await callTool(operation, { ...target, bootTimeoutMs: 10 }).catch(
+        (error) => error,
+      );
+      expect(failure).toBeInstanceOf(DeviceBootTimeoutError);
+      expect(failure.operation).toBe(operation);
+      expect(failure.message).toContain(`${operation} timeout exhausted`);
+      expect(failure.budgetMs).toBe(10);
+    });
   }
 
   test("advertises the combined preparation budget including omitted defaults", () => {

--- a/test/server/deviceTools.platformPreparation.test.ts
+++ b/test/server/deviceTools.platformPreparation.test.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../../src/utils/deviceTimeouts";
+import {
+  DEFAULT_DEVICE_READY_TIMEOUT_MS,
+  MAX_DEVICE_READY_TIMEOUT_MS,
+} from "../../src/utils/deviceTimeouts";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   getAndroidSchema,
@@ -58,6 +61,40 @@ describe("platform device preparation tools", () => {
       typeof result === "string" ? result : ((result as any).content?.[0]?.text ?? "{}"),
     );
   }
+
+  test("advertises the combined preparation budget including omitted defaults", () => {
+    for (const [name, schema, target] of [
+      ["getAndroid", getAndroidSchema, { avdName: "Pixel" }],
+      ["getApple", getAppleSchema, { udid: "sim-udid" }],
+    ] as const) {
+      const definition = ToolRegistry.getToolDefinitions().find((tool) => tool.name === name)!;
+      const properties = definition.inputSchema.properties as Record<
+        string,
+        { description: string }
+      >;
+      for (const field of ["bootTimeoutMs", "automationReadyTimeoutMs"]) {
+        expect(properties[field].description).toContain(
+          `bootTimeoutMs + automationReadyTimeoutMs must be <= ${MAX_DEVICE_READY_TIMEOUT_MS}`,
+        );
+        expect(properties[field].description).toContain("including defaults for omitted fields");
+      }
+      const maximumWithDefaultBoot = MAX_DEVICE_READY_TIMEOUT_MS - DEFAULT_DEVICE_READY_TIMEOUT_MS;
+      expect(properties.automationReadyTimeoutMs.description).toContain(
+        `when bootTimeoutMs is omitted, this must be <= ${maximumWithDefaultBoot}`,
+      );
+      expect(
+        schema.safeParse({ ...target, automationReadyTimeoutMs: maximumWithDefaultBoot }).success,
+      ).toBe(true);
+      expect(
+        schema.safeParse({ ...target, automationReadyTimeoutMs: maximumWithDefaultBoot + 1 })
+          .success,
+      ).toBe(false);
+      expect(
+        schema.safeParse({ ...target, bootTimeoutMs: 90_000, automationReadyTimeoutMs: 800_000 })
+          .success,
+      ).toBe(true);
+    }
+  });
 
   test("getAndroid returns the AVD to ADB serial and port mapping", async () => {
     const emulator: BootedDevice = {

--- a/test/server/deviceTools.provisionDevice.test.ts
+++ b/test/server/deviceTools.provisionDevice.test.ts
@@ -2281,6 +2281,121 @@ describe("provisionDevice handler", () => {
     expect(operationStore.failCalls).toBe(0);
   });
 
+  test.each(["android", "ios"] as const)(
+    "preserves %s boot timeout classification",
+    async (platform) => {
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const provisioned = provisionedTestDevice(platform, false);
+      exactProvisioner.provision = async () => provisioned;
+      deviceManager.setDeviceImages(platform, [provisioned.device]);
+      deviceManager.waitForDeviceReady = async (_device, _timeout, _handle, signal) => {
+        return new Promise((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+        });
+      };
+      setDeviceToolsDependencies({ timer });
+      const response = await ToolRegistry.getTool("provisionDevice")!.handler({
+        ...provisionTestArgs(platform, `boot-timeout-${platform}`),
+        timeoutMs: 180_000,
+      });
+      const payload = JSON.parse((response as any).content[0].text);
+      expect(payload.error.code).toBe("timeout");
+      expect(payload.error.message).toContain("provisionDevice timeout exhausted");
+      expect(payload.error.message).toContain("waiting for device boot readiness");
+    },
+  );
+
+  test.each([false, true])(
+    "a delayed reservation release preserves acquisition outcome (failure=%s)",
+    async (failReadiness) => {
+      const timer = new FakeTimer();
+      const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+      sessionManager.stopCleanupTimer();
+      const pool = new DevicePool(
+        sessionManager,
+        "daemon-session",
+        timer,
+        undefined,
+        deviceManager,
+      );
+      const booted = {
+        name: "phone-api-36-a",
+        platform: "android" as const,
+        deviceId: "emulator-5554",
+      };
+      deviceManager.setBootedDevices("android", [booted]);
+      await pool.initializeWithDevices([booted]);
+      DaemonState.getInstance().initialize(sessionManager, pool);
+      exactProvisioner.provision = async () => provisionedTestDevice("android", false);
+      let releaseRequested = false;
+      const released = Promise.withResolvers<void>();
+      pool.reserveDeviceForReadiness = async () =>
+        Object.assign(
+          async () => {
+            releaseRequested = true;
+            await released.promise;
+          },
+          { owner: Symbol("test-reservation") },
+        );
+      setDeviceToolsDependencies({
+        timer,
+        ensureCtrlProxyReady: async () => {
+          if (failReadiness) {
+            throw new Error("original readiness failure");
+          }
+        },
+      });
+      try {
+        const response = await ToolRegistry.getTool("provisionDevice")!.handler({
+          ...provisionTestArgs("android", `delayed-release-${failReadiness}`),
+          timeoutMs: 1_000,
+        });
+        const payload = JSON.parse((response as any).content[0].text);
+        expect(releaseRequested).toBe(true);
+        if (failReadiness) {
+          expect(payload.error.message).toContain("original readiness failure");
+          expect(sessionManager.getAllSessionIds()).toEqual([]);
+        } else {
+          expect(payload.sessionUuid).toBeDefined();
+          expect(sessionManager.getSession(payload.sessionUuid)?.assignedDevice).toBe(
+            booted.deviceId,
+          );
+        }
+        expect(deviceManager.wasMethodCalled("killDevice")).toBe(false);
+      } finally {
+        released.resolve();
+      }
+    },
+  );
+
+  test("bounds a pending final session binding by the provision deadline", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    sessionManager.stopCleanupTimer();
+    const pool = new DevicePool(sessionManager, "daemon-session", timer, undefined, deviceManager);
+    const booted = {
+      name: "phone-api-36-a",
+      platform: "android" as const,
+      deviceId: "emulator-5554",
+    };
+    deviceManager.setBootedDevices("android", [booted]);
+    await pool.initializeWithDevices([booted]);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    exactProvisioner.provision = async () => provisionedTestDevice("android", false);
+    pool.bindOrReuseDeviceSession = async () => await new Promise<string>(() => {});
+    setDeviceToolsDependencies({ timer, ensureCtrlProxyReady: async () => {} });
+    const response = await ToolRegistry.getTool("provisionDevice")!.handler({
+      ...provisionTestArgs("android", "pending-final-binding"),
+      timeoutMs: 1_000,
+    });
+    const payload = JSON.parse((response as any).content[0].text);
+    expect(payload.error.code).toBe("timeout");
+    expect(payload.error.message).toContain("binding the device session");
+    expect(sessionManager.getAllSessionIds()).toEqual([]);
+  });
+
   test("enforces timeoutMs across exact provisioning before boot begins", async () => {
     const timer = new FakeTimer();
     let provisionSignal: AbortSignal | undefined;

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -21,10 +21,7 @@ import {
   clearDirectSessionDevices,
   resolveDirectSessionDevice,
 } from "../../src/server/directSessionDeviceRegistry";
-import {
-  DEFAULT_DEVICE_READY_TIMEOUT_MS,
-  MAX_DEVICE_READY_TIMEOUT_MS,
-} from "../../src/utils/deviceTimeouts";
+import { MAX_DEVICE_READY_TIMEOUT_MS } from "../../src/utils/deviceTimeouts";
 import {
   MAX_RUNNER_READINESS_TIMEOUT_MS,
   MIN_RUNNER_READINESS_TIMEOUT_MS,
@@ -647,7 +644,7 @@ describe("startDevice handler", () => {
     expect(result.deviceId).toBe("emulator-5556");
     expect(result.sessionUuid).toBe("owner-session");
     expect(fakeDeviceUtils.getExecutedOperations()).toContain("killDevice:Unknown (emulator-5554)");
-    expect(fakeDeviceUtils.getExecutedOperations()).toContain("startDevice:Pixel_7_API_34:120000");
+    expect(fakeDeviceUtils.getExecutedOperations()).toContain("startDevice:Pixel_7_API_34:360000");
     expect(pool.getDevice("emulator-5556")).toMatchObject({
       sessionId: "owner-session",
       status: "busy",
@@ -1501,11 +1498,9 @@ describe("startDevice handler", () => {
     const result = await callStartDevice({ platform: "ios" });
 
     expect(result.source).toBe("cold-boot");
+    expect(fakeDeviceUtils.getExecutedOperations()).toContain(`startDevice:iPhone 15:360000`);
     expect(fakeDeviceUtils.getExecutedOperations()).toContain(
-      `startDevice:iPhone 15:${DEFAULT_DEVICE_READY_TIMEOUT_MS}`,
-    );
-    expect(fakeDeviceUtils.getExecutedOperations()).toContain(
-      `waitForDeviceReady:iPhone 15:${DEFAULT_DEVICE_READY_TIMEOUT_MS}`,
+      `waitForDeviceReady:iPhone 15:360000`,
     );
   });
 

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -21,14 +21,13 @@ import {
   DeviceLockStatesResourceContent,
   readinessFromServiceStatus,
   queryDeviceServiceStatus,
+  type AndroidServiceStatusLookup,
 } from "../../../src/server/bootedDeviceResources";
 import { BootedDevice, Platform } from "../../../src/models";
 import { DaemonState } from "../../../src/daemon/daemonState";
 import { DevicePool } from "../../../src/daemon/devicePool";
 import { DeviceSessionRegistry } from "../../../src/daemon/deviceSessionRegistry";
 import { SessionManager } from "../../../src/daemon/sessionManager";
-import { AndroidCtrlProxyClient } from "../../../src/features/observe/android/AndroidCtrlProxyClient";
-import { AndroidCtrlProxyManager } from "../../../src/utils/CtrlProxyManager";
 import { z } from "zod/v4";
 
 describe("MCP Booted Device Resources", () => {
@@ -589,6 +588,48 @@ describe("MCP Booted Device Resources", () => {
       }
     });
 
+    test("preserves pool counts until every iOS discovery source completes", async () => {
+      const physicalDevice = { ...mockIosDevice2, deviceId: "00008110-001234567890001E" };
+      fakeDeviceUtils.setBootedDevices("ios", [mockIosDevice1, physicalDevice]);
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const sessions = new SessionManager(timer, new FakeDeviceSessionPersistence());
+      const { FakeInstalledAppsRepository } =
+        await import("../../fakes/FakeInstalledAppsRepository");
+      const pool = new DevicePool(
+        sessions,
+        "test-daemon",
+        timer,
+        new FakeInstalledAppsRepository(),
+        fakeDeviceUtils,
+      );
+      await pool.initializeWithDevices([physicalDevice, mockIosDevice1]);
+      await pool.assignDeviceToSession("physical-session", "ios");
+      fakeDeviceUtils.setBootedDevices("ios", [mockIosDevice1]);
+      fakeDeviceUtils.failedSources.add("ios-physical");
+      DaemonState.getInstance().initialize(sessions, pool);
+      const { client } = fixture.getContext();
+      const read = async () => {
+        const response = await client.request(
+          { method: "resources/read", params: { uri: "automobile:devices/booted/ios" } },
+          z.object({ contents: z.array(z.object({ text: z.string() })) }),
+        );
+        return JSON.parse(response.contents[0].text) as BootedDevicesResourceContent;
+      };
+      try {
+        const partial = await read();
+        expect(partial.observationComplete).toBe(false);
+        expect(partial.devices.map((device) => device.deviceId)).toEqual([mockIosDevice1.deviceId]);
+        expect(partial.poolStatus).toMatchObject({ total: 2, idle: 1, assigned: 1 });
+        fakeDeviceUtils.failedSources.clear();
+        const complete = await read();
+        expect(complete.observationComplete).toBe(true);
+        expect(complete.poolStatus?.total).toBe(1);
+      } finally {
+        sessions.stopCleanupTimer();
+      }
+    });
+
     test("should include pool status when daemon is initialized", async function () {
       fakeDeviceUtils.setBootedDevices("android", [mockAndroidDevice1, mockAndroidDevice2]);
 
@@ -1140,36 +1181,27 @@ describe("booted device readiness", () => {
   });
 
   test("reads Android connection transitions without creating a connection", async () => {
-    let connected = true;
-    const existing = spyOn(AndroidCtrlProxyClient, "getExistingInstance").mockReturnValue({
-      isConnected: () => connected,
-    } as AndroidCtrlProxyClient);
-    const create = spyOn(AndroidCtrlProxyClient, "getInstance").mockImplementation(() => {
-      throw new Error("Inventory must not create a client");
-    });
-    const manager = spyOn(AndroidCtrlProxyManager, "getInstance").mockReturnValue({
-      isInstalled: async () => true,
-      isEnabled: async () => true,
-      getInstalledApkSha256: async () => null,
-    } as AndroidCtrlProxyManager);
-    try {
-      const device = {
-        name: "Pixel",
-        platform: "android" as const,
-        deviceId: "emulator-5554",
-        source: "local" as const,
-      };
-      expect((await queryDeviceServiceStatus(device))?.running).toBe(true);
-      connected = false;
-      expect((await queryDeviceServiceStatus(device))?.running).toBe(false);
-      existing.mockReturnValue(null);
-      expect((await queryDeviceServiceStatus(device))?.running).toBe(false);
-      expect(create).not.toHaveBeenCalled();
-    } finally {
-      existing.mockRestore();
-      create.mockRestore();
-      manager.mockRestore();
-    }
+    const connections = new Set(["emulator-5554"]);
+    const lookup: AndroidServiceStatusLookup = {
+      getManager: () => ({
+        isInstalled: async () => true,
+        isEnabled: async () => true,
+        getInstalledApkSha256: async () => null,
+      }),
+      isConnected: (deviceId) => connections.has(deviceId),
+    };
+    const device = {
+      name: "Pixel",
+      platform: "android" as const,
+      deviceId: "emulator-5554",
+      source: "local" as const,
+    };
+    expect((await queryDeviceServiceStatus(device, lookup))?.running).toBe(true);
+    connections.clear();
+    expect((await queryDeviceServiceStatus(device, lookup))?.running).toBe(false);
+    expect(
+      (await queryDeviceServiceStatus({ ...device, deviceId: "unseen" }, lookup))?.running,
+    ).toBe(false);
   });
 
   test("reports an unavailable Android service as not ready", () => {

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -20,12 +20,15 @@ import {
   BootedDevicesResourceContent,
   DeviceLockStatesResourceContent,
   readinessFromServiceStatus,
+  queryDeviceServiceStatus,
 } from "../../../src/server/bootedDeviceResources";
 import { BootedDevice, Platform } from "../../../src/models";
 import { DaemonState } from "../../../src/daemon/daemonState";
 import { DevicePool } from "../../../src/daemon/devicePool";
 import { DeviceSessionRegistry } from "../../../src/daemon/deviceSessionRegistry";
 import { SessionManager } from "../../../src/daemon/sessionManager";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android/AndroidCtrlProxyClient";
+import { AndroidCtrlProxyManager } from "../../../src/utils/CtrlProxyManager";
 import { z } from "zod/v4";
 
 describe("MCP Booted Device Resources", () => {
@@ -87,6 +90,21 @@ describe("MCP Booted Device Resources", () => {
     }
     // Reset to default device manager
     setDeviceManager(null);
+  });
+
+  test("marks iOS physical discovery failure incomplete even when simctl succeeds", async () => {
+    fakeDeviceUtils.failedSources.add("ios-physical");
+    const { client } = fixture.getContext();
+    const result = await client.request(
+      {
+        method: "resources/read",
+        params: { uri: "automobile:devices/booted/ios" },
+      },
+      z.object({ contents: z.array(z.object({ text: z.string() })) }),
+    );
+    const data: BootedDevicesResourceContent = JSON.parse(result.contents[0].text);
+    expect(data.observationComplete).toBe(false);
+    expect(data.platformObservations.ios?.observationComplete).toBe(false);
   });
 
   describe("Resource Listing", () => {
@@ -1092,8 +1110,44 @@ describe("booted device readiness", () => {
     isCompatible: true,
   };
 
-  test("keeps Android readiness unknown until the live runner is verified", () => {
-    expect(readinessFromServiceStatus("android", compatibleService)).toEqual({ state: "unknown" });
+  test("reports a connected Android runner as ready and an unobserved runner as unknown", () => {
+    expect(readinessFromServiceStatus("android", compatibleService)).toEqual({ state: "ready" });
+    expect(readinessFromServiceStatus("android", { ...compatibleService, running: false })).toEqual(
+      { state: "unknown" },
+    );
+  });
+
+  test("reads Android connection transitions without creating a connection", async () => {
+    let connected = true;
+    const existing = spyOn(AndroidCtrlProxyClient, "getExistingInstance").mockReturnValue({
+      isConnected: () => connected,
+    } as AndroidCtrlProxyClient);
+    const create = spyOn(AndroidCtrlProxyClient, "getInstance").mockImplementation(() => {
+      throw new Error("Inventory must not create a client");
+    });
+    const manager = spyOn(AndroidCtrlProxyManager, "getInstance").mockReturnValue({
+      isInstalled: async () => true,
+      isEnabled: async () => true,
+      getInstalledApkSha256: async () => null,
+    } as AndroidCtrlProxyManager);
+    try {
+      const device = {
+        name: "Pixel",
+        platform: "android" as const,
+        deviceId: "emulator-5554",
+        source: "local" as const,
+      };
+      expect((await queryDeviceServiceStatus(device))?.running).toBe(true);
+      connected = false;
+      expect((await queryDeviceServiceStatus(device))?.running).toBe(false);
+      existing.mockReturnValue(null);
+      expect((await queryDeviceServiceStatus(device))?.running).toBe(false);
+      expect(create).not.toHaveBeenCalled();
+    } finally {
+      existing.mockRestore();
+      create.mockRestore();
+      manager.mockRestore();
+    }
   });
 
   test("reports an unavailable Android service as not ready", () => {

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -105,6 +105,28 @@ describe("MCP Booted Device Resources", () => {
     const data: BootedDevicesResourceContent = JSON.parse(result.contents[0].text);
     expect(data.observationComplete).toBe(false);
     expect(data.platformObservations.ios?.observationComplete).toBe(false);
+    expect(data.sourceObservations).toEqual({
+      "ios-simulator": { observationComplete: true },
+      "ios-physical": { observationComplete: false },
+    });
+  });
+
+  test("preserves physical iOS completeness when simulator discovery fails", async () => {
+    fakeDeviceUtils.failedSources.add("ios-simulator");
+    const { client } = fixture.getContext();
+    const result = await client.request(
+      {
+        method: "resources/read",
+        params: { uri: "automobile:devices/booted/ios" },
+      },
+      z.object({ contents: z.array(z.object({ text: z.string() })) }),
+    );
+    const data: BootedDevicesResourceContent = JSON.parse(result.contents[0].text);
+    expect(data.observationComplete).toBe(false);
+    expect(data.sourceObservations).toEqual({
+      "ios-simulator": { observationComplete: false },
+      "ios-physical": { observationComplete: true },
+    });
   });
 
   describe("Resource Listing", () => {

--- a/test/utils/RunnerReadinessService.test.ts
+++ b/test/utils/RunnerReadinessService.test.ts
@@ -1091,6 +1091,45 @@ describe("RunnerReadinessService", () => {
     expect(restartedClient.healthCalls).toBe(1);
   });
 
+  for (const skipCtrlProxyDownload of [false, true]) {
+    test(`uses the final iOS runner port after ${skipCtrlProxyDownload ? "cached start" : "setup"}`, async () => {
+      const iosManager = new FakeIosManager();
+      const staleClient = new FakeReadinessClient();
+      staleClient.connected = false;
+      // The stale port could belong to another healthy runner. Never probe it.
+      const readyClient = new FakeReadinessClient();
+      const requestedPorts: number[] = [];
+      const timer = new FakeTimer();
+      const reallocate = async () => {
+        timer.advanceTime(90_000);
+        iosManager.servicePort = 9_876;
+      };
+      iosManager.onSetup = reallocate;
+      iosManager.onStart = reallocate;
+      const { service } = createService({
+        timer,
+        iosManager,
+        getIosClient: (_device, port) => {
+          requestedPorts.push(port);
+          return port === 9_876 ? readyClient : staleClient;
+        },
+      });
+
+      await service.ensureReady({
+        device: iosDevice,
+        requestedIdentity: "platform=ios deviceId=IOS-UDID",
+        totalDeadlineMs: 180_000,
+        readinessTimeoutMs: 30_000,
+        skipCtrlProxyDownload,
+      });
+
+      expect(requestedPorts).toEqual([8_765, 9_876]);
+      expect(staleClient.connectionCalls).toBe(0);
+      expect(staleClient.healthCalls).toBe(0);
+      expect(readyClient.healthCalls).toBe(1);
+    });
+  }
+
   test("cancels the iOS force-restart when its readiness budget expires", async () => {
     const timer = new FakeTimer();
     const iosManager = new FakeIosManager();

--- a/test/utils/deviceBootService.test.ts
+++ b/test/utils/deviceBootService.test.ts
@@ -1,6 +1,10 @@
 import type { ChildProcess } from "node:child_process";
 import { describe, expect, it } from "bun:test";
-import { DeviceBootService, type DeviceBootProgress } from "../../src/utils/deviceBootService";
+import {
+  DeviceBootService,
+  DeviceBootTimeoutError,
+  type DeviceBootProgress,
+} from "../../src/utils/deviceBootService";
 import { FakeDeviceMatcher } from "../fakes/FakeDeviceMatcher";
 import { DefaultDeviceMatcher } from "../../src/utils/deviceMatcher";
 import { pickAndroidSystemImage } from "../../src/utils/deviceProvisioning";
@@ -42,6 +46,57 @@ function service(
 }
 
 describe("DeviceBootService", () => {
+  it.each([90_000, 180_000])(
+    "preserves the provision budget through a %ims cold boot",
+    async (bootMs) => {
+      const devices = new FakeDeviceUtils();
+      const matcher = new FakeDeviceMatcher();
+      const timer = new FakeTimer();
+      devices.setDeviceImages("android", [image]);
+      matcher.setImageResult(image);
+      const original = devices.waitForDeviceReady.bind(devices);
+      devices.waitForDeviceReady = async (...args) => {
+        timer.advanceTime(bootMs);
+        return original(...args);
+      };
+      const result = await service(devices, matcher, undefined, timer).boot({
+        platform: "android",
+        operationName: "provisionDevice",
+        timeoutMs: 480_000,
+      });
+      expect(result.source).toBe("cold-boot");
+      expect(timer.now()).toBe(bootMs);
+    },
+  );
+
+  it("reports the provision operation and boot phase on its absolute deadline", async () => {
+    const devices = new FakeDeviceUtils();
+    const matcher = new FakeDeviceMatcher();
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    devices.setDeviceImages("android", [image]);
+    matcher.setImageResult(image);
+    devices.waitForDeviceReady = async (_device, _timeout, _handle, signal) => {
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    };
+    const error = await service(devices, matcher, undefined, timer)
+      .boot({
+        platform: "android",
+        operationName: "provisionDevice",
+        timeoutMs: 180_000,
+      })
+      .catch((error: unknown) => error);
+    expect(error).toBeInstanceOf(DeviceBootTimeoutError);
+    expect(error).toMatchObject({
+      code: "timeout",
+      operation: "provisionDevice",
+      phase: "waiting for device boot readiness",
+      budgetMs: 180_000,
+    });
+  });
+
   it("cold-boots and awaits readiness without MCP-only side effects", async () => {
     const devices = new FakeDeviceUtils();
     const matcher = new FakeDeviceMatcher();
@@ -817,7 +872,7 @@ describe("DeviceBootService", () => {
     expect(result.sourceImage).toBeUndefined();
     expect(result.processHandle).toBeUndefined();
     expect(result.processId).toBeUndefined();
-    expect(devices.getExecutedOperations()).toContain("waitForDeviceReady:Pixel_9_API_35:120000");
+    expect(devices.getExecutedOperations()).toContain("waitForDeviceReady:Pixel_9_API_35:180000");
   });
 
   it("cancels a failed cold boot through its launch handle", async () => {

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -715,6 +715,34 @@ describe("SimCtlClient boot self-verification", () => {
     expect(harness.shutdownInvocations()).toBe(0);
   });
 
+  test("does not spend the cold-boot budget focusing an already booted simulator", async () => {
+    let openSignal: AbortSignal | undefined;
+    const harness = createConcurrentStartHarness(
+      () => Promise.resolve(createExecResult("", "")),
+      bootedSimulatorListResult,
+      {
+        openSimulatorApp: (signal) => {
+          openSignal = signal;
+          return rejectWhenAborted(signal);
+        },
+      },
+    );
+    let completed = false;
+    const start = harness
+      .createClient()
+      .startSimulator(UDID, 180_000)
+      .then(() => {
+        completed = true;
+      });
+    await waitForCondition(() => openSignal !== undefined, "Simulator.app focus");
+    harness.timer.advanceTime(1_000);
+    await drainMicrotasks();
+    expect(completed).toBe(true);
+    expect(openSignal?.aborted).toBe(true);
+    expect(harness.shutdownInvocations()).toBe(0);
+    await start;
+  });
+
   test("does not reuse stale success after an idle start is shut down", async () => {
     const harness = createConcurrentStartHarness(() => Promise.resolve(createExecResult("", "")));
     const firstHandle = await harness.createClient().startSimulator(UDID, 5_000);


### PR DESCRIPTION
Device acquisition in 0.0.70 can report usable Android devices as unready, time out while checking an old iOS runner port, and show conflicting inventory after incomplete discovery. A reachable older daemon can also bypass reconciliation when its PID record is missing.

This change reads daemon identity from the serving socket, preserves pre-dispatch version/build errors, and reconciles only before a device mutation is admitted. Android inventory uses existing live connection evidence; desktop inventory retains incomplete snapshots and resolves stable device identities without guessing between ambiguous images. iOS readiness follows the runner's final port and bounds optional window focus independently of cold boot.

Acquisition defaults now allow 180 seconds for OS boot and 180 seconds for runner provisioning. Explicit caller budgets remain bounded. Provisioning retains typed timeout diagnostics and cancels queued or late session publication with owner checks, while delayed reservation release cannot turn a successful acquisition into destructive rollback.

The named acquisition tools advertise the combined boot/readiness maximum, including defaults, and retain that validation after extending their shared schema. The platform-preparation suite passes all 15 tests, including both tools' advertised contract and runtime budget boundaries.

Inventory preserves positive observations from healthy platforms when another platform is unavailable, and uses platform-scoped UI keys while retaining raw daemon command identifiers. Released database rows cannot be reactivated by delayed autolock metadata. PID metadata is reused only when the serving process PID, known build, and entry-script identity agree.

Inventory also exposes source-level completeness so a failed physical iOS scan cannot hide simulator images. The desktop consumer falls back to platform/global completeness for older daemons. All 77 inventory/parser/Compose UI tests and 33 booted-device resource tests pass. A pre-existing CI deadline test now uses its existing deterministic clock; its suite passed ten repetitions (110 test executions).

Canceled autolock metadata persistence now releases the pool assignment mutex without waiting for database writes and preserves replacement-session ownership. Explicit refresh failures retain cached inventory, selection, and filters. Partial-discovery warnings remain visible even without cached rows, and pool counts retain tracked devices until the platform observation is complete. Android connection lookup and pool metadata tests use narrow injected fakes. Follow-up validation passed 79 Kotlin tests, 172 pool tests, 34 resource tests, build, lint, typecheck, Detekt, and formatting.

Validation: 1,036 TypeScript lifecycle/database/CLI/socket tests, the client request-timeout suite, and 75 Kotlin inventory/parser/Compose UI tests passed. Build, lint, Detekt, all 13 execution-boundary checks, formatting, and the TypeScript baseline gate passed. Generated tool schemas were refreshed. Live read-only discovery verified an Android emulator and iOS simulator; cold-boot and timeout regressions were exercised with fakes and fake clocks, not a live cold-boot cycle. Existing interfaces, identity fields, cancellation context, and installed Zod were reused; no dependency was added. CI exposed two client-timeout fixtures that still advanced the old deadline; those now exercise the new default and caller override.
