### PR TITLE
fix: preserve gated tool discovery after device acquisition

### DIFF
--- a/src/server/NetworkState.ts
+++ b/src/server/NetworkState.ts
@@ -315,20 +315,20 @@ export class NetworkState {
 
     try {
       // Always notify the live traffic resource
-      this.notifier.notifyResourceUpdated("automobile://network/traffic/live");
+      this.notifier.notifyResourceUpdated("automobile:network/traffic/live");
 
       // Notify errors resource if any errors in batch
       if (hasErrors) {
-        this.notifier.notifyResourceUpdated("automobile://network/traffic/errors");
+        this.notifier.notifyResourceUpdated("automobile:network/traffic/errors");
       }
 
       // Notify slow resource if any slow requests in batch
       if (hasSlow) {
-        this.notifier.notifyResourceUpdated("automobile://network/traffic/slow");
+        this.notifier.notifyResourceUpdated("automobile:network/traffic/slow");
       }
 
       // Stats resource always gets notified (it computes aggregates on read)
-      this.notifier.notifyResourceUpdated("automobile://network/stats");
+      this.notifier.notifyResourceUpdated("automobile:network/stats");
     } catch (e) {
       logger.error(`[NetworkState] Failed to send notifications: ${e}`);
     }

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -75,6 +75,7 @@ import { getDbWriteBarrier } from "../db/dbWriteBarrier";
 import { isAdbMissingDeviceError } from "../utils/android-cmdline-tools/AdbDeviceHealth";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { combineAbortSignals, getAbortSignal, runWithAbortSignal } from "../utils/AbortContext";
+import { ResourceRegistry } from "./resourceRegistry";
 import { getToolSelectionContext } from "../features/toolSelection/toolSelectionContext";
 import { executionTracker } from "./executionTracker";
 import {
@@ -4023,6 +4024,33 @@ async function resolveAndroidStartStableDeviceLifecycleTarget(
   return { platform: "android", stableId: [...stableIds][0] };
 }
 
+function availableDeviceResourceNote() {
+  const listedResourceUris = new Set(
+    getToolSelectionContext()?.routingSessionUuid
+      ? ResourceRegistry.getResourceDefinitions().map((resource) => resource.uri)
+      : [],
+  );
+  const resourceUris = [
+    BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED,
+    `${BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED}/android`,
+    `${BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED}/ios`,
+    DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES,
+    `${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}/android`,
+    `${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}/ios`,
+  ];
+  const availableResourceUris = resourceUris.filter((uri) => listedResourceUris.has(uri));
+  return {
+    message:
+      "Acquire a booted device with getAndroid { deviceId } or getApple { deviceId }. " +
+      (availableResourceUris.length > 0
+        ? "For available images and richer per-device detail, read these MCP resources:"
+        : "After acquiring a device, refresh resources/list to discover available images and richer per-device detail."),
+    resources: availableResourceUris,
+    uriPrefix:
+      "All resource URIs use the 'automobile:' prefix. URIs like 'android://devices' are not supported.",
+  };
+}
+
 export function registerDeviceTools() {
   // List AVDs handler
   const listDeviceImagesHandler = async (args: ListDeviceImagesArgs) => {
@@ -4108,21 +4136,7 @@ export function registerDeviceTools() {
       devices,
       count: devices.length,
       discovery,
-      note: {
-        message:
-          "Acquire a booted device with getAndroid { deviceId } or getApple { deviceId }. " +
-          "For available (not-yet-booted) images and richer per-device detail, read these MCP resources:",
-        resources: [
-          BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED,
-          `${BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED}/android`,
-          `${BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED}/ios`,
-          DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES,
-          `${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}/android`,
-          `${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}/ios`,
-        ],
-        uriPrefix:
-          "All resource URIs use the 'automobile:' prefix. URIs like 'android://devices' are not supported.",
-      },
+      note: availableDeviceResourceNote(),
     });
   };
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -4026,9 +4026,7 @@ async function resolveAndroidStartStableDeviceLifecycleTarget(
 
 function availableDeviceResourceNote() {
   const listedResourceUris = new Set(
-    getToolSelectionContext()?.routingSessionUuid
-      ? ResourceRegistry.getResourceDefinitions().map((resource) => resource.uri)
-      : [],
+    ResourceRegistry.getResourceDefinitions().map((resource) => resource.uri),
   );
   const resourceUris = [
     BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED,
@@ -4044,7 +4042,7 @@ function availableDeviceResourceNote() {
       "Acquire a booted device with getAndroid { deviceId } or getApple { deviceId }. " +
       (availableResourceUris.length > 0
         ? "For available images and richer per-device detail, read these MCP resources:"
-        : "After acquiring a device, refresh resources/list to discover available images and richer per-device detail."),
+        : "Refresh resources/list to discover available images and richer per-device detail."),
     resources: availableResourceUris,
     uriPrefix:
       "All resource URIs use the 'automobile:' prefix. URIs like 'android://devices' are not supported.",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -884,30 +884,36 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         !result?.isError &&
         getDeviceSessionIdFromResult(result)
       ) {
-        const listed = new Set((await listSessionTools()).tools.map((tool) => tool.name));
-        const gatedTools = ToolRegistry.getAllTools()
-          .filter(
-            (tool) => ToolRegistry.isUserConfigurableTool(tool.name) && !listed.has(tool.name),
-          )
-          .map((tool) => tool.name)
-          .sort();
-        let enriched = false;
-        result = {
-          ...result,
-          content: result.content.map((item: { type: string; text?: string }) => {
-            if (enriched || item.type !== "text" || typeof item.text !== "string") {
-              return item;
-            }
-            enriched = true;
-            return {
-              ...item,
-              text: stringifyToolResponse({ ...JSON.parse(item.text), gatedTools }),
-            };
-          }),
-          ...(result.structuredContent
-            ? { structuredContent: { ...result.structuredContent, gatedTools } }
-            : {}),
-        };
+        try {
+          const listed = new Set((await listSessionTools()).tools.map((tool) => tool.name));
+          const gatedTools = ToolRegistry.getAllTools()
+            .filter(
+              (tool) => ToolRegistry.isUserConfigurableTool(tool.name) && !listed.has(tool.name),
+            )
+            .map((tool) => tool.name)
+            .sort();
+          let enriched = false;
+          result = {
+            ...result,
+            content: result.content.map((item: { type: string; text?: string }) => {
+              if (enriched || item.type !== "text" || typeof item.text !== "string") {
+                return item;
+              }
+              enriched = true;
+              return {
+                ...item,
+                text: stringifyToolResponse({ ...JSON.parse(item.text), gatedTools }),
+              };
+            }),
+            ...(result.structuredContent
+              ? { structuredContent: { ...result.structuredContent, gatedTools } }
+              : {}),
+          };
+        } catch (error) {
+          // Acquisition already succeeded. Preserve its session handle so the
+          // proxy can bind and heartbeat it even if optional discovery fails.
+          logger.warn("[MCP] Could not enrich acquisition with gated tools", { tool: name, error });
+        }
       }
       const isRecordingIdCleanup =
         name === "videoRecording" &&

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -797,7 +797,21 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         : undefined;
 
     let cleanupAcquisitionRelease: (() => void) | undefined;
+    const releasedAcquisitionSessions = new Set<string>();
     try {
+      if (isDeviceSessionAcquisitionTool(name)) {
+        // A handler can mint and release a session before returning its UUID.
+        // Retain release identities for this call only, through publication.
+        const onSessionReleased = (sessionUuid: string) => {
+          releasedAcquisitionSessions.add(sessionUuid);
+        };
+        const unregister = ToolRegistry.registerSessionBindingReleaseHandler({ onSessionReleased });
+        const unsubscribe = SessionReleaseBroadcaster.subscribe(onSessionReleased);
+        cleanupAcquisitionRelease = () => {
+          unregister();
+          unsubscribe();
+        };
+      }
       if (
         daemonMode &&
         providedSessionUuid &&
@@ -875,20 +889,6 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       const acquiredSessionUuid = isDeviceSessionAcquisitionTool(name)
         ? getDeviceSessionIdFromResult(result)
         : undefined;
-      let acquiredSessionReleased = false;
-      if (acquiredSessionUuid) {
-        const onSessionReleased = (releasedSessionUuid: string) => {
-          if (releasedSessionUuid === acquiredSessionUuid) {
-            acquiredSessionReleased = true;
-          }
-        };
-        const unregister = ToolRegistry.registerSessionBindingReleaseHandler({ onSessionReleased });
-        const unsubscribe = SessionReleaseBroadcaster.subscribe(onSessionReleased);
-        cleanupAcquisitionRelease = () => {
-          unregister();
-          unsubscribe();
-        };
-      }
       // Evaluate the returned session directly: a seeded transport may retain
       // its old binding, and a concurrent acquisition may publish another one.
       // Reuse the same route/label union as tools/list without publishing yet.
@@ -985,7 +985,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       const response = stripToolResultStructuredContent(result, omissionReason);
       // Publish only after all asynchronous enrichment finishes, so concurrent
       // direct acquisitions bind in response order. Keep this path synchronous.
-      if (acquiredSessionReleased) {
+      if (acquiredSessionUuid && releasedAcquisitionSessions.has(acquiredSessionUuid)) {
         throw new ActionableError(
           `Device session ${acquiredSessionUuid} was released during acquisition. Call ${name} again to acquire a device.`,
         );

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -39,6 +39,32 @@ import {
 // Import the resource registry
 import { ResourceRegistry } from "./resourceRegistry";
 
+async function awaitWithCancellation<T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  if (signal.aborted) {
+    promise.catch(() => undefined);
+    throw new ActionableError("MCP request was cancelled during acquisition.");
+  }
+  let onAbort: (() => void) | undefined;
+  const cancellation = new Promise<never>((_, reject) => {
+    onAbort = () => reject(new ActionableError("MCP request was cancelled during acquisition."));
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+  promise.catch(() => undefined);
+  try {
+    return await Promise.race([promise, cancellation]);
+  } finally {
+    if (onAbort) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  }
+}
+
 // Import all tool registration functions
 import { registerObserveTools } from "./observeTools";
 import { registerInteractionTools } from "./interactionTools";
@@ -889,6 +915,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       const acquiredSessionUuid = isDeviceSessionAcquisitionTool(name)
         ? getDeviceSessionIdFromResult(result)
         : undefined;
+      let acquisitionEnrichmentCancelled = false;
       // Evaluate the returned session directly: a seeded transport may retain
       // its old binding, and a concurrent acquisition may publish another one.
       // Reuse the same route/label union as tools/list without publishing yet.
@@ -899,7 +926,9 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       ) {
         try {
           const listed = new Set(
-            (await listSessionTools(acquiredSessionUuid)).tools.map((tool) => tool.name),
+            (
+              await awaitWithCancellation(listSessionTools(acquiredSessionUuid), requestSignal)
+            ).tools.map((tool) => tool.name),
           );
           const gatedTools = ToolRegistry.getAllTools()
             .filter(
@@ -925,10 +954,14 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
               : {}),
           };
         } catch (error) {
+          acquisitionEnrichmentCancelled ||= Boolean(requestSignal?.aborted);
           // Acquisition already succeeded. Preserve its session handle so the
           // proxy can bind and heartbeat it even if optional discovery fails.
           logger.warn("[MCP] Could not enrich acquisition with gated tools", { tool: name, error });
         }
+      }
+      if (acquisitionEnrichmentCancelled || requestSignal?.aborted) {
+        throw new ActionableError("MCP request was cancelled during acquisition.");
       }
       const isRecordingIdCleanup =
         name === "videoRecording" &&

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,6 +3,7 @@ import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprot
 import { ActionableError } from "../models";
 import { formatToolParamError } from "./toolParamError";
 import { reviveNonFiniteArguments } from "../utils/nonFiniteJson";
+import { stringifyToolResponse } from "../utils/toolUtils";
 import { logger } from "../utils/logger";
 import { defaultTimer } from "../utils/SystemTimer";
 import { executionTracker } from "./executionTracker";
@@ -420,7 +421,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   };
 
   // Register tool definitions using the lower-level interface
-  server.server.setRequestHandler(ListToolsRequestSchema, async () => {
+  const listSessionTools = async () => {
     const sessionId = options.sessionContext?.sessionId;
     const routingSessionUuid = sessionToolBinding.effectiveSessionUuid(sessionId);
     const connectionProfileUuid = sessionToolBinding.connectionToolSelectionProfileUuid(sessionId);
@@ -486,7 +487,8 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         (definition): definition is (typeof definitions)[number] => definition !== undefined,
       ),
     };
-  });
+  };
+  server.server.setRequestHandler(ListToolsRequestSchema, listSessionTools);
 
   // Add ping handler as per MCP specification
   // Note: Using runtime access since TypeScript import has issues
@@ -844,7 +846,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
             startTime: execution.startTime,
           });
       }
-      const result = await runWithAbortSignal(requestSignal, () =>
+      let result = await runWithAbortSignal(requestSignal, () =>
         runWithToolSelectionContext(
           {
             // A bound derived session may still target a sibling label. Resolve
@@ -873,6 +875,39 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         sessionToolBinding.bind(sessionId, getDeviceSessionIdFromResult(result))
       ) {
         ToolRegistry.notifyToolListChanged();
+      }
+      // Report the exact profile-filtered complement after binding, using the
+      // same route/label union as tools/list. Repeated acquisitions also report
+      // current overrides, rather than only the first binding transition.
+      if (
+        (name === "getAndroid" || name === "getApple") &&
+        !result?.isError &&
+        getDeviceSessionIdFromResult(result)
+      ) {
+        const listed = new Set((await listSessionTools()).tools.map((tool) => tool.name));
+        const gatedTools = ToolRegistry.getAllTools()
+          .filter(
+            (tool) => ToolRegistry.isUserConfigurableTool(tool.name) && !listed.has(tool.name),
+          )
+          .map((tool) => tool.name)
+          .sort();
+        let enriched = false;
+        result = {
+          ...result,
+          content: result.content.map((item: { type: string; text?: string }) => {
+            if (enriched || item.type !== "text" || typeof item.text !== "string") {
+              return item;
+            }
+            enriched = true;
+            return {
+              ...item,
+              text: stringifyToolResponse({ ...JSON.parse(item.text), gatedTools }),
+            };
+          }),
+          ...(result.structuredContent
+            ? { structuredContent: { ...result.structuredContent, gatedTools } }
+            : {}),
+        };
       }
       const isRecordingIdCleanup =
         name === "videoRecording" &&

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -421,9 +421,10 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   };
 
   // Register tool definitions using the lower-level interface
-  const listSessionTools = async () => {
+  const listSessionTools = async (
+    routingSessionUuid = sessionToolBinding.effectiveSessionUuid(options.sessionContext?.sessionId),
+  ) => {
     const sessionId = options.sessionContext?.sessionId;
-    const routingSessionUuid = sessionToolBinding.effectiveSessionUuid(sessionId);
     const connectionProfileUuid = sessionToolBinding.connectionToolSelectionProfileUuid(sessionId);
     const selectionSessionManager =
       options.toolSelectionSessionManager ??
@@ -488,7 +489,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       ),
     };
   };
-  server.server.setRequestHandler(ListToolsRequestSchema, listSessionTools);
+  server.server.setRequestHandler(ListToolsRequestSchema, () => listSessionTools());
 
   // Add ping handler as per MCP specification
   // Note: Using runtime access since TypeScript import has issues
@@ -795,6 +796,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
           }
         : undefined;
 
+    let cleanupAcquisitionRelease: (() => void) | undefined;
     try {
       if (
         daemonMode &&
@@ -870,22 +872,35 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
           () => tool.handler(handlerParams, progressCallback, requestSignal),
         ),
       );
-      if (
-        isDeviceSessionAcquisitionTool(name) &&
-        sessionToolBinding.bind(sessionId, getDeviceSessionIdFromResult(result))
-      ) {
-        ToolRegistry.notifyToolListChanged();
+      const acquiredSessionUuid = isDeviceSessionAcquisitionTool(name)
+        ? getDeviceSessionIdFromResult(result)
+        : undefined;
+      let acquiredSessionReleased = false;
+      if (acquiredSessionUuid) {
+        const onSessionReleased = (releasedSessionUuid: string) => {
+          if (releasedSessionUuid === acquiredSessionUuid) {
+            acquiredSessionReleased = true;
+          }
+        };
+        const unregister = ToolRegistry.registerSessionBindingReleaseHandler({ onSessionReleased });
+        const unsubscribe = SessionReleaseBroadcaster.subscribe(onSessionReleased);
+        cleanupAcquisitionRelease = () => {
+          unregister();
+          unsubscribe();
+        };
       }
-      // Report the exact profile-filtered complement after binding, using the
-      // same route/label union as tools/list. Repeated acquisitions also report
-      // current overrides, rather than only the first binding transition.
+      // Evaluate the returned session directly: a seeded transport may retain
+      // its old binding, and a concurrent acquisition may publish another one.
+      // Reuse the same route/label union as tools/list without publishing yet.
       if (
         (name === "getAndroid" || name === "getApple") &&
         !result?.isError &&
-        getDeviceSessionIdFromResult(result)
+        acquiredSessionUuid
       ) {
         try {
-          const listed = new Set((await listSessionTools()).tools.map((tool) => tool.name));
+          const listed = new Set(
+            (await listSessionTools(acquiredSessionUuid)).tools.map((tool) => tool.name),
+          );
           const gatedTools = ToolRegistry.getAllTools()
             .filter(
               (tool) => ToolRegistry.isUserConfigurableTool(tool.name) && !listed.has(tool.name),
@@ -967,7 +982,18 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       if (omissionReason !== null && responseCarriesStructuredContent(result)) {
         logger.debug("[MCP] Omitted structuredContent", { tool: name, reason: omissionReason });
       }
-      return stripToolResultStructuredContent(result, omissionReason);
+      const response = stripToolResultStructuredContent(result, omissionReason);
+      // Publish only after all asynchronous enrichment finishes, so concurrent
+      // direct acquisitions bind in response order. Keep this path synchronous.
+      if (acquiredSessionReleased) {
+        throw new ActionableError(
+          `Device session ${acquiredSessionUuid} was released during acquisition. Call ${name} again to acquire a device.`,
+        );
+      }
+      if (acquiredSessionUuid && sessionToolBinding.bind(sessionId, acquiredSessionUuid)) {
+        ToolRegistry.notifyToolListChanged();
+      }
+      return response;
     } catch (error) {
       if (error instanceof TerminalSessionError) {
         const sessionOwnershipLost = {
@@ -1015,6 +1041,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       }
       throw error;
     } finally {
+      cleanupAcquisitionRelease?.();
       executionTracker.endExecution(execution.id);
     }
   });

--- a/src/server/networkResources.ts
+++ b/src/server/networkResources.ts
@@ -12,13 +12,13 @@ import { computePercentile } from "../utils/percentile";
 const NETWORK_RESOURCE_URIS = {
   REQUEST: "automobile:network/request/{requestId}",
   TRAFFIC: "automobile:network/traffic",
-  LIVE: "automobile://network/traffic/live",
-  ERRORS: "automobile://network/traffic/errors",
-  SLOW: "automobile://network/traffic/slow",
-  STATS: "automobile://network/stats",
-  STATE: "automobile://network/state",
-  MOCKS: "automobile://network/mocks",
-  CONNECTIVITY: "automobile://network/connectivity",
+  LIVE: "automobile:network/traffic/live",
+  ERRORS: "automobile:network/traffic/errors",
+  SLOW: "automobile:network/traffic/slow",
+  STATS: "automobile:network/stats",
+  STATE: "automobile:network/state",
+  MOCKS: "automobile:network/mocks",
+  CONNECTIVITY: "automobile:network/connectivity",
 } as const;
 
 const TRAFFIC_QUERY_KEYS = [

--- a/test/server/NetworkState.test.ts
+++ b/test/server/NetworkState.test.ts
@@ -278,9 +278,9 @@ describe("NetworkState", () => {
       state.onNetworkEvent(makeNotification());
       timer.advanceTime(200);
 
-      expect(notifier.notifications).toContain("automobile://network/traffic/live");
-      expect(notifier.notifications).toContain("automobile://network/stats");
-      expect(notifier.notifications).not.toContain("automobile://network/traffic/errors");
+      expect(notifier.notifications).toContain("automobile:network/traffic/live");
+      expect(notifier.notifications).toContain("automobile:network/stats");
+      expect(notifier.notifications).not.toContain("automobile:network/traffic/errors");
     });
 
     it("notifies errors resource on 4xx/5xx", () => {
@@ -288,7 +288,7 @@ describe("NetworkState", () => {
       state.onNetworkEvent(makeNotification({ statusCode: 500 }));
       timer.advanceTime(200);
 
-      expect(notifier.notifications).toContain("automobile://network/traffic/errors");
+      expect(notifier.notifications).toContain("automobile:network/traffic/errors");
     });
 
     it("filters to errors only", () => {
@@ -329,7 +329,7 @@ describe("NetworkState", () => {
       state.onNetworkEvent(makeNotification({ durationMs: 1500 }));
       timer.advanceTime(200);
 
-      expect(notifier.notifications).toContain("automobile://network/traffic/slow");
+      expect(notifier.notifications).toContain("automobile:network/traffic/slow");
     });
 
     it("does not notify slow resource on fast request", () => {
@@ -339,7 +339,7 @@ describe("NetworkState", () => {
       state.onNetworkEvent(makeNotification({ durationMs: 100 }));
       timer.advanceTime(200);
 
-      expect(notifier.notifications).not.toContain("automobile://network/traffic/slow");
+      expect(notifier.notifications).not.toContain("automobile:network/traffic/slow");
     });
 
     it("debounces rapid notifications", () => {
@@ -356,8 +356,8 @@ describe("NetworkState", () => {
       timer.advanceTime(100);
 
       // Should only fire one batch of notifications
-      expect(notifier.notifications).toContain("automobile://network/traffic/live");
-      expect(notifier.notifications).toContain("automobile://network/stats");
+      expect(notifier.notifications).toContain("automobile:network/traffic/live");
+      expect(notifier.notifications).toContain("automobile:network/stats");
     });
   });
 

--- a/test/server/deviceTools.listDevices.test.ts
+++ b/test/server/deviceTools.listDevices.test.ts
@@ -5,7 +5,6 @@ import {
   setDeviceToolsDependencies,
 } from "../../src/server/deviceTools";
 import { ResourceRegistry } from "../../src/server/resourceRegistry";
-import { runWithToolSelectionContext } from "../../src/features/toolSelection/toolSelectionContext";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import type { BootedDevice } from "../../src/models";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
@@ -127,18 +126,35 @@ describe("listDevices tool (#5870)", () => {
     ).toBe(true);
   });
 
-  test("does not recommend unreadable resources before acquisition", async () => {
-    const payload = await callListDevices();
-
-    expect(payload.note).toBeDefined();
-    const noteText = JSON.stringify(payload.note);
-    expect(payload.note.resources).toEqual([]);
-    expect(noteText).not.toContain("automobile:devices/");
-    expect(noteText).toContain("getAndroid");
-    expect(noteText).toContain("resources/list");
+  test("does not recommend inventory resources absent from the registry", async () => {
+    const inventory = ResourceRegistry.getAllResources().filter((resource) =>
+      resource.uri.startsWith("automobile:devices/"),
+    );
+    for (const resource of inventory) {
+      ResourceRegistry.unregister(resource.uri);
+    }
+    try {
+      const payload = await callListDevices();
+      expect(payload.note).toBeDefined();
+      const noteText = JSON.stringify(payload.note);
+      expect(payload.note.resources).toEqual([]);
+      expect(noteText).not.toContain("automobile:devices/");
+      expect(noteText).toContain("getAndroid");
+      expect(noteText).toContain("resources/list");
+    } finally {
+      for (const resource of inventory) {
+        ResourceRegistry.register(
+          resource.uri,
+          resource.name,
+          resource.description,
+          resource.mimeType,
+          resource.handler,
+        );
+      }
+    }
   });
 
-  test("only recommends registered resources when a session is bound", async () => {
+  test("recommends registered inventory resources without a device session", async () => {
     const uri = "automobile:devices/booted";
     const previous = ResourceRegistry.getResource(uri);
     ResourceRegistry.register(uri, "booted", "booted devices", "application/json", async () => ({
@@ -146,10 +162,7 @@ describe("listDevices tool (#5870)", () => {
       text: "[]",
     }));
     try {
-      const payload = await runWithToolSelectionContext(
-        { routingSessionUuid: "device-session" },
-        () => callListDevices(),
-      );
+      const payload = await callListDevices();
       expect(payload.note.resources).toContain(uri);
       const listed = ResourceRegistry.getResourceDefinitions().map((resource) => resource.uri);
       for (const recommended of payload.note.resources) {

--- a/test/server/deviceTools.listDevices.test.ts
+++ b/test/server/deviceTools.listDevices.test.ts
@@ -4,6 +4,8 @@ import {
   resetDeviceToolsDependencies,
   setDeviceToolsDependencies,
 } from "../../src/server/deviceTools";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import { runWithToolSelectionContext } from "../../src/features/toolSelection/toolSelectionContext";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import type { BootedDevice } from "../../src/models";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
@@ -125,13 +127,43 @@ describe("listDevices tool (#5870)", () => {
     ).toBe(true);
   });
 
-  test("keeps the resource pointers as a note", async () => {
+  test("does not recommend unreadable resources before acquisition", async () => {
     const payload = await callListDevices();
 
     expect(payload.note).toBeDefined();
     const noteText = JSON.stringify(payload.note);
-    expect(noteText).toContain("automobile:devices/booted");
-    expect(noteText).toContain("automobile:devices/images");
+    expect(payload.note.resources).toEqual([]);
+    expect(noteText).not.toContain("automobile:devices/");
+    expect(noteText).toContain("getAndroid");
+    expect(noteText).toContain("resources/list");
+  });
+
+  test("only recommends registered resources when a session is bound", async () => {
+    const uri = "automobile:devices/booted";
+    const previous = ResourceRegistry.getResource(uri);
+    ResourceRegistry.register(uri, "booted", "booted devices", "application/json", async () => ({
+      uri,
+      text: "[]",
+    }));
+    try {
+      const payload = await runWithToolSelectionContext(
+        { routingSessionUuid: "device-session" },
+        () => callListDevices(),
+      );
+      expect(payload.note.resources).toContain(uri);
+      const listed = ResourceRegistry.getResourceDefinitions().map((resource) => resource.uri);
+      for (const recommended of payload.note.resources) {expect(listed).toContain(recommended);}
+    } finally {
+      ResourceRegistry.unregister(uri);
+      if (previous)
+        {ResourceRegistry.register(
+          previous.uri,
+          previous.name,
+          previous.description,
+          previous.mimeType,
+          previous.handler,
+        );}
+    }
   });
 
   test("marks discovery complete when every requested platform succeeds", async () => {

--- a/test/server/deviceTools.listDevices.test.ts
+++ b/test/server/deviceTools.listDevices.test.ts
@@ -152,17 +152,20 @@ describe("listDevices tool (#5870)", () => {
       );
       expect(payload.note.resources).toContain(uri);
       const listed = ResourceRegistry.getResourceDefinitions().map((resource) => resource.uri);
-      for (const recommended of payload.note.resources) {expect(listed).toContain(recommended);}
+      for (const recommended of payload.note.resources) {
+        expect(listed).toContain(recommended);
+      }
     } finally {
       ResourceRegistry.unregister(uri);
-      if (previous)
-        {ResourceRegistry.register(
+      if (previous) {
+        ResourceRegistry.register(
           previous.uri,
           previous.name,
           previous.description,
           previous.mimeType,
           previous.handler,
-        );}
+        );
+      }
     }
   });
 

--- a/test/server/networkResources.test.ts
+++ b/test/server/networkResources.test.ts
@@ -163,6 +163,14 @@ describe("network resource registration", () => {
     ResourceRegistry.clearResources();
   });
 
+  it("uses the canonical automobile:path form for every network resource", () => {
+    registerNetworkResources();
+    const uris = ResourceRegistry.getResourceDefinitions().map((resource) => resource.uri);
+    expect(uris).toContain("automobile:network/traffic/live");
+    expect(uris).toContain("automobile:network/stats");
+    expect(uris.some((uri) => uri.startsWith("automobile://"))).toBe(false);
+  });
+
   it("registers one RFC 6570 query template for traffic filters", () => {
     registerNetworkResources();
 

--- a/test/server/sessionToolSelection.integration.test.ts
+++ b/test/server/sessionToolSelection.integration.test.ts
@@ -20,71 +20,79 @@ describe("per-session exact-tool selection", () => {
   });
 
   for (const acquisition of ["getAndroid", "getApple"]) {
-    test.each(["broadcast", "plan"])(
-      acquisition + " rejects publication after a %s release during lookup",
-      async (source) => {
-        const lookupStarted = Promise.withResolvers<void>();
-        const releaseLookup = Promise.withResolvers<void>();
-        fixture = new McpTestFixture({
-          sessionToolSelectionService: {
-            isEnabled: async (_sessionUuid, toolName, declaredDefault) => {
-              if (toolName === "inputText") {
-                lookupStarted.resolve();
-                await releaseLookup.promise;
-              }
-              return declaredDefault;
-            },
+    test.each([
+      ["broadcast", "lookup"],
+      ["plan", "lookup"],
+      ["broadcast", "handler"],
+      ["plan", "handler"],
+    ])(acquisition + " rejects publication after a %s release during %s", async (source, stage) => {
+      const lookupStarted = Promise.withResolvers<void>();
+      const releaseLookup = Promise.withResolvers<void>();
+      fixture = new McpTestFixture({
+        sessionToolSelectionService: {
+          isEnabled: async (_sessionUuid, toolName, declaredDefault) => {
+            if (toolName === "inputText" && stage === "lookup") {
+              lookupStarted.resolve();
+              await releaseLookup.promise;
+            }
+            return declaredDefault;
           },
-        });
-        await fixture.setup();
-        ToolRegistry.clearTools();
-        ToolRegistry.register(
-          acquisition,
-          "acquire",
-          z.object({}),
-          async () => ({
+        },
+      });
+      await fixture.setup();
+      ToolRegistry.clearTools();
+      ToolRegistry.register(
+        acquisition,
+        "acquire",
+        z.object({}),
+        async () => {
+          if (stage === "handler") {
+            lookupStarted.resolve();
+            await releaseLookup.promise;
+          }
+          return {
             content: [{ type: "text", text: JSON.stringify({ sessionUuid: "released-session" }) }],
-          }),
-          { defaultEnabled: true },
-        );
-        ToolRegistry.register("inputText", "input", z.object({}), async () => ({ content: [] }), {
-          defaultEnabled: false,
-        });
-        ToolRegistry.register(
-          "inspectRouting",
-          "routing",
-          z.object({}),
-          async () => ({
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify({
-                  sessionUuid: getToolSelectionContext()?.routingSessionUuid,
-                }),
-              },
-            ],
-          }),
-          { defaultEnabled: true },
-        );
-        const pending = fixture.client.request(
-          { method: "tools/call", params: { name: acquisition, arguments: {} } },
-          z.any(),
-        );
-        await lookupStarted.promise;
-        if (source === "broadcast") {
-          SessionReleaseBroadcaster.emit("released-session", "released-during-discovery");
-        } else {
-          ToolRegistry.notifySessionBindingReleased("released-session");
-        }
-        releaseLookup.resolve();
-        await expect(pending).rejects.toThrow(/released during acquisition/);
-        const routed = await fixture.client.request(
-          { method: "tools/call", params: { name: "inspectRouting", arguments: {} } },
-          z.any(),
-        );
-        expect(JSON.parse(routed.content[0].text)).toEqual({});
-      },
-    );
+          };
+        },
+        { defaultEnabled: true },
+      );
+      ToolRegistry.register("inputText", "input", z.object({}), async () => ({ content: [] }), {
+        defaultEnabled: false,
+      });
+      ToolRegistry.register(
+        "inspectRouting",
+        "routing",
+        z.object({}),
+        async () => ({
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                sessionUuid: getToolSelectionContext()?.routingSessionUuid,
+              }),
+            },
+          ],
+        }),
+        { defaultEnabled: true },
+      );
+      const pending = fixture.client.request(
+        { method: "tools/call", params: { name: acquisition, arguments: {} } },
+        z.any(),
+      );
+      await lookupStarted.promise;
+      if (source === "broadcast") {
+        SessionReleaseBroadcaster.emit("released-session", "released-during-discovery");
+      } else {
+        ToolRegistry.notifySessionBindingReleased("released-session");
+      }
+      releaseLookup.resolve();
+      await expect(pending).rejects.toThrow(/released during acquisition/);
+      const routed = await fixture.client.request(
+        { method: "tools/call", params: { name: "inspectRouting", arguments: {} } },
+        z.any(),
+      );
+      expect(JSON.parse(routed.content[0].text)).toEqual({});
+    });
 
     test(acquisition + " reports the acquired profile on a seeded transport", async () => {
       fixture = new McpTestFixture({

--- a/test/server/sessionToolSelection.integration.test.ts
+++ b/test/server/sessionToolSelection.integration.test.ts
@@ -17,6 +17,67 @@ describe("per-session exact-tool selection", () => {
     ToolRegistry.clearTools();
   });
 
+  for (const acquisition of ["getAndroid", "getApple"]) {
+    test(
+      acquisition + " names gated tools after acquisition and respects re-enabling",
+      async () => {
+        fixture = new McpTestFixture();
+        await fixture.setup();
+        ToolRegistry.clearTools();
+        ToolRegistry.register(
+          acquisition,
+          "acquire",
+          z.object({}),
+          async () => ({
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({ sessionUuid: "acquired-session", timing: { total: 1 } }),
+              },
+            ],
+          }),
+          { defaultEnabled: true },
+        );
+        ToolRegistry.register("inputText", "input", z.object({}), async () => ({ content: [] }), {
+          defaultEnabled: false,
+        });
+        ToolRegistry.register("hiddenTool", "hidden", z.object({}), async () => ({ content: [] }), {
+          defaultEnabled: false,
+          hidden: true,
+        });
+        registerToolSelectionTools();
+        const acquire = async () => {
+          const response = await fixture!.client.request(
+            { method: "tools/call", params: { name: acquisition, arguments: {} } },
+            z.any(),
+          );
+          return JSON.parse(response.content[0].text);
+        };
+        const payload = await acquire();
+        expect(payload.sessionUuid).toBe("acquired-session");
+        expect(payload.timing).toEqual({ total: 1 });
+        expect(payload.gatedTools).toEqual(["inputText"]);
+        const listed = await fixture.client.listTools();
+        expect(listed.tools.map((tool) => tool.name)).not.toContain("inputText");
+        const control = listed.tools.find((tool) => tool.name === "setToolEnabled")!;
+        expect((control.inputSchema.properties!.toolName as { enum: string[] }).enum).toContain(
+          "inputText",
+        );
+        await fixture.client.request(
+          {
+            method: "tools/call",
+            params: { name: "setToolEnabled", arguments: { toolName: payload.gatedTools[0] } },
+          },
+          z.any(),
+        );
+        expect((await acquire()).gatedTools).toEqual([]);
+        expect((await fixture.client.listTools()).tools.map((tool) => tool.name)).toContain(
+          "inputText",
+        );
+      },
+    );
+  }
+
   test("enables one exact tool without exposing its former group sibling", async () => {
     const enabled = new Set<string>();
     const profileService: Pick<SessionToolSelectionService, "isEnabled" | "setEnabled"> = {

--- a/test/server/sessionToolSelection.integration.test.ts
+++ b/test/server/sessionToolSelection.integration.test.ts
@@ -4,6 +4,8 @@ import type { SessionToolSelectionService } from "../../src/features/toolSelecti
 import { registerToolSelectionTools } from "../../src/server/toolSelectionTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { McpTestFixture } from "../fixtures/mcpTestFixture";
+import { getToolSelectionContext } from "../../src/features/toolSelection/toolSelectionContext";
+import { SessionReleaseBroadcaster } from "../../src/server/sessionReleaseBroadcast";
 
 describe("per-session exact-tool selection", () => {
   let fixture: McpTestFixture | undefined;
@@ -18,6 +20,182 @@ describe("per-session exact-tool selection", () => {
   });
 
   for (const acquisition of ["getAndroid", "getApple"]) {
+    test.each(["broadcast", "plan"])(
+      acquisition + " rejects publication after a %s release during lookup",
+      async (source) => {
+        const lookupStarted = Promise.withResolvers<void>();
+        const releaseLookup = Promise.withResolvers<void>();
+        fixture = new McpTestFixture({
+          sessionToolSelectionService: {
+            isEnabled: async (_sessionUuid, toolName, declaredDefault) => {
+              if (toolName === "inputText") {
+                lookupStarted.resolve();
+                await releaseLookup.promise;
+              }
+              return declaredDefault;
+            },
+          },
+        });
+        await fixture.setup();
+        ToolRegistry.clearTools();
+        ToolRegistry.register(
+          acquisition,
+          "acquire",
+          z.object({}),
+          async () => ({
+            content: [{ type: "text", text: JSON.stringify({ sessionUuid: "released-session" }) }],
+          }),
+          { defaultEnabled: true },
+        );
+        ToolRegistry.register("inputText", "input", z.object({}), async () => ({ content: [] }), {
+          defaultEnabled: false,
+        });
+        ToolRegistry.register(
+          "inspectRouting",
+          "routing",
+          z.object({}),
+          async () => ({
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  sessionUuid: getToolSelectionContext()?.routingSessionUuid,
+                }),
+              },
+            ],
+          }),
+          { defaultEnabled: true },
+        );
+        const pending = fixture.client.request(
+          { method: "tools/call", params: { name: acquisition, arguments: {} } },
+          z.any(),
+        );
+        await lookupStarted.promise;
+        if (source === "broadcast") {
+          SessionReleaseBroadcaster.emit("released-session", "released-during-discovery");
+        } else {
+          ToolRegistry.notifySessionBindingReleased("released-session");
+        }
+        releaseLookup.resolve();
+        await expect(pending).rejects.toThrow(/released during acquisition/);
+        const routed = await fixture.client.request(
+          { method: "tools/call", params: { name: "inspectRouting", arguments: {} } },
+          z.any(),
+        );
+        expect(JSON.parse(routed.content[0].text)).toEqual({});
+      },
+    );
+
+    test(acquisition + " reports the acquired profile on a seeded transport", async () => {
+      fixture = new McpTestFixture({
+        sessionContext: { initialSessionToolBinding: "old-session" },
+        sessionToolSelectionService: {
+          isEnabled: async (sessionUuid, toolName, declaredDefault) =>
+            toolName === "inputText" ? sessionUuid === "old-session" : declaredDefault,
+        },
+      });
+      await fixture.setup();
+      ToolRegistry.clearTools();
+      ToolRegistry.register(
+        acquisition,
+        "acquire",
+        z.object({}),
+        async () => ({
+          content: [{ type: "text", text: JSON.stringify({ sessionUuid: "new-session" }) }],
+        }),
+        { defaultEnabled: true },
+      );
+      ToolRegistry.register("inputText", "input", z.object({}), async () => ({ content: [] }), {
+        defaultEnabled: false,
+      });
+      expect((await fixture.client.listTools()).tools.map((tool) => tool.name)).toContain(
+        "inputText",
+      );
+      const response = await fixture.client.request(
+        { method: "tools/call", params: { name: acquisition, arguments: {} } },
+        z.any(),
+      );
+      expect(JSON.parse(response.content[0].text)).toEqual({
+        sessionUuid: "new-session",
+        gatedTools: ["inputText"],
+      });
+    });
+
+    test(acquisition + " publishes concurrent acquisitions in response order", async () => {
+      const lookupStarted = Promise.withResolvers<void>();
+      const releaseLookup = Promise.withResolvers<void>();
+      let held = false;
+      fixture = new McpTestFixture({
+        sessionToolSelectionService: {
+          isEnabled: async (sessionUuid, toolName, declaredDefault) => {
+            if (toolName !== "inputText") {
+              return declaredDefault;
+            }
+            if (sessionUuid === "session-a" && !held) {
+              held = true;
+              lookupStarted.resolve();
+              await releaseLookup.promise;
+            }
+            return sessionUuid === "session-b";
+          },
+        },
+      });
+      await fixture.setup();
+      ToolRegistry.clearTools();
+      ToolRegistry.register(
+        acquisition,
+        "acquire",
+        z.object({ target: z.string() }),
+        async (args) => ({
+          content: [{ type: "text", text: JSON.stringify({ sessionUuid: args.target }) }],
+        }),
+        { defaultEnabled: true },
+      );
+      ToolRegistry.register("inputText", "input", z.object({}), async () => ({ content: [] }), {
+        defaultEnabled: false,
+      });
+      ToolRegistry.register(
+        "inspectRouting",
+        "routing",
+        z.object({}),
+        async () => ({
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ sessionUuid: getToolSelectionContext()?.routingSessionUuid }),
+            },
+          ],
+        }),
+        { defaultEnabled: true },
+      );
+      const acquire = async (target: string) => {
+        const response = await fixture!.client.request(
+          { method: "tools/call", params: { name: acquisition, arguments: { target } } },
+          z.any(),
+        );
+        return JSON.parse(response.content[0].text);
+      };
+      const first = acquire("session-a");
+      try {
+        await lookupStarted.promise;
+        expect(await acquire("session-b")).toEqual({ sessionUuid: "session-b", gatedTools: [] });
+        expect((await fixture.client.listTools()).tools.map((tool) => tool.name)).toContain(
+          "inputText",
+        );
+      } finally {
+        releaseLookup.resolve();
+      }
+      expect(await first).toEqual({ sessionUuid: "session-a", gatedTools: ["inputText"] });
+      expect((await fixture.client.listTools()).tools.map((tool) => tool.name)).not.toContain(
+        "inputText",
+      );
+      const routed = await fixture.client.request(
+        { method: "tools/call", params: { name: "inspectRouting", arguments: {} } },
+        z.any(),
+      );
+      expect(JSON.parse(routed.content[0].text)).toEqual({ sessionUuid: "session-a" });
+    });
+
     test(acquisition + " preserves acquisition when profile discovery fails", async () => {
       fixture = new McpTestFixture({
         sessionToolSelectionService: {

--- a/test/server/sessionToolSelection.integration.test.ts
+++ b/test/server/sessionToolSelection.integration.test.ts
@@ -18,6 +18,47 @@ describe("per-session exact-tool selection", () => {
   });
 
   for (const acquisition of ["getAndroid", "getApple"]) {
+    test(acquisition + " preserves acquisition when profile discovery fails", async () => {
+      fixture = new McpTestFixture({
+        sessionToolSelectionService: {
+          isEnabled: async (_sessionUuid, toolName, declaredDefault) => {
+            if (toolName === "inputText") {
+              throw new Error("profile database unavailable");
+            }
+            return declaredDefault;
+          },
+        },
+      });
+      await fixture.setup();
+      ToolRegistry.clearTools();
+      ToolRegistry.register(
+        acquisition,
+        "acquire",
+        z.object({}),
+        async () => ({
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ sessionUuid: "acquired-session", timing: { total: 1 } }),
+            },
+          ],
+        }),
+        { defaultEnabled: true },
+      );
+      ToolRegistry.register("inputText", "input", z.object({}), async () => ({ content: [] }), {
+        defaultEnabled: false,
+      });
+      const response = await fixture.client.request(
+        { method: "tools/call", params: { name: acquisition, arguments: {} } },
+        z.any(),
+      );
+      expect(response.isError).not.toBe(true);
+      expect(JSON.parse(response.content[0].text)).toEqual({
+        sessionUuid: "acquired-session",
+        timing: { total: 1 },
+      });
+    });
+
     test(
       acquisition + " names gated tools after acquisition and respects re-enabling",
       async () => {


### PR DESCRIPTION
## Summary

`getAndroid` and `getApple` now return `gatedTools` so clients can find optional tools after acquisition refreshes `tools/list`. The names come from the acquired session UUID and the existing profile/label selection logic. Enrichment failures preserve the successful acquisition response; concurrent acquisitions publish bindings in response order, and a release during lookup prevents publication.

`listDevices` recommends only inventory resources present in `resources/list`, including before device acquisition. If none are registered, it directs clients to refresh discovery. Network resource registration and update notifications consistently use `automobile:network/...` URIs.

## Linked Issue

Closes [#6814](https://github.com/kaeawc/auto-mobile/issues/6814).

## Bug / Regression Context

Refreshing discovery after acquisition hides optional tools. Returning the gated names makes `setToolEnabled` usable at that transition. Resource hints also previously named unavailable resources before acquisition, and seven network resources used a different URI form.

## Validation

- All seven `turbo:validate` tasks pass with four unit-test workers.
- Type checking reports no new errors; repository-wide formatting passes.
- 38 focused MCP integration and resource tests pass, including seeded transports, deferred concurrent acquisitions, cancellation and releases during the handler or enrichment through both release channels, and profile lookup failure for both platforms.
- Resource guidance and network notification regression tests pass.
- Independent review found no remaining issues after the routing and release guards.
- Reuses existing selection, serialization, and release notification interfaces; no new dependencies.
