### PR TITLE
fix: return settled system tray tap observations

### DIFF
--- a/docs/design-docs/plat/android/system-tray-lookfor.md
+++ b/docs/design-docs/plat/android/system-tray-lookfor.md
@@ -26,6 +26,18 @@ systemTray({
 })
 ```
 
+## Tap observation result
+
+After dispatching a notification or action-button tap, the tool polls for a
+fresh screen change and a 1-second quiet period, with a 2.5-second polling
+budget. A settled result includes `settled: true` and the final observation,
+so inline Reply returns its input field rather than the pre-tap shade.
+
+If the effect cannot be confirmed within that budget, the response keeps
+dispatch-level `success: true`, sets `settled: false`, and omits the
+observation. Re-observe before continuing; do not interpret an unsettled
+result as proof that the tap failed or retry the tap automatically.
+
 ## Android implementation
 
 Open/close the tray (preferred, emulator):

--- a/src/features/observe/ObservePoll.ts
+++ b/src/features/observe/ObservePoll.ts
@@ -141,7 +141,7 @@ function nextPollMinTimestamp(
  * screen.
  */
 export async function pollObserveUntil(
-  observeScreen: ObserveScreen,
+  observeScreen: Pick<ObserveScreen, "execute">,
   timer: Timer,
   options: ObservePollOptions,
   onObservation: (

--- a/src/features/observe/SettleObserve.ts
+++ b/src/features/observe/SettleObserve.ts
@@ -17,7 +17,7 @@ const DEFAULT_STABLE_READS = 2;
  * capture attributes, including occlusion metadata, so every remaining change is
  * actionable instability.
  */
-function isStabilityDiffEmpty(diff: ObserveDiff): boolean {
+export function isStabilityDiffEmpty(diff: ObserveDiff): boolean {
   return (
     diff.added.length === 0 &&
     diff.removed.length === 0 &&

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -120,6 +120,7 @@ import {
   ensureSystemTrayOpen,
   ensureSystemTrayClosed,
   captureSystemTrayTerminalEvidence,
+  observeSystemTrayAfterTap,
   resolveNotificationTapElement,
   resolveNotificationSwipeElement,
   tapElement,
@@ -1666,7 +1667,7 @@ export function registerInteractionTools() {
       }
 
       if (args.action === "tap") {
-        let { match } = await waitForNotificationMatch(
+        let { observation: baseline, match } = await waitForNotificationMatch(
           device,
           notification,
           appMatchTexts,
@@ -1692,6 +1693,7 @@ export function registerInteractionTools() {
           );
           if (reMatch.match) {
             match = reMatch.match;
+            baseline = reMatch.observation;
           } else {
             throw new ActionableError(
               "Expanded collapsed notification group but could not re-match the notification. " +
@@ -1708,18 +1710,19 @@ export function registerInteractionTools() {
         }
 
         await tapElement(device, tapMatch.element);
-        const { observeScreenFactory } = getSystemTrayDependencies();
-        const observeScreen = observeScreenFactory(device);
-        const nextObservation = await observeScreen.execute({
-          skipScreenshot: true,
-          skipAccessibilityAudit: true,
-        });
+        const { observation: nextObservation, settled } = await observeSystemTrayAfterTap(
+          device,
+          baseline,
+        );
         await captureSystemTrayTerminalEvidence(device, nextObservation);
 
         return createJSONToolResponse({
-          message: notification.tapActionLabel
-            ? `Tapped notification action "${notification.tapActionLabel}"`
-            : "Tapped notification",
+          message:
+            (notification.tapActionLabel
+              ? `Tapped notification action "${notification.tapActionLabel}"`
+              : "Tapped notification") +
+            (settled ? "" : "; effect not yet settled — re-observe before continuing"),
+          settled,
           match: match.match.matches,
           tapTarget: {
             text: tapMatch.text,

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -1599,6 +1599,7 @@ export function registerInteractionTools() {
     device: BootedDevice,
     args: SystemTrayArgs,
     progress?: ProgressCallback,
+    signal?: AbortSignal,
   ) => {
     try {
       const awaitTimeoutMs = resolveSystemTrayAwaitTimeout(args.awaitTimeout);
@@ -1713,6 +1714,7 @@ export function registerInteractionTools() {
         const { observation: nextObservation, settled } = await observeSystemTrayAfterTap(
           device,
           baseline,
+          signal,
         );
         await captureSystemTrayTerminalEvidence(device, nextObservation);
 

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -251,10 +251,9 @@ export const observeSystemTrayAfterTap = async (
   baseline: ObserveResult,
 ): Promise<{ observation?: ObserveResult; settled: boolean }> => {
   const { observeScreenFactory, timer } = getSystemTrayDependencies();
-  const minTimestamp =
-    device.platform === "ios"
-      ? hierarchyUpdatedAtToMillis(baseline.viewHierarchy)
-      : await getDetector(device).getObservationTimestamp();
+  // ADB clock probes can fall back to host time. Only hierarchy timestamps
+  // are guaranteed to share the poller's device clock domain on both platforms.
+  const minTimestamp = hierarchyUpdatedAtToMillis(baseline.viewHierarchy);
   let quietSinceMs: number | undefined;
   const outcome = await pollObserveUntil(
     observeScreenFactory(device),

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -2,6 +2,13 @@
  * System tray helper functions for notification handling.
  * Extracted from interactionTools.ts for maintainability.
  */
+import { hierarchyUpdatedAtToMillis } from "../features/observe/observeTimestamp";
+import { pollObserveUntil } from "../features/observe/ObservePoll";
+import {
+  diffObserveResult,
+  isSameObservationScreen,
+} from "../features/observe/output/ObserveResultOutput";
+import { isStabilityDiffEmpty } from "../features/observe/SettleObserve";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
 import {
@@ -165,6 +172,10 @@ export const SYSTEM_TRAY_CLEAR_MAX_ITERATIONS = 25;
 export const SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS =
   SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS_FROM_HINTS;
 export const EXPAND_GROUP_SETTLE_MS = 500;
+// Match TapOnElement's post-action polling budget and hierarchy quiet period.
+const SYSTEM_TRAY_POST_TAP_TIMEOUT_MS = 2500;
+const SYSTEM_TRAY_POST_TAP_POLL_MS = 150;
+const SYSTEM_TRAY_POST_TAP_QUIET_MS = 1000;
 
 // ============================================================================
 // Internal Types
@@ -234,6 +245,49 @@ const observeSystemTray = (
     skipScreenshot: true,
     skipAccessibilityAudit: true,
   });
+
+export const observeSystemTrayAfterTap = async (
+  device: BootedDevice,
+  baseline: ObserveResult,
+): Promise<{ observation?: ObserveResult; settled: boolean }> => {
+  const { observeScreenFactory, timer } = getSystemTrayDependencies();
+  const minTimestamp =
+    device.platform === "ios"
+      ? hierarchyUpdatedAtToMillis(baseline.viewHierarchy)
+      : await getDetector(device).getObservationTimestamp();
+  let quietSinceMs: number | undefined;
+  const outcome = await pollObserveUntil(
+    observeScreenFactory(device),
+    timer,
+    {
+      timeoutMs: SYSTEM_TRAY_POST_TAP_TIMEOUT_MS,
+      pollMs: SYSTEM_TRAY_POST_TAP_POLL_MS,
+      initialMinTimestampMs: minTimestamp,
+    },
+    (observation, previous) => {
+      // A freshly captured source screen still does not prove a tap effect.
+      if (
+        isSameObservationScreen(baseline, observation) &&
+        isStabilityDiffEmpty(diffObserveResult(baseline, observation))
+      ) {
+        quietSinceMs = undefined;
+        return false;
+      }
+      if (
+        !previous ||
+        !isSameObservationScreen(previous, observation) ||
+        !isStabilityDiffEmpty(diffObserveResult(previous, observation))
+      ) {
+        quietSinceMs = timer.now();
+        return false;
+      }
+      quietSinceMs ??= timer.now();
+      return timer.now() - quietSinceMs >= SYSTEM_TRAY_POST_TAP_QUIET_MS;
+    },
+  );
+  // Never label an unsettled/expired sample as the tap's observed effect.
+  return outcome.stopped ? { observation: outcome.observation, settled: true } : { settled: false };
+};
 
 export const captureSystemTrayTerminalEvidence = async (
   device: BootedDevice,

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -249,6 +249,7 @@ const observeSystemTray = (
 export const observeSystemTrayAfterTap = async (
   device: BootedDevice,
   baseline: ObserveResult,
+  signal?: AbortSignal,
 ): Promise<{ observation?: ObserveResult; settled: boolean }> => {
   const { observeScreenFactory, timer } = getSystemTrayDependencies();
   // ADB clock probes can fall back to host time. Only hierarchy timestamps
@@ -262,6 +263,7 @@ export const observeSystemTrayAfterTap = async (
       timeoutMs: SYSTEM_TRAY_POST_TAP_TIMEOUT_MS,
       pollMs: SYSTEM_TRAY_POST_TAP_POLL_MS,
       initialMinTimestampMs: minTimestamp,
+      signal,
     },
     (observation, previous) => {
       // A freshly captured source screen still does not prove a tap effect.

--- a/test/server/systemTray.test.ts
+++ b/test/server/systemTray.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../src/server/interactionTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import {
+  observeSystemTrayAfterTap,
   ensureSystemTrayClosed,
   ensureSystemTrayOpen,
   tapElement,
@@ -150,6 +151,141 @@ const advancePendingSleeps = async (timer: FakeTimer, steps: number): Promise<vo
     }
   }
 };
+
+describe("systemTray post-tap observation", () => {
+  afterEach(() => {
+    resetSystemTrayDependencies();
+    ToolRegistry.clearTools();
+  });
+
+  for (const tapActionLabel of [undefined, "Reply"]) {
+    test(`waits for a delayed effect to settle for ${tapActionLabel ?? "notification body"}`, async () => {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const fakeAdb = new SequencedFakeAdbExecutor([1000, 2000]);
+      const before = createObservation(createTrayHierarchy("Reply"));
+      const intermediate = createObservation(createTrayHierarchy("Opening reply"));
+      const after = createObservation(createTrayHierarchy("Reply"));
+      after.viewHierarchy!.hierarchy.node.node[0].$["resource-id"] =
+        "com.android.systemui:id/remote_input_text";
+      const fakeObserveScreen = new FakeObserveScreen();
+      fakeObserveScreen.setObserveResult((index) => {
+        if (index === 0) {
+          return before;
+        }
+        const frame =
+          fakeTimer.now() >= 750 ? after : fakeTimer.now() >= 450 ? intermediate : before;
+        return {
+          ...frame,
+          viewHierarchy: { ...frame.viewHierarchy!, updatedAt: 2001 + fakeTimer.now() },
+        };
+      });
+      setSystemTrayDependencies({
+        timer: fakeTimer,
+        adbFactory: () => fakeAdb,
+        observeScreenFactory: () => fakeObserveScreen,
+      });
+      ToolRegistry.clearTools();
+      registerInteractionTools();
+      const handler = ToolRegistry.getTool("systemTray")!.deviceAwareHandler!;
+      const response = await handler(device, {
+        action: "tap",
+        notification: { title: "Reply", tapActionLabel },
+        platform: "android",
+      });
+      const payload = JSON.parse((response.content[0] as { text: string }).text);
+      expect(payload.success).toBe(true);
+      expect(payload.settled).toBe(true);
+      expect(JSON.stringify(payload.observation)).toContain("remote_input_text");
+      expect(fakeTimer.now()).toBeGreaterThanOrEqual(1750);
+      expect(fakeTimer.now()).toBeLessThanOrEqual(2500);
+      expect(fakeObserveScreen.getExecuteOptions()[1]).toMatchObject({
+        skipWaitForFresh: false,
+        minTimestamp: 2001,
+        skipScreenshot: true,
+        skipAccessibilityAudit: true,
+      });
+      expect(
+        fakeAdb.getExecutedCommands().filter((command) => command.includes("input tap")),
+      ).toHaveLength(1);
+    });
+  }
+
+  test("settles iOS effects when the device clock trails the host", async () => {
+    const timer = new FakeTimer();
+    timer.advanceTime(100000);
+    timer.enableAutoAdvance();
+    const baseline = createObservation({ ...createTrayHierarchy("Reply"), updatedAt: 900 });
+    const observer = new FakeObserveScreen();
+    observer.setObserveResult(
+      createObservation({ ...createTrayHierarchy("Send"), updatedAt: 1000 }),
+    );
+    setSystemTrayDependencies({ timer, observeScreenFactory: () => observer });
+    const result = await observeSystemTrayAfterTap({ ...device, platform: "ios" }, baseline);
+    expect(result.settled).toBe(true);
+    expect(observer.getExecuteOptions()[0].minTimestamp).toBe(901);
+    expect(timer.now()).toBe(101050);
+  });
+
+  for (const alternating of [false, true]) {
+    test(`${alternating ? "does not settle alternating" : "settles a new"} window with the same tree`, async () => {
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const baseline = createObservation({ ...createTrayHierarchy("Reply"), updatedAt: 900 });
+      baseline.activeWindow = { appId: "messages", activityName: "Source" };
+      const observer = new FakeObserveScreen();
+      observer.setObserveResult((index) => ({
+        ...baseline,
+        activeWindow: { appId: "messages", activityName: alternating && index % 2 ? "B" : "A" },
+        viewHierarchy: { ...baseline.viewHierarchy!, updatedAt: 2001 + timer.now() },
+      }));
+      setSystemTrayDependencies({
+        timer,
+        adbFactory: () => new SequencedFakeAdbExecutor([2000]),
+        observeScreenFactory: () => observer,
+      });
+      const result = await observeSystemTrayAfterTap(device, baseline);
+      expect(result.settled).toBe(!alternating);
+      expect(timer.now()).toBe(alternating ? 2550 : 1050);
+    });
+  }
+
+  for (const stale of [false, true]) {
+    test(`omits uncertain evidence when ${stale ? "changed captures are stale" : "no effect arrives"}`, async () => {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const fakeAdb = new SequencedFakeAdbExecutor([1000, 2000]);
+      const before = createObservation(createTrayHierarchy("Reply"));
+      const fakeObserveScreen = new FakeObserveScreen();
+      fakeObserveScreen.setObserveResult((index) => ({
+        ...before,
+        freshness: { isFresh: !stale },
+        viewHierarchy: {
+          ...createTrayHierarchy(stale && index > 0 ? "Changed" : "Reply"),
+          updatedAt: 2001 + fakeTimer.now(),
+        },
+      }));
+      setSystemTrayDependencies({
+        timer: fakeTimer,
+        adbFactory: () => fakeAdb,
+        observeScreenFactory: () => fakeObserveScreen,
+      });
+      registerInteractionTools();
+      const response = await ToolRegistry.getTool("systemTray")!.deviceAwareHandler!(device, {
+        action: "tap",
+        notification: { title: "Reply" },
+        platform: "android",
+      });
+      const payload = JSON.parse((response.content[0] as { text: string }).text);
+      expect(payload.success).toBe(true);
+      expect(payload.settled).toBe(false);
+      expect(payload.message).toContain("effect not yet settled");
+      expect(payload.observation).toBeUndefined();
+      expect(payload.observationDiff).toBeUndefined();
+      expect(fakeTimer.now()).toBe(2550);
+    });
+  }
+});
 
 describe("systemTray find", () => {
   afterEach(() => {
@@ -1258,7 +1394,7 @@ describe("systemTray group expansion", () => {
 
   test("tap action expands collapsed group then re-matches", async () => {
     const fakeTimer = new FakeTimer();
-    const fakeAdb = new SequencedFakeAdbExecutor([1000, 1000]);
+    const fakeAdb = new SequencedFakeAdbExecutor([1000, 1000, 2000]);
 
     const collapsedHierarchy = createTrayWithGroupedNotifications("FUBStaging", [
       "Zillow Real-Time Tour request",
@@ -1269,12 +1405,13 @@ describe("systemTray group expansion", () => {
       "Test message",
     ]);
 
-    const fakeObserveScreen = new SequencedObserveScreen([
-      createObservation(collapsedHierarchy),
-      createObservation(expandedHierarchy),
-      createObservation(expandedHierarchy),
-      createObservation(expandedHierarchy),
-    ]);
+    const fakeObserveScreen = new FakeObserveScreen();
+    fakeObserveScreen.setObserveResult((index) =>
+      createObservation({
+        ...(index === 0 ? collapsedHierarchy : expandedHierarchy),
+        updatedAt: 2001 + fakeTimer.now(),
+      }),
+    );
 
     setSystemTrayDependencies({
       timer: fakeTimer,
@@ -1294,8 +1431,13 @@ describe("systemTray group expansion", () => {
       platform: "android",
     });
     await waitForPendingSleep(fakeTimer);
+    fakeTimer.enableAutoAdvance();
     fakeTimer.advanceTime(EXPAND_GROUP_SETTLE_MS);
-    await tap;
+    const response = await tap;
+    const payload = JSON.parse((response.content[0] as { text: string }).text);
+    // Expanding the group is not evidence that the subsequent notification tap worked.
+    expect(payload.settled).toBe(false);
+    expect(payload.observation).toBeUndefined();
 
     const tapCommands = fakeAdb.getExecutedCommands().filter((cmd) => cmd.includes("input tap"));
     expect(tapCommands).toHaveLength(2);

--- a/test/server/systemTray.test.ts
+++ b/test/server/systemTray.test.ts
@@ -163,7 +163,7 @@ describe("systemTray post-tap observation", () => {
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
       const fakeAdb = new SequencedFakeAdbExecutor([1000, 2000]);
-      const before = createObservation(createTrayHierarchy("Reply"));
+      const before = createObservation({ ...createTrayHierarchy("Reply"), updatedAt: 2000 });
       const intermediate = createObservation(createTrayHierarchy("Opening reply"));
       const after = createObservation(createTrayHierarchy("Reply"));
       after.viewHierarchy!.hierarchy.node.node[0].$["resource-id"] =
@@ -211,21 +211,27 @@ describe("systemTray post-tap observation", () => {
     });
   }
 
-  test("settles iOS effects when the device clock trails the host", async () => {
-    const timer = new FakeTimer();
-    timer.advanceTime(100000);
-    timer.enableAutoAdvance();
-    const baseline = createObservation({ ...createTrayHierarchy("Reply"), updatedAt: 900 });
-    const observer = new FakeObserveScreen();
-    observer.setObserveResult(
-      createObservation({ ...createTrayHierarchy("Send"), updatedAt: 1000 }),
-    );
-    setSystemTrayDependencies({ timer, observeScreenFactory: () => observer });
-    const result = await observeSystemTrayAfterTap({ ...device, platform: "ios" }, baseline);
-    expect(result.settled).toBe(true);
-    expect(observer.getExecuteOptions()[0].minTimestamp).toBe(901);
-    expect(timer.now()).toBe(101050);
-  });
+  for (const platform of ["android", "ios"] as const) {
+    test(`settles ${platform} effects when the device clock trails host fallback time`, async () => {
+      const timer = new FakeTimer();
+      timer.advanceTime(100000);
+      timer.enableAutoAdvance();
+      const baseline = createObservation({ ...createTrayHierarchy("Reply"), updatedAt: 900 });
+      const observer = new FakeObserveScreen();
+      observer.setObserveResult(
+        createObservation({ ...createTrayHierarchy("Send"), updatedAt: 1000 }),
+      );
+      setSystemTrayDependencies({
+        timer,
+        adbFactory: () => new SequencedFakeAdbExecutor([100000]),
+        observeScreenFactory: () => observer,
+      });
+      const result = await observeSystemTrayAfterTap({ ...device, platform }, baseline);
+      expect(result.settled).toBe(true);
+      expect(observer.getExecuteOptions()[0].minTimestamp).toBe(901);
+      expect(timer.now()).toBe(101050);
+    });
+  }
 
   for (const alternating of [false, true]) {
     test(`${alternating ? "does not settle alternating" : "settles a new"} window with the same tree`, async () => {

--- a/test/server/systemTray.test.ts
+++ b/test/server/systemTray.test.ts
@@ -256,6 +256,33 @@ describe("systemTray post-tap observation", () => {
     });
   }
 
+  test("stops post-tap observation when the request is cancelled", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const controller = new AbortController();
+    const observer = new FakeObserveScreen();
+    observer.setObserveResult((index) => {
+      if (index > 0) controller.abort(new Error("request cancelled"));
+      return createObservation({ ...createTrayHierarchy("Reply"), updatedAt: 1000 + index });
+    });
+    setSystemTrayDependencies({
+      timer,
+      adbFactory: () => new SequencedFakeAdbExecutor([900]),
+      observeScreenFactory: () => observer,
+    });
+    registerInteractionTools();
+    const pending = ToolRegistry.getTool("systemTray")!.deviceAwareHandler!(
+      device,
+      { action: "tap", notification: { title: "Reply" }, platform: "android" },
+      undefined,
+      controller.signal,
+    );
+    await expect(pending).rejects.toThrow("Operation cancelled");
+    expect(observer.getExecuteCallCount()).toBe(2);
+    expect(observer.getExecuteOptions()[1].signal).toBe(controller.signal);
+    expect(timer.now()).toBe(0);
+  });
+
   for (const stale of [false, true]) {
     test(`omits uncertain evidence when ${stale ? "changed captures are stale" : "no effect arrives"}`, async () => {
       const fakeTimer = new FakeTimer();


### PR DESCRIPTION
## Summary

Notification Reply taps could return the pre-tap shade because the handler observed immediately and allowed cached data. The tap response now uses the existing fresh-observation poller to wait for a screen change and a 1-second quiet period within a 2.5-second polling budget.

Settled responses include the final observation. When the effect cannot be confirmed, the response retains dispatch-level success, sets `settled: false`, omits the observation, and tells the caller to re-observe. Group expansion keeps its own baseline, and timestamp floors stay in device time on Android and iOS.

## Linked Issue

Closes [#6816](https://github.com/kaeawc/auto-mobile/issues/6816).

## Validation

- 51 targeted system-tray and shared settle tests pass, including delayed Reply, intermediate transitions, stale/unchanged captures, Android/iOS clock skew and host-time fallback, and alternating windows.
- TypeScript new-error gate and build pass.
- Full Turbo lint/build/test and boundary checks pass: 15,262 unit tests across four workers (300-second overall worker budget).
- Runtime, delivery, and temporal review findings addressed with regressions.
- Reuses existing polling, structural diff, timestamp, and FakeTimer seams; no new dependencies.

## Device Verification

Verified with deterministic fakes. The reported Messages flow has not been repeated on a live emulator in this task.
