### PR TITLE
fix: collapse Android IME keys in compact observations

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -452,7 +452,17 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     val sortedWindowRoots =
       windowEntries
         .sortedWith(compareBy<WindowEntry> { it.windowLayer }.thenBy { it.windowId })
-        .map { it.hierarchy }
+        .map {
+          // Preserve IME ownership after window roots are combined (issue #6795).
+          // The desktop projection folds this subtree; raw captures retain every key.
+          if (it.windowType == "input_method" && !it.packageName.isNullOrBlank()) {
+            it.hierarchy.copy(
+              extras = it.hierarchy.extras.orEmpty() + ("automobile:imePackage" to it.packageName)
+            )
+          } else {
+            it.hierarchy
+          }
+        }
     val unifiedHierarchy =
       if (sortedWindowRoots.isEmpty()) null else UIElementInfo(children = sortedWindowRoots)
 

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -1308,6 +1308,41 @@ class ViewHierarchyExtractorTest {
     assertTrue(serialized.contains("com.android.systemui:id/clock"))
   }
 
+  @Test
+  fun `unified hierarchy preserves IME subtree identity and raw key detail`() {
+    val appRoot = fakeNode(packageName = "example.keyboard", text = "Settings")
+    val imeRoot =
+      fakeNode(
+        packageName = "example.keyboard",
+        text = "Keyboard",
+        children = listOf(fakeNode(packageName = "example.keyboard", text = "Q")),
+      )
+    val result =
+      extractor.extractFromAllWindows(
+        listOf(
+          fakeWindow(id = 1, layer = 0, root = appRoot, focused = true),
+          fakeWindow(
+            id = 2,
+            layer = 1,
+            root = imeRoot,
+            type = AccessibilityWindowInfo.TYPE_INPUT_METHOD,
+          ),
+        ),
+        appRoot,
+        disableAllFiltering = true,
+        occlusionEnabled = false,
+      )
+    val roots = result.hierarchy!!.node as kotlinx.serialization.json.JsonArray
+    val app = roots[0] as kotlinx.serialization.json.JsonObject
+    val ime = roots[1] as kotlinx.serialization.json.JsonObject
+    assertNull(app["extras"])
+    assertEquals(
+      kotlinx.serialization.json.JsonPrimitive("example.keyboard"),
+      (ime["extras"] as kotlinx.serialization.json.JsonObject)["automobile:imePackage"],
+    )
+    assertTrue(ime.toString().contains("\"Q\""))
+  }
+
   private fun fakeNode(
     packageName: String,
     text: String? = null,

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -241,6 +241,14 @@ The `deviceId` fields exist so the value that `listDevices` and the
 | 🎯 <code>accessibilityFocus</code> | Sets or clears Android TalkBack focus by resource ID, text, or content description. |
 | 🔀 <code>setToolEnabled</code>     | Enables or disables one exact AutoMobile tool for the current MCP session.          |
 
+On Android, compact observations fold captured soft-keyboard keys into a single
+`keyboard: { visible: true, package: "…" }` summary. Use `sendKeys` for text input
+and semantic keys, or `keyboard` to open or close it. `observe` with
+`project: "full"` or `raw: true` retains the individual keys. Folding requires
+a control-proxy build that supplies IME window identity; older builds retain
+their existing key output. An absent summary means no IME identity was captured,
+not a confirmed hidden keyboard.
+
 For the observe → act → observe behavior behind interaction tools, see the
 [interaction loop](design-docs/mcp/interaction-loop.md). For per-session public
 tool selection, see [Dynamic Tools](using/dynamic-tools.md).

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3260,6 +3260,20 @@
       },
       "type": "object",
       "properties": {
+        "keyboard": {
+          "type": "object",
+          "properties": {
+            "visible": {
+              "type": "boolean",
+              "const": true
+            },
+            "package": {
+              "type": "string"
+            }
+          },
+          "required": ["visible", "package"],
+          "additionalProperties": false
+        },
         "screenSize": {
           "type": "object",
           "properties": {
@@ -10108,6 +10122,20 @@
             {
               "type": "object",
               "properties": {
+                "keyboard": {
+                  "type": "object",
+                  "properties": {
+                    "visible": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "package": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["visible", "package"],
+                  "additionalProperties": false
+                },
                 "isDiff": {
                   "type": "boolean",
                   "const": true

--- a/src/features/observe/ObserveElementCollector.ts
+++ b/src/features/observe/ObserveElementCollector.ts
@@ -5,7 +5,11 @@ import { isClickableElementProperties } from "../../utils/elementProperties";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import { DefaultElementParser } from "../utility/ElementParser";
 import { FlattenedElementEntry, IdentifyMediaViews } from "./IdentifyMediaViews";
-import { ElementProvenance, setElementProvenance } from "./output/elementProvenance";
+import {
+  ElementProvenance,
+  setElementProvenance,
+  setCapturedKeyboard,
+} from "./output/elementProvenance";
 
 export interface ObserveElementCollector {
   collect(
@@ -28,6 +32,7 @@ export class DefaultObserveElementCollector implements ObserveElementCollector {
     const scrollable: Element[] = [];
     const flattenedEntries: FlattenedElementEntry[] = [];
     let currentIndex = 0;
+    let keyboardPackage: string | undefined;
 
     // Each root/window becomes its own ancestry group so downstream skeleton
     // hoisting/suppression can tell a genuine descendant from an unrelated node
@@ -45,12 +50,13 @@ export class DefaultObserveElementCollector implements ObserveElementCollector {
     const provenanceState: ProvenanceState = { enter: 0, records: [] };
 
     for (const { root, group } of rootGroups) {
-      this.collectFromRoot(root, group, provenanceState, {
-        clickable,
-        scrollable,
-        flattenedEntries,
-        nextIndex: () => currentIndex++,
-      });
+      keyboardPackage =
+        this.collectFromRoot(root, group, platform, provenanceState, {
+          clickable,
+          scrollable,
+          flattenedEntries,
+          nextIndex: () => currentIndex++,
+        }) ?? keyboardPackage;
     }
 
     finalizeProvenanceExits(provenanceState.records);
@@ -60,12 +66,18 @@ export class DefaultObserveElementCollector implements ObserveElementCollector {
       .map((entry) => entry.element);
     const media = this.mediaClassifier.classify(viewHierarchy, platform, flattenedEntries);
 
-    return { clickable, scrollable, text, media };
+    const elements: NonNullable<ObserveResult["elements"]> = { clickable, scrollable, text, media };
+    // Like element ancestry, this is output-projection metadata, not raw element content.
+    if (keyboardPackage) {
+      setCapturedKeyboard(elements, { visible: true, package: keyboardPackage });
+    }
+    return elements;
   }
 
   private collectFromRoot(
     rootNode: ViewHierarchyNode,
     group: number,
+    platform: "android" | "ios",
     provenanceState: ProvenanceState,
     collections: {
       clickable: Element[];
@@ -73,13 +85,23 @@ export class DefaultObserveElementCollector implements ObserveElementCollector {
       flattenedEntries: FlattenedElementEntry[];
       nextIndex: () => number;
     },
-  ): void {
+  ): string | undefined {
     // Stack of enclosing parsed nodes (by tree depth) so each parsed node links
     // to its nearest parsed ancestor — bounds-less nodes are skipped in the
     // arrays but must not break ancestry between the nodes that survive.
     const ancestors: { depth: number; provenance: ElementProvenance }[] = [];
+    let keyboardRoot: { depth: number; package: string } | undefined;
+    let capturedKeyboardPackage: string | undefined;
 
     this.parser.traverseNode(rootNode, (node: ViewHierarchyNode, depth: number) => {
+      const nodeProperties = this.parser.extractNodeProperties(node);
+      keyboardRoot = nextKeyboardRoot(
+        keyboardRoot,
+        nodeProperties.extras?.["automobile:imePackage"],
+        depth,
+        platform,
+      );
+      capturedKeyboardPackage = keyboardRoot?.package ?? capturedKeyboardPackage;
       // Pop stale same-or-deeper entries for EVERY visited node, before the
       // bounds-less early return — otherwise a skipped wrapper never terminates a
       // preceding parsed sibling's ancestry, and the wrapper's parsed descendants
@@ -96,27 +118,17 @@ export class DefaultObserveElementCollector implements ObserveElementCollector {
 
       const parent = ancestors.length > 0 ? ancestors[ancestors.length - 1].provenance : undefined;
       const enter = provenanceState.enter++;
-      const provenance: ElementProvenance = { group, enter, exit: enter };
+      const provenance: ElementProvenance = {
+        group,
+        enter,
+        exit: enter,
+        keyboardPackage: keyboardRoot?.package,
+      };
       setElementProvenance(parsedNode, provenance);
       provenanceState.records.push({ provenance, parent });
       ancestors.push({ depth, provenance });
 
-      const nodeProperties = this.parser.extractNodeProperties(node);
-      // A `checkable` node (Android `Switch`/`SwitchCompat`/`CheckBox`) commonly
-      // sits inside a clickable preference row with `clickable="false"` on the
-      // switch itself — the parent row owns the tap, the switch only reflects
-      // state. Without this, such a node is invisible to every downstream
-      // collection and its `checked` state never reaches the skeleton
-      // projection's `toggle` affordance (issue #6257).
-      if (
-        isClickableElementProperties(nodeProperties) ||
-        isTruthy(nodeProperties.checkable as boolean | string | undefined)
-      ) {
-        collections.clickable.push(parsedNode);
-      }
-      if (nodeProperties.scrollable === "true" || nodeProperties.scrollable === true) {
-        collections.scrollable.push(parsedNode);
-      }
+      collectActionableNode(parsedNode, nodeProperties, collections);
 
       const accessibilityText = nodeProperties.text || nodeProperties["content-desc"] || undefined;
       collections.flattenedEntries.push({
@@ -126,7 +138,36 @@ export class DefaultObserveElementCollector implements ObserveElementCollector {
         text: accessibilityText,
       });
     });
+    return capturedKeyboardPackage;
   }
+}
+
+/** Categorize actions independently of traversal and IME ownership. */
+function collectActionableNode(
+  element: Element,
+  properties: Element,
+  collections: { clickable: Element[]; scrollable: Element[] },
+): void {
+  // A non-clickable switch still needs its toggle affordance (issue #6257).
+  if (isClickableElementProperties(properties) || isTruthy(properties.checkable)) {
+    collections.clickable.push(element);
+  }
+  if (isTruthy(properties.scrollable)) {
+    collections.scrollable.push(element);
+  }
+}
+
+/** Track IME ownership even through bounds-less wrappers, ending it at the next sibling. */
+function nextKeyboardRoot(
+  current: { depth: number; package: string } | undefined,
+  imePackage: unknown,
+  depth: number,
+  platform: "android" | "ios",
+): { depth: number; package: string } | undefined {
+  if (platform === "android" && typeof imePackage === "string" && imePackage.length > 0) {
+    return { depth, package: imePackage };
+  }
+  return current && depth > current.depth ? current : undefined;
 }
 
 /** Shared pre-order counter and parent records accumulated across all roots. */

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -170,10 +170,15 @@ export function sanitizeObserveResult(
  * is never mutated" contract holds; only `out` (the clone) is edited.
  */
 function projectSkeletonOnto(out: ObserveResult, source: ObserveResult): void {
-  const { skeleton, context } = source.elements
+  const { skeleton, context, keyboard } = source.elements
     ? projectSkeleton(source.elements)
-    : { skeleton: [] as SkeletonElement[], context: [] as SkeletonElement[] };
+    : { skeleton: [] as SkeletonElement[], context: [] as SkeletonElement[], keyboard: undefined };
   out.skeleton = skeleton;
+  if (keyboard) {
+    out.keyboard = keyboard;
+  } else {
+    delete out.keyboard;
+  }
   if (context.length > 0) {
     out.context = context;
   } else {
@@ -594,6 +599,7 @@ export interface ObserveDiffNodeChange {
  * current state text).
  */
 export interface ObserveDiff {
+  keyboard?: ObserveResult["keyboard"];
   isDiff: true;
   /**
    * Actionable-only selector surface (issue #6221 items 1 and 4.1), ALWAYS
@@ -638,6 +644,8 @@ export interface ObserveDiff {
 }
 
 export interface DiffObserveConfig {
+  /** Compact output suppresses captured IME subtrees; full/raw diffs retain them. */
+  collapseKeyboard?: boolean;
   /**
    * Top-level scalar ObserveResult fields to diff. Defaults to
    * `DIFF_SCALAR_FIELDS`. `updatedAt` is deliberately excluded from the default
@@ -806,7 +814,7 @@ function platformClassNameForDiff(node: Record<string, unknown>): string {
  * key is globally unique by position and identical cells in sibling subtrees do
  * not collide.
  */
-function flattenForDiff(obs: ObserveResult): FlatObserveNode[] {
+function flattenForDiff(obs: ObserveResult, collapseKeyboard = false): FlatObserveNode[] {
   const out: FlatObserveNode[] = [];
   const walk = (
     node: ViewHierarchyNode | undefined,
@@ -818,6 +826,9 @@ function flattenForDiff(obs: ObserveResult): FlatObserveNode[] {
       return;
     }
     const rec = node as unknown as Record<string, unknown>;
+    if (collapseKeyboard && node.extras?.["automobile:imePackage"]) {
+      return;
+    }
     const localKey = nodeKey(rec, siblingIndex);
     const pathKey = parentPath === "" ? localKey : `${parentPath}${PATH_KEY_SEP}${localKey}`;
     out.push({ pathKey, key: localKey, attributes: nodeAttributes(rec), ancestorClasses });
@@ -1396,8 +1407,8 @@ export function diffObserveResult(
   next: ObserveResult,
   cfg?: DiffObserveConfig,
 ): ObserveDiff {
-  const nextFlatNodes = flattenForDiff(next);
-  const baseByKey = groupByKey(flattenForDiff(baseline));
+  const nextFlatNodes = flattenForDiff(next, cfg?.collapseKeyboard);
+  const baseByKey = groupByKey(flattenForDiff(baseline, cfg?.collapseKeyboard));
   const nextByKey = groupByKey(nextFlatNodes);
   // Occurrence-index map for ambiguous elementIds among `next`'s nodes (PR #6242
   // review PRRT_kwDOP-GF5M6fq3iI) — see computeElementIdOccurrenceIndexes' doc.

--- a/src/features/observe/output/SkeletonProjection.ts
+++ b/src/features/observe/output/SkeletonProjection.ts
@@ -5,7 +5,12 @@ import {
   hasAccessibilityAction,
 } from "../../../utils/elementProperties";
 import type { Affordance, ObserveResult, SkeletonElement } from "../../../models/ObserveResult";
-import { ElementProvenance, getElementProvenance, isStrictAncestor } from "./elementProvenance";
+import {
+  ElementProvenance,
+  getElementProvenance,
+  getCapturedKeyboard,
+  isStrictAncestor,
+} from "./elementProvenance";
 
 /**
  * Interactable Skeleton Projection (issue #4388).
@@ -189,7 +194,10 @@ function strictlyContains(
  */
 function accumulateByIdentity(elements: ObserveElements): SkeletonAccumulator[] {
   const byIdentity = new Map<string, SkeletonAccumulator>();
-  for (const el of [...elements.clickable, ...elements.scrollable, ...elements.text]) {
+  const appElements = [...elements.clickable, ...elements.scrollable, ...elements.text].filter(
+    (element) => !getElementProvenance(element)?.keyboardPackage,
+  );
+  for (const el of appElements) {
     const bounds = boundsTuple(el);
     if (!bounds) {
       continue;
@@ -608,6 +616,7 @@ function collapseSystemUiBlock(nonActionable: SkeletonAccumulator[]): SkeletonAc
 
 /** The `skeleton` (actionable) and `context` (non-actionable) halves of a projection. */
 export interface SkeletonProjectionResult {
+  keyboard?: ObserveResult["keyboard"];
   /** Actionable-only rows (`affordances.length >= 1`); the surface a client should act on. */
   skeleton: SkeletonElement[];
   /**
@@ -645,9 +654,21 @@ export function projectSkeleton(elements: ObserveElements): SkeletonProjectionRe
   assignDuplicateIndexes(actionable);
 
   return {
+    keyboard: getCapturedKeyboard(elements) ?? keyboardSummary(elements),
     skeleton: actionable.map(toSkeletonEntry),
     context: collapseSystemUiBlock(nonActionable).map(toSkeletonEntry),
   };
+}
+
+/** Report only observed IME identity; missing capture evidence does not mean hidden. */
+function keyboardSummary(elements: ObserveElements): ObserveResult["keyboard"] {
+  for (const element of [...elements.clickable, ...elements.scrollable, ...elements.text]) {
+    const packageName = getElementProvenance(element)?.keyboardPackage;
+    if (packageName) {
+      return { visible: true, package: packageName };
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/src/features/observe/output/elementProvenance.ts
+++ b/src/features/observe/output/elementProvenance.ts
@@ -1,4 +1,16 @@
 import type { Element } from "../../../models/Element";
+import type { ObserveResult } from "../../../models/ObserveResult";
+
+const CAPTURED_KEYBOARD = Symbol("auto-mobile.capturedKeyboard");
+
+/** Capture-level IME identity also survives when there are no accessible keys. */
+export function setCapturedKeyboard(elements: object, keyboard: ObserveResult["keyboard"]): void {
+  Object.defineProperty(elements, CAPTURED_KEYBOARD, { value: keyboard });
+}
+
+export function getCapturedKeyboard(elements: object): ObserveResult["keyboard"] {
+  return (elements as { [CAPTURED_KEYBOARD]?: ObserveResult["keyboard"] })[CAPTURED_KEYBOARD];
+}
 
 /**
  * Root/window ancestry provenance for a collected element (issue #5881).
@@ -34,6 +46,8 @@ export interface ElementProvenance {
   enter: number;
   /** Maximum `enter` within this node's parsed subtree (inclusive interval end). */
   exit: number;
+  /** Android IME root identity inherited by descendants; never inferred from key labels. */
+  keyboardPackage?: string;
 }
 
 /**

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -186,6 +186,8 @@ export interface ObserveResult {
    * never `tapOn`/`inputText`/etc.
    */
   skeleton?: SkeletonElement[];
+  /** Observed Android IME window, replacing its individual keys in compact output. */
+  keyboard?: { visible: true; package: string };
 
   /**
    * Non-actionable rows from the same projection that produces `skeleton`

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -537,7 +537,9 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
         } else if (
           shouldDiffObservation(baseline, sanitized, classifyObservationAction(ctx.name, ctx.args))
         ) {
-          const diff = diffObserveResult(baseline, sanitized);
+          const diff = diffObserveResult(baseline, sanitized, {
+            collapseKeyboard: servedObservation.skeleton !== undefined,
+          });
           // Always attach a usable selector surface alongside the diff (issue #6221
           // item 4.1): a client that gets a diff must never be left with no
           // `skeleton` to act on — including when the request is `raw:true` /
@@ -559,6 +561,13 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
             payload.observation as ObserveResult,
             cfg,
           );
+          diff.keyboard =
+            servedObservation.skeleton !== undefined
+              ? servedObservation.keyboard
+              : sanitizeObserveResult(payload.observation as ObserveResult, {
+                  ...cfg,
+                  project: "skeleton",
+                }).keyboard;
           // Issue #6258: a diff must not silently drop `activeWindow`/`freshness`
           // either — see resolveDiffScreenState. Both fields come through as
           // `undefined` when the underlying observation lacks them, which drops

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -690,6 +690,7 @@ export const observeDiffNodeChangeSchema = z
  */
 export const observeDiffSchema = z
   .object({
+    keyboard: z.object({ visible: z.literal(true), package: z.string() }).optional(),
     isDiff: z.literal(true),
     skeleton: z
       .array(skeletonElementSchema)
@@ -846,6 +847,7 @@ const perfSnapshotSchema = z.object({
 
 export const observeResultSchema = z
   .object({
+    keyboard: z.object({ visible: z.literal(true), package: z.string() }).optional(),
     screenSize: screenSizeSchema.optional(),
     systemInsets: systemInsetsSchema.optional(),
     insets: observationInsetsSchema.optional(),

--- a/test/features/observe/output/KeyboardProjection.test.ts
+++ b/test/features/observe/output/KeyboardProjection.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import type { ObserveResult } from "../../../../src/models/ObserveResult";
+import type { ViewHierarchyNode } from "../../../../src/models/ViewHierarchyResult";
+import { DefaultObserveElementCollector } from "../../../../src/features/observe/ObserveElementCollector";
+import { sanitizeObserveResult } from "../../../../src/features/observe/output/ObserveResultOutput";
+
+function observation(platform: "android" | "ios" = "android", keyboard = true): ObserveResult {
+  const node = (text: string): ViewHierarchyNode => ({
+    $: { text, clickable: true, bounds: { left: 0, top: 0, right: 100, bottom: 100 } },
+  });
+  const viewHierarchy = {
+    hierarchy: {
+      node: {
+        $: {},
+        node: [
+          node("SAVE"),
+          ...(keyboard
+            ? [
+                {
+                  $: { extras: { "automobile:imePackage": "example.keyboard" } },
+                  node: [
+                    node("Q"),
+                    node("Next"),
+                    {
+                      $: {
+                        text: "Suggestion",
+                        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+                      },
+                    },
+                  ],
+                },
+              ]
+            : []),
+          node("App control"),
+        ],
+      },
+    },
+  };
+  return {
+    updatedAt: 1,
+    screenSize: { width: 100, height: 200 },
+    systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+    viewHierarchy,
+    elements: new DefaultObserveElementCollector().collect(viewHierarchy, platform),
+  };
+}
+
+describe("Android keyboard output projection", () => {
+  test("reports a captured keyboard even without accessible keys", () => {
+    const source = observation();
+    source.viewHierarchy!.hierarchy.node!.node![1].node = [];
+    source.elements = new DefaultObserveElementCollector().collect(
+      source.viewHierarchy!,
+      "android",
+    );
+    const result = sanitizeObserveResult(source, { dropElements: true, project: "skeleton" });
+    expect(result.keyboard).toEqual({ visible: true, package: "example.keyboard" });
+    expect(JSON.stringify(source.elements)).not.toContain("keyboard");
+  });
+  test("folds keyboard descendants while retaining overlapping app controls", () => {
+    const source = observation();
+    const before = JSON.stringify(source);
+    const result = sanitizeObserveResult(source, { dropElements: true, project: "skeleton" });
+    expect(result.skeleton?.map((entry) => entry.label)).toEqual(["SAVE", "App control"]);
+    expect(result.keyboard).toEqual({ visible: true, package: "example.keyboard" });
+    expect(result.context).toBeUndefined();
+    expect(JSON.stringify(source)).toBe(before);
+  });
+
+  test("full output retains every keyboard node", () => {
+    const source = observation();
+    const result = sanitizeObserveResult(source, { dropElements: false, project: "full" });
+    expect(result.elements?.clickable.map((entry) => entry.text)).toEqual([
+      "SAVE",
+      "Q",
+      "Next",
+      "App control",
+    ]);
+    expect(result.viewHierarchy).toBeDefined();
+    expect(result.keyboard).toBeUndefined();
+  });
+
+  test("does not invent visibility without keyboard capture evidence", () => {
+    expect(
+      sanitizeObserveResult(observation("android", false), {
+        dropElements: true,
+        project: "skeleton",
+      }).keyboard,
+    ).toBeUndefined();
+  });
+
+  test("does not fold iOS nodes carrying Android extras", () => {
+    const result = sanitizeObserveResult(observation("ios"), {
+      dropElements: true,
+      project: "skeleton",
+    });
+    expect(result.skeleton?.map((entry) => entry.label)).toContain("Q");
+    expect(result.keyboard).toBeUndefined();
+  });
+});

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -11,6 +11,7 @@ import {
 import { serverConfig } from "../../src/utils/ServerConfig";
 import { GFXINFO_DUMP_MARKER } from "../../src/features/observe/output/ObserveResultOutput";
 import type { ObserveResult } from "../../src/models/ObserveResult";
+import { setElementProvenance } from "../../src/features/observe/output/elementProvenance";
 
 /**
  * Build a minimal ObserveResult whose hierarchy carries trimmable attributes:
@@ -1046,6 +1047,55 @@ describe("finalizeToolResponse", () => {
       const parsed = JSON.parse(finalized.content[0].text);
       expect(parsed.observation.context).toEqual(obsSc.context);
     });
+
+    test.each(["skeleton", "full"] as const)(
+      "%s diffs preserve the keyboard projection contract",
+      (project) => {
+        const { store } = makeStore();
+        finalizeToolResponse(createStructuredToolResponse(sameScreenObserve()), {
+          name: "observe",
+          sessionUuid: "s1",
+          baselineStore: store,
+        });
+        const next = sameScreenObserve();
+        (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+        const key = {
+          text: "Q",
+          clickable: true,
+          bounds: { left: 0, top: 100, right: 50, bottom: 150 },
+        };
+        setElementProvenance(key, {
+          group: 1,
+          enter: 1,
+          exit: 1,
+          keyboardPackage: "example.keyboard",
+        });
+        next.elements = { clickable: [key], text: [key], scrollable: [], media: [] };
+        (next.viewHierarchy!.hierarchy.node as any).node.push({
+          extras: { "automobile:imePackage": "example.keyboard" },
+          node: [key],
+        });
+        const result = finalizeToolResponse(
+          createStructuredToolResponse({ success: true, observation: next }),
+          {
+            name: "tapOn",
+            args: { project },
+            sessionUuid: "s1",
+            baselineStore: store,
+          },
+        );
+        const observation = (result.structuredContent as any).observation;
+        expect(observation.isDiff).toBe(true);
+        expect(observation.keyboard).toEqual({ visible: true, package: "example.keyboard" });
+        expect(observation.skeleton).toEqual([]);
+        expect(observation.added.some((entry: any) => entry.attributes.text === "Q")).toBe(
+          project === "full",
+        );
+        expect(JSON.parse(result.content[0].text).observation.keyboard).toEqual(
+          observation.keyboard,
+        );
+      },
+    );
 
     test("a diff with no surviving readout row omits `context` entirely rather than emitting `[]`", () => {
       const { store } = makeStore();


### PR DESCRIPTION
## Summary

When an Android text field opens the soft keyboard, compact observations now replace individual IME keys with `keyboard: { visible: true, package }`. App controls remain selectable, including overlapping controls from the keyboard's own settings package. Full/raw output retains key details.

The Android extractor already knows the IME window type but discarded that ownership when combining window roots. Preserve the IME package on its root, carry ancestry through the existing non-serialized provenance seam, and fold only that subtree in skeleton/context and compact action diffs. Keep the summary even when the IME exposes no accessible keys. Missing metadata remains unknown rather than claiming the keyboard is hidden.

Closes [#6795](https://github.com/kaeawc/auto-mobile/issues/6795).

## Validation

- Regression reproduced before implementation: Q and Next incorrectly appeared in the compact skeleton.
- 151 targeted TypeScript tests pass, including empty IME, overlapping app controls, iOS exclusion, immutable input, and compact/full action diffs.
- 89 Android `ViewHierarchyExtractorTest` tests pass, including wire identity and retained raw keys.
- Typecheck reports no new errors; Kotlin formatting passes.
- `AUTOMOBILE_UNIT_TEST_WORKERS=4 AUTOMOBILE_TEST_WALL_TIMEOUT_SECONDS=600 bun run turbo:validate` passes: all seven tasks, including 15,262 tests. Individual test timeout limits were unchanged; reduced concurrency avoided downloader timeouts observed under host contention.
- 63 output-schema tests pass; generated tool definitions are current.

## Reuse and delivery

Uses Kotlin data-class `copy`, standard map operations, and the existing TypeScript element-provenance mechanism; no dependency added. Small private collector helpers separate category classification and IME ancestry tracking to stay within the complexity gate.

The Android helper must be rebuilt from this change through the normal artifact release process. Older helpers retain existing per-key output without inventing keyboard visibility. No real-device validation is claimed.
