### PR TITLE
fix: clarify schema validation errors

### DIFF
--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -601,7 +601,7 @@ export const systemTraySchema = withAppIdAliases(
     if (!hasCriteria) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: `${value.action} action requires at least one notification criteria (title, body, or appId)`,
+        message: `${value.action} requires at least one criterion under 'notification': notification: { title | body | appId }`,
       });
     }
 

--- a/src/server/toolParamError.ts
+++ b/src/server/toolParamError.ts
@@ -75,7 +75,22 @@ function coverageKey(unionId: number, path: ReadonlyArray<PropertyKey>): string 
   return `${unionId}#${path.map(String).join(".")}`;
 }
 
-function formatSelectorIssue(issue: ZodIssue, toolName: string, path: string): string | undefined {
+function formatSelectorIssue(
+  issue: ZodIssue,
+  toolName: string,
+  path: string,
+  rawInput: unknown,
+): string | undefined {
+  if (
+    toolName === "tapOn" &&
+    path === "selector" &&
+    issue.code === "invalid_type" &&
+    issue.expected === "object" &&
+    rawInput !== undefined &&
+    !isProvidedInput(rawInput, issue.path)
+  ) {
+    return "selector is required: selector: { elementId | testTag | text | accessibilityLink | textAny }";
+  }
   if (issue.code !== "unrecognized_keys" || toolName !== "tapOn" || path !== "selector") {
     return undefined;
   }
@@ -98,7 +113,8 @@ function formatMissingPlatformIssue(
 function formatIssue(issue: ZodIssue, toolName: string, rawInput: unknown): string {
   const path = issue.path.length ? issue.path.join(".") : "parameters";
   const actionableIssue =
-    formatSelectorIssue(issue, toolName, path) ?? formatMissingPlatformIssue(issue, path, rawInput);
+    formatSelectorIssue(issue, toolName, path, rawInput) ??
+    formatMissingPlatformIssue(issue, path, rawInput);
   if (actionableIssue) {
     return actionableIssue;
   }

--- a/test/server/interactionSchemaErrors.test.ts
+++ b/test/server/interactionSchemaErrors.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { systemTraySchema, tapOnSchema } from "../../src/server/interactionTools";
+import { formatToolParamError } from "../../src/server/toolParamError";
+
+describe("actionable interaction schema errors", () => {
+  for (const action of ["find", "tap"]) {
+    test.each([
+      {},
+      { text: "mt sms" },
+      { title: "sender" },
+      { body: "mt sms" },
+      { appId: "com.app" },
+    ])(`systemTray ${action} names the notification object for %j`, (criteria) => {
+      const input = { action, ...criteria };
+      const result = systemTraySchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (result.success) {
+        throw new Error("expected invalid criteria");
+      }
+      expect(formatToolParamError("systemTray", result.error, input)).toContain(
+        `${action} requires at least one criterion under 'notification': notification: { title | body | appId }`,
+      );
+    });
+    test.each(["title", "body", "appId"])(`systemTray ${action} accepts notification.%s`, (key) => {
+      expect(systemTraySchema.safeParse({ action, notification: { [key]: "value" } }).success).toBe(
+        true,
+      );
+    });
+  }
+
+  test.each([{}, { elementId: "com.app:id/button" }])(
+    "tapOn missing selector gives its shape for %j",
+    (input) => {
+      const result = tapOnSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (result.success) {
+        throw new Error("expected missing selector");
+      }
+      const message = formatToolParamError("tapOn", result.error, input);
+      const hint =
+        "selector is required: selector: { elementId | testTag | text | accessibilityLink | textAny }";
+      expect(message).toContain(hint);
+      expect(message.split(hint)).toHaveLength(2);
+    },
+  );
+
+  test.each([null, 42, "button"])(
+    "tapOn supplied malformed selector remains a type error: %j",
+    (selector) => {
+      const input = { selector };
+      const result = tapOnSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (result.success) {
+        throw new Error("expected invalid selector");
+      }
+      const message = formatToolParamError("tapOn", result.error, input);
+      expect(message).toContain("selector expected object");
+      expect(message).not.toContain("selector is required");
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Schema-validation errors now show the containing object: `systemTray` points callers to `notification: { title | body | appId }`, and `tapOn` names `selector: { elementId | testTag | text | accessibilityLink | textAny }` when the selector is missing. Validation rules are unchanged; malformed supplied selectors retain their type errors.

Closes [#6815](https://github.com/kaeawc/auto-mobile/issues/6815).

## Bug / Regression Context

Passing notification criteria or an observed `elementId` at the top level produced errors that did not show where those fields belong. The fix updates the existing schema message and selector formatter, reusing the existing input-presence helper without new dependencies.

## Validation

- Regression tests first reproduced 12 failing cases; all 21 new cases now pass.
- 219 focused schema tests and 53 formatter regression tests passed.
- Runtime review found no actionable findings; its four relevant suites passed 125 tests.
- Typecheck reports no new errors.
