### PR TITLE
fix(tap): propagate iOS hierarchy budget and cancellation

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -1145,7 +1145,11 @@ export class TapOnElement extends BaseVisualChange {
     screenSize?: ObserveResult["screenSize"],
     signal?: AbortSignal,
   ): Promise<ViewHierarchyResult | null> {
+    throwIfAborted(signal);
     const effectiveTimeoutMs = Math.max(0, timeoutMs);
+    if (effectiveTimeoutMs === 0) {
+      return null;
+    }
     switch (this.device.platform) {
       case "android": {
         const rawHierarchy = await refreshAndroidViewHierarchy(
@@ -1159,7 +1163,15 @@ export class TapOnElement extends BaseVisualChange {
       }
       case "ios": {
         const xcTestClient = IOSCtrlProxyClient.getInstance(this.device);
-        const rawHierarchy = await xcTestClient.getAccessibilityHierarchy();
+        const rawHierarchy = await xcTestClient.getAccessibilityHierarchy(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          signal,
+          effectiveTimeoutMs,
+        );
         return rawHierarchy ? this.prepareViewHierarchyForResponse(rawHierarchy, screenSize) : null;
       }
       default:

--- a/test/features/action/TapOnElement.iosBudget.test.ts
+++ b/test/features/action/TapOnElement.iosBudget.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, expect, spyOn, test } from "bun:test";
+import { TapOnElement } from "../../../src/features/action/TapOnElement";
+import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
+import { PortManager } from "../../../src/utils/PortManager";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeIOSCtrlProxy } from "../../fakes/FakeIOSCtrlProxy";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+let restore: () => void;
+let tap: TapOnElement;
+let client: FakeIOSCtrlProxy;
+let read: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  PortManager.reset();
+  PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
+  client = new FakeIOSCtrlProxy();
+  read = spyOn(client, "getAccessibilityHierarchy");
+  const instance = spyOn(IOSCtrlProxyClient, "getInstance").mockImplementation(() => client as any);
+  restore = () => instance.mockRestore();
+  tap = new TapOnElement(
+    { name: "test", platform: "ios", deviceId: "test-ios-budget" },
+    new FakeAdbClient(),
+    { timer: new FakeTimer() },
+  );
+});
+
+afterEach(() => {
+  restore();
+  read.mockRestore();
+  PortManager.reset();
+  PortManager.setPortAvailabilityCheckerForTesting(null);
+});
+
+test("iOS hierarchy refresh forwards the caller's remaining budget and signal", async () => {
+  const signal = new AbortController().signal;
+  await tap["refreshViewHierarchy"](37, undefined, signal);
+  expect(client.getHierarchyRequestTimeouts()).toEqual([37]);
+  expect(read.mock.calls[0]?.[5]).toBe(signal);
+});
+
+test.each([0, -10])("an expired budget %s starts no hierarchy request", async (budget) => {
+  expect(await tap["refreshViewHierarchy"](budget)).toBeNull();
+  expect(client.getHierarchyRequestTimeouts()).toEqual([]);
+  expect(read).not.toHaveBeenCalled();
+});
+
+test("an aborted refresh rethrows cancellation without starting a request", async () => {
+  const controller = new AbortController();
+  const reason = new Error("cancelled refresh");
+  controller.abort(reason);
+  await expect(tap["refreshViewHierarchy"](37, undefined, controller.signal)).rejects.toThrow(
+    "Operation cancelled",
+  );
+  expect(client.getHierarchyRequestTimeouts()).toEqual([]);
+});


### PR DESCRIPTION
An iOS `tapOn` hierarchy refresh discarded the caller's remaining timeout and cancellation signal, letting CtrlProxy use its default hierarchy timeout during bounded searches. Forward both through the existing client API. Exhausted budgets return without device work, and pre-aborted calls fail through the existing cancellation helper.

Closes [issue 6615](https://github.com/kaeawc/auto-mobile/issues/6615). Addresses one independently reproducible W1 instance from [issue 6333](https://github.com/kaeawc/auto-mobile/issues/6333); connection-setup budgeting and shared deadline adoption remain in the campaign queue.

Validation: regression tests reproduced the dropped timeout and swallowed cancellation; 12 focused hierarchy/search tests pass. All seven `bun run turbo:validate --env-mode=loose` tasks pass, and `bun run typecheck` reports no new errors. No dependencies or new production abstractions added.
