### PR TITLE
chore(ios): epic #6372 follow-ups — dedup runner predicates / permission vocab / iOS version parse

### DIFF
--- a/src/daemon/DeviceCriteriaMatcher.ts
+++ b/src/daemon/DeviceCriteriaMatcher.ts
@@ -1,5 +1,6 @@
 import { BootedDevice, DeviceInfo, Platform } from "../models";
 import type { PooledDevice } from "./devicePool";
+import { iosVersionStringFromRuntimeId } from "../utils/ios-cmdline-tools/iosVersion";
 
 export interface DeviceAllocationCriteria {
   platform?: Platform;
@@ -264,7 +265,6 @@ export class DeviceCriteriaMatcher {
   }
 
   private iosVersionFromRuntime(runtime?: string): string | undefined {
-    const match = runtime?.match(/iOS[-_](\d+(?:[-_]\d+)*)/);
-    return match?.[1].replace(/[-_]/g, ".");
+    return iosVersionStringFromRuntimeId(runtime);
   }
 }

--- a/src/features/action/IosSimulatorPermissions.ts
+++ b/src/features/action/IosSimulatorPermissions.ts
@@ -2,6 +2,8 @@ import { errorMessage } from "../../utils/describeUnknownError";
 import type { BootedDevice, ExecResult } from "../../models";
 import {
   SimulatorTccSqliteClient,
+  permissionForTccService,
+  tccServiceForPermission,
   type TccPermissionReader,
 } from "../../utils/ios-cmdline-tools/SimulatorTccSqliteClient";
 import type { HostCommandExecutor } from "../../utils/HostCommandExecutor";
@@ -86,22 +88,6 @@ export class SqliteTccPermissionReader extends SimulatorTccSqliteClient {
   }
 }
 
-const TCC_SERVICE_BY_PERMISSION = new Map<string, string>([
-  ["calendar", "kTCCServiceCalendar"],
-  ["camera", "kTCCServiceCamera"],
-  ["contacts", "kTCCServiceAddressBook"],
-  ["contacts-limited", "kTCCServiceAddressBook"],
-  ["location", "kTCCServiceLocationWhenInUse"],
-  ["location-always", "kTCCServiceLocationAlways"],
-  ["media-library", "kTCCServiceMediaLibrary"],
-  ["microphone", "kTCCServiceMicrophone"],
-  ["motion", "kTCCServiceMotion"],
-  ["photos", "kTCCServicePhotos"],
-  ["photos-add", "kTCCServicePhotosAdd"],
-  ["reminders", "kTCCServiceReminders"],
-  ["siri", "kTCCServiceSiri"],
-]);
-
 export function isIosSimulatorDevice(device: BootedDevice): boolean {
   return isIosSimulatorUdid(device.deviceId);
 }
@@ -110,21 +96,6 @@ export function normalizePermissions(permissions: string[] | undefined): string[
   return (permissions ?? [])
     .map((permission) => permission.trim())
     .filter((permission) => permission.length > 0);
-}
-
-function tccServiceForPermission(permission: string): string {
-  return permission.startsWith("kTCCService")
-    ? permission
-    : (TCC_SERVICE_BY_PERMISSION.get(permission) ?? permission);
-}
-
-function permissionForTccService(service: string): string {
-  for (const [permission, tccService] of TCC_SERVICE_BY_PERMISSION) {
-    if (tccService === service) {
-      return permission;
-    }
-  }
-  return service;
 }
 
 function stateFromAuthValue(

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -2255,12 +2255,16 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       const argsOut = processInfo?.command ?? "";
       if (
         !argsOut.includes("CtrlProxy") ||
-        (await this.isDaemonManagedSimulatorXcodebuildProcess(argsOut, processInfo))
+        (await this.processClient.isDaemonManagedSimulatorXcodebuildProcess({
+          command: argsOut,
+          ppid: processInfo?.ppid,
+          environment: processInfo?.environment,
+        }))
       ) {
         continue;
       }
       const identityText = `${argsOut} ${processInfo?.environment ?? ""}`;
-      if (!IOSCtrlProxyManager.hasDeviceIdentity(identityText, this.device.deviceId)) {
+      if (!this.processClient.hasDeviceIdentity(identityText, this.device.deviceId)) {
         continue;
       }
       const port =
@@ -2294,10 +2298,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         continue;
       }
       const processInfo = await this.processClient.getProcessInfo(pid, deadline);
-      if (
-        !processInfo ||
-        !IOSCtrlProxyManager.isDirectCtrlProxyRunnerCommand(processInfo.command)
-      ) {
+      if (!processInfo || !this.processClient.isDirectCtrlProxyRunnerCommand(processInfo.command)) {
         continue;
       }
       const port =
@@ -2345,7 +2346,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     for (const port of candidatePorts) {
       const listeningProcesses = await this.findListeningProcessesOnPort(port);
       for (const process of listeningProcesses) {
-        if (!IOSCtrlProxyManager.isDirectCtrlProxyRunnerCommand(process.command)) {
+        if (!this.processClient.isDirectCtrlProxyRunnerCommand(process.command)) {
           continue;
         }
         // A direct in-simulator runner with a daemon-managed xcodebuild/shell ancestor is
@@ -2465,12 +2466,12 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   private isOwnedCtrlProxyRunnerProcess(process: ListeningProcess): boolean {
-    if (!IOSCtrlProxyManager.isCtrlProxyRunnerCommand(process.command)) {
+    if (!this.processClient.isCtrlProxyRunnerCommand(process.command)) {
       return false;
     }
     return (
-      IOSCtrlProxyManager.hasDeviceIdentity(process.command, this.device.deviceId) ||
-      IOSCtrlProxyManager.hasDeviceIdentity(process.environment ?? "", this.device.deviceId)
+      this.processClient.hasDeviceIdentity(process.command, this.device.deviceId) ||
+      this.processClient.hasDeviceIdentity(process.environment ?? "", this.device.deviceId)
     );
   }
 
@@ -2485,7 +2486,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         return false;
       }
       if (
-        IOSCtrlProxyManager.hasDeviceIdentity(processInfo.command, this.device.deviceId) ||
+        this.processClient.hasDeviceIdentity(processInfo.command, this.device.deviceId) ||
         processInfo.command.includes(this.device.deviceId)
       ) {
         return true;
@@ -2513,7 +2514,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       deadline?: number;
     } = {},
   ): Promise<DaemonManagedRunnerTreeRoot> {
-    if (!IOSCtrlProxyManager.isCtrlProxyRunnerCommand(process.command)) {
+    if (!processClient.isCtrlProxyRunnerCommand(process.command)) {
       return { kind: "not_daemon_managed" };
     }
 
@@ -2521,7 +2522,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     let parentPid = process.ppid;
     const visitedPids = new Set<number>([process.pid]);
 
-    if (IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(process.command)) {
+    if (IOSCtrlProxyProcessClient.isDaemonManagedSimulatorXcodebuildCommandShape(process.command)) {
       rootPid = IOSCtrlProxyManager.rootPidForDaemonManagedProcess(
         process.pid,
         process.ppid,
@@ -2607,7 +2608,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     pid: number,
     requireOrphanedRoot: boolean | undefined,
   ): DaemonManagedRunnerParentRoot | null {
-    if (!IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(process.command)) {
+    if (
+      !IOSCtrlProxyProcessClient.isDaemonManagedSimulatorXcodebuildCommandShape(process.command)
+    ) {
       return null;
     }
     return {
@@ -2616,7 +2619,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         process.ppid,
         requireOrphanedRoot,
       ),
-      terminal: IOSCtrlProxyManager.isShellCommand(process.command),
+      terminal: IOSCtrlProxyProcessClient.isShellCommand(process.command),
     };
   }
 
@@ -2638,84 +2641,12 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     return processes.map((process) => `PID ${process.pid} (cmd: ${process.command})`).join(", ");
   }
 
-  private static hasDeviceIdentity(text: string, deviceId: string): boolean {
-    return (
-      text.includes(`id=${deviceId}`) ||
-      text.includes(`AUTOMOBILE_DEVICE_ID=${deviceId}`) ||
-      text.includes(`SIMCTL_CHILD_AUTOMOBILE_DEVICE_ID=${deviceId}`)
-    );
-  }
-
-  private async isDaemonManagedSimulatorXcodebuildProcess(
-    command: string,
-    processInfo?: { ppid?: number; environment?: string } | null,
-  ): Promise<boolean> {
-    const environment = processInfo?.environment ?? "";
-    if (!IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(command)) {
-      return false;
-    }
-    if (processInfo?.ppid === 1) {
-      return true;
-    }
-    if (await this.hasOrphanedDaemonManagedShellParent(processInfo?.ppid)) {
-      return true;
-    }
-    return !IOSCtrlProxyManager.hasExternalXcodebuildIdentity(environment);
-  }
-
-  private async hasOrphanedDaemonManagedShellParent(
-    parentPid: number | undefined,
-  ): Promise<boolean> {
-    if (parentPid === undefined || parentPid <= 1) {
-      return false;
-    }
-    const parentInfo = await this.processClient.getProcessInfo(parentPid);
-    if (!parentInfo || parentInfo.ppid !== 1) {
-      return false;
-    }
-    return (
-      IOSCtrlProxyManager.isShellCommand(parentInfo.command) &&
-      IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(parentInfo.command)
-    );
-  }
-
-  private static isDaemonManagedSimulatorXcodebuildCommandShape(command: string): boolean {
-    return (
-      command.includes("xcodebuild") &&
-      command.includes("test-without-building") &&
-      command.includes("-xctestrun") &&
-      command.includes("platform=iOS Simulator") &&
-      command.includes("-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService") &&
-      !command.includes("CTRL_PROXY_IOS_PORT=") &&
-      !command.includes("AUTOMOBILE_DEVICE_ID=")
-    );
-  }
-
-  private static isShellCommand(command: string): boolean {
-    return /(?:^|\/)(?:ba|z|c|t?c|k)?sh(?:\s|$)/.test(command);
-  }
-
-  private static hasExternalXcodebuildIdentity(environment: string): boolean {
-    return (
-      environment.includes("CTRL_PROXY_IOS_PORT=") ||
-      environment.includes("AUTOMOBILE_DEVICE_ID=") ||
-      environment.includes("SIMCTL_CHILD_AUTOMOBILE_DEVICE_ID=")
-    );
-  }
-
-  private static isCtrlProxyRunnerCommand(command: string): boolean {
-    return (
-      command.includes("CtrlProxy") &&
-      (command.includes("xcodebuild") ||
-        command.includes("CtrlProxyUITests") ||
-        command.includes("CtrlProxyUITests-Runner") ||
-        command.includes(".xctestrun"))
-    );
-  }
-
-  private static isDirectCtrlProxyRunnerCommand(command: string): boolean {
-    return command.includes("CtrlProxyUITests-Runner");
-  }
+  // Runner-identification predicates (hasDeviceIdentity, isCtrlProxyRunnerCommand,
+  // isDirectCtrlProxyRunnerCommand, isDaemonManagedSimulatorXcodebuildProcess and its
+  // supporting shape/shell helpers) now live solely on IOSCtrlProxyProcessClient — see
+  // IOSCtrlProxyProcessClient.ts. Keeping private copies here let them silently diverge
+  // (#6372 follow-up); callers in this file delegate to `this.processClient` /
+  // `IOSCtrlProxyProcessClient` instead.
 
   /**
    * Check if the tracked iproxy process is alive.

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -20,6 +20,7 @@ import { createGlobalPerformanceTracker } from "../PerformanceTracker";
 import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../deviceTimeouts";
 import { PlistClient, type PlistReader } from "./PlistClient";
 import { inferIosFormFactor, isIosSimulatorUdid } from "./iosDeviceType";
+import { iosVersionStringFromRuntimeId } from "./iosVersion";
 import { getAbortSignal } from "../AbortContext";
 import { Mutex } from "async-mutex";
 import { iosSimulatorCapabilityInventory } from "../../features/device-control/virtualDeviceCapabilities";
@@ -416,16 +417,7 @@ function normalizeIosVersion(
     return trimmedOsVersion;
   }
 
-  if (!runtimeId) {
-    return undefined;
-  }
-
-  const match = runtimeId.match(/iOS[-_](\d+(?:[-_]\d+)*)/);
-  if (!match) {
-    return undefined;
-  }
-
-  return match[1].replace(/_/g, ".").replace(/-/g, ".");
+  return iosVersionStringFromRuntimeId(runtimeId);
 }
 
 /** Numeric, component-wise comparison of dotted version strings. */

--- a/src/utils/ios-cmdline-tools/SimulatorTccSqliteClient.ts
+++ b/src/utils/ios-cmdline-tools/SimulatorTccSqliteClient.ts
@@ -61,6 +61,18 @@ export function tccServiceForPermission(permission: string): string {
     : (TCC_SERVICE_BY_PERMISSION.get(permission) ?? permission);
 }
 
+/** The inverse of {@link tccServiceForPermission}: the AutoMobile permission
+ * name for a raw `kTCCService*` identifier, or the service string unchanged
+ * when it isn't one of the known services. */
+export function permissionForTccService(service: string): string {
+  for (const [permission, tccService] of TCC_SERVICE_BY_PERMISSION) {
+    if (tccService === service) {
+      return permission;
+    }
+  }
+  return service;
+}
+
 function sqliteParameterValue(value: string): string {
   return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }

--- a/src/utils/ios-cmdline-tools/iosVersion.ts
+++ b/src/utils/ios-cmdline-tools/iosVersion.ts
@@ -15,6 +15,27 @@ export function parseIosMajorVersion(version: string | undefined | null): number
 }
 
 /**
+ * Extract the dotted iOS version string (e.g. `"17.2"`) embedded in a
+ * CoreSimulator runtime identifier such as
+ * `com.apple.CoreSimulator.SimRuntime.iOS-17-2`. Returns `undefined` when the
+ * identifier carries no iOS version token.
+ *
+ * This is the single source of truth for runtime-identifier version parsing;
+ * SimCtlClient's `normalizeIosVersion` and DeviceCriteriaMatcher's
+ * `iosVersionFromRuntime` used to each hand-roll their own copy of this regex
+ * (#6372 follow-up).
+ */
+export function iosVersionStringFromRuntimeId(
+  runtimeId: string | undefined | null,
+): string | undefined {
+  if (!runtimeId) {
+    return undefined;
+  }
+  const match = runtimeId.match(/iOS[-_](\d+(?:[-_]\d+)*)/i);
+  return match ? match[1].replace(/[-_]/g, ".") : undefined;
+}
+
+/**
  * Resolve the major iOS version for a booted simulator `udid` from the JSON
  * emitted by `simctl list devices <udid> --json`. The payload groups devices by
  * runtime identifier (e.g. `com.apple.CoreSimulator.SimRuntime.iOS-18-6`), so we
@@ -42,12 +63,12 @@ export function iosMajorVersionFromSimctlListDevices(json: string, udid: string)
   const devices = (parsed as { devices?: Record<string, Array<{ udid?: string }>> }).devices ?? {};
   for (const [runtimeId, deviceList] of Object.entries(devices)) {
     if (Array.isArray(deviceList) && deviceList.some((device) => device?.udid === udid)) {
-      const match = runtimeId.match(/iOS[-_](\d+)/i);
+      const major = parseIosMajorVersion(iosVersionStringFromRuntimeId(runtimeId));
       // Keep scanning: a udid should appear under exactly one runtime, but if an
       // earlier-iterated runtime id carries no iOS version token, later runtimes
       // may still resolve it rather than short-circuiting to null.
-      if (match) {
-        return parseInt(match[1], 10);
+      if (major !== null) {
+        return major;
       }
     }
   }

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -59,7 +59,7 @@ export class IOSCtrlProxyProcessClient {
       if (!process || !process.command.includes("CtrlProxy")) {
         continue;
       }
-      if (this.isDaemonManagedSimulatorXcodebuildProcess(process)) {
+      if (await this.isDaemonManagedSimulatorXcodebuildProcess(process)) {
         continue;
       }
       if (!this.hasDeviceIdentity(`${process.command} ${process.environment ?? ""}`, deviceId)) {
@@ -281,20 +281,62 @@ export class IOSCtrlProxyProcessClient {
     return command.includes("CtrlProxyUITests-Runner");
   }
 
-  isDaemonManagedSimulatorXcodebuildProcess(process: CtrlProxyProcessInfo): boolean {
+  /**
+   * The single source of truth for identifying a daemon-managed
+   * `xcodebuild test-without-building` runner, as opposed to an externally
+   * (e.g. hot-reload) launched xcodebuild process. A process matches when its
+   * command has the daemon shape AND either:
+   *  - it is already reparented to PID 1 (the common orphaned-root case), or
+   *  - its immediate parent is an orphaned shell wrapping the same shape
+   *    (the daemon launches the runner through `sh -c`, so the shell -
+   *    not the runner itself - is what gets reparented to PID 1), or
+   *  - its own environment carries none of the external-xcodebuild identity
+   *    markers.
+   */
+  async isDaemonManagedSimulatorXcodebuildProcess(process: CtrlProxyProcessInfo): Promise<boolean> {
     const command = process.command;
-    const shape =
+    if (!IOSCtrlProxyProcessClient.isDaemonManagedSimulatorXcodebuildCommandShape(command)) {
+      return false;
+    }
+    if (process.ppid === 1) {
+      return true;
+    }
+    if (await this.hasOrphanedDaemonManagedShellParent(process.ppid)) {
+      return true;
+    }
+    return !this.hasExternalXcodebuildIdentity(process.environment ?? "");
+  }
+
+  private async hasOrphanedDaemonManagedShellParent(
+    parentPid: number | undefined,
+  ): Promise<boolean> {
+    if (parentPid === undefined || parentPid <= 1) {
+      return false;
+    }
+    const parentInfo = await this.getProcessInfo(parentPid);
+    if (!parentInfo || parentInfo.ppid !== 1) {
+      return false;
+    }
+    return (
+      IOSCtrlProxyProcessClient.isShellCommand(parentInfo.command) &&
+      IOSCtrlProxyProcessClient.isDaemonManagedSimulatorXcodebuildCommandShape(parentInfo.command)
+    );
+  }
+
+  static isDaemonManagedSimulatorXcodebuildCommandShape(command: string): boolean {
+    return (
       command.includes("xcodebuild") &&
       command.includes("test-without-building") &&
       command.includes("-xctestrun") &&
       command.includes("platform=iOS Simulator") &&
       command.includes("-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService") &&
       !command.includes("CTRL_PROXY_IOS_PORT=") &&
-      !command.includes("AUTOMOBILE_DEVICE_ID=");
-    return (
-      shape &&
-      (process.ppid === 1 || !this.hasExternalXcodebuildIdentity(process.environment ?? ""))
+      !command.includes("AUTOMOBILE_DEVICE_ID=")
     );
+  }
+
+  static isShellCommand(command: string): boolean {
+    return /(?:^|\/)(?:ba|z|c|t?c|k)?sh(?:\s|$)/.test(command);
   }
 
   private async findPids(pattern: string, exact: boolean, deadline?: number): Promise<number[]> {
@@ -336,7 +378,7 @@ export class IOSCtrlProxyProcessClient {
     return match ? Number.parseInt(match[1], 10) : null;
   }
 
-  private hasExternalXcodebuildIdentity(environment: string): boolean {
+  hasExternalXcodebuildIdentity(environment: string): boolean {
     return (
       environment.includes("CTRL_PROXY_IOS_PORT=") ||
       environment.includes("AUTOMOBILE_DEVICE_ID=") ||

--- a/test/daemon/DeviceCriteriaMatcher.test.ts
+++ b/test/daemon/DeviceCriteriaMatcher.test.ts
@@ -190,6 +190,19 @@ describe("DeviceCriteriaMatcher", () => {
       expect(matcher.deviceImageMatchesCriteria(image, { iosVersion: "16.0" })).toBe(false);
     });
 
+    // iosVersionFromRuntime now delegates to the shared iosVersionStringFromRuntimeId
+    // helper, which matches "iOS" case-insensitively like iosVersion.ts's own
+    // simctl-list-devices parser always did. Before that dedup, this private copy
+    // only matched an exact-case "iOS" token (#6372 follow-up).
+    test("matches iOS version from a differently-cased runtime id", () => {
+      const image = deviceImage({
+        name: "iPhone 15",
+        platform: "ios",
+        runtime: "com.apple.CoreSimulator.SimRuntime.IOS-17-5",
+      });
+      expect(matcher.deviceImageMatchesCriteria(image, { iosVersion: "17.5" })).toBe(true);
+    });
+
     test("rejects platform mismatch", () => {
       const image = deviceImage({ name: "Pixel", platform: "android" });
       expect(matcher.deviceImageMatchesCriteria(image, { platform: "ios" })).toBe(false);

--- a/test/features/action/GrantIosSimulatorPermissions.test.ts
+++ b/test/features/action/GrantIosSimulatorPermissions.test.ts
@@ -317,6 +317,44 @@ describe("IosSimulatorPermissions", () => {
     });
   });
 
+  test("queries the siri permission via the single canonical TCC-service vocabulary (#6372 dedup)", async () => {
+    // IosSimulatorPermissions and SimulatorTccSqliteClient used to keep their own
+    // copies of the permission<->kTCCService mapping. This exercises a permission
+    // near the end of the table so a re-introduced private, out-of-sync copy
+    // (missing "siri", say) would show up as an unresolved raw service string
+    // instead of the "siri" permission name.
+    const tccReader: TccPermissionReader = {
+      readPermissions: async () => [
+        {
+          service: "kTCCServiceSiri",
+          client: "com.example.app",
+          auth_value: 2,
+          allowed: null,
+          prompt_count: null,
+        },
+      ],
+    };
+    const action = new IosSimulatorPermissions(simulatorDevice, new FakeSimCtlClient(), tccReader);
+
+    const result = await action.getPermissions("com.example.app", ["siri"]);
+
+    expect(result.permissions).toEqual([
+      {
+        permission: "siri",
+        service: "kTCCServiceSiri",
+        state: "granted",
+        authValue: 2,
+        raw: {
+          service: "kTCCServiceSiri",
+          client: "com.example.app",
+          auth_value: 2,
+          allowed: null,
+          prompt_count: null,
+        },
+      },
+    ]);
+  });
+
   test("keeps the legacy injected sqlite reader constructor available", async () => {
     const sqlite = new FakeSqliteCommandExecutor();
     const reader = new SqliteTccPermissionReader(sqlite, "/Users/tester");

--- a/test/utils/ios-cmdline-tools/SimulatorTccSqliteClient.test.ts
+++ b/test/utils/ios-cmdline-tools/SimulatorTccSqliteClient.test.ts
@@ -7,6 +7,8 @@ import type {
 } from "../../../src/utils/HostCommandExecutor";
 import {
   SimulatorTccSqliteClient,
+  permissionForTccService,
+  tccServiceForPermission,
   type TccDatabaseFileSystem,
 } from "../../../src/utils/ios-cmdline-tools/SimulatorTccSqliteClient";
 import { FakeTimer } from "../../fakes/FakeTimer";
@@ -61,6 +63,35 @@ class FakeSqliteExecutor implements HostCommandExecutor {
 }
 
 describe("SimulatorTccSqliteClient", () => {
+  test("tccServiceForPermission and permissionForTccService are inverses on the canonical vocabulary (#6372 dedup)", () => {
+    // These two functions - and IosSimulatorPermissions's grant/query paths -
+    // all derive from the single TCC_SERVICE_BY_PERMISSION table in this
+    // module. A permission that maps to a service this round-trip doesn't
+    // recover would indicate the vocabulary drifted apart again.
+    const canonicalPermissions = [
+      "calendar",
+      "camera",
+      "contacts",
+      "location",
+      "location-always",
+      "media-library",
+      "microphone",
+      "motion",
+      "photos",
+      "photos-add",
+      "reminders",
+      "siri",
+    ];
+    for (const permission of canonicalPermissions) {
+      const service = tccServiceForPermission(permission);
+      expect(service.startsWith("kTCCService")).toBe(true);
+      expect(permissionForTccService(service)).toBe(permission);
+    }
+    // Unknown permissions and already-qualified services pass through unchanged.
+    expect(tccServiceForPermission("kTCCServiceCamera")).toBe("kTCCServiceCamera");
+    expect(permissionForTccService("kTCCServiceUnknown")).toBe("kTCCServiceUnknown");
+  });
+
   test("owns TCC path resolution and issues parameterized sqlite argv queries", async () => {
     const executor = new FakeSqliteExecutor();
     const fileSystem = new FakeTccFileSystem();

--- a/test/utils/ios-cmdline-tools/iosVersion.test.ts
+++ b/test/utils/ios-cmdline-tools/iosVersion.test.ts
@@ -3,6 +3,7 @@ import {
   parseIosMajorVersion,
   iosMajorVersionFromSimctlListDevices,
   iosMajorVersionFromDevicectlDetails,
+  iosVersionStringFromRuntimeId,
 } from "../../../src/utils/ios-cmdline-tools/iosVersion";
 
 describe("parseIosMajorVersion", () => {
@@ -127,6 +128,44 @@ describe("iosMajorVersionFromSimctlListDevices", () => {
       },
     });
     expect(iosMajorVersionFromSimctlListDevices(multi, udid)).toBe(18);
+  });
+});
+
+describe("iosVersionStringFromRuntimeId", () => {
+  test("extracts the dotted version from a hyphenated runtime id", () => {
+    expect(iosVersionStringFromRuntimeId("com.apple.CoreSimulator.SimRuntime.iOS-17-2")).toBe(
+      "17.2",
+    );
+  });
+
+  test("extracts the dotted version from an underscore-separated runtime id", () => {
+    expect(iosVersionStringFromRuntimeId("com.apple.CoreSimulator.SimRuntime.iOS_18_0")).toBe(
+      "18.0",
+    );
+  });
+
+  test("returns undefined for a non-iOS runtime id", () => {
+    expect(
+      iosVersionStringFromRuntimeId("com.apple.CoreSimulator.SimRuntime.watchOS-11-0"),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for missing input", () => {
+    expect(iosVersionStringFromRuntimeId(undefined)).toBeUndefined();
+    expect(iosVersionStringFromRuntimeId(null)).toBeUndefined();
+    expect(iosVersionStringFromRuntimeId("")).toBeUndefined();
+  });
+
+  // Regression guard for the divergence between the three call sites that used
+  // to hand-roll this regex independently: SimCtlClient's normalizeIosVersion
+  // and DeviceCriteriaMatcher's iosVersionFromRuntime matched only case-sensitive
+  // "iOS", while this module's own iosMajorVersionFromSimctlListDevices matched
+  // case-insensitively. A differently-cased beta runtime id would silently
+  // resolve a version in one call site and not the other (#6372 follow-up).
+  test("matches case-insensitively, unlike the old SimCtlClient/DeviceCriteriaMatcher copies", () => {
+    expect(iosVersionStringFromRuntimeId("com.apple.CoreSimulator.SimRuntime.IOS-18-0")).toBe(
+      "18.0",
+    );
   });
 });
 

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -144,6 +144,33 @@ describe("IOSCtrlProxyProcessClient", () => {
     expect(host.getExecutedCommands()).toContain("ps -p 42 -o ppid= -o args=");
   });
 
+  test("does not report a daemon-managed runner behind an orphaned shell as external, even when its own environment carries a device identity marker (#6372 predicate-divergence regression)", async () => {
+    const host = new FakeHostCommandExecutor();
+    host.setCommandResponse("pgrep -x xcodebuild", result("42\n"));
+    host.setCommandResponse(
+      "ps -p 42 -o ppid= -o args=",
+      result(
+        "500 xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun -destination platform=iOS Simulator,id=DEVICE-1 -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService",
+      ),
+    );
+    // The runner's own environment carries AUTOMOBILE_DEVICE_ID=, which in
+    // isolation looks like an externally (hot-reload) launched xcodebuild.
+    host.setCommandResponse("ps eww -p 42 -o command=", result("AUTOMOBILE_DEVICE_ID=DEVICE-1"));
+    // But its immediate parent is an orphaned shell wrapping the same
+    // daemon-managed xcodebuild shape, so the runner is still daemon-owned.
+    host.setCommandResponse(
+      "ps -p 500 -o ppid= -o args=",
+      result(
+        "1 /bin/sh -c xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun -destination platform=iOS Simulator,id=DEVICE-1 -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService",
+      ),
+    );
+    const client = new IOSCtrlProxyProcessClient(host, new FakeTimer());
+
+    const process = await client.findExternalXcodebuildCtrlProxyProcess("DEVICE-1");
+
+    expect(process).toBeNull();
+  });
+
   test("does not identify a recycled PID as a CtrlProxy runner", async () => {
     const host = new FakeHostCommandExecutor();
     host.setCommandResponse("kill -0 42", result());


### PR DESCRIPTION
## Summary

Small verified follow-up cleanups from the epic #6372 body (the "Smaller follow-ups" section). Each is an independent, low-risk fix with a unit test:

- **dedup runner-identification predicates** — IOSCtrlProxyManager kept private copies of IOSCtrlProxyProcessClient's runner-identification predicates that had diverged; the Manager now reuses the ProcessClient's canonical predicates.
- **port-reservation leak on stop() throw** — investigated and **skipped** (see below): the current behavior is intentional, not a bug.
- **dedup permission/TCC-service vocabulary** — the permission name / TCC-service mapping duplicated across three tables in SimulatorTccSqliteClient is unified to one source.
- **dedup iOS major-version extraction** — the simctl runtime-identifier major-version extraction (previously duplicated with divergent regex/fallbacks) is unified into one helper.

Part of the epic #6372 burndown.

## Per-item status

**Implemented — dedup runner-identification predicates.** `IOSCtrlProxyProcessClient.ts` already exported `hasDeviceIdentity`, `isCtrlProxyRunnerCommand`, and `isDirectCtrlProxyRunnerCommand`; `IOSCtrlProxyManager` kept byte-identical *private* copies that could silently re-diverge. More importantly, `isDaemonManagedSimulatorXcodebuildProcess` had **already** diverged: `IOSCtrlProxyManager`'s copy additionally recognizes a daemon-managed runner behind an *orphaned shell parent*, while `IOSCtrlProxyProcessClient`'s copy did not. That gap meant `IOSCtrlProxyProcessClient.findExternalXcodebuildCtrlProxyProcess` could misidentify a daemon-owned runner as an externally-launched (hot-reload) process whenever its own environment happened to carry `AUTOMOBILE_DEVICE_ID=`. Fixed by moving the orphaned-shell-parent check onto `IOSCtrlProxyProcessClient` (the single source of truth) and having `IOSCtrlProxyManager` delegate to it everywhere. New regression test: `test/utils/ios/IOSCtrlProxyProcessClient.test.ts`.

**Skipped as not-a-bug — port-reservation leak on stop() throw.** The epic description reads as: `stop()` throws before `PortManager.release()`, leaking the reservation on error. Investigated `git log -p` on that block: this is **deliberate hardening from #5830** ("harden CtrlProxy process lifecycle"), not an oversight. When SIGKILL fails to terminate the tracked runner, `stop()` intentionally keeps the port reserved (and keeps tracking the still-alive PID) so a different device/manager cannot reuse a port that a zombie runner may still be bound to — confirmed by an existing test (`"stop() retains runner ownership and fails when SIGKILL cannot terminate it"`) that explicitly asserts the port stays allocated after a failed stop. Wrapping the release in `try/finally` would regress that fix and reintroduce the port-reuse race. No change made; noting for the epic checklist.

**Implemented — dedup permission/TCC-service vocabulary.** `SimulatorTccSqliteClient.ts`'s `TCC_SERVICE_BY_PERMISSION` map and `tccServiceForPermission` were duplicated byte-for-byte in `IosSimulatorPermissions.ts` (private table + private function + a private reverse-lookup `permissionForTccService` with no canonical counterpart). Added `permissionForTccService` as a canonical export next to `tccServiceForPermission` on `SimulatorTccSqliteClient.ts`; `IosSimulatorPermissions.ts` now imports both instead of hand-rolling its own copies. Behavior is unchanged (round-trip verified). New tests: a round-trip consistency test in `SimulatorTccSqliteClient.test.ts`, plus a query-path regression test in `GrantIosSimulatorPermissions.test.ts`.

**Implemented — dedup iOS major-version extraction.** Found *three* independent implementations of "extract the dotted iOS version from a `SimRuntime` identifier": `iosVersion.ts`'s `iosMajorVersionFromSimctlListDevices` (case-insensitive `iOS`, major-only capture), `SimCtlClient.ts`'s `normalizeIosVersion` (case-sensitive `iOS`, full dotted-version capture), and `DeviceCriteriaMatcher.ts`'s `iosVersionFromRuntime` (same as SimCtlClient's, independently re-implemented). The case-sensitivity difference is a real divergence: a differently-cased runtime id (e.g. a beta build) would resolve in one call site and silently fail to resolve in the other two. Added one exported `iosVersionStringFromRuntimeId` helper to `iosVersion.ts` (case-insensitive, full dotted-version capture) and made all three call sites derive from it. New tests in `iosVersion.test.ts` and a regression test in `DeviceCriteriaMatcher.test.ts` covering the differently-cased-runtime-id case.

## Test plan

- [x] `bun run format` / `bun run format:check` — clean
- [x] `bun run typecheck` — typecheck gate: no new type errors
- [x] `bun run lint` — oxlint ratchet gate: no new violations
- [x] Targeted `bun test` across all touched files (IOSCtrlProxyProcessClient, IOSCtrlProxyManager, SimulatorTccSqliteClient, GrantIosSimulatorPermissions/IosPhysicalPermissions, iosVersion, DeviceCriteriaMatcher, SimCtlClient variants) — all pass
- [x] Confirmed pre-existing, unrelated socket-integration test flakiness (EPERM on unix socket listen) reproduces identically on unmodified `upstream/main` in this sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>