### PR TITLE
test: property-based tests for getApple tool and its timeout budget

### DIFF
--- a/test/daemon/getApplePreparationTimeout.property.test.ts
+++ b/test/daemon/getApplePreparationTimeout.property.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import {
+  DEFAULT_MCP_REQUEST_TIMEOUT_MS,
+  MIN_START_DEVICE_MCP_TIMEOUT_MS,
+  START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS,
+  resolveMcpRequestTimeoutMs,
+} from "../../src/daemon/mcpRequestTimeout";
+import type { DaemonRequest } from "../../src/daemon/types";
+import {
+  DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS,
+  DEFAULT_DEVICE_READY_TIMEOUT_MS,
+  MAX_DEVICE_READY_TIMEOUT_MS,
+} from "../../src/utils/deviceTimeouts";
+import { DEFAULT_RUNNER_PROVISION_TIMEOUT_MS } from "../../src/utils/runnerReadinessConfig";
+
+// Property-based tests for the transport-timeout budget the daemon derives for a
+// `getApple` request — the "underlying component" that keeps the socket alive
+// for the full device-preparation window. See test/utils/Backoff.property.test.ts
+// for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const DEFAULT_PREPARATION_BUDGET_MS =
+  DEFAULT_DEVICE_READY_TIMEOUT_MS +
+  DEFAULT_RUNNER_PROVISION_TIMEOUT_MS +
+  START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS;
+
+function getAppleRequest(args: Record<string, unknown>, timeoutMs?: number): DaemonRequest {
+  return {
+    id: "prop",
+    type: "mcp_request",
+    method: "tools/call",
+    params: { name: "getApple", arguments: args },
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+  };
+}
+
+// Independent re-derivation of the daemon's budget math, used as the oracle. A
+// value only counts toward the boot/automation sum when it is a finite positive
+// number; anything else falls back to the tool's default.
+function positiveFinite(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function expectedNamedBudget(args: Record<string, unknown>): number {
+  const boot = positiveFinite(args.bootTimeoutMs) ?? DEFAULT_DEVICE_READY_TIMEOUT_MS;
+  const auto = positiveFinite(args.automationReadyTimeoutMs) ?? DEFAULT_RUNNER_PROVISION_TIMEOUT_MS;
+  return Math.min(boot + auto, MAX_DEVICE_READY_TIMEOUT_MS) + START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS;
+}
+
+function expectedResolved(args: Record<string, unknown>, timeoutMs?: number): number {
+  const base =
+    typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
+      ? timeoutMs
+      : DEFAULT_MCP_REQUEST_TIMEOUT_MS;
+  return Math.max(base, MIN_START_DEVICE_MCP_TIMEOUT_MS, expectedNamedBudget(args));
+}
+
+// Cover the realistic operating range plus the junk values the resolver must
+// treat as "use the default": non-positive, non-finite, and absent.
+const timeoutValue = fc.oneof(
+  fc.integer({ min: 1, max: MAX_DEVICE_READY_TIMEOUT_MS }),
+  fc.integer({ min: MAX_DEVICE_READY_TIMEOUT_MS, max: Number.MAX_SAFE_INTEGER }),
+  fc.constantFrom(0, -1, -50_000, Number.NaN, Number.POSITIVE_INFINITY),
+);
+const optionalTimeout = fc.option(timeoutValue, { nil: undefined });
+const preparationArgs = fc.record(
+  { bootTimeoutMs: optionalTimeout, automationReadyTimeoutMs: optionalTimeout },
+  { requiredKeys: [] },
+);
+const optionalRequestTimeout = fc.option(timeoutValue, { nil: undefined });
+
+describe("getApple MCP request timeout budget (property-based)", () => {
+  test("matches the independently derived budget for any argument shape", () => {
+    fc.assert(
+      fc.property(preparationArgs, optionalRequestTimeout, (args, requestTimeout) => {
+        return (
+          resolveMcpRequestTimeoutMs(getAppleRequest(args, requestTimeout)) ===
+          expectedResolved(args, requestTimeout)
+        );
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("is never below the getApple/startDevice floor", () => {
+    fc.assert(
+      fc.property(preparationArgs, optionalRequestTimeout, (args, requestTimeout) => {
+        return (
+          resolveMcpRequestTimeoutMs(getAppleRequest(args, requestTimeout)) >=
+          MIN_START_DEVICE_MCP_TIMEOUT_MS
+        );
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  // Without a client-supplied request timeout the whole budget is driven by the
+  // preparation window, which is capped so the socket cannot idle out mid-boot.
+  test("stays below the daemon socket idle timeout when the client omits timeoutMs", () => {
+    fc.assert(
+      fc.property(preparationArgs, (args) => {
+        return (
+          resolveMcpRequestTimeoutMs(getAppleRequest(args)) < DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS
+        );
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  // Garbage boot/automation values (zero, negative, NaN, Infinity, absent) all
+  // collapse to the same default preparation budget.
+  test("junk or omitted timeouts collapse to the default preparation budget", () => {
+    const junk = fc.constantFrom(undefined, 0, -1, Number.NaN, Number.POSITIVE_INFINITY);
+    fc.assert(
+      fc.property(junk, junk, (boot, auto) => {
+        const args: Record<string, unknown> = {
+          ...(boot !== undefined ? { bootTimeoutMs: boot } : {}),
+          ...(auto !== undefined ? { automationReadyTimeoutMs: auto } : {}),
+        };
+        return resolveMcpRequestTimeoutMs(getAppleRequest(args)) === DEFAULT_PREPARATION_BUDGET_MS;
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  // Enlarging either requested window (with no client timeoutMs to dominate the
+  // max) can only hold or raise the budget, never lower it.
+  test("is monotonic non-decreasing in the requested boot window", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: MAX_DEVICE_READY_TIMEOUT_MS }),
+        fc.integer({ min: 0, max: MAX_DEVICE_READY_TIMEOUT_MS }),
+        fc.integer({ min: 1, max: MAX_DEVICE_READY_TIMEOUT_MS }),
+        (boot, delta, auto) => {
+          const smaller = resolveMcpRequestTimeoutMs(
+            getAppleRequest({ bootTimeoutMs: boot, automationReadyTimeoutMs: auto }),
+          );
+          const larger = resolveMcpRequestTimeoutMs(
+            getAppleRequest({ bootTimeoutMs: boot + delta, automationReadyTimeoutMs: auto }),
+          );
+          return larger >= smaller;
+        },
+      ),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("saturates at the capped preparation budget for arbitrarily large windows", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: MAX_DEVICE_READY_TIMEOUT_MS, max: Number.MAX_SAFE_INTEGER }),
+        fc.integer({ min: MAX_DEVICE_READY_TIMEOUT_MS, max: Number.MAX_SAFE_INTEGER }),
+        (boot, auto) => {
+          const resolved = resolveMcpRequestTimeoutMs(
+            getAppleRequest({ bootTimeoutMs: boot, automationReadyTimeoutMs: auto }),
+          );
+          return resolved === MAX_DEVICE_READY_TIMEOUT_MS + START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS;
+        },
+      ),
+      RUN_OPTIONS,
+    );
+  });
+
+  // getApple and getAndroid share `resolveNamedDevicePreparationBudgetMs`, so
+  // identical timeout arguments must yield identical transport budgets.
+  test("resolves the same budget as getAndroid for identical arguments", () => {
+    fc.assert(
+      fc.property(preparationArgs, optionalRequestTimeout, (args, requestTimeout) => {
+        const apple = resolveMcpRequestTimeoutMs(getAppleRequest(args, requestTimeout));
+        const androidRequest: DaemonRequest = {
+          id: "prop",
+          type: "mcp_request",
+          method: "tools/call",
+          params: { name: "getAndroid", arguments: args },
+          ...(requestTimeout !== undefined ? { timeoutMs: requestTimeout } : {}),
+        };
+        return apple === resolveMcpRequestTimeoutMs(androidRequest);
+      }),
+      RUN_OPTIONS,
+    );
+  });
+});
+
+// A concrete anchor alongside the properties: the documented default budget.
+describe("getApple MCP request timeout budget (example)", () => {
+  test("default preparation budget is 180s + 180s + overhead", () => {
+    expect(resolveMcpRequestTimeoutMs(getAppleRequest({ udid: "sim" }))).toBe(
+      DEFAULT_PREPARATION_BUDGET_MS,
+    );
+  });
+});

--- a/test/server/getAppleSchema.property.test.ts
+++ b/test/server/getAppleSchema.property.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import { getAndroidSchema, getAppleSchema } from "../../src/server/deviceTools";
+import {
+  DEFAULT_DEVICE_READY_TIMEOUT_MS,
+  MAX_DEVICE_READY_TIMEOUT_MS,
+} from "../../src/utils/deviceTimeouts";
+import { MIN_RUNNER_READINESS_TIMEOUT_MS } from "../../src/utils/runnerReadinessConfig";
+
+// Property-based tests for the `getApple` tool's input contract. See
+// test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+// A small pool of identifiers so equal/different/absent combinations all recur
+// densely — random unbounded strings would almost never collide, leaving the
+// "udid === deviceId is accepted" branch untested.
+const ID_POOL = ["udid-A", "udid-B", "SIM-0000-1111", "abc"] as const;
+const optionalId = fc.option(fc.constantFrom(...ID_POOL), { nil: undefined });
+
+const KNOWN_KEYS = ["udid", "deviceId", "bootTimeoutMs", "automationReadyTimeoutMs"];
+
+// Timeout fields pass their own `.int().max(MAX)` (and `.min(MIN)` for the
+// automation field) individually, so these generators isolate the cross-field
+// `bootTimeoutMs + automationReadyTimeoutMs <= MAX` refinement.
+const validBoot = fc.integer({ min: 1, max: MAX_DEVICE_READY_TIMEOUT_MS });
+const validAuto = fc.integer({
+  min: MIN_RUNNER_READINESS_TIMEOUT_MS,
+  max: MAX_DEVICE_READY_TIMEOUT_MS,
+});
+
+/** Build an args object, omitting fields whose value is `undefined`. */
+function args(
+  udid?: string,
+  deviceId?: string,
+  extra?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...(udid !== undefined ? { udid } : {}),
+    ...(deviceId !== undefined ? { deviceId } : {}),
+    ...(extra ?? {}),
+  };
+}
+
+describe("getAppleSchema identifier contract (property-based)", () => {
+  // A caller must name a simulator, and when they name it twice the two
+  // spellings must agree — otherwise the schema cannot know which device the
+  // caller meant. No timeout fields are supplied, so the sum refine (defaults
+  // 180s + 180s <= MAX) always passes and only the identifier logic is tested.
+  test("succeeds iff at least one identifier is present and any two agree", () => {
+    fc.assert(
+      fc.property(optionalId, optionalId, (udid, deviceId) => {
+        const result = getAppleSchema.safeParse(args(udid, deviceId));
+        const bothMissing = udid === undefined && deviceId === undefined;
+        const conflict = udid !== undefined && deviceId !== undefined && udid !== deviceId;
+        return result.success === (!bothMissing && !conflict);
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("neither identifier present reports the 'Provide udid or deviceId' issue on `udid`", () => {
+    const result = getAppleSchema.safeParse(args(undefined, undefined));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path.join(".") === "udid");
+      expect(issue?.message).toContain("Provide udid or deviceId");
+    }
+  });
+
+  test("two different identifiers report `identifier_conflict` on `deviceId`", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...ID_POOL), fc.constantFrom(...ID_POOL), (udid, deviceId) => {
+        fc.pre(udid !== deviceId);
+        const result = getAppleSchema.safeParse(args(udid, deviceId));
+        if (result.success) {
+          return false;
+        }
+        const issue = result.error.issues.find((i) => i.path.join(".") === "deviceId");
+        return (
+          issue !== undefined &&
+          issue.message.includes("identifier_conflict") &&
+          issue.message.includes(udid) &&
+          issue.message.includes(deviceId)
+        );
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  // The handler resolves the effective UDID as `args.udid ?? args.deviceId`;
+  // for every accepted input that resolution is a non-empty string equal to one
+  // of the supplied identifiers (never a value the caller did not name).
+  test("accepted inputs preserve the identifier the handler resolves", () => {
+    fc.assert(
+      fc.property(optionalId, optionalId, (udid, deviceId) => {
+        const result = getAppleSchema.safeParse(args(udid, deviceId));
+        if (!result.success) {
+          return true;
+        }
+        const resolved = result.data.udid ?? result.data.deviceId;
+        return (
+          typeof resolved === "string" &&
+          resolved.length > 0 &&
+          (resolved === udid || resolved === deviceId)
+        );
+      }),
+      RUN_OPTIONS,
+    );
+  });
+});
+
+describe("getAppleSchema timeout contract (property-based)", () => {
+  test("succeeds iff bootTimeoutMs + automationReadyTimeoutMs <= MAX", () => {
+    fc.assert(
+      fc.property(validBoot, validAuto, (bootTimeoutMs, automationReadyTimeoutMs) => {
+        const result = getAppleSchema.safeParse(
+          args("sim", undefined, { bootTimeoutMs, automationReadyTimeoutMs }),
+        );
+        return (
+          result.success === bootTimeoutMs + automationReadyTimeoutMs <= MAX_DEVICE_READY_TIMEOUT_MS
+        );
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  // An omitted bootTimeoutMs still counts as its default in the sum, so the
+  // ceiling on a lone automationReadyTimeoutMs is MAX - DEFAULT, not MAX.
+  test("omitted bootTimeoutMs contributes its default to the sum", () => {
+    fc.assert(
+      fc.property(validAuto, (automationReadyTimeoutMs) => {
+        const result = getAppleSchema.safeParse(
+          args("sim", undefined, { automationReadyTimeoutMs }),
+        );
+        const withinBudget =
+          DEFAULT_DEVICE_READY_TIMEOUT_MS + automationReadyTimeoutMs <= MAX_DEVICE_READY_TIMEOUT_MS;
+        return result.success === withinBudget;
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  // Non-integer, zero, and negative timeouts fail the field-level guards before
+  // the cross-field refine ever runs.
+  test("rejects non-integer or non-positive bootTimeoutMs", () => {
+    fc.assert(
+      fc.property(
+        fc.oneof(
+          fc.double({ min: 0.1, max: 0.9, noNaN: true }),
+          fc.integer({ min: -10_000, max: 0 }),
+        ),
+        (bootTimeoutMs) => {
+          const result = getAppleSchema.safeParse(args("sim", undefined, { bootTimeoutMs }));
+          return result.success === false;
+        },
+      ),
+      RUN_OPTIONS,
+    );
+  });
+});
+
+describe("getAppleSchema strictness (property-based)", () => {
+  test("rejects any unknown top-level key", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1 }).filter((k) => !KNOWN_KEYS.includes(k)),
+        (key) => {
+          const result = getAppleSchema.safeParse(args("sim", undefined, { [key]: "value" }));
+          return result.success === false;
+        },
+      ),
+      RUN_OPTIONS,
+    );
+  });
+});
+
+describe("getApple / getAndroid schema parity (property-based)", () => {
+  // Both device-preparation tools share `devicePreparationTimeoutSchema`, so a
+  // timeout pair accepted by one must be accepted by the other (each supplied
+  // with its own required identifier).
+  test("identical timeout pairs are accepted or rejected the same way by both schemas", () => {
+    fc.assert(
+      fc.property(validBoot, validAuto, (bootTimeoutMs, automationReadyTimeoutMs) => {
+        const timeouts = { bootTimeoutMs, automationReadyTimeoutMs };
+        const apple = getAppleSchema.safeParse({ udid: "sim", ...timeouts });
+        const android = getAndroidSchema.safeParse({ avdName: "Pixel", ...timeouts });
+        return apple.success === android.success;
+      }),
+      RUN_OPTIONS,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds fast-check property-based tests for the two purely-functional components behind the `getApple` MCP tool call, which previously had only example-based coverage:

- **`getAppleSchema` input contract** (`test/server/getAppleSchema.property.test.ts`) — the tool's argument validation in `src/server/deviceTools.ts`:
  - identifier rules: success iff at least one of `udid`/`deviceId` is present and any two agree; the "Provide udid or deviceId" issue on `udid` when neither is given; the `identifier_conflict` issue on `deviceId` when the two spellings differ; and that accepted inputs preserve the identifier the handler resolves (`args.udid ?? args.deviceId`).
  - timeout rules: the cross-field `bootTimeoutMs + automationReadyTimeoutMs <= MAX` refine, the omitted-`bootTimeoutMs`-uses-its-default behavior, field-level rejection of non-integer/non-positive values, and `.strict()` unknown-key rejection.
  - parity with `getAndroidSchema` for identical timeout pairs (shared `devicePreparationTimeoutSchema`).

- **Daemon transport-timeout budget** (`test/daemon/getApplePreparationTimeout.property.test.ts`) — `resolveMcpRequestTimeoutMs` in `src/daemon/mcpRequestTimeout.ts` for `getApple` requests: equivalence to an independently derived oracle over arbitrary argument shapes, the start-device floor, the sub-idle-timeout cap when the client omits `timeoutMs`, collapse of junk/omitted boot & automation timeouts to the default budget, monotonicity in the requested window, saturation at the capped budget for arbitrarily large windows, and parity with `getAndroid`.

Seeds are pinned (matching the repo's PBT convention) and every test runs well under the 100ms unit budget. No production code changed.

## Validation

- [x] `bun test` — 17 new tests pass across the two files
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `oxlint` clean on both new files; `bun run format:check` clean
- [x] New tests run in <100ms and inject no real DB or timers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AViKSJhUcDDgWutuUgfnrc

---
_Generated by [Claude Code](https://claude.ai/code/session_01AViKSJhUcDDgWutuUgfnrc)_