### PR TITLE
fix(video): unique iOS recording capture path per start attempt (#6851)

### DIFF
--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -703,12 +703,11 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
       throw new ActionableError("simctl is not available. Install Xcode command line tools.");
     }
 
-    const capturePath = path.join(config.outputDirectory, `${config.recordingId}-raw.mov`);
-
-    const args = ["io", device.deviceId, "recordVideo", capturePath];
+    const captureBaseName = `${config.recordingId}-raw`;
 
     const maxAttempts = Math.max(1, this.iosRecordingStartMaxAttempts);
     const attemptFailures: string[] = [];
+    let previousCapturePath: string | undefined;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       throwIfRecordingStartAborted(config.abortSignal, "iOS");
@@ -716,18 +715,28 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
       if (remainingBeforeSpawn <= 0) {
         break;
       }
-      if (attempt > 1) {
-        // `simctl io ... recordVideo` creates the capture file *before* it emits the
-        // "Recording started" handshake, so an attempt we killed for missing that
-        // handshake leaves a partial .mov behind — and simctl refuses to record over
-        // an existing file (exit 17, "cannot save recorded video output into a file
-        // that already exists"), which would make the #4076 retry fail in exactly the
-        // case it exists for. The partial can never hold a usable recording (the
-        // handshake never completed), so drop it. Safe to unlink here: the previous
-        // attempt's capture process was already reaped by cleanupFailedIosStart
-        // below, so simctl cannot recreate the file after the unlink.
-        await this.removeStaleCapture(capturePath);
+      // Give every attempt its own capture file. `simctl io ... recordVideo` creates
+      // the target *before* it emits the "Recording started" handshake, so an attempt
+      // we killed for missing that handshake leaves a partial .mov behind — and simctl
+      // refuses to record over an existing file (exit 17, "cannot save recorded video
+      // output into a file that already exists"). Reusing one path made the retry
+      // depend on unlinking that partial before the dying capture process could
+      // recreate it; losing that race exit-17'd the retry and failed the whole start
+      // (issue #6851). A per-attempt path is immune regardless of cleanup timing —
+      // the retry never targets the first attempt's leftover. Attempt 1 keeps the
+      // bare `<id>-raw.mov` name so the common first-try success path is unchanged.
+      const capturePath = path.join(
+        config.outputDirectory,
+        attempt === 1 ? `${captureBaseName}.mov` : `${captureBaseName}-attempt${attempt}.mov`,
+      );
+      const args = ["io", device.deviceId, "recordVideo", capturePath];
+      if (previousCapturePath !== undefined) {
+        // Best-effort disk hygiene only: drop the prior attempt's partial so retries
+        // don't leak `.mov` files. Correctness no longer depends on this succeeding —
+        // the unique path above already prevents the exit-17 collision.
+        await this.removeStaleCapture(previousCapturePath);
       }
+      previousCapturePath = capturePath;
       const captureProcess = await simctl.startCommandArgs(args, {
         stdio: ["ignore", "ignore", "pipe"],
       });

--- a/test/features/video/FfmpegVideoProcessingBackend.test.ts
+++ b/test/features/video/FfmpegVideoProcessingBackend.test.ts
@@ -272,9 +272,70 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function () {
     const handle = await backend.start(mockConfig);
 
     const capturePath = path.join(mockConfig.outputDirectory, "test-recording-raw.mov");
-    expect(attempts).toEqual([capturePath, capturePath]);
+    const retryCapturePath = path.join(
+      mockConfig.outputDirectory,
+      "test-recording-raw-attempt2.mov",
+    );
+    // Each attempt targets its own file, so the retry can never collide with the
+    // first attempt's partial; the first attempt's partial is still removed for
+    // disk hygiene (issue #6851 hardened the earlier #6833 fix).
+    expect(attempts).toEqual([capturePath, retryCapturePath]);
     expect(removed).toEqual([capturePath]);
     expect(handle.recordingId).toBe("test-recording");
+  });
+
+  test("uses a distinct capture path per attempt so a surviving partial cannot exit-17 the retry (#6851)", async function () {
+    // Reproduce the race in #6851: the first attempt's partial capture survives
+    // cleanup (the killed simctl recreated it after the unlink, or the remove lost
+    // the race). If the retry reused the same path it would hit simctl exit 17
+    // ("cannot save ... file already exists") and the whole start would fail. A
+    // distinct path per attempt is immune regardless of cleanup timing.
+    const existingCaptures = new Set<string>();
+    const attempts: string[] = [];
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const simctl = {
+      isAvailable: async () => true,
+      startCommandArgs: async (args: string[]) => {
+        const capturePath = args[3];
+        attempts.push(capturePath);
+        if (existingCaptures.has(capturePath)) {
+          return makeExistingFileChild(timer);
+        }
+        existingCaptures.add(capturePath);
+        // First attempt spawns but never emits the handshake (cold-simulator miss),
+        // so it is treated as a failed start and retried.
+        return makeCaptureChild(attempts.length >= 2, timer);
+      },
+      executeCommandArgs: async () => diagnosticsExecResult("iPhone 17 Pro (udid) (Booted)"),
+    } as unknown as SimCtl;
+    // A remover that never actually deletes the partial — models the cleanup race
+    // in which correctness must not depend on the removal succeeding.
+    const remover = {
+      remove: async () => {},
+    };
+
+    backend = new FfmpegVideoProcessingBackend(
+      undefined,
+      () => simctl,
+      undefined,
+      undefined,
+      undefined,
+      timer,
+      remover,
+    );
+    (backend as any).ensureFfmpegAvailable = async () => {};
+    (backend as any).iosRecordingStartTimeoutMs = 25;
+    mockConfig.device = { ...mockDevice, platform: "ios", deviceId: "ios-unique-path-udid" };
+
+    const handle = await backend.start(mockConfig);
+
+    expect(handle.recordingId).toBe("test-recording");
+    expect(attempts.length).toBe(2);
+    // The two attempts must target different files; otherwise the surviving partial
+    // from attempt 1 makes attempt 2 exit 17.
+    expect(attempts[0]).not.toBe(attempts[1]);
+    expect(new Set(attempts).size).toBe(2);
   });
 
   test("kills an iOS recorder that is still waiting for its start handshake when shutdown aborts", async function () {


### PR DESCRIPTION
## Summary

Fixes an intermittent CI flake where iOS `videoRecording` start fails with `simctl` exit 17 — *"cannot save recorded video output into a file that already exists (use -f to override)"* (`NSPOSIXErrorDomain code=17`).

`FfmpegVideoProcessingBackend.startIos` runs up to 2 start attempts but computed `capturePath` **once** before the loop, so both attempts wrote to the same `<recordingId>-raw.mov`. `simctl io ... recordVideo` creates the target *before* it emits the "Recording started" handshake, so an attempt we kill for missing the handshake leaves a partial `.mov` behind. The retry's correctness depended on `removeStaleCapture` unlinking that partial before the dying capture process could recreate it — a race. When cleanup lost the race, the retry also hit exit 17 and the whole start failed.

Each attempt now targets its **own** capture file: attempt 1 keeps the bare `<recordingId>-raw.mov` name (common first-try success path unchanged), retries append `-attempt<n>`. The retry can never collide with a leftover partial regardless of cleanup timing. The prior attempt's partial is still removed best-effort for disk hygiene, but correctness no longer depends on it.

## Linked Issue

Closes #6851

## Bug / Regression Context

- **Prior attempts:** #6833 added `removeStaleCapture` before retries — a best-effort unlink that races the dying capture process.
- **Observed symptom:** `test/integration/iosVideoRecordingStartStop.integration.test.ts:292` fails with exit 17 "file already exists"; recurred 3× across unrelated branches, self-cleared on re-run (environmental race, not a code regression).
- **Repro steps / conditions:** first start attempt misses the "Recording started" handshake (cold/loaded simulator) → killed, leaving a partial → cleanup loses the race → retry reuses the same path → simctl exit 17.

## Validation

- [x] `bun run lint` + `bun test` pass (only pre-existing unrelated `webrtcDeviceCaptureLoad` skip-label flake fails, reproduced on base)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] iOS change is host-side simctl orchestration only; covered by fast unit tests
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Reuses existing helpers (`removeStaleCapture`, injected remover/timer/simctl seams)

## Testing

- New unit test `uses a distinct capture path per attempt so a surviving partial cannot exit-17 the retry (#6851)`: models the cleanup race with a no-op remover — red before the fix (both attempts exit 17), green after (retry uses a distinct path and succeeds).
- Updated `#6833` test to assert per-attempt paths (`-raw.mov`, `-raw-attempt2.mov`) while still verifying the prior partial is removed.
- Existing happy-path test (attempt-1 path unchanged) stays green.

## Follow-ups

- [ ] None. The two secondary observations in #6851 (windows-latest drift-check timeout; Gradle 429 rate-limit) are explicitly monitoring/human-infra items, out of scope here.