### PR TITLE
fix(devices): report isRunning for the booted Android emulator in listDeviceImages

### DIFF
--- a/src/features/utility/DeviceState.ts
+++ b/src/features/utility/DeviceState.ts
@@ -18,6 +18,7 @@ import {
   iosNotifyutilRegisteredSetReadPostCommand,
   parseNotifyutilState,
 } from "../../utils/ios-cmdline-tools/notifyutil";
+import { isAndroidEmulatorSerial } from "../../utils/androidSerial";
 
 export type DoNotDisturbMode = "off" | "none" | "priority" | "alarms";
 
@@ -356,11 +357,6 @@ const ANDROID_PHYSICAL_NETWORK_CONDITION_UNSUPPORTED_ERROR =
   "console (`adb emu network ...`), which physical devices do not expose. On a physical device " +
   "the radios can only be toggled fully on/off (svc data/wifi, privileged). Use an emulator or a " +
   "host-side proxy for degraded-network testing.";
-
-/** Android emulators report an `emulator-<port>` serial; everything else is physical. */
-function isAndroidEmulatorSerial(deviceId: string): boolean {
-  return deviceId.startsWith("emulator-");
-}
 
 /**
  * The emulator console answers `OK` on success and `KO: <reason>` on failure —

--- a/src/features/utility/DisplayConfig.ts
+++ b/src/features/utility/DisplayConfig.ts
@@ -9,6 +9,7 @@ import { outputLooksLikeShellFailure } from "../../utils/android-cmdline-tools/s
 import { logger } from "../../utils/logger";
 import { SimCtlClient, type SimCtl } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
+import { isAndroidEmulatorSerial } from "../../utils/androidSerial";
 
 /**
  * The argv-shaped slice of the simctl client this feature needs. Routing
@@ -129,11 +130,6 @@ const IOS_DENSITY_UNSUPPORTED_ERROR =
   "display density.";
 
 const ANDROID_UNSUPPORTED_PLATFORM_ERROR = "Display configuration is only supported on Android.";
-
-/** Android emulators report an `emulator-<port>` serial; everything else is physical. */
-function isAndroidEmulatorSerial(deviceId: string): boolean {
-  return deviceId.startsWith("emulator-");
-}
 
 /**
  * Parse `settings get system font_scale`. An unset value ("null") means the

--- a/src/utils/androidSerial.ts
+++ b/src/utils/androidSerial.ts
@@ -1,0 +1,12 @@
+/**
+ * adb reserves the `emulator-<port>` serial shape for locally-running Android
+ * emulators; every other serial belongs to a physical handset. Several call
+ * sites had grown their own copy of this predicate, so keep exactly one
+ * spelling here (issue #6850 review).
+ */
+const ANDROID_EMULATOR_SERIAL_PATTERN = /^emulator-\d+$/;
+
+/** True when `deviceId` is an adb emulator serial (e.g. `emulator-5554`). */
+export function isAndroidEmulatorSerial(deviceId: string): boolean {
+  return ANDROID_EMULATOR_SERIAL_PATTERN.test(deviceId);
+}

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -423,16 +423,33 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
   async listDeviceImages(platform: SomePlatform): Promise<DeviceInfo[]> {
     switch (platform) {
       case "android":
-        return this.emulator.listAvds();
+        return this.listAndroidDeviceImages();
       case "ios":
         return this.listIosDeviceImagesIfAvailable({ swallowDiscoveryErrors: false });
       case "either":
-        const emulators = await this.emulator.listAvds();
+        const emulators = await this.listAndroidDeviceImages();
         const simulators = await this.listIosDeviceImagesIfAvailable({
           swallowDiscoveryErrors: true,
         });
         return [...emulators, ...simulators];
     }
+  }
+
+  /**
+   * List Android AVD images with live isRunning state. `listAvds` reports every
+   * AVD as isRunning:false; the iOS listing already reports its booted state
+   * from simctl, so this overlays the booted-emulator scan to keep the two
+   * platforms' image listings symmetric (issue #6850). `getBootedDevices`
+   * swallows discovery failures to an empty list, so a scan failure degrades to
+   * isRunning:false rather than failing the listing.
+   */
+  private async listAndroidDeviceImages(): Promise<DeviceInfo[]> {
+    const [images, bootedDevices] = await Promise.all([
+      this.emulator.listAvds(),
+      this.emulator.getBootedDevices(),
+    ]);
+    const runningAvdNames = new Set(bootedDevices.map((device) => device.name));
+    return images.map((image) => ({ ...image, isRunning: runningAvdNames.has(image.name) }));
   }
 
   /**

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -14,6 +14,7 @@ import type { DiscoverySource } from "./discoverySource";
 import { AndroidEmulatorClient } from "./android-cmdline-tools/AndroidEmulatorClient";
 import { deleteAvd } from "./android-cmdline-tools/avdmanager";
 import { logger } from "./logger";
+import { isAndroidEmulatorSerial } from "./androidSerial";
 import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "./deviceTimeouts";
 import { getAbortSignal, runWithAbortSignal } from "./AbortContext";
 import { defaultTimer, type Timer } from "./SystemTimer";
@@ -442,13 +443,22 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
    * platforms' image listings symmetric (issue #6850). `getBootedDevices`
    * swallows discovery failures to an empty list, so a scan failure degrades to
    * isRunning:false rather than failing the listing.
+   *
+   * Only `emulator-<port>` serials may contribute to the overlay: the booted
+   * scan also reports physical handsets, whose `name` is ro.product.model, and
+   * a handset modelled like an AVD would otherwise mark that AVD running and
+   * let bootMatchedImage() hand back the handset instead of booting the AVD.
    */
   private async listAndroidDeviceImages(): Promise<DeviceInfo[]> {
     const [images, bootedDevices] = await Promise.all([
       this.emulator.listAvds(),
       this.emulator.getBootedDevices(),
     ]);
-    const runningAvdNames = new Set(bootedDevices.map((device) => device.name));
+    const runningAvdNames = new Set(
+      bootedDevices
+        .filter((device) => isAndroidEmulatorSerial(device.deviceId))
+        .map((device) => device.name),
+    );
     return images.map((image) => ({ ...image, isRunning: runningAvdNames.has(image.name) }));
   }
 

--- a/test/utils/deviceUtils.test.ts
+++ b/test/utils/deviceUtils.test.ts
@@ -390,6 +390,7 @@ describe("MultiPlatformDeviceManager", () => {
       } as unknown as SimCtlClient;
       const fakeEmulator = {
         listAvds: async () => [androidImage],
+        getBootedDevices: async () => [],
       } as unknown as AndroidEmulatorClient;
 
       const manager = new MultiPlatformDeviceManager(
@@ -420,6 +421,7 @@ describe("MultiPlatformDeviceManager", () => {
       } as unknown as SimCtlClient;
       const fakeEmulator = {
         listAvds: async () => [androidImage],
+        getBootedDevices: async () => [],
       } as unknown as AndroidEmulatorClient;
 
       const manager = new MultiPlatformDeviceManager(
@@ -432,6 +434,52 @@ describe("MultiPlatformDeviceManager", () => {
 
       expect(devices).toEqual([androidImage]);
     });
+  });
+
+  test("listDeviceImages(android) reports isRunning for the booted emulator, like iOS", async () => {
+    // Issue #6850: the Android image listing hardcoded isRunning:false even for
+    // the emulator being driven, while iOS reports its booted state correctly.
+    const runningImage: DeviceInfo = { name: "Pixel_8", platform: "android", isRunning: false };
+    const idleImage: DeviceInfo = { name: "Pixel_Tablet", platform: "android", isRunning: false };
+    const fakeEmulator = {
+      listAvds: async () => [runningImage, idleImage],
+      getBootedDevices: async (): Promise<BootedDevice[]> => [
+        { name: "Pixel_8", platform: "android", deviceId: "emulator-5554", source: "local" },
+      ],
+    } as unknown as AndroidEmulatorClient;
+
+    const manager = new MultiPlatformDeviceManager(
+      new FakeAdbClient() as unknown as AdbClient,
+      undefined,
+      fakeEmulator,
+    );
+
+    const devices = await manager.listDeviceImages("android");
+
+    expect(devices).toEqual([
+      { name: "Pixel_8", platform: "android", isRunning: true },
+      { name: "Pixel_Tablet", platform: "android", isRunning: false },
+    ]);
+  });
+
+  test("listDeviceImages(android) degrades to isRunning:false when booted discovery fails", async () => {
+    const image: DeviceInfo = { name: "Pixel_8", platform: "android", isRunning: false };
+    const fakeEmulator = {
+      listAvds: async () => [image],
+      // getBootedDevices already swallows discovery failures to an empty list;
+      // the listing must still succeed rather than fail on a missing boot scan.
+      getBootedDevices: async (): Promise<BootedDevice[]> => [],
+    } as unknown as AndroidEmulatorClient;
+
+    const manager = new MultiPlatformDeviceManager(
+      new FakeAdbClient() as unknown as AdbClient,
+      undefined,
+      fakeEmulator,
+    );
+
+    await expect(manager.listDeviceImages("android")).resolves.toEqual([
+      { name: "Pixel_8", platform: "android", isRunning: false },
+    ]);
   });
 
   test("listDeviceImages(ios) surfaces iOS image discovery failures", async () => {

--- a/test/utils/deviceUtils.test.ts
+++ b/test/utils/deviceUtils.test.ts
@@ -482,6 +482,50 @@ describe("MultiPlatformDeviceManager", () => {
     ]);
   });
 
+  test("listDeviceImages(android) ignores a physical handset whose model matches an AVD name", async () => {
+    // getBootedDevices also reports physical handsets, whose `name` is
+    // ro.product.model. A handset that happens to be modelled "Pixel_8" must not
+    // mark the like-named AVD running, or bootMatchedImage() hands back the
+    // handset instead of booting the AVD (issue #6850 review).
+    const image: DeviceInfo = { name: "Pixel_8", platform: "android", isRunning: false };
+    const fakeEmulator = {
+      listAvds: async () => [image],
+      getBootedDevices: async (): Promise<BootedDevice[]> => [
+        { name: "Pixel_8", platform: "android", deviceId: "39081FDJH00QZQ", source: "local" },
+      ],
+    } as unknown as AndroidEmulatorClient;
+
+    const manager = new MultiPlatformDeviceManager(
+      new FakeAdbClient() as unknown as AdbClient,
+      undefined,
+      fakeEmulator,
+    );
+
+    await expect(manager.listDeviceImages("android")).resolves.toEqual([
+      { name: "Pixel_8", platform: "android", isRunning: false },
+    ]);
+  });
+
+  test("listDeviceImages(android) still reports the AVD running for an emulator-NNNN serial", async () => {
+    const image: DeviceInfo = { name: "Pixel_8", platform: "android", isRunning: false };
+    const fakeEmulator = {
+      listAvds: async () => [image],
+      getBootedDevices: async (): Promise<BootedDevice[]> => [
+        { name: "Pixel_8", platform: "android", deviceId: "emulator-5554", source: "local" },
+      ],
+    } as unknown as AndroidEmulatorClient;
+
+    const manager = new MultiPlatformDeviceManager(
+      new FakeAdbClient() as unknown as AdbClient,
+      undefined,
+      fakeEmulator,
+    );
+
+    await expect(manager.listDeviceImages("android")).resolves.toEqual([
+      { name: "Pixel_8", platform: "android", isRunning: true },
+    ]);
+  });
+
   test("listDeviceImages(ios) surfaces iOS image discovery failures", async () => {
     const fakeSimctl = {
       isAvailable: async () => true,


### PR DESCRIPTION
Follow-up to #6833 (the "D-1" item that was still present on `main`).

## Problem

`listDeviceImages(android)` reported `isRunning: false` for **every** AVD — including the emulator currently being driven — because `AndroidEmulatorClient.listAvds()` hardcodes `isRunning: false` and nothing overlaid live boot state. iOS reports it correctly: `SimCtlClient.listSimulatorImages()` derives `isRunning` from `device.state === "Booted"`.

## Fix

Enrich the Android image listing at the same layer that already guarantees the iOS value — `MultiPlatformDeviceManager.listDeviceImages`. A new private `listAndroidDeviceImages()` overlays a one-shot booted-emulator scan (`getBootedDevices()`) onto the AVD list, matching a listed AVD's name against the booted set. Both `android` and `either` go through it.

- `getBootedDevices()` already swallows discovery failures to an empty list, so a scan failure degrades to `isRunning: false` rather than failing the listing.
- The fix is kept out of `AndroidEmulatorClient.listAvds()` / the `startEmulator` existence-check path deliberately, so the launch flow does not incur an extra device scan (and the port-reservation scan-sequence tests stay intact).

## Tests

Failing-first, then fix (one commit). Added to `test/utils/deviceUtils.test.ts`:
- `listDeviceImages(android)` reports `isRunning: true` for the booted emulator and `false` for an idle one.
- `listDeviceImages(android)` degrades to `isRunning: false` when booted discovery returns empty.

## Validation

- `bun run typecheck` — no new type errors
- `bun run format:check` — clean
- plain-oxlint diff (`bunx oxlint --format=unix src test`, line/col stripped) vs `main` — 0 new entries
- `bun test` across the device-image / emulator / doctor suites — 669 pass, 0 fail

Fixes #6850
