### PR TITLE
fix(getAndroid): pre-boot avdName+serial validation; readiness-marker clobber; #6833 follow-ups

### DIFF
--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2266,8 +2266,12 @@ type TeardownResolvedTarget =
       bootedDevice: BootedDevice;
     };
 
+function isAndroidEmulatorSerial(deviceId: string): boolean {
+  return deviceId.startsWith("emulator-");
+}
+
 function isVirtualAndroidDevice(device: BootedDevice): boolean {
-  return device.platform === "android" && device.deviceId.startsWith("emulator-");
+  return device.platform === "android" && isAndroidEmulatorSerial(device.deviceId);
 }
 
 function resolveKillDeviceStableTarget(
@@ -3464,6 +3468,59 @@ function validateBootIdentity(
  * Anything else is a genuine `identifier_conflict`, reportable only here,
  * because the mapping from AVD name to serial is not known until discovery.
  */
+/**
+ * Reject a contradictory `avdName` + serial-shaped `deviceId` pair BEFORE any
+ * boot. `validateRequestedAndroidSerial` is the post-boot authority, but by the
+ * time it runs a stopped AVD has already been cold-booted and then killed just
+ * to report the conflict (Codex thread on #6833). When the `deviceId` is a
+ * running-emulator serial, the device it names is knowable from one discovery
+ * sweep without booting anything, so the mismatch can be reported up front.
+ *
+ * This fires only for the serial-shaped case: a non-serial `deviceId` is an AVD
+ * image name, whose mapping is not known until discovery, so it stays the
+ * post-boot recheck's job. Anything ambiguous — discovery unavailable this
+ * sweep, or a running device whose runtime name is still `Unknown (<serial>)` —
+ * likewise defers, so this check only ever rejects a pair it can positively
+ * contradict.
+ */
+async function validateRequestedAndroidSerialBeforeBoot(
+  pair: { avdName: string; deviceId: string } | undefined,
+  deviceUtils: PlatformDeviceManager,
+): Promise<void> {
+  if (!pair) {
+    return;
+  }
+  const { avdName, deviceId } = pair;
+  if (!avdName || !isAndroidEmulatorSerial(deviceId) || avdName === deviceId) {
+    return;
+  }
+  const discovery = await deviceUtils.getBootedDevicesDetailed("android", {
+    bypassAndroidDeviceListCache: true,
+  });
+  if (!discovery.succeededPlatforms.has("android")) {
+    // Discovery was unavailable this sweep; a pair we cannot yet contradict is
+    // deferred to the post-boot recheck rather than rejected on missing data.
+    return;
+  }
+  const running = discovery.devices.find(
+    (device) => device.platform === "android" && device.deviceId === deviceId,
+  );
+  if (running && isUnknownAndroidRuntimeName(running)) {
+    // The serial is running but its AVD name is not resolvable yet; the
+    // post-boot recheck decides with pool/incarnation context.
+    return;
+  }
+  if (running && running.name === avdName) {
+    return;
+  }
+  throw new ActionableError(
+    `identifier_conflict: avdName '${avdName}' and deviceId '${deviceId}' name ` +
+      `different devices — '${deviceId}' ` +
+      (running ? `is running AVD '${running.name}'` : "is not running") +
+      `. Pass only the identifier you mean.`,
+  );
+}
+
 export function validateRequestedAndroidSerial(
   pair: { avdName: string; deviceId: string } | undefined,
   device: BootedDevice,
@@ -6447,6 +6504,12 @@ export function registerDeviceTools() {
       | Awaited<ReturnType<typeof reserveStartDeviceLifecycleReservations>>
       | undefined;
     try {
+      // Reject a contradictory getAndroid avdName + serial pair before booting,
+      // so a stopped AVD is not cold-booted and killed just to report it.
+      await validateRequestedAndroidSerialBeforeBoot(
+        budgets.requestedAndroidIdentifierPair,
+        deviceUtils,
+      );
       lifecycleReservations = await reserveStartDeviceLifecycleReservations(
         args,
         budgets,

--- a/src/utils/deviceReadinessLock.ts
+++ b/src/utils/deviceReadinessLock.ts
@@ -227,9 +227,21 @@ export async function trackDeviceAcquisitionReadiness<T>(
 /** Move an in-flight acquisition marker to a replacement device identity. */
 export function moveDeviceAcquisitionReadiness(fromKey: string, toKey: string): void {
   const marker = deviceAcquisitionReadiness.get(fromKey);
-  if (marker && fromKey !== toKey) {
-    deviceAcquisitionReadiness.set(toKey, marker);
+  if (!marker || fromKey === toKey) {
+    return;
   }
+  // Do not clobber a distinct in-flight acquisition already tracking readiness
+  // for the replacement identity. Overwriting it would hand every awaiter on
+  // `toKey` this marker instead, so the awaiter could stop waiting the instant
+  // this acquisition settles while the other's CtrlProxy setup is still
+  // mid-flight — the double-setup race the marker exists to prevent. That
+  // acquisition already covers `toKey`'s awaiters, so leaving it in place is
+  // strictly safer than replacing it.
+  const existing = deviceAcquisitionReadiness.get(toKey);
+  if (existing && existing !== marker) {
+    return;
+  }
+  deviceAcquisitionReadiness.set(toKey, marker);
 }
 
 /**

--- a/src/utils/deviceReadinessLock.ts
+++ b/src/utils/deviceReadinessLock.ts
@@ -194,7 +194,39 @@ function cleanupReadinessWaiter(waiter: ReadinessWaiter): void {
  * readiness has been recorded and the caller's own satisfaction check
  * (re-run in a loop) passes without redoing setup.
  */
-const deviceAcquisitionReadiness = new Map<string, Promise<void>>();
+interface AcquisitionReadinessEntry {
+  /**
+   * Every acquisition still in flight for this key, in arrival order. A
+   * recovery can move one acquisition's marker onto a key another acquisition
+   * is already tracking, so a key can legitimately cover more than one.
+   */
+  pending: Promise<void>[];
+  /**
+   * What awaiters receive. A lone pending acquisition is handed out by
+   * identity; two or more are composed so the key stays pending until the LAST
+   * of them settles.
+   */
+  marker: Promise<void>;
+}
+
+const deviceAcquisitionReadiness = new Map<string, AcquisitionReadinessEntry>();
+
+/** Install (or clear) the pending set for `key` and recompute its marker. */
+function setAcquisitionReadinessPending(key: string, pending: Promise<void>[]): void {
+  if (pending.length === 0) {
+    deviceAcquisitionReadiness.delete(key);
+    return;
+  }
+  deviceAcquisitionReadiness.set(key, {
+    pending,
+    marker:
+      pending.length === 1
+        ? pending[0]!
+        : // Markers never reject (they settle from a `finally`), but allSettled
+          // keeps a composite safe regardless of how a member was produced.
+          Promise.allSettled(pending).then(() => undefined),
+  });
+}
 
 /**
  * Run `fn` while `key` is marked as having readiness acquisition in flight.
@@ -209,16 +241,22 @@ export async function trackDeviceAcquisitionReadiness<T>(
   const marker = new Promise<void>((resolve) => {
     settle = resolve;
   });
-  deviceAcquisitionReadiness.set(key, marker);
+  const existing = deviceAcquisitionReadiness.get(key);
+  setAcquisitionReadinessPending(key, existing ? [...existing.pending, marker] : [marker]);
   try {
     return await fn();
   } finally {
     settle();
     // A recovery can replace a device serial after this acquisition begins.
-    // Clear every alias of this marker, not only its original key.
-    for (const [markerKey, current] of deviceAcquisitionReadiness) {
-      if (current === marker) {
-        deviceAcquisitionReadiness.delete(markerKey);
+    // Drop this marker from every alias it reached, not only its original key,
+    // and keep an alias alive while another acquisition it covers is still in
+    // flight.
+    for (const [markerKey, entry] of [...deviceAcquisitionReadiness]) {
+      if (entry.pending.includes(marker)) {
+        setAcquisitionReadinessPending(
+          markerKey,
+          entry.pending.filter((pending) => pending !== marker),
+        );
       }
     }
   }
@@ -226,22 +264,25 @@ export async function trackDeviceAcquisitionReadiness<T>(
 
 /** Move an in-flight acquisition marker to a replacement device identity. */
 export function moveDeviceAcquisitionReadiness(fromKey: string, toKey: string): void {
-  const marker = deviceAcquisitionReadiness.get(fromKey);
-  if (!marker || fromKey === toKey) {
+  const from = deviceAcquisitionReadiness.get(fromKey);
+  if (!from || fromKey === toKey) {
     return;
   }
   // Do not clobber a distinct in-flight acquisition already tracking readiness
-  // for the replacement identity. Overwriting it would hand every awaiter on
-  // `toKey` this marker instead, so the awaiter could stop waiting the instant
-  // this acquisition settles while the other's CtrlProxy setup is still
-  // mid-flight — the double-setup race the marker exists to prevent. That
-  // acquisition already covers `toKey`'s awaiters, so leaving it in place is
-  // strictly safer than replacing it.
+  // for the replacement identity, and do not drop it either: retain BOTH until
+  // both settle. Replacing it would hand every awaiter on `toKey` this marker
+  // instead, and merely keeping it would let `toKey` clear the moment that
+  // other acquisition settles while this one is still mid-flight. Either way an
+  // awaiter could stop waiting with a CtrlProxy setup still running and start a
+  // duplicate one - the double-setup race the marker exists to prevent (#6280).
   const existing = deviceAcquisitionReadiness.get(toKey);
-  if (existing && existing !== marker) {
-    return;
-  }
-  deviceAcquisitionReadiness.set(toKey, marker);
+  const merged = existing
+    ? [
+        ...existing.pending,
+        ...from.pending.filter((pending) => !existing.pending.includes(pending)),
+      ]
+    : [...from.pending];
+  setAcquisitionReadinessPending(toKey, merged);
 }
 
 /**
@@ -249,5 +290,5 @@ export function moveDeviceAcquisitionReadiness(fromKey: string, toKey: string): 
  * acquisition is currently binding/recording readiness for it.
  */
 export function getDeviceAcquisitionReadiness(key: string): Promise<void> | undefined {
-  return deviceAcquisitionReadiness.get(key);
+  return deviceAcquisitionReadiness.get(key)?.marker;
 }

--- a/test/server/deviceTools.platformPreparation.test.ts
+++ b/test/server/deviceTools.platformPreparation.test.ts
@@ -352,6 +352,50 @@ describe("platform device preparation tools", () => {
 
     expect(failure).toBeInstanceOf(ActionableError);
     expect((failure as ActionableError).message).toContain("identifier_conflict");
+    // The conflict is decided from a discovery sweep, so no device is booted
+    // (and then killed) only to report it.
+    expect(deviceUtils.wasMethodCalled("startDevice")).toBe(false);
+  });
+
+  test("getAndroid rejects a stopped AVD paired with a foreign running serial before booting", async () => {
+    // avdName names a stopped AVD; the requested serial is running a different
+    // AVD. The pair is contradictory without booting anything, so the old
+    // post-boot recheck (which cold-booted Pixel_A and killed it) is wrong here.
+    deviceUtils.setDeviceImages("android", [
+      { platform: "android", name: "Pixel_A", isRunning: false, source: "local" },
+    ]);
+    deviceUtils.setBootedDevices("android", [
+      { platform: "android", name: "Pixel_B", deviceId: "emulator-5556" },
+    ]);
+
+    const failure = await callTool("getAndroid", {
+      avdName: "Pixel_A",
+      deviceId: "emulator-5556",
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(ActionableError);
+    expect((failure as ActionableError).message).toContain("identifier_conflict");
+    expect((failure as ActionableError).message).toContain("Pixel_B");
+    expect(deviceUtils.wasMethodCalled("startDevice")).toBe(false);
+  });
+
+  test("getAndroid rejects an avdName paired with a serial that is not running before booting", async () => {
+    // Neither identifier maps to a running device: the serial is absent from
+    // discovery. That is still a contradiction the caller must resolve, decided
+    // before any boot.
+    deviceUtils.setDeviceImages("android", [
+      { platform: "android", name: "Pixel_C", isRunning: false, source: "local" },
+    ]);
+
+    const failure = await callTool("getAndroid", {
+      avdName: "Pixel_C",
+      deviceId: "emulator-5599",
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(ActionableError);
+    expect((failure as ActionableError).message).toContain("identifier_conflict");
+    expect((failure as ActionableError).message).toContain("not running");
+    expect(deviceUtils.wasMethodCalled("startDevice")).toBe(false);
   });
 
   test("getApple rejects contradictory udid and deviceId instead of silently preferring one", () => {

--- a/test/utils/deviceReadinessLock.test.ts
+++ b/test/utils/deviceReadinessLock.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import {
+  deviceReadinessLockKey,
+  getDeviceAcquisitionReadiness,
+  moveDeviceAcquisitionReadiness,
+  trackDeviceAcquisitionReadiness,
+} from "../../src/utils/deviceReadinessLock";
+
+describe("moveDeviceAcquisitionReadiness", () => {
+  test("moves an in-flight marker onto a replacement key that has none", async () => {
+    const fromKey = deviceReadinessLockKey("android", "emulator-5554");
+    const toKey = deviceReadinessLockKey("android", "emulator-5560");
+
+    let settle!: () => void;
+    const started = new Promise<void>((resolve) => {
+      settle = resolve;
+    });
+    const tracked = trackDeviceAcquisitionReadiness(fromKey, async () => {
+      await started;
+    });
+    // Let trackDeviceAcquisitionReadiness install its marker.
+    await Promise.resolve();
+
+    const marker = getDeviceAcquisitionReadiness(fromKey);
+    expect(marker).toBeDefined();
+
+    moveDeviceAcquisitionReadiness(fromKey, toKey);
+    expect(getDeviceAcquisitionReadiness(toKey)).toBe(marker);
+
+    settle();
+    await tracked;
+    // Settling clears every alias of the marker, including the moved-to key.
+    expect(getDeviceAcquisitionReadiness(toKey)).toBeUndefined();
+    expect(getDeviceAcquisitionReadiness(fromKey)).toBeUndefined();
+  });
+
+  test("does not clobber a distinct in-flight marker already tracking the replacement key", async () => {
+    // A recovery replaces acquisition A's serial with one that a concurrent
+    // acquisition B is already preparing. Moving A's marker onto B's key must
+    // not evict B's marker: an awaiter on that key would otherwise be handed
+    // A's marker and could stop waiting the moment A settles while B's CtrlProxy
+    // setup is still mid-flight — the double-setup race the marker prevents.
+    const fromKey = deviceReadinessLockKey("android", "emulator-5554");
+    const sharedKey = deviceReadinessLockKey("android", "emulator-5560");
+
+    let settleA!: () => void;
+    const startedA = new Promise<void>((resolve) => {
+      settleA = resolve;
+    });
+    let settleB!: () => void;
+    const startedB = new Promise<void>((resolve) => {
+      settleB = resolve;
+    });
+
+    const trackedA = trackDeviceAcquisitionReadiness(fromKey, async () => {
+      await startedA;
+    });
+    const trackedB = trackDeviceAcquisitionReadiness(sharedKey, async () => {
+      await startedB;
+    });
+    await Promise.resolve();
+
+    const markerB = getDeviceAcquisitionReadiness(sharedKey);
+    const markerA = getDeviceAcquisitionReadiness(fromKey);
+    expect(markerB).toBeDefined();
+    expect(markerA).not.toBe(markerB);
+
+    moveDeviceAcquisitionReadiness(fromKey, sharedKey);
+
+    // B's live marker is preserved; A's did not overwrite it.
+    expect(getDeviceAcquisitionReadiness(sharedKey)).toBe(markerB);
+
+    settleA();
+    settleB();
+    await Promise.all([trackedA, trackedB]);
+  });
+});

--- a/test/utils/deviceReadinessLock.test.ts
+++ b/test/utils/deviceReadinessLock.test.ts
@@ -6,17 +6,33 @@ import {
   trackDeviceAcquisitionReadiness,
 } from "../../src/utils/deviceReadinessLock";
 
+/** Drain pending microtasks (composite markers resolve across several ticks). */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+interface Deferred {
+  settle: () => void;
+  started: Promise<void>;
+}
+
+function deferred(): Deferred {
+  let settle!: () => void;
+  const started = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+  return { settle, started };
+}
+
 describe("moveDeviceAcquisitionReadiness", () => {
   test("moves an in-flight marker onto a replacement key that has none", async () => {
     const fromKey = deviceReadinessLockKey("android", "emulator-5554");
     const toKey = deviceReadinessLockKey("android", "emulator-5560");
 
-    let settle!: () => void;
-    const started = new Promise<void>((resolve) => {
-      settle = resolve;
-    });
+    const a = deferred();
     const tracked = trackDeviceAcquisitionReadiness(fromKey, async () => {
-      await started;
+      await a.started;
     });
     // Let trackDeviceAcquisitionReadiness install its marker.
     await Promise.resolve();
@@ -25,38 +41,33 @@ describe("moveDeviceAcquisitionReadiness", () => {
     expect(marker).toBeDefined();
 
     moveDeviceAcquisitionReadiness(fromKey, toKey);
+    // A lone pending acquisition is handed out by identity - no composite.
     expect(getDeviceAcquisitionReadiness(toKey)).toBe(marker);
 
-    settle();
+    a.settle();
     await tracked;
     // Settling clears every alias of the marker, including the moved-to key.
     expect(getDeviceAcquisitionReadiness(toKey)).toBeUndefined();
     expect(getDeviceAcquisitionReadiness(fromKey)).toBeUndefined();
   });
 
-  test("does not clobber a distinct in-flight marker already tracking the replacement key", async () => {
+  test("keeps the replacement key pending until the incoming acquisition also settles", async () => {
     // A recovery replaces acquisition A's serial with one that a concurrent
-    // acquisition B is already preparing. Moving A's marker onto B's key must
-    // not evict B's marker: an awaiter on that key would otherwise be handed
-    // A's marker and could stop waiting the moment A settles while B's CtrlProxy
-    // setup is still mid-flight — the double-setup race the marker prevents.
+    // acquisition B is already preparing. B settling first must NOT clear the
+    // shared key while A is still binding: an awaiter that sampled the key
+    // would otherwise see nothing pending and start a duplicate CtrlProxy
+    // setup - the #6280 double-setup race the marker exists to prevent.
     const fromKey = deviceReadinessLockKey("android", "emulator-5554");
     const sharedKey = deviceReadinessLockKey("android", "emulator-5560");
 
-    let settleA!: () => void;
-    const startedA = new Promise<void>((resolve) => {
-      settleA = resolve;
-    });
-    let settleB!: () => void;
-    const startedB = new Promise<void>((resolve) => {
-      settleB = resolve;
-    });
+    const a = deferred();
+    const b = deferred();
 
     const trackedA = trackDeviceAcquisitionReadiness(fromKey, async () => {
-      await startedA;
+      await a.started;
     });
     const trackedB = trackDeviceAcquisitionReadiness(sharedKey, async () => {
-      await startedB;
+      await b.started;
     });
     await Promise.resolve();
 
@@ -67,11 +78,105 @@ describe("moveDeviceAcquisitionReadiness", () => {
 
     moveDeviceAcquisitionReadiness(fromKey, sharedKey);
 
-    // B's live marker is preserved; A's did not overwrite it.
-    expect(getDeviceAcquisitionReadiness(sharedKey)).toBe(markerB);
+    const shared = getDeviceAcquisitionReadiness(sharedKey);
+    expect(shared).toBeDefined();
+    let sharedSettled = false;
+    void shared!.then(() => {
+      sharedSettled = true;
+    });
 
-    settleA();
-    settleB();
-    await Promise.all([trackedA, trackedB]);
+    // B finishes first - the shared key still covers A.
+    b.settle();
+    await trackedB;
+    await flush();
+    expect(sharedSettled).toBe(false);
+    expect(getDeviceAcquisitionReadiness(sharedKey)).toBeDefined();
+
+    a.settle();
+    await trackedA;
+    await flush();
+    expect(sharedSettled).toBe(true);
+    expect(getDeviceAcquisitionReadiness(sharedKey)).toBeUndefined();
+    expect(getDeviceAcquisitionReadiness(fromKey)).toBeUndefined();
+  });
+
+  test("keeps the replacement key pending when the moved acquisition settles first", async () => {
+    // The mirror case: A (moved onto B's key) settles first. B's own setup is
+    // still in flight, so the key must stay pending until B settles too.
+    const fromKey = deviceReadinessLockKey("android", "emulator-5554");
+    const sharedKey = deviceReadinessLockKey("android", "emulator-5560");
+
+    const a = deferred();
+    const b = deferred();
+
+    const trackedA = trackDeviceAcquisitionReadiness(fromKey, async () => {
+      await a.started;
+    });
+    const trackedB = trackDeviceAcquisitionReadiness(sharedKey, async () => {
+      await b.started;
+    });
+    await Promise.resolve();
+
+    moveDeviceAcquisitionReadiness(fromKey, sharedKey);
+
+    const shared = getDeviceAcquisitionReadiness(sharedKey);
+    expect(shared).toBeDefined();
+    let sharedSettled = false;
+    void shared!.then(() => {
+      sharedSettled = true;
+    });
+
+    a.settle();
+    await trackedA;
+    await flush();
+    expect(sharedSettled).toBe(false);
+    expect(getDeviceAcquisitionReadiness(sharedKey)).toBeDefined();
+
+    b.settle();
+    await trackedB;
+    await flush();
+    expect(sharedSettled).toBe(true);
+    expect(getDeviceAcquisitionReadiness(sharedKey)).toBeUndefined();
+  });
+
+  test("is a no-op when the source key has no in-flight acquisition", async () => {
+    const fromKey = deviceReadinessLockKey("android", "emulator-5554");
+    const toKey = deviceReadinessLockKey("android", "emulator-5560");
+
+    const b = deferred();
+    const trackedB = trackDeviceAcquisitionReadiness(toKey, async () => {
+      await b.started;
+    });
+    await Promise.resolve();
+    const markerB = getDeviceAcquisitionReadiness(toKey);
+
+    moveDeviceAcquisitionReadiness(fromKey, toKey);
+    expect(getDeviceAcquisitionReadiness(toKey)).toBe(markerB);
+
+    b.settle();
+    await trackedB;
+    expect(getDeviceAcquisitionReadiness(toKey)).toBeUndefined();
+  });
+
+  test("moving the same marker twice onto one key does not double-count it", async () => {
+    // `startDevice` publishes a recovered replacement marker and then moves the
+    // marker again for the settled boot identity; both can name the same key.
+    const fromKey = deviceReadinessLockKey("android", "emulator-5554");
+    const toKey = deviceReadinessLockKey("android", "emulator-5560");
+
+    const a = deferred();
+    const tracked = trackDeviceAcquisitionReadiness(fromKey, async () => {
+      await a.started;
+    });
+    await Promise.resolve();
+
+    moveDeviceAcquisitionReadiness(fromKey, toKey);
+    moveDeviceAcquisitionReadiness(fromKey, toKey);
+    expect(getDeviceAcquisitionReadiness(toKey)).toBe(getDeviceAcquisitionReadiness(fromKey));
+
+    a.settle();
+    await tracked;
+    expect(getDeviceAcquisitionReadiness(toKey)).toBeUndefined();
+    expect(getDeviceAcquisitionReadiness(fromKey)).toBeUndefined();
   });
 });


### PR DESCRIPTION
Follow-up to [#6833](https://github.com/kaeawc/auto-mobile/pull/6833) (merged, closed [#6845](https://github.com/kaeawc/auto-mobile/issues/6845)). Each fix is its own commit with a regression test that failed before the fix.

## 1. getAndroid: reject a contradictory `avdName` + serial pair before booting (P2)

From the Codex review thread left open on [#6833](https://github.com/kaeawc/auto-mobile/pull/6833). `validateRequestedAndroidSerial` only ran **after** `bootService.boot()`, so `getAndroid({ avdName: "Pixel_A", deviceId: "emulator-5556" })` where that serial is a different (or stopped) AVD cold-booted `Pixel_A` and then killed it just to return `identifier_conflict`.

- factor the emulator-serial shape into `isAndroidEmulatorSerial(deviceId)`, reused inside `isVirtualAndroidDevice` so the shape has one spelling;
- add `validateRequestedAndroidSerialBeforeBoot(pair, deviceUtils)`, called at the top of `prepareDevice`'s try block before any lifecycle reservation or boot. It fires only when both an `avdName` and a serial-shaped `deviceId` are present and differ, does a single `getBootedDevicesDetailed("android", { bypassAndroidDeviceListCache: true })`, and throws `identifier_conflict` when the serial runs under a different AVD **or** is not running at all. It deliberately **defers** to the post-boot recheck when discovery was unavailable this sweep or the running device still reports an `Unknown (<serial>)` runtime name;
- `validateRequestedAndroidSerial` stays as the post-boot identity authority.

**Reviewer notes**
- This adds one extra `getBootedDevicesDetailed` round-trip on the `avdName`+`deviceId` path. That path did no pre-boot discovery before, because `budgets.stableTarget` short-circuits `resolveStartStableDeviceLifecycleTarget`.
- A non-serial `deviceId` (an AVD image name) is still only validated by the post-boot recheck, by design — the AVD-name→serial mapping is not known until discovery.

Tests in `test/server/deviceTools.platformPreparation.test.ts` assert `wasMethodCalled("startDevice") === false` for a stopped AVD + foreign serial and for an unmappable (not-running) pair, plus the same no-boot assertion added to the existing running-AVD conflict test; the running-AVD + its-own-serial success case stays green.

## 2. Deferred plausible-only findings from [#6833](https://github.com/kaeawc/auto-mobile/pull/6833)

### Fixed: `moveDeviceAcquisitionReadiness` marker clobber

`moveDeviceAcquisitionReadiness` unconditionally overwrote the replacement key with the moved marker. When a recovery replaced one acquisition's serial with one a concurrent acquisition was already preparing, the move evicted that acquisition's in-flight marker; an awaiter on the shared key (`ensureReadinessUpgraded` in `ToolExecutionContext`) would then be handed the moved marker and could stop waiting the instant it settled while the other acquisition's CtrlProxy setup was still mid-flight — the double-setup race the per-device marker exists to prevent ([#6280](https://github.com/kaeawc/auto-mobile/issues/6280) follow-up). Guarded so the move never overwrites a distinct in-flight marker already tracking the replacement identity. New isolated unit test `test/utils/deviceReadinessLock.test.ts`.

### Investigated, not reproducible as defects (no change)

- **replay releases its lifecycle lease before persisting success (TOCTOU).** In `canReplayCompletedProvisionDeviceOperation`, the lease is released in `finally` only after `revalidateLiveProvisionDeviceSession` has re-established readiness, recorded it, and (re)attached the session — all under the lease. The subsequent `backfillProvisionDeviceCutout` + `completeProvisionDeviceOperation` are a pure result transform and a DB row write; neither touches the device. The lifecycle lease serializes create/boot/destroy, and once readiness is recorded and the session attached the device is protected by session ownership (`busy`), not the lease — exactly as for any provision that returns. Releasing before the DB write exposes no lifecycle race.
- **`boot: false` replay returns cached success without a ground-truth "still booted" check.** `boot: false` provisioning deliberately neither boots the device nor exposes a live session (`does not expose a session for boot:false ...` test; result is `lifecycleState: "created"`, `readiness: not_requested`). There is no booted state to re-verify, so the `!args.boot` short-circuit past `revalidateProvisionDeviceReplay` is correct.
- **phase deadline landing inside `reuseOwnedAutolockSession`.** The one `await` (`getOrCreateSession`) is followed by a full ownership revalidation (`refreshed !== session`, `isSessionAssignmentCurrent`, `isAdmittedForAutomation`) that throws `session_ownership_lost`-style on any change, and the caller checks `throwIfRequestAborted()` immediately before. Reusing a session the same client already owns is idempotent even past a soft deadline, and no pool/session mutation runs on a stale actor. No correctness defect.

## Validation
`bun run typecheck` (no new errors), `bun run format:check`, plain-oxlint diff vs `origin/main` (`bunx oxlint --format=unix src test`, line/columns stripped) adds no new entries, and `bun test test/server test/db test/daemon test/utils` is green (9193 pass, 0 fail).
