### PR TITLE
chore(deps): ignore sharp + @img native matrix in Dependabot (manual pin-script bumps only)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,16 +15,6 @@ updates:
     open-pull-requests-limit: 10
     # Set versioning strategy appropriate for a library/package
     versioning-strategy: "increase-if-necessary"
-    groups:
-      # sharp ships libvips as a separately-linked native matrix (top-level
-      # `sharp` + every `@img/sharp-*` platform binary). Bump them together in
-      # one PR so a partial update can never split the matrix — validated safe
-      # under Bun on macOS + Linux (arm64/x64) at 0.35.3; see
-      # docs/design-docs/image-backend.md.
-      sharp:
-        patterns:
-          - "sharp"
-          - "@img/sharp-*"
     ignore:
       # These top-level entries are transitive pins hoisted to a single copy by
       # scripts/release/pin-runtime-deps.ts (issue #5421), NOT packages our code
@@ -53,6 +43,32 @@ updates:
       # runtime effect. Allow only patch updates to the pinned 1.4.x line.
       - dependency-name: "sax"
         update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      # sharp is bumped by hand, never by Dependabot (PR #6820). Two reasons,
+      # either of which alone is fatal:
+      #
+      #   1. sharp ships libvips as a separately-linked native matrix — the
+      #      top-level `sharp` plus 23 `@img/sharp-*` / `@img/sharp-libvips-*`
+      #      entries in optionalDependencies, 24 in all — and every one of them
+      #      must move in lock-step. Dependabot only bumps the entries eligible
+      #      at the moment it opens the PR: #6820 moved `sharp` 0.35.3 -> 0.35.4
+      #      and 17 of the 23, leaving six behind, so `sharp` failed to load on
+      #      linux-x64, the image backend silently fell back to Jimp, and the
+      #      WebP encoding test reddened the required Node build. A `groups:`
+      #      rule only makes a split *less likely*, which is why the group that
+      #      used to live here is gone; scripts/check-sharp-matrix-coherence.ts
+      #      is the gate that actually rejects one.
+      #   2. Any sharp change also invalidates the committed
+      #      scripts/release/runtime-graph.json that the pinned-runtime-graph
+      #      check verifies (issue #5421), and Dependabot cannot regenerate it.
+      #      A human must run
+      #      `bun run build && bun scripts/release/pin-runtime-deps.ts --write && bun install`
+      #      and commit package.json + bun.lock + runtime-graph.json together;
+      #      see docs/design-docs/release/runtime-dependency-pinning.md.
+      #
+      # No `update-types:` here on purpose — ignore every version, patches
+      # included, since even a patch splits the matrix and stales the manifest.
+      - dependency-name: "sharp"
+      - dependency-name: "@img/*"
   # Android Gradle dependencies
   - package-ecosystem: "gradle"
     directory: "/android"

--- a/docs/design-docs/release/runtime-dependency-pinning.md
+++ b/docs/design-docs/release/runtime-dependency-pinning.md
@@ -72,7 +72,16 @@ manifest) and enforced by:
 ## Refreshing the graph (dependency / security updates)
 
 When a runtime dependency or a security override changes the resolved graph
-(e.g. a Dependabot bump to `sharp`, `jimp`, or one of their transitives):
+(e.g. a Dependabot bump to `jimp` or one of their transitives, or a manual
+`sharp` bump):
+
+> `sharp` and every `@img/*` entry are ignored in `.github/dependabot.yml` and
+> must be bumped by hand. Dependabot bumps only the entries eligible when it
+> opens the PR, which splits sharp's 24-entry native matrix (PR #6820 left six
+> behind and sharp stopped loading on linux-x64), and it cannot regenerate
+> `scripts/release/runtime-graph.json`. Bump `sharp` together with every
+> `@img/sharp-*` / `@img/sharp-libvips-*` pin, then follow the steps below;
+> `scripts/check-sharp-matrix-coherence.ts` rejects a partial bump.
 
 1. Update the version(s) as usual and run `bun install` so `bun.lock` reflects
    the new resolution.

--- a/scripts/check-sharp-matrix-coherence.ts
+++ b/scripts/check-sharp-matrix-coherence.ts
@@ -11,10 +11,10 @@ import { join } from "node:path";
  * packages currently eligible for an update — the installed matrix is
  * incoherent and sharp can fail to load at runtime.
  *
- * `.github/dependabot.yml` groups these so they *tend* to bump together, but a
- * `groups` rule does not enforce completeness. This check is the actual gate:
- * it rejects any partial bump so the invariant holds regardless of how the
- * update arrived.
+ * `.github/dependabot.yml` ignores `sharp` and `@img/*` outright (a `groups`
+ * rule only made a split less likely, never impossible — see #6820), so the
+ * matrix only ever moves by hand. This check is the actual gate: it rejects any
+ * partial bump so the invariant holds regardless of how the update arrived.
  */
 
 interface PackageJson {


### PR DESCRIPTION
## Summary

Dependabot PR [#6820](https://github.com/kaeawc/auto-mobile/pull/6820) (closed) tried to bump the sharp group and broke a required check: it moved `sharp` 0.35.3 to 0.35.4 and 17 of the 23 `@img/*` entries, leaving six platform binaries behind. On linux-x64 sharp failed to load, the image backend fell back to Jimp, and `JimpBackend does not encode WebP` reddened the required Node build. Dependabot also cannot regenerate the committed `scripts/release/runtime-graph.json` that the pinned runtime-graph gate ([#5421](https://github.com/kaeawc/auto-mobile/issues/5421)) verifies.

## Change

- `.github/dependabot.yml`: ignore all versions of `sharp` and `@img/*` (no `update-types`, so patches are ignored too). Removed the now-dead `groups: sharp` block; the comment records why grouping was insufficient and how to bump by hand.
- `scripts/check-sharp-matrix-coherence.ts`: doc comment no longer references the removed group.
- `docs/design-docs/release/runtime-dependency-pinning.md`: note that sharp bumps are manual via the pin script.

## Validation

- `scripts/validate_dependabot.sh`: valid YAML
- `all_fast_validate_checks.sh --only dependabot,sharp-matrix,runtime-pins`: 3/3 OK
- docs group (mkdocs-nav, codex-skills, lychee): 3/3 OK
- `bun run format:check`, `bun run typecheck`: clean