### PR TITLE
fix(video): do not fail iOS recording start on a slow simctl state probe (#6857)

### DIFF
--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -54,7 +54,17 @@ export const IOS_RECORDING_FILE_READY_TIMEOUT_MS = 15000;
 const IOS_RECORDING_FILE_READY_INITIAL_BACKOFF_MS = 100;
 const IOS_RECORDING_FILE_READY_MAX_BACKOFF_MS = 1000;
 const FFMPEG_POST_PROCESS_TIMEOUT_MS = 60000;
-const IOS_RECORDING_START_TIMEOUT_MS = 5000;
+// Total budget for the whole iOS start path: the simctl availability probe, the
+// spawn, and every attempt's "Recording started" handshake. The handshake is the
+// expensive part — simctl only emits it after encoding the first video frame — and
+// the budget is split across the bounded retries, so the original 5s left each
+// attempt under two seconds. On the self-hosted macOS runner (which also runs
+// xcodebuild and Simulator) that was routinely too short, so essentially every PR
+// saw the iOS video-recording lane fail with "Timed out waiting for Recording
+// started" (#6857). Keep it bounded — an actually-wedged simulator must still
+// fail rather than hang — but at the same order as the stop-side waits, which
+// already carry the "loaded CI macOS runner" rationale.
+export const IOS_RECORDING_START_TIMEOUT_MS = 15000;
 const IOS_RECORDING_START_CLEANUP_TIMEOUT_MS = 500;
 // A cold or loaded simulator can silently miss the very first `recordVideo`
 // start handshake (#4076): simctl produces no "Recording started" and no error,
@@ -62,7 +72,16 @@ const IOS_RECORDING_START_CLEANUP_TIMEOUT_MS = 500;
 // before failing, capturing simulator state on each miss so a genuine wedge is
 // diagnosable rather than surfacing as a bare timeout.
 const IOS_RECORDING_START_MAX_ATTEMPTS = 2;
-const IOS_RECORDING_DIAGNOSTIC_TIMEOUT_MS = 5000;
+// Budget for the terminal attempt's simulator-state probe. Nothing is waiting on
+// the start deadline once the last attempt has failed, so the probe gets a budget a
+// loaded host can actually deliver — `xcrun simctl list devices` regularly needs
+// more than a few hundred milliseconds there, and a probe that times out reports
+// nothing about the simulator at all (#6857).
+const IOS_RECORDING_DIAGNOSTIC_TIMEOUT_MS = 3000;
+// Budget for a between-attempt probe. That one still shares the start deadline with
+// the pending retry, so it stays a small slice: enriching a failure must never
+// starve the attempt that could still succeed.
+const IOS_RECORDING_RETRY_DIAGNOSTIC_TIMEOUT_MS = 250;
 // `simctl` emits this only after processing its first video frame. The earlier
 // "Defaulting to display" diagnostic proves only display selection, which can
 // still produce a zero-byte capture on a cold simulator.
@@ -885,6 +904,7 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
       input.simctl,
       input.device,
       input.startDeadlineMs,
+      input.attempt >= input.maxAttempts,
     );
     logger.warn(
       `[FfmpegVideo] iOS recording start attempt ${input.attempt}/${input.maxAttempts} failed: ${input.error} (${diagnostics})`,
@@ -917,11 +937,25 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     simctl: SimCtl,
     device: BootedDevice,
     startDeadlineMs: number,
+    isFinalAttempt: boolean,
   ): Promise<string> {
-    const diagnosticBudgetMs = Math.max(0, Math.min(250, startDeadlineMs - this.timer.now()));
+    if (isFinalAttempt) {
+      // No retry is left to protect, so the probe is deliberately NOT clipped to the
+      // (usually exhausted) start deadline. Clipping it meant the one attempt whose
+      // diagnostics matter most reported "startup budget exhausted" and never looked.
+      return await this.captureSimulatorDiagnostics(
+        simctl,
+        device,
+        IOS_RECORDING_DIAGNOSTIC_TIMEOUT_MS,
+      );
+    }
+    const diagnosticBudgetMs = Math.max(
+      0,
+      Math.min(IOS_RECORDING_RETRY_DIAGNOSTIC_TIMEOUT_MS, startDeadlineMs - this.timer.now()),
+    );
     return diagnosticBudgetMs > 0
       ? await this.captureSimulatorDiagnostics(simctl, device, diagnosticBudgetMs)
-      : "simulator state unavailable: startup budget exhausted";
+      : "simulator state unknown: start budget reserved for the pending retry";
   }
 
   /**
@@ -934,15 +968,24 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     device: BootedDevice,
     timeoutMs: number,
   ): Promise<string> {
+    const budgetMs = Math.min(IOS_RECORDING_DIAGNOSTIC_TIMEOUT_MS, timeoutMs);
+    const probeStartedAtMs = this.timer.now();
     try {
       const result = await simctl.executeCommandArgs(
         ["list", "devices", device.deviceId],
-        Math.min(IOS_RECORDING_DIAGNOSTIC_TIMEOUT_MS, timeoutMs),
+        budgetMs,
       );
       const text = (result.stdout || result.stderr || "").replace(/\s+/g, " ").trim();
       return text ? `simulator state: ${text.slice(0, 500)}` : "simulator state: (empty)";
     } catch (error) {
       const reason = errorMessage(error);
+      // A probe that burned its whole budget says nothing about the simulator — only
+      // that the host was too busy to answer in time. Reporting that as "unavailable"
+      // reads like a definitive "the simulator is gone" and sent the triage of #6857
+      // after the probe instead of the handshake timeout that actually failed the start.
+      if (this.timer.now() - probeStartedAtMs >= budgetMs) {
+        return `simulator state unknown: state probe exceeded its ${budgetMs}ms budget (host may be loaded): ${reason}`;
+      }
       return `simulator state unavailable: ${reason}`;
     }
   }

--- a/test/features/video/FfmpegVideoProcessingBackend.test.ts
+++ b/test/features/video/FfmpegVideoProcessingBackend.test.ts
@@ -7,6 +7,7 @@ import {
   containsIosRecordingStartMessage,
   FfmpegVideoProcessingBackend,
   IOS_RECORDING_FILE_READY_TIMEOUT_MS,
+  IOS_RECORDING_START_TIMEOUT_MS,
   IOS_RECORDING_STOP_TIMEOUT_MS,
   pipeCaptureToEncoder,
   PROCESS_EXIT_TIMEOUT_MS,
@@ -432,7 +433,177 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function () {
     expect(starts).toBe(2); // exhausted the bounded retry budget
   });
 
-  test("fails and reaps a slow iOS start within the five-second total budget", async function () {
+  // A capture child that spawns immediately but only emits the recordVideo
+  // handshake after `handshakeDelayMs` of fake time, the way `simctl` behaves on a
+  // macOS runner that is also busy with xcodebuild and Simulator.
+  function makeSlowHandshakeChild(handshakeDelayMs: number, timer: Timer): ChildProcess {
+    const stderr = new PassThrough();
+    const child = new EventEmitter() as ChildProcess;
+    Object.assign(child, {
+      stderr,
+      stdout: null,
+      stdin: null,
+      killed: false,
+      exitCode: null,
+      signalCode: null,
+      pid: 4242,
+      kill: () => {
+        (child as unknown as { killed: boolean }).killed = true;
+        queueMicrotask(() => {
+          child.emit("exit", 0, "SIGINT");
+          child.emit("close");
+        });
+        return true;
+      },
+    });
+    timer.setTimeout(() => child.emit("spawn"), 0);
+    timer.setTimeout(() => stderr.write("Recording started\n"), handshakeDelayMs);
+    return child;
+  }
+
+  test("starts iOS recording when a loaded host needs over five seconds to hand shake (#6857)", async function () {
+    let starts = 0;
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const simctl = {
+      isAvailable: async () => true,
+      startCommandArgs: async () => {
+        starts++;
+        return makeSlowHandshakeChild(6000, timer);
+      },
+      executeCommandArgs: async () => diagnosticsExecResult("iPhone 17 Pro (udid) (Booted)"),
+    } as unknown as SimCtl;
+
+    backend = new FfmpegVideoProcessingBackend(
+      undefined,
+      () => simctl,
+      undefined,
+      undefined,
+      undefined,
+      timer,
+    );
+    (backend as any).ensureFfmpegAvailable = async () => {};
+    mockConfig.device = { ...mockDevice, platform: "ios", deviceId: "ios-loaded-host-udid" };
+
+    const handle = await backend.start(mockConfig);
+
+    expect(handle.recordingId).toBe("test-recording");
+    expect(starts).toBe(1); // the first attempt's handshake window outlasts a loaded host
+  });
+
+  test("reports a state probe that exhausts its own budget as unknown, not unavailable (#6857)", async function () {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const probeBudgets: Array<number | undefined> = [];
+    const simctl = {
+      isAvailable: async () => true,
+      startCommandArgs: async () => makeCaptureChild(false, timer), // never hand shakes
+      executeCommandArgs: async (_args: string[], timeoutMs?: number) => {
+        probeBudgets.push(timeoutMs);
+        await timer.sleep(timeoutMs ?? 0); // burn the whole probe budget, then time out
+        throw new Error(`Command timed out after ${timeoutMs}ms: xcrun simctl list devices udid`);
+      },
+    } as unknown as SimCtl;
+
+    backend = new FfmpegVideoProcessingBackend(
+      undefined,
+      () => simctl,
+      undefined,
+      undefined,
+      undefined,
+      timer,
+    );
+    (backend as any).ensureFfmpegAvailable = async () => {};
+    (backend as any).iosRecordingStartTimeoutMs = 25;
+    (backend as any).iosRecordingStartMaxAttempts = 1;
+    mockConfig.device = { ...mockDevice, platform: "ios", deviceId: "ios-slow-probe-udid" };
+
+    let error: Error | undefined;
+    try {
+      await backend.start(mockConfig);
+    } catch (caught) {
+      error = caught as Error;
+    }
+
+    expect(error).toBeDefined();
+    // A probe that ran out of time proves nothing about the simulator, so it must not
+    // be reported as a definitive "unavailable" state.
+    expect(error!.message).toContain("simulator state unknown");
+    expect(error!.message).not.toContain("simulator state unavailable");
+    // The terminal attempt has no retry left to protect, so it gets a budget a loaded
+    // host can actually deliver instead of the old 250ms slice.
+    expect(probeBudgets).toEqual([3000]);
+  });
+
+  test("still reports a definitive simctl failure as an unavailable state (#6857)", async function () {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const simctl = {
+      isAvailable: async () => true,
+      startCommandArgs: async () => makeCaptureChild(false, timer),
+      executeCommandArgs: async () => {
+        throw new Error("Invalid device: ios-missing-udid");
+      },
+    } as unknown as SimCtl;
+
+    backend = new FfmpegVideoProcessingBackend(
+      undefined,
+      () => simctl,
+      undefined,
+      undefined,
+      undefined,
+      timer,
+    );
+    (backend as any).ensureFfmpegAvailable = async () => {};
+    (backend as any).iosRecordingStartTimeoutMs = 25;
+    (backend as any).iosRecordingStartMaxAttempts = 1;
+    mockConfig.device = { ...mockDevice, platform: "ios", deviceId: "ios-missing-udid" };
+
+    let error: Error | undefined;
+    try {
+      await backend.start(mockConfig);
+    } catch (caught) {
+      error = caught as Error;
+    }
+
+    expect(error).toBeDefined();
+    expect(error!.message).toContain("simulator state unavailable");
+    expect(error!.message).toContain("Invalid device: ios-missing-udid");
+  });
+
+  test("keeps the between-attempt state probe small so the retry keeps its budget (#6857)", async function () {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const probeBudgets: Array<number | undefined> = [];
+    const simctl = {
+      isAvailable: async () => true,
+      startCommandArgs: async () => makeCaptureChild(false, timer),
+      executeCommandArgs: async (_args: string[], timeoutMs?: number) => {
+        probeBudgets.push(timeoutMs);
+        return diagnosticsExecResult("iPhone 17 Pro (udid) (Booted)");
+      },
+    } as unknown as SimCtl;
+
+    backend = new FfmpegVideoProcessingBackend(
+      undefined,
+      () => simctl,
+      undefined,
+      undefined,
+      undefined,
+      timer,
+    );
+    (backend as any).ensureFfmpegAvailable = async () => {};
+    (backend as any).iosRecordingStartTimeoutMs = 2000;
+    mockConfig.device = { ...mockDevice, platform: "ios", deviceId: "ios-probe-budget-udid" };
+
+    await expect(backend.start(mockConfig)).rejects.toThrow("Failed to start iOS recording");
+
+    // Attempt 1 shares the start deadline with the pending retry; the terminal attempt
+    // does not, so only it gets the full diagnostic budget.
+    expect(probeBudgets).toEqual([250, 3000]);
+  });
+
+  test("fails and reaps a slow iOS start within the bounded total budget", async function () {
     const timer = new FakeTimer();
     const stderr = new PassThrough();
     const signals: Array<NodeJS.Signals | number | undefined> = [];
@@ -472,16 +643,19 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function () {
     (backend as any).iosRecordingStartMaxAttempts = 1;
     mockConfig.device = { ...mockDevice, platform: "ios", deviceId: "ios-slow-udid" };
 
+    // The single attempt gets the whole start budget minus the cleanup slice reserved
+    // for reaping it, so the handshake wait is the only pending timer.
+    const handshakeBudgetMs = IOS_RECORDING_START_TIMEOUT_MS - 500;
     const starting = backend.start(mockConfig);
-    for (let i = 0; i < 20 && !timer.getPendingTimeouts().includes(4500); i++) {
+    for (let i = 0; i < 20 && !timer.getPendingTimeouts().includes(handshakeBudgetMs); i++) {
       await Promise.resolve();
     }
-    expect(timer.getPendingTimeouts()).toEqual([4500]);
+    expect(timer.getPendingTimeouts()).toEqual([handshakeBudgetMs]);
 
-    timer.advanceTime(4500);
+    timer.advanceTime(handshakeBudgetMs);
     await expect(starting).rejects.toThrow("Failed to start iOS recording");
 
-    expect(timer.now()).toBeLessThanOrEqual(5000);
+    expect(timer.now()).toBeLessThanOrEqual(IOS_RECORDING_START_TIMEOUT_MS);
     expect(signals).toEqual(["SIGKILL"]);
     expect(timer.getPendingTimeoutCount()).toBe(0);
     expect(stderr.listenerCount("data")).toBe(0);
@@ -570,9 +744,9 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function () {
     for (let attempt = 0; attempt < 20 && probeSignal === undefined; attempt++) {
       await Promise.resolve();
     }
-    expect(timer.getPendingTimeouts()).toEqual([5000]);
+    expect(timer.getPendingTimeouts()).toEqual([IOS_RECORDING_START_TIMEOUT_MS]);
 
-    timer.advanceTime(5000);
+    timer.advanceTime(IOS_RECORDING_START_TIMEOUT_MS);
     await expect(starting).rejects.toThrow("FFmpeg is not available");
     expect(probeSignal?.aborted).toBe(true);
     expect(timer.getPendingTimeoutCount()).toBe(0);
@@ -618,9 +792,9 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function () {
     for (let attempt = 0; attempt < 20 && availabilitySignal === undefined; attempt++) {
       await Promise.resolve();
     }
-    expect(timer.getPendingTimeouts()).toEqual([5000]);
+    expect(timer.getPendingTimeouts()).toEqual([IOS_RECORDING_START_TIMEOUT_MS]);
 
-    timer.advanceTime(5000);
+    timer.advanceTime(IOS_RECORDING_START_TIMEOUT_MS);
     await expect(starting).rejects.toThrow("Timed out checking simctl availability");
     expect(availabilitySignal?.aborted).toBe(true);
     expect(captureStarts).toBe(0);


### PR DESCRIPTION
## Summary

Fixes [#6857](https://github.com/kaeawc/auto-mobile/issues/6857), the surviving failure mode of the iOS videoRecording lane after [#6854](https://github.com/kaeawc/auto-mobile/pull/6854) (lineage: [#6851](https://github.com/kaeawc/auto-mobile/issues/6851)).

The issue as filed blamed the 250 ms `xcrun simctl list devices` probe. That probe is diagnostics-only: it runs inside the `catch` of an attempt that has already failed and only decorates the error string. The real abort is the handshake budget arithmetic in `startIos`: a 5 s total start budget covered the availability probe, the spawn, and every attempt's "Recording started" handshake, split across retries, leaving each attempt roughly 1.5 s to see a handshake that simctl only emits after encoding the first frame. On the loaded self-hosted macOS runner that was routinely too short. The 5 s came from `50bcb3bca` (#5960), whose intent was "bound the start path"; no heartbeat or protocol deadline depends on the number.

## Fix

1. `IOS_RECORDING_START_TIMEOUT_MS` 5000 to 15000 (exported). Still bounded; same order as the stop-side waits that already carry the loaded-runner rationale. Per-attempt handshake window goes from about 1.5 s to about 7 s.
2. A state probe that exhausts its whole budget now reports `simulator state unknown: state probe exceeded its Nms budget (host may be loaded)` instead of `simulator state unavailable`, which read as a definitive "simulator is gone". A fast definitive simctl failure still reports `unavailable`.
3. The terminal attempt's diagnostic probe gets its own 3 s budget and is no longer clipped to the exhausted start deadline (previously it reported "startup budget exhausted" and never probed). Between-attempt probes keep 250 ms so they cannot starve the retry.

## Tests

Four new tests in `test/features/video/FfmpegVideoProcessingBackend.test.ts`, each failing first: a 6 s handshake on a loaded host now starts (reproduced the exact issue error string before the fix); budget-exhausting probe reports unknown; definitive simctl failure still reports unavailable; probe budgets are `[250, 3000]` across attempts. Three pre-existing budget-arithmetic tests now import the exported constant and assert the same invariants.

## Validation

typecheck gate clean (143 baseline), format:check clean, oxlint diff vs main empty, `bun test test/features/video` 211 pass, `bun test test/features` 6835 pass, broad server/db/daemon/utils suite 0 new failures vs main.

Not in scope: reaping orphaned xcodebuild/Simulator processes before the lane starts (workflow change, tracked in the issue).