### PR TITLE
test(ios): retain session ownership through recording integration

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -355,6 +355,7 @@ jobs:
               - 'bunfig.toml'
               - 'test/setup/**'
               - 'test/integration/iosVideoRecordingStartStop.integration.test.ts'
+              - 'test/helpers/sessionOwnershipHeartbeat.ts'
               - 'test/features/navigation/iosNavigationGraphWorkflow.test.ts'
               - 'package.json'
               - 'bun.lock'

--- a/test/helpers/sessionOwnershipHeartbeat.test.ts
+++ b/test/helpers/sessionOwnershipHeartbeat.test.ts
@@ -3,6 +3,26 @@ import { FakeTimer } from "../fakes/FakeTimer";
 import { startSessionOwnershipHeartbeat } from "./sessionOwnershipHeartbeat";
 
 describe("startSessionOwnershipHeartbeat", () => {
+  test("propagates an initial renewal failure before starting the keeper", async () => {
+    const timer = new FakeTimer();
+    let calls = 0;
+
+    await expect(
+      startSessionOwnershipHeartbeat({
+        intervalMs: 2_000,
+        timer,
+        renew: async () => {
+          calls++;
+          throw new Error("daemon heartbeat timed out");
+        },
+      }),
+    ).rejects.toThrow("daemon heartbeat timed out");
+
+    expect(calls).toBe(1);
+    await timer.advanceTimeAsync(10_000);
+    expect(calls).toBe(1);
+  });
+
   test("renews immediately and at the configured cadence until cleanup", async () => {
     const timer = new FakeTimer();
     const calls: AbortSignal[] = [];

--- a/test/helpers/sessionOwnershipHeartbeat.test.ts
+++ b/test/helpers/sessionOwnershipHeartbeat.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { startSessionOwnershipHeartbeat } from "./sessionOwnershipHeartbeat";
+
+describe("startSessionOwnershipHeartbeat", () => {
+  test("renews immediately and at the configured cadence until cleanup", async () => {
+    const timer = new FakeTimer();
+    const calls: AbortSignal[] = [];
+    const heartbeat = await startSessionOwnershipHeartbeat({
+      intervalMs: 2_000,
+      timer,
+      renew: async (signal) => {
+        calls.push(signal);
+      },
+    });
+
+    expect(calls).toHaveLength(1);
+    await timer.advanceTimeAsync(1_999);
+    expect(calls).toHaveLength(1);
+    await timer.advanceTimeAsync(1);
+    expect(calls).toHaveLength(2);
+
+    expect(await heartbeat.stop()).toBeNull();
+    await timer.advanceTimeAsync(2_000);
+    expect(calls).toHaveLength(2);
+  });
+
+  test("cancels an in-flight renewal during bounded cleanup", async () => {
+    const timer = new FakeTimer();
+    let renewal = 0;
+    let inFlightSignal: AbortSignal | undefined;
+    const heartbeat = await startSessionOwnershipHeartbeat({
+      intervalMs: 2_000,
+      timer,
+      renew: async (signal) => {
+        renewal++;
+        if (renewal === 1) {
+          return;
+        }
+        inFlightSignal = signal;
+        await new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve()));
+      },
+    });
+
+    await timer.advanceTimeAsync(2_000);
+    expect(inFlightSignal).toBeDefined();
+
+    expect(await heartbeat.stop()).toBeNull();
+    expect(inFlightSignal!.aborted).toBe(true);
+  });
+});

--- a/test/helpers/sessionOwnershipHeartbeat.ts
+++ b/test/helpers/sessionOwnershipHeartbeat.ts
@@ -1,0 +1,88 @@
+import { SingleFlightInterval } from "../../src/daemon/SingleFlightInterval";
+import { defaultTimer, type Timer } from "../../src/utils/SystemTimer";
+
+const DEFAULT_STOP_TIMEOUT_MS = 5_000;
+
+export interface SessionOwnershipHeartbeat {
+  assertHealthy(): void;
+  stop(): Promise<Error | null>;
+}
+
+export interface SessionOwnershipHeartbeatOptions {
+  intervalMs: number;
+  renew(signal: AbortSignal): Promise<void>;
+  timer?: Timer;
+  stopTimeoutMs?: number;
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+/**
+ * Keeps a session held by a sequence of one-shot CLI clients alive. Each CLI
+ * process tears down its proxy heartbeat on exit, so long integration setup and
+ * recording work must renew through the daemon's public heartbeat command.
+ */
+export async function startSessionOwnershipHeartbeat(
+  options: SessionOwnershipHeartbeatOptions,
+): Promise<SessionOwnershipHeartbeat> {
+  const timer = options.timer ?? defaultTimer;
+  let stopped = false;
+  let failure: Error | null = null;
+  let activeAbortController: AbortController | null = null;
+
+  const heartbeat = new SingleFlightInterval(
+    timer,
+    options.intervalMs,
+    async () => {
+      if (stopped) {
+        return;
+      }
+      const controller = new AbortController();
+      activeAbortController = controller;
+      try {
+        await options.renew(controller.signal);
+      } catch (error) {
+        if (!stopped && !controller.signal.aborted) {
+          failure ??= asError(error);
+        }
+        throw error;
+      } finally {
+        if (activeAbortController === controller) {
+          activeAbortController = null;
+        }
+      }
+    },
+    {
+      stopTimeoutMs: options.stopTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS,
+      onError: () => {},
+    },
+  );
+
+  try {
+    await heartbeat.run();
+  } catch (error) {
+    await heartbeat.stop();
+    throw asError(error);
+  }
+  heartbeat.start();
+
+  return {
+    assertHealthy(): void {
+      if (failure) {
+        throw new Error(`session ownership heartbeat failed: ${failure.message}`, {
+          cause: failure,
+        });
+      }
+    },
+    async stop(): Promise<Error | null> {
+      stopped = true;
+      activeAbortController?.abort();
+      const settled = await heartbeat.stop();
+      return settled
+        ? null
+        : new Error("session ownership heartbeat did not settle before cleanup timeout");
+    },
+  };
+}

--- a/test/integration/iosVideoRecordingStartStop.integration.test.ts
+++ b/test/integration/iosVideoRecordingStartStop.integration.test.ts
@@ -21,6 +21,7 @@ const DEFAULT_TEST_TIMEOUT_MS = 420000;
 // The daemon's default ownership timeout is 10s. Renew well within that window
 // while one-shot CLI calls are doing iOS setup or leaving a recording active.
 const SESSION_HEARTBEAT_INTERVAL_MS = 2_000;
+const SESSION_HEARTBEAT_COMMAND_TIMEOUT_MS = 5_000;
 
 interface ToolTextResponse {
   content?: Array<{ type?: string; text?: string }>;
@@ -86,7 +87,11 @@ function formatError(error: unknown): string {
   return String(error);
 }
 
-async function runLocalCliOutput(args: string[], signal?: AbortSignal): Promise<string> {
+async function runLocalCliOutput(
+  args: string[],
+  signal?: AbortSignal,
+  timeout?: number,
+): Promise<string> {
   // The workflow warms CtrlProxy in the daemon process before this test runs.
   // Calling the local CLI keeps start and stop in that same process; importing
   // the tool handler here would create a second cold DeviceSessionManager and
@@ -97,6 +102,7 @@ async function runLocalCliOutput(args: string[], signal?: AbortSignal): Promise<
     {
       maxBuffer: 10 * 1024 * 1024,
       signal,
+      timeout,
     },
   );
   return stdout;
@@ -112,7 +118,11 @@ async function startVideoRecordingSessionHeartbeat(
   return startSessionOwnershipHeartbeat({
     intervalMs: SESSION_HEARTBEAT_INTERVAL_MS,
     renew: async (signal) => {
-      await runLocalCliOutput(["--daemon", "heartbeat", sessionUuid], signal);
+      await runLocalCliOutput(
+        ["--daemon", "heartbeat", sessionUuid],
+        signal,
+        SESSION_HEARTBEAT_COMMAND_TIMEOUT_MS,
+      );
     },
   });
 }

--- a/test/integration/iosVideoRecordingStartStop.integration.test.ts
+++ b/test/integration/iosVideoRecordingStartStop.integration.test.ts
@@ -5,6 +5,10 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import { defaultTimer } from "../../src/utils/SystemTimer";
+import {
+  startSessionOwnershipHeartbeat,
+  type SessionOwnershipHeartbeat,
+} from "../helpers/sessionOwnershipHeartbeat";
 
 const execFileAsync = promisify(execFile);
 const RUN_INTEGRATION = process.env.AUTOMOBILE_IOS_VIDEO_RECORDING_INTEGRATION === "1";
@@ -14,6 +18,9 @@ const LOCAL_CLI_ENTRYPOINT = fileURLToPath(new URL("../../dist/src/index.js", im
 // screenshot readiness check, rather than stopping immediately after startup.
 const DEFAULT_WAIT_MS = 10000;
 const DEFAULT_TEST_TIMEOUT_MS = 420000;
+// The daemon's default ownership timeout is 10s. Renew well within that window
+// while one-shot CLI calls are doing iOS setup or leaving a recording active.
+const SESSION_HEARTBEAT_INTERVAL_MS = 2_000;
 
 interface ToolTextResponse {
   content?: Array<{ type?: string; text?: string }>;
@@ -79,7 +86,7 @@ function formatError(error: unknown): string {
   return String(error);
 }
 
-async function runLocalCli(args: string[]): Promise<ToolTextResponse> {
+async function runLocalCliOutput(args: string[], signal?: AbortSignal): Promise<string> {
   // The workflow warms CtrlProxy in the daemon process before this test runs.
   // Calling the local CLI keeps start and stop in that same process; importing
   // the tool handler here would create a second cold DeviceSessionManager and
@@ -89,9 +96,25 @@ async function runLocalCli(args: string[]): Promise<ToolTextResponse> {
     [LOCAL_CLI_ENTRYPOINT, "--cli", ...args],
     {
       maxBuffer: 10 * 1024 * 1024,
+      signal,
     },
   );
-  return JSON.parse(stdout) as ToolTextResponse;
+  return stdout;
+}
+
+async function runLocalCli(args: string[], signal?: AbortSignal): Promise<ToolTextResponse> {
+  return JSON.parse(await runLocalCliOutput(args, signal)) as ToolTextResponse;
+}
+
+async function startVideoRecordingSessionHeartbeat(
+  sessionUuid: string,
+): Promise<SessionOwnershipHeartbeat> {
+  return startSessionOwnershipHeartbeat({
+    intervalMs: SESSION_HEARTBEAT_INTERVAL_MS,
+    renew: async (signal) => {
+      await runLocalCliOutput(["--daemon", "heartbeat", sessionUuid], signal);
+    },
+  });
 }
 
 async function runVideoRecordingCli(
@@ -190,6 +213,7 @@ describeIntegration("iOS videoRecording start-stop integration", () => {
       let stopPayload: RecordingToolResult | undefined;
       let outputPath: string | undefined;
       let sessionUuid: string | undefined;
+      let sessionHeartbeat: SessionOwnershipHeartbeat | undefined;
       let stopped = false;
 
       try {
@@ -198,7 +222,9 @@ describeIntegration("iOS videoRecording start-stop integration", () => {
           throw new Error("AUTOMOBILE_IOS_VIDEO_RECORDING_DEVICE_ID is required");
         }
         sessionUuid = await acquireVideoRecordingSession(deviceId);
+        sessionHeartbeat = await startVideoRecordingSessionHeartbeat(sessionUuid);
         await bindVideoRecordingSession(sessionUuid, deviceId);
+        sessionHeartbeat.assertHealthy();
 
         startPayload = await runVideoRecordingCli(sessionUuid, [
           "--action",
@@ -227,6 +253,7 @@ describeIntegration("iOS videoRecording start-stop integration", () => {
         outputPath = started.outputPath;
         expect(recordingId).toBeString();
         expect(outputPath).toBeString();
+        sessionHeartbeat.assertHealthy();
 
         const waitMs = getWaitMs();
         const firstWaitMs = Math.floor(waitMs / 2);
@@ -240,6 +267,7 @@ describeIntegration("iOS videoRecording start-stop integration", () => {
           await execFileAsync("xcrun", ["simctl", "ui", deviceId, "appearance", "light"]);
         }
         await defaultTimer.sleep(waitMs - firstWaitMs);
+        sessionHeartbeat.assertHealthy();
 
         stopPayload = await runVideoRecordingCli(sessionUuid, [
           "--action",
@@ -303,6 +331,13 @@ describeIntegration("iOS videoRecording start-stop integration", () => {
             .filter((line): line is string => Boolean(line))
             .join("\n"),
         );
+      } finally {
+        const heartbeatCleanupError = await sessionHeartbeat?.stop();
+        if (heartbeatCleanupError) {
+          console.warn(
+            `iOS recording session heartbeat cleanup failed: ${heartbeatCleanupError.message}`,
+          );
+        }
       }
     },
     getTestTimeoutMs(),

--- a/test/scripts/iosIntegrationWorkflowChangeGuard.test.ts
+++ b/test/scripts/iosIntegrationWorkflowChangeGuard.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { load } from "js-yaml";
 import { loadJobSteps, loadWorkflow } from "../helpers/workflowSteps";
 
 const WORKFLOW = ".github/workflows/pull_request.yml";
@@ -21,5 +22,18 @@ describe("Fast Validation independence from XCTestRunner", () => {
     expect(job).toBeDefined();
     expect(job?.if).toContain("ios_integration_should_run");
     expect(loadJobSteps(WORKFLOW, "ios-xctest-runner-simulator-tests").length).toBeGreaterThan(0);
+  });
+
+  test("runs XCTestRunner when its recording session heartbeat helper changes", () => {
+    const filterStep = loadJobSteps(WORKFLOW, "detect-changes").find(
+      (step) => step.id === "filter-native-integration",
+    );
+    const filters = filterStep?.with?.filters;
+    expect(typeof filters).toBe("string");
+
+    const nativeIntegration = load(filters as string) as { native_integration?: string[] };
+    expect(nativeIntegration.native_integration).toContain(
+      "test/helpers/sessionOwnershipHeartbeat.ts",
+    );
   });
 });


### PR DESCRIPTION
The iOS recording integration can lose session ownership between its short-lived CLI calls. [PR 6856](https://github.com/kaeawc/auto-mobile/pull/6856) failed with a heartbeat age of 21,226 ms against the 10,000 ms session policy. Each CLI proxy stops renewing when its process exits.

Keep the integration session alive using the existing daemon heartbeat command immediately after acquisition and every two seconds through setup, recording, and stop. Bound each heartbeat subprocess to five seconds and cancel the keeper in finally. Session enforcement and production TTLs remain intact.

Validation: three deterministic timer tests pass, including cadence, cancellation, and initial failure propagation. Build, targeted lint, and formatting pass. The real simulator integration requires CI and was skipped locally. This addresses session expiration; the separate recording first-frame timeout remains under investigation.
