### PR TITLE
test: stabilize Windows log-pruner retry assertion

### DIFF
--- a/test/utils/logPruner.test.ts
+++ b/test/utils/logPruner.test.ts
@@ -631,13 +631,18 @@ describe("logPruner transient unlink failures (Windows EBUSY/EPERM)", () => {
   test("does not retry a non-transient unlink failure", async () => {
     await withTempLogDir(async (dir) => {
       const launchLog = "daemon-launch-4242.log";
-      await writeFile(path.join(dir, launchLog), "x");
+      const launchLogPath = path.join(dir, launchLog);
+      await writeFile(launchLogPath, "x");
+      const { mtimeMs } = await stat(launchLogPath);
 
       let attempts = 0;
 
       await pruneLogFiles({
         ...deadNamespace,
         dir,
+        // Derive the sweep clock from the file mtime so the -1ms stale
+        // precondition does not depend on filesystem and wall clocks agreeing.
+        now: mtimeMs,
         unlink: async () => {
           attempts += 1;
           throw errnoError("EISDIR");


### PR DESCRIPTION
The Windows unit lane skipped the non-transient unlink test before reaching its injected `unlink`. The timestamp ordering that caused the skip is inferred from the zero-attempt failure and stale-file gate; it was not reproduced on a Windows runner.

Derive the test's injected clock from the created file's mtime. This preserves the retry behavior under test while making the stale precondition deterministic without depending on filesystem and wall clocks agreeing.

Validated with:

- `bun test test/utils/logPruner.test.ts`
- `bunx oxfmt --check test/utils/logPruner.test.ts`
- `bunx oxlint test/utils/logPruner.test.ts`
