### PR TITLE
refactor(device-identity)!: remove the ADB transport id from the Android device model

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
@@ -23,8 +23,9 @@ data class BootedDevicesResponse(
 @Serializable
 data class DeviceIdentity(
   val stableId: String,
+  // Key for one connection epoch of the device: `<deviceId>#<incarnation>` when the daemon's pool
+  // knows the incarnation, otherwise the bare serial, which carries no epoch information.
   val connectionId: String,
-  val transportId: String? = null,
 )
 
 @Serializable

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceResourceParserTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceResourceParserTest.kt
@@ -47,6 +47,10 @@ class DeviceResourceParserTest {
     assertEquals(true, result.sourceObservations["ios-simulator"]?.observationComplete)
     assertEquals(false, result.sourceObservations["ios-physical"]?.observationComplete)
     assertEquals("Pixel_8", result.devices.single().identity?.stableId)
+    // The connection epoch is what distinguishes one occupant of a reused
+    // serial from the next, so a parser regression that drops or mangles it
+    // must not pass on the stableId assertion alone.
+    assertEquals("emulator-5554#3", result.devices.single().identity?.connectionId)
     assertEquals(1, result.totalCount)
     assertEquals(1, result.androidCount)
     assertEquals(0, result.iosCount)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceResourceParserTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceResourceParserTest.kt
@@ -34,7 +34,7 @@ class DeviceResourceParserTest {
                   "source": "local",
                   "isVirtual": true,
                   "status": "booted",
-                  "identity": { "stableId": "Pixel_8", "connectionId": "transport-1" }
+                  "identity": { "stableId": "Pixel_8", "connectionId": "emulator-5554#3" }
               }
           ]
       }

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -2457,9 +2457,6 @@
             "platform": {
               "type": "string",
               "enum": ["android", "ios"]
-            },
-            "transportId": {
-              "type": "string"
             }
           },
           "required": ["name", "deviceId", "platform"],

--- a/skills/device-session-lifecycle/SKILL.md
+++ b/skills/device-session-lifecycle/SKILL.md
@@ -33,11 +33,35 @@ distinguishing "same serial, new boot" from "same device", and since #6863 it
 is the ONLY epoch token in the model — the ADB transport id is gone from
 `BootedDevice`/`PooledDevice`, and discovery carries nothing else. Anything
 identity-sensitive must be keyed on the incarnation; runtime identity is
-validated by serial + platform + name (with `Unknown (<serial>)` tolerated as
-"the console could not answer", never as "a different device"), and a boundary
-is observed as **disappearance then reappearance** — the pool evicts an entry
-the moment discovery stops listing the serial and re-adds it under a fresh
-incarnation.
+validated by serial + platform + name, and a boundary is observed as
+**disappearance then reappearance** — the pool evicts an entry the moment
+discovery stops listing the serial and re-adds it under a fresh incarnation.
+
+**`Unknown (<serial>)` means "no information", uniformly.** It is the
+placeholder Android discovery emits when the emulator console did not answer
+`avd name`, and it is guarded by `isAndroidEmulatorSerial` (a handset's name is
+`ro.product.model`, so handsets keep serial-only identity). The same rule
+applies in all three places the name is read:
+
+1. **Comparing observations** (`deviceTools.isSameBootedDeviceIdentity` /
+   `isConfirmedDeviceReplacement`): never evidence of a replacement AND never
+   evidence of continuity — the two predicates are deliberately not each
+   other's negation. During shutdown, a still-listed serial whose name probe
+   stopped answering is the same device still present, so the wait runs on to
+   real absence; only a RESOLVED, different name declares a replacement.
+2. **Destructive actions** (`killDevice`, `deleteDevice`): the pooled AVD label
+   must be confirmed by the runtime (`AndroidEmulatorClient.resolveRunningAvdName`,
+   bounded by the CALLER's remaining teardown/kill deadline — never an
+   independent timer). A different name refuses; an unanswered probe also
+   refuses (`target_identity_unresolved`), naming `adb -s <serial> emu kill` as
+   the manual escape. There is no fail-open branch. A tool-level `force` option
+   for an emulator whose console is wedged is tracked as a separate follow-up.
+3. **Publishing identity** (`DevicePool.describesPooledRuntime`, the booted-devices
+   resource): the placeholder is not agreement, so the resource withholds BOTH
+   the pooled epoch (`connectionId` falls back to the bare serial) and the
+   pooled AVD label (`stableId` falls back to discovery's own name). The pool's
+   internal `matchesRuntimeIdentity` still TOLERATES the placeholder so an
+   unreadable console never evicts a live entry — tolerance is not agreement.
 
 **Documented blind spot**: a same-serial restart faster than one discovery
 interval never reaches the pool, so it reads as continuity. Every host-side
@@ -45,7 +69,8 @@ cache keyed on the epoch must therefore SELF-HEAL on failure (evict and rebuild
 once before surfacing the error — see the append-helper cache in
 `src/daemon/socketServer.ts`), and any destructive action that would act on a
 pool-cached AVD name must re-resolve it from the runtime first
-(`AndroidEmulatorClient.resolveRunningAvdName`, used by killDevice/deleteDevice).
+(`AndroidEmulatorClient.resolveRunningAvdName`, used by killDevice/deleteDevice)
+and refuse when that re-resolution does not answer.
 Historical entries in `references/history.md` that reason about `transportId`
 (e.g. #5372) describe the pre-#6863 model; do not reintroduce the field.
 

--- a/skills/device-session-lifecycle/SKILL.md
+++ b/skills/device-session-lifecycle/SKILL.md
@@ -63,6 +63,26 @@ applies in all three places the name is read:
    internal `matchesRuntimeIdentity` still TOLERATES the placeholder so an
    unreadable console never evicts a live entry — tolerance is not agreement.
 
+**The pool state that carries the rule: `PooledDevice.identityUnresolved`.**
+When a discovery sweep observes the placeholder on a LIVE entry, the pool
+quarantines that entry instead of choosing between two wrong answers. The entry
+is kept — same session, same `incarnation` — but:
+
+- `selectAssignableIdleDevice` skips it;
+- `assertSessionReadyForAutomation` (the single choke point every tool execution
+  passes through) refuses, naming the serial and the pooled AVD label;
+- `describesPooledRuntime` reads the state, so the resource publishes no pool
+  context;
+- `deviceTools.getValidatedPooledAndroidAvdName` returns undefined, so no
+  destructive path can act on the cached label — including the stopped-image
+  inventory path in `deleteDevice`, which previously bypassed the
+  unresolved-runtime guard on the strength of that label.
+
+Leaving the quarantine is decided by the next discovery that READS a name: the
+pooled label (or the AVD this pool started) restores the entry unchanged, and a
+different name is a replacement — a fresh incarnation, the old session retired,
+exactly as an observed disappearance. Handsets never enter the state.
+
 **Documented blind spot**: a same-serial restart faster than one discovery
 interval never reaches the pool, so it reads as continuity. Every host-side
 cache keyed on the epoch must therefore SELF-HEAL on failure (evict and rebuild
@@ -70,9 +90,26 @@ once before surfacing the error — see the append-helper cache in
 `src/daemon/socketServer.ts`), and any destructive action that would act on a
 pool-cached AVD name must re-resolve it from the runtime first
 (`AndroidEmulatorClient.resolveRunningAvdName`, used by killDevice/deleteDevice)
-and refuse when that re-resolution does not answer.
-Historical entries in `references/history.md` that reason about `transportId`
-(e.g. #5372) describe the pre-#6863 model; do not reintroduce the field.
+and refuse when that re-resolution does not answer — and that confirmation runs
+BEFORE the shutdown's preparation side effects (stopping recordings, closing the
+CtrlProxy singleton, detaching observers), so a refusal leaves a still-running
+device fully intact.
+
+**Self-heal on HELPER failure, never on a RUNNER verdict.** The two outcomes are
+distinguished by the result type (`AppendTextFailureSource`), never by inspecting
+`charsSent === 0`:
+
+- the helper itself failed (threw, transport error, stale cached helper) → evict,
+  rebuild once, retry. With a confirmed prefix the retry resumes the unconfirmed
+  SUFFIX and carries NO validator (the original validation was already spent and
+  the prefix has advanced the runner's frame epoch); with nothing confirmed it
+  retries the whole text WITH the original validator, because nothing was
+  validated-and-sent yet;
+- the RUNNER returned a verdict (`success: false`, e.g. a stale `frameContext`)
+  → surface it as-is. No rebuild, no replay: the helper worked, and replaying
+  would type into a UI the runner explicitly refused.
+  Historical entries in `references/history.md` that reason about `transportId`
+  (e.g. #5372) describe the pre-#6863 model; do not reintroduce the field.
 
 ## 2. Invariants (the contract every fix must preserve)
 

--- a/skills/device-session-lifecycle/SKILL.md
+++ b/skills/device-session-lifecycle/SKILL.md
@@ -84,7 +84,19 @@ is kept — same session, same `incarnation` — but:
 - **destructive confirmation** — `deviceTools.getValidatedPooledAndroidAvdName`
   returns undefined, so no destructive path can act on the cached label —
   including the stopped-image inventory path in `deleteDevice`, which previously
-  bypassed the unresolved-runtime guard on the strength of that label;
+  bypassed the unresolved-runtime guard on the strength of that label. Dropping
+  the label is not enough for a KILL, because it also drops the confirmation the
+  label exists to trigger: a quarantined entry produces its own `quarantined`
+  capture kind whose runtime confirmation is MANDATORY (an unanswered console or
+  a differing name refuses), and `AndroidEmulatorClient.killDevice` refuses when
+  both the requested and the discovered name are the placeholder — two unknowns
+  are not an equality;
+- **in-flight work** — entering the quarantine cancels and drains the bound
+  session's already-registered executions through the injected
+  `cancelDeviceSessionExecutions` seam (the one the ADB-reset quarantine uses).
+  The admission gate only refuses LATER calls; an execution already in flight
+  keeps issuing serial-addressed operations. The session and the `incarnation`
+  survive — only the work is stopped;
 - **stream routing** — the daemon builds its `DeviceSessionResolver` over the
   pool quarantine, so a quarantined serial has NO routing identity in either
   direction (serial→uuid and uuid→serial), and each push server
@@ -99,6 +111,22 @@ Leaving the quarantine is decided by the next discovery that READS a name: the
 pooled label (or the AVD this pool started) restores the entry unchanged, and a
 different name is a replacement — a fresh incarnation, the old session retired,
 exactly as an observed disappearance. Handsets never enter the state.
+
+**A disagreement only leaves the quarantine through the replacement actually
+installing.** `replacePooledDeviceForRuntimeIdentity` installs it by evicting the
+old incarnation, and `evictMissingPooledDevice` DEFERS eviction while killDevice
+holds a shutdown reservation — so the refresh reloads the very entry the
+discovered runtime disagrees with. Reconciling there would read the disagreeing
+name as proof of continuity; instead that entry is quarantined (and its metadata
+left alone) until the replacement installs. The rule in one line: the quarantine
+lifts on an identity MATCH, never on a differing name.
+
+**The teardown's own discovery is authoritative over the pool's label.** On the
+FIRST discovery after a different AVD takes a pooled serial, the pool has not
+quarantined anything yet and still holds the previous occupant's label.
+`deleteDevice`'s unresolved-runtime guard therefore reads its OWN observation,
+not `getValidatedPooledAndroidAvdName`: a booted emulator this discovery cannot
+name refuses the stopped-image inventory path outright.
 
 **Documented blind spot**: a same-serial restart faster than one discovery
 interval never reaches the pool, so it reads as continuity. Every host-side

--- a/skills/device-session-lifecycle/SKILL.md
+++ b/skills/device-session-lifecycle/SKILL.md
@@ -64,19 +64,36 @@ applies in all three places the name is read:
    unreadable console never evicts a live entry — tolerance is not agreement.
 
 **The pool state that carries the rule: `PooledDevice.identityUnresolved`.**
-When a discovery sweep observes the placeholder on a LIVE entry, the pool
-quarantines that entry instead of choosing between two wrong answers. The entry
+When any discovery observes the placeholder on a LIVE entry — a refresh sweep or
+the liveness check an assignment runs itself — the pool quarantines that entry
+instead of choosing between two wrong answers. The entry
 is kept — same session, same `incarnation` — but:
 
-- `selectAssignableIdleDevice` skips it;
-- `assertSessionReadyForAutomation` (the single choke point every tool execution
-  passes through) refuses, naming the serial and the pooled AVD label;
-- `describesPooledRuntime` reads the state, so the resource publishes no pool
-  context;
-- `deviceTools.getValidatedPooledAndroidAvdName` returns undefined, so no
-  destructive path can act on the cached label — including the stopped-image
-  inventory path in `deleteDevice`, which previously bypassed the
-  unresolved-runtime guard on the strength of that label.
+- **assignment** — the shared gate `ensurePooledDevicePresentForUse` reports it
+  as not assignable, so `selectAssignableIdleDevice` skips it AND the
+  exact-device paths (`bindOrReuseDeviceSession`, autolock, both via
+  `validateOrReloadIdlePooledDevice`) refuse with an error naming the serial.
+  This covers the entry the assignment's OWN liveness check just quarantined:
+  the operation that ENTERS the quarantine fails at assignment rather than
+  returning a session that then fails every tool;
+- **tool execution** — `assertSessionReadyForAutomation` (the single choke point
+  every tool execution passes through) refuses, naming the serial and the pooled
+  AVD label;
+- **publishing** — `describesPooledRuntime` reads the state, so the resource
+  publishes no pool context;
+- **destructive confirmation** — `deviceTools.getValidatedPooledAndroidAvdName`
+  returns undefined, so no destructive path can act on the cached label —
+  including the stopped-image inventory path in `deleteDevice`, which previously
+  bypassed the unresolved-runtime guard on the strength of that label;
+- **stream routing** — the daemon builds its `DeviceSessionResolver` over the
+  pool quarantine, so a quarantined serial has NO routing identity in either
+  direction (serial→uuid and uuid→serial), and each push server
+  (observation/hierarchy, telemetry, performance, failures) drops that serial's
+  device-attributed frames instead of broadcasting them to all-device
+  subscribers — logged once per quarantine, not once per frame. The registry
+  record is untouched underneath, so lifting the quarantine resumes the SAME
+  `deviceSessionUuid`; a replacement instead mints a new incarnation, whose uuid
+  routes while the retired one stays unresolvable.
 
 Leaving the quarantine is decided by the next discovery that READS a name: the
 pooled label (or the AVD this pool started) restores the entry unchanged, and a

--- a/skills/device-session-lifecycle/SKILL.md
+++ b/skills/device-session-lifecycle/SKILL.md
@@ -29,9 +29,25 @@ not found" = transport session, not pool session), #5411 (pool session
 rebind), the #5256 epic (epoch identity was missing entirely).
 
 `incarnation` (bumped only at pooled-entry **creation**) is the sole thing
-distinguishing "same serial, new boot" from "same device". Anything
-identity-sensitive must be keyed on it, with unknown `transportId` treated as
-wildcard (#5372 regression: strict compare broke every Android cold boot).
+distinguishing "same serial, new boot" from "same device", and since #6863 it
+is the ONLY epoch token in the model — the ADB transport id is gone from
+`BootedDevice`/`PooledDevice`, and discovery carries nothing else. Anything
+identity-sensitive must be keyed on the incarnation; runtime identity is
+validated by serial + platform + name (with `Unknown (<serial>)` tolerated as
+"the console could not answer", never as "a different device"), and a boundary
+is observed as **disappearance then reappearance** — the pool evicts an entry
+the moment discovery stops listing the serial and re-adds it under a fresh
+incarnation.
+
+**Documented blind spot**: a same-serial restart faster than one discovery
+interval never reaches the pool, so it reads as continuity. Every host-side
+cache keyed on the epoch must therefore SELF-HEAL on failure (evict and rebuild
+once before surfacing the error — see the append-helper cache in
+`src/daemon/socketServer.ts`), and any destructive action that would act on a
+pool-cached AVD name must re-resolve it from the runtime first
+(`AndroidEmulatorClient.resolveRunningAvdName`, used by killDevice/deleteDevice).
+Historical entries in `references/history.md` that reason about `transportId`
+(e.g. #5372) describe the pre-#6863 model; do not reintroduce the field.
 
 ## 2. Invariants (the contract every fix must preserve)
 
@@ -105,9 +121,9 @@ wildcard (#5372 regression: strict compare broke every Android cold boot).
    killDevice success on `adb emu kill` ack, install success on the wrong
    simulator. Smell: success derived from a command's ack, not from
    ground-truth polling. (#3334, #3393, #5294, #2387, #5237)
-4. **Identity by mutable key** — serial/UDID/transportId used where an
-   incarnation or epoch UUID belongs. Smell: `deviceId` in a map key for
-   anything longer-lived than one call. (#3393, #5267, #5369, epic #5256)
+4. **Identity by mutable key** — serial/UDID used where an incarnation or
+   epoch UUID belongs. Smell: `deviceId` in a map key for anything
+   longer-lived than one call. (#3393, #5267, #5369, epic #5256, #6863)
 5. **Heartbeat bookkeeping vs real liveness** — grace windows,
    `hasReceivedHeartbeat`, agent think-time gaps. Smell: expiry math with two
    clocks or two flags. (#2443, #5288, #5411)
@@ -239,10 +255,11 @@ comments. **A refactor that drops a comment silently drops an invariant.**
   `FakeTimer` auto-fires scheduled intervals when advanced a full period
   (don't also fire manually); `initializeWithDevices` is deliberately a
   silent pre-populate (no ready listeners).
-- **Known blind spot**: unit fakes can't represent live adb transport
-  population timing — #5369 shipped green through unit tests. Anything
-  touching pool runtime identity (`transportId`, incarnation matching on
-  real reconnects) needs a live-emulator check: `/manual-test` sweep, or
+- **Known blind spot**: unit fakes can't represent live adb reconnect timing —
+  #5369 shipped green through unit tests. Anything touching pool runtime
+  identity (incarnation boundaries, name matching on real reconnects, the
+  fast-restart case the pool cannot observe) needs a live-emulator check:
+  `/manual-test` sweep, or
   `--cli startDevice`/`killDevice` against a real emulator; with ≥2
   emulators, sanity-check returned `deviceId` against `adb emu avd name`.
 - Streaming changes (`deviceSessionUuid` stamping, subscription routing)

--- a/skills/device-session-lifecycle/references/history.md
+++ b/skills/device-session-lifecycle/references/history.md
@@ -94,6 +94,12 @@ daemon and desktop ship together):
   mismatch on every Android cold boot, emulator torn down. Fix: unknown
   transportId is a wildcard. **Not caught by unit tests** (needed live adb
   transport timing).
+- #6863: `transportId` removed from the identity model entirely — pool
+  `incarnation` is the only epoch token. The two entries above are HISTORY:
+  the fast same-serial reconnect they fixed is now an accepted, documented
+  blind spot, handled by self-healing epoch-keyed caches and by re-resolving
+  an AVD name from the runtime before any destructive action. Do not
+  reintroduce the field.
 - #5258 → #5365: multiplexed subscriptions — `subscriptionId` echoed on
   subscribe and stamped on every frame (backfill included);
   unsubscribe/update_cadence per-subscription; pong/close/error

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1231,7 +1231,14 @@ export class Daemon {
   }
 
   private setupDeviceSessionRouting(): void {
-    const resolver = createRegistryDeviceSessionResolver(this.deviceSessionRegistry);
+    // The pool's unresolved-identity quarantine is the second input: while it
+    // holds for a serial, the registry record stays put but the resolver withholds
+    // it in both directions and every push server drops that serial's frames, so a
+    // possible replacement AVD's passive events cannot reach the previous AVD's
+    // subscribers (#6863 review).
+    const resolver = createRegistryDeviceSessionResolver(this.deviceSessionRegistry, (deviceId) =>
+      this.devicePool.isPooledIdentityUnresolved(deviceId),
+    );
     const { deviceDataStream, performancePush, failuresPush, telemetryPush } =
       this.getDeviceSessionRoutingTargets();
     this.deviceDataStreamServer = deviceDataStream;

--- a/src/daemon/daemonState.ts
+++ b/src/daemon/daemonState.ts
@@ -106,5 +106,11 @@ export class DaemonState implements DaemonStateLike {
     this.sessionManager = null;
     this.devicePool = null;
     this.deviceSessionRegistry = null;
+    // The resolver {@link initialize} installed closes over the pool being
+    // retired here. Leaving it registered would keep that pool alive and keep
+    // answering direct-mode feature code with its epochs, so a per-device cache
+    // could hold state across the reset. Clearing it restores the no-daemon
+    // answer ("no epoch information") until the next initialize.
+    setDeviceIncarnationResolver(undefined);
   }
 }

--- a/src/daemon/daemonState.ts
+++ b/src/daemon/daemonState.ts
@@ -1,6 +1,7 @@
 import { SessionManager } from "./sessionManager";
 import { DevicePool } from "./devicePool";
 import { DeviceSessionRegistry } from "./deviceSessionRegistry";
+import { setDeviceIncarnationResolver } from "../utils/deviceIncarnation";
 
 export interface DaemonStateLike {
   isInitialized(): boolean;
@@ -50,6 +51,11 @@ export class DaemonState implements DaemonStateLike {
     this.sessionManager = sessionManager;
     this.devicePool = devicePool;
     this.deviceSessionRegistry = deviceSessionRegistry;
+    // The pool's incarnation counter is the only connection-epoch token in the
+    // identity model, and feature code caching per-device state must be able to
+    // read it without importing the daemon. Publish it here, where the live
+    // pool is known.
+    setDeviceIncarnationResolver((deviceId) => devicePool.getDeviceIncarnation(deviceId));
   }
 
   /**

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -9,7 +9,11 @@ import {
 } from "./socketServer/index";
 import type { ObserveResult, Platform, ViewHierarchyResult } from "../models";
 import type { StorageChangedEvent } from "../features/storage/storageTypes";
-import { type DeviceSessionResolver, nullDeviceSessionResolver } from "./deviceSessionResolver";
+import {
+  type DeviceSessionResolver,
+  nullDeviceSessionResolver,
+  SuspendedDeviceRoutingLog,
+} from "./deviceSessionResolver";
 import type { DeviceSessionRecord } from "./deviceSessionRegistry";
 import { DEVICE_DATA_STREAM_SOCKET_CONFIG } from "./daemonFiles";
 import type { ScreenshotMetadata } from "../features/observe/ScreenshotMetadata";
@@ -363,6 +367,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     return this.currentFrameContexts.get(deviceId);
   }
   private deviceSessionResolver: DeviceSessionResolver = nullDeviceSessionResolver;
+  private readonly suspendedRoutingLog = new SuspendedDeviceRoutingLog();
   private onSubscriberConnected: OnSubscriberConnectedCallback | null = null;
   private onScreenshotCadenceChanged: OnScreenshotCadenceChangedCallback | null = null;
   private onHierarchyCadenceChanged: OnHierarchyCadenceChangedCallback | null = null;
@@ -404,11 +409,30 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   }
 
   /**
+   * Whether frames attributed to this serial must be dropped because the pool's
+   * entry for it is quarantined — see
+   * {@link DeviceSessionResolver.isRoutingSuspended}. Logged once per quarantine,
+   * not once per frame.
+   */
+  private isDeviceRoutingSuspended(deviceId: string): boolean {
+    return this.suspendedRoutingLog.shouldDropFrame(
+      this.deviceSessionResolver,
+      deviceId,
+      "DeviceDataStream",
+    );
+  }
+
+  /**
    * Stamp a device-attributed frame with the live `deviceSessionUuid` for its
    * serial and push it, routing on that uuid. A serial with no live epoch resolves
-   * to `null`, reaching only all-device subscribers.
+   * to `null`, reaching only all-device subscribers; a serial whose pooled identity
+   * is quarantined reaches nobody, because the serial is the only attribution the
+   * frame has and it is exactly what is in doubt (#6863 review).
    */
   private pushForDevice(deviceId: string, message: DeviceDataStreamMessage): number {
+    if (this.isDeviceRoutingSuspended(deviceId)) {
+      return 0;
+    }
     const deviceSessionUuid = this.deviceSessionResolver.resolveUuid(deviceId);
     return this.pushToSubscribers({
       message: { ...message, deviceSessionUuid },
@@ -624,6 +648,9 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     navigationGraph: NavigationGraphStreamData,
     deviceId: string | null,
   ): void {
+    if (deviceId !== null && this.isDeviceRoutingSuspended(deviceId)) {
+      return;
+    }
     const deviceSessionUuid = deviceId ? this.deviceSessionResolver.resolveUuid(deviceId) : null;
     const message: DeviceDataStreamMessage = {
       type: "navigation_update",

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5669,10 +5669,37 @@ export class DevicePool {
    * serial can be reused by a different runtime before the next refresh. A join
    * that has not been checked this way must not publish pool-derived epoch
    * information about the discovered runtime (#6863 review).
+   *
+   * `Unknown (<serial>)` answers this question with NO. The placeholder means
+   * the emulator console did not answer `avd name`, so it is not information:
+   * {@link matchesRuntimeIdentity} tolerates it in the direction that matters
+   * there (it must never evict a live entry), but tolerance is not agreement,
+   * and this predicate exists precisely to gate what gets PUBLISHED about the
+   * discovered runtime. Same rule, both directions: a placeholder is never
+   * evidence of a replacement and never evidence of continuity.
    */
   describesPooledRuntime(expected: Pick<BootedDevice, "deviceId" | "name" | "platform">): boolean {
     const pooled = this.devices.get(expected.deviceId);
-    return pooled !== undefined && this.matchesRuntimeIdentity(pooled, expected);
+    if (pooled === undefined || !this.matchesRuntimeIdentity(pooled, expected)) {
+      return false;
+    }
+    return !this.hasUnresolvedEmulatorName(expected);
+  }
+
+  /**
+   * Whether a discovered name is the `Unknown (<serial>)` placeholder rather
+   * than a name read from the runtime. Guarded by {@link isAndroidEmulatorSerial}
+   * because a handset's name is `ro.product.model` and its identity rides on its
+   * globally-unique serial, not on its name.
+   */
+  private hasUnresolvedEmulatorName(
+    expected: Pick<BootedDevice, "deviceId" | "name" | "platform">,
+  ): boolean {
+    return (
+      expected.platform === "android" &&
+      isAndroidEmulatorSerial(expected.deviceId) &&
+      expected.name === unknownAndroidRuntimeName(expected.deviceId)
+    );
   }
 
   /**

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5827,6 +5827,11 @@ export class DevicePool {
    *    read. The tolerance is guarded by {@link isAndroidEmulatorSerial}
    *    because a handset's name is `ro.product.model`, which is not unique;
    *    handsets stay on strict name equality behind their unique serial.
+   *
+   * The placeholder tolerance exists ONLY to avoid that eviction. It is not
+   * agreement: {@link reconcilePooledIdentityResolution} quarantines the entry
+   * the moment a sweep tolerates one, and every consumer that would ACT on the
+   * pooled identity reads that state instead of this predicate.
    */
   private namesAgreeOnIdentity(
     pooled: PooledDevice,

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5671,6 +5671,20 @@ export class DevicePool {
    * (see `daemon/deviceSessionRegistry.ts`). Name handling is delegated to
    * {@link namesAgreeOnIdentity}.
    */
+  /**
+   * Whether this pool's entry for a serial describes the runtime a discovery
+   * listing just reported on it — false when there is no entry at all.
+   *
+   * Public because consumers JOIN discovery to pool state by serial alone, and a
+   * serial can be reused by a different runtime before the next refresh. A join
+   * that has not been checked this way must not publish pool-derived epoch
+   * information about the discovered runtime (#6863 review).
+   */
+  describesPooledRuntime(expected: Pick<BootedDevice, "deviceId" | "name" | "platform">): boolean {
+    const pooled = this.devices.get(expected.deviceId);
+    return pooled !== undefined && this.matchesRuntimeIdentity(pooled, expected);
+  }
+
   private matchesRuntimeIdentity(
     pooled: PooledDevice,
     expected: Pick<BootedDevice, "deviceId" | "name" | "platform">,

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -206,6 +206,27 @@ export interface PooledDevice {
    * pooled identity is withheld until a resolved name settles it — see
    * {@link DevicePool.reconcilePooledIdentityResolution}.
    *
+   * The transitions, all of them:
+   *
+   * - **enter** — any discovery (a refresh sweep, or the liveness check an
+   *   assignment runs itself) observes the placeholder on a live entry. Entering
+   *   also CANCELS AND DRAINS the bound session's in-flight executions through
+   *   the injected `cancelDeviceSessionExecutions` seam
+   *   ({@link DevicePool.enterPooledIdentityQuarantine}): the admission gate only
+   *   refuses LATER calls, while an execution already registered keeps issuing
+   *   serial-addressed operations. The session and the `incarnation` survive;
+   *   only the work in flight is stopped.
+   * - **enter** — a resolved name DISAGREES but the replacement could not be
+   *   installed, because `evictMissingPooledDevice` defers eviction while
+   *   killDevice holds a shutdown reservation
+   *   ({@link DevicePool.quarantineDeferredPooledReplacement}).
+   * - **leave, restored** — a resolved name MATCHES. Same entry, same session,
+   *   same `incarnation`.
+   * - **leave, replaced** — a resolved name DISAGREES and the replacement
+   *   installs: a fresh incarnation, the old session retired, exactly as an
+   *   observed disappearance. A disagreement NEVER lifts the quarantine on the
+   *   old entry by itself.
+   *
    * The five consumers that read this state:
    *
    * 1. **Assignment** — the shared gate
@@ -221,6 +242,11 @@ export interface PooledDevice {
    *    AVD label.
    * 4. **Destructive confirmation** — `deviceTools.getValidatedPooledAndroidAvdName`
    *    returns undefined, so no kill/delete path can act on the cached label.
+   *    The kill does not merely drop the label: a quarantined entry produces a
+   *    `quarantined` capture whose runtime confirmation is MANDATORY (the
+   *    emulator console must name itself; an unanswered probe or a differing
+   *    name refuses), because dropping the label also dropped the confirmation
+   *    it exists to trigger.
    * 5. **Stream routing** — the daemon's `DeviceSessionResolver` withholds the
    *    serial↔uuid mapping in both directions and every push server drops that
    *    serial's frames, so a possible replacement's passive events cannot reach
@@ -5902,10 +5928,7 @@ export class DevicePool {
    * naming the serial ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863)
    * review).
    */
-  private async enterPooledIdentityQuarantine(
-    pooled: PooledDevice,
-    reason: string,
-  ): Promise<void> {
+  private async enterPooledIdentityQuarantine(pooled: PooledDevice, reason: string): Promise<void> {
     if (pooled.identityUnresolved === true) {
       return;
     }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -202,9 +202,29 @@ export interface PooledDevice {
    * The placeholder is not evidence of a replacement (it would evict a live
    * emulator on a transient console read) and it is not evidence of continuity
    * either, so the entry is neither evicted nor trusted: session and
-   * `incarnation` are preserved, and everything that would ACT on the pooled
-   * identity is withheld until a resolved name settles it — see
+   * `incarnation` are preserved, and everything that would ACT on or ROUTE BY the
+   * pooled identity is withheld until a resolved name settles it — see
    * {@link DevicePool.reconcilePooledIdentityResolution}.
+   *
+   * The five consumers that read this state:
+   *
+   * 1. **Assignment** — the shared gate
+   *    ({@link DevicePool.ensurePooledDevicePresentForUse}) reports a quarantined
+   *    entry as not assignable, including one the assignment's OWN liveness check
+   *    just quarantined, so idle selection skips it and the exact-device paths
+   *    (`bindOrReuseDeviceSession`, autolock) refuse by serial.
+   * 2. **Tool execution** — {@link DevicePool.assertSessionReadyForAutomation},
+   *    the one choke point every tool passes through, refuses a session bound to
+   *    the serial.
+   * 3. **Publishing** — {@link DevicePool.describesPooledRuntime} reads it, so the
+   *    booted-devices resource publishes neither the pooled epoch nor the pooled
+   *    AVD label.
+   * 4. **Destructive confirmation** — `deviceTools.getValidatedPooledAndroidAvdName`
+   *    returns undefined, so no kill/delete path can act on the cached label.
+   * 5. **Stream routing** — the daemon's `DeviceSessionResolver` withholds the
+   *    serial↔uuid mapping in both directions and every push server drops that
+   *    serial's frames, so a possible replacement's passive events cannot reach
+   *    the previous AVD's subscribers.
    */
   identityUnresolved?: boolean;
 }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -6340,6 +6340,16 @@ export class DevicePool {
   }
 
   /**
+   * Connection epoch of the pooled device on `deviceId`, or undefined when the
+   * serial is not pooled. The canonical answer for every per-device cache that
+   * must not survive a same-serial reincarnation; see
+   * `utils/deviceIncarnation.ts`.
+   */
+  getDeviceIncarnation(deviceId: string): number | undefined {
+    return this.devices.get(deviceId)?.incarnation;
+  }
+
+  /**
    * Get device assigned to session
    */
   getDeviceForSession(sessionId: string): PooledDevice | null {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -194,6 +194,19 @@ export interface PooledDevice {
    * (issue: DevicePool shutdown-marker same-serial-reuse race, follow-up to PR #5015).
    */
   incarnation: number;
+  /**
+   * Quarantine flag: the LATEST discovery observation for this LIVE entry
+   * carried the `Unknown (<serial>)` placeholder, so the pool no longer knows
+   * which AVD is on the serial.
+   *
+   * The placeholder is not evidence of a replacement (it would evict a live
+   * emulator on a transient console read) and it is not evidence of continuity
+   * either, so the entry is neither evicted nor trusted: session and
+   * `incarnation` are preserved, and everything that would ACT on the pooled
+   * identity is withheld until a resolved name settles it — see
+   * {@link DevicePool.reconcilePooledIdentityResolution}.
+   */
+  identityUnresolved?: boolean;
 }
 
 interface RollbackAssignment {
@@ -710,6 +723,7 @@ export class DevicePool {
           if (pooledDevice) {
             pooledDevice.iosVersion = device.iosVersion;
             this.applyMutableRuntimeMetadata(pooledDevice, device, "refresh");
+            this.reconcilePooledIdentityResolution(pooledDevice, device);
             return runtimeReplaced;
           }
           this.devices.set(device.deviceId, {
@@ -2197,6 +2211,7 @@ export class DevicePool {
     assignmentLockHeld: boolean,
   ): Promise<boolean> {
     if (this.matchesRuntimeIdentity(device, bootedDevice)) {
+      this.reconcilePooledIdentityResolution(device, bootedDevice);
       return this.confirmLivePooledDevice(device);
     }
     const replaced = await this.replaceIdlePooledDeviceForLivenessCheck(
@@ -4172,6 +4187,18 @@ export class DevicePool {
 
     while (device) {
       const skippedDeviceId = device.id;
+      if (device.identityUnresolved) {
+        // Quarantined: the serial is there, but which AVD answers on it is not
+        // known, so handing it to a session would bind that session to a runtime
+        // the pool cannot name (#6863 review).
+        logger.warn(
+          `[DevicePool] Cannot assign ${device.id}: its AVD identity is unresolved until the ` +
+            "next discovery reads a name",
+        );
+        candidates = candidates.filter((candidate) => candidate.id !== skippedDeviceId);
+        device = this.selectIdleDevice(candidates);
+        continue;
+      }
       if (this.shouldValidatePooledDevicePresence(device)) {
         if (await this.ensurePooledDevicePresentForUse(device, true, true)) {
           return { device, livenessUnknown };
@@ -5683,7 +5710,70 @@ export class DevicePool {
     if (pooled === undefined || !this.matchesRuntimeIdentity(pooled, expected)) {
       return false;
     }
-    return !this.hasUnresolvedEmulatorName(expected);
+    // Read the quarantine state, plus this observation's own placeholder: a
+    // caller can reach here with a discovery listing the pool has not folded in
+    // yet, and that listing is the newer evidence of the two.
+    return !pooled.identityUnresolved && !this.hasUnresolvedEmulatorName(expected);
+  }
+
+  /**
+   * Whether the pool has an entry for `deviceId` whose identity is currently
+   * QUARANTINED — see {@link PooledDevice.identityUnresolved}.
+   *
+   * Public because the tool layer refuses serial-addressed work on a quarantined
+   * entry: the serial resolves, but which AVD answers on it does not, and every
+   * destructive or stateful action would be acting on a label the pool can no
+   * longer tie to the runtime ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+   */
+  isPooledIdentityUnresolved(deviceId: string): boolean {
+    return this.devices.get(deviceId)?.identityUnresolved === true;
+  }
+
+  /**
+   * Enter or leave the unresolved-identity quarantine for a live entry a
+   * discovery sweep just observed under a TOLERATED name match.
+   *
+   * Entering: the observation is the `Unknown (<serial>)` placeholder. The entry
+   * stays exactly as it is — same session, same `incarnation` — because the
+   * placeholder is not evidence that the serial was reused; it is only evidence
+   * that the pool can no longer prove it was not.
+   *
+   * Leaving: the observation carries a RESOLVED name. Reaching here at all means
+   * {@link namesAgreeOnIdentity} accepted it, i.e. it is the pooled label (or the
+   * AVD this pool started), which is proof of continuity — so the entry goes back
+   * to live, unchanged. A resolved name that DISAGREES never reaches this method:
+   * {@link matchesRuntimeIdentity} rejects it upstream and the entry is replaced
+   * under a fresh incarnation, retiring the old session exactly as an observed
+   * disappearance does.
+   *
+   * Guarded by {@link hasReusableSerial}: a handset's serial is never reassigned
+   * and its name (`ro.product.model`) is not identity, so there is no continuity
+   * question for the placeholder to leave open.
+   */
+  private reconcilePooledIdentityResolution(
+    pooled: PooledDevice,
+    discovered: Pick<BootedDevice, "deviceId" | "name" | "platform">,
+  ): void {
+    if (!this.hasReusableSerial(pooled)) {
+      return;
+    }
+    const unresolved = this.hasUnresolvedEmulatorName(discovered);
+    if (unresolved === (pooled.identityUnresolved === true)) {
+      return;
+    }
+    if (unresolved) {
+      pooled.identityUnresolved = true;
+      logger.warn(
+        `[DevicePool] Quarantining ${pooled.id}: discovery could not read the AVD name, so the ` +
+          `pooled identity '${pooled.avdName ?? pooled.name}' can no longer be tied to the runtime`,
+      );
+      return;
+    }
+    delete pooled.identityUnresolved;
+    logger.info(
+      `[DevicePool] Lifting the identity quarantine on ${pooled.id}: discovery read ` +
+        `'${discovered.name}'`,
+    );
   }
 
   /**
@@ -6562,6 +6652,19 @@ export class DevicePool {
     // session; execution cancellation only happens later in retirement, so this
     // is the gate that closes that window (see #5494, follow-up to #5452/#5491).
     const assignedDeviceId = this.sessionManager.getSession(sessionId)?.assignedDevice;
+    // The one choke point every tool execution passes through, so the
+    // unresolved-identity quarantine is enforced here rather than per tool: the
+    // session addresses its device BY SERIAL, and while the quarantine holds the
+    // pool cannot say which AVD answers on that serial (#6863 review).
+    const quarantined = assignedDeviceId ? this.devices.get(assignedDeviceId) : undefined;
+    if (quarantined?.identityUnresolved) {
+      throw new ActionableError(
+        `Refusing to run on Android emulator '${quarantined.id}': this daemon has it recorded as ` +
+          `AVD '${quarantined.avdName ?? quarantined.name}', but discovery could not read the AVD ` +
+          "name from the runtime, so its identity is unresolved. Retry after the next device " +
+          "discovery resolves it, or re-acquire the device.",
+      );
+    }
     if (assignedDeviceId && this.isDeviceUnderShutdown(assignedDeviceId)) {
       throw new ActionableError(
         `Session '${sessionId}' is bound to device '${assignedDeviceId}', which is shutting down. ` +

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -154,8 +154,6 @@ export interface PooledDevice {
   id: string; // Device ID (e.g., "emulator-5554")
   name: string; // Device name (e.g., "Pixel 7")
   platform: Platform; // Device platform
-  /** ADB transport identity for Android devices; changes when a serial reconnects. */
-  transportId?: string;
   sessionId: string | null; // Session currently using it, null if idle
   status: DeviceStatus; // Current status
   lastUsedAt: number; // Last usage timestamp
@@ -616,7 +614,6 @@ export class DevicePool {
         id: device.deviceId,
         name: device.name,
         platform: device.platform,
-        transportId: device.transportId,
         sessionId: null,
         status: "idle",
         lastUsedAt: now,
@@ -718,7 +715,6 @@ export class DevicePool {
             id: device.deviceId,
             name: device.name,
             platform: device.platform,
-            transportId: device.transportId,
             sessionId: null,
             status: "idle",
             lastUsedAt: now,
@@ -824,7 +820,6 @@ export class DevicePool {
         id: device.deviceId,
         name: device.name,
         platform: device.platform,
-        transportId: device.transportId,
         sessionId: null,
         status: "idle",
         lastUsedAt: now,

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2123,14 +2123,27 @@ export class DevicePool {
   }
 
   /**
-   * Whether a pooled entry must be re-proved present before it is handed out.
+   * Whether a pooled entry must be re-proved PRESENT before it is handed out.
    *
-   * Emulator console ports are the reused identifiers: `emulator-5554` is
-   * handed to whichever AVD boots into that console slot next, so a pooled
-   * entry for one can be silently stale. A handset serial is globally unique
-   * and never reassigned, so the ordinary refresh prune is sufficient there.
+   * Every Android entry must: a handset unplugged after the last refresh is
+   * gone from `adb devices` but still sitting in the pool, and assigning it
+   * hands a session a device that cannot answer (#6863 review).
    */
   private shouldValidatePooledDevicePresence(device: PooledDevice): boolean {
+    return device.platform === "android";
+  }
+
+  /**
+   * Whether a pooled entry's serial can be REASSIGNED to a different runtime.
+   *
+   * Emulator console ports are the reused identifiers: `emulator-5554` is handed
+   * to whichever AVD boots into that console slot next, so a serial that is
+   * present still has to prove it is the same runtime. A handset serial is
+   * globally unique and never reassigned, so presence is the whole question
+   * there — and its name (`ro.product.model`) is not identity, so running it
+   * through identity reconciliation could only produce false replacements.
+   */
+  private hasReusableSerial(device: PooledDevice): boolean {
     return device.platform === "android" && consolePortFromSerial(device.id) !== null;
   }
 
@@ -2154,7 +2167,9 @@ export class DevicePool {
 
     const bootedDevice = discovery.devices.find((booted) => booted.deviceId === device.id);
     if (bootedDevice) {
-      return await this.reconcileDiscoveredPooledDevice(device, bootedDevice, assignmentLockHeld);
+      return this.hasReusableSerial(device)
+        ? await this.reconcileDiscoveredPooledDevice(device, bootedDevice, assignmentLockHeld)
+        : this.confirmLivePooledDevice(device);
     }
 
     if (deferRecovery && this.shouldRebootDisconnectedAndroidDevice(device)) {
@@ -2182,18 +2197,7 @@ export class DevicePool {
     assignmentLockHeld: boolean,
   ): Promise<boolean> {
     if (this.matchesRuntimeIdentity(device, bootedDevice)) {
-      if (this.devices.get(device.id) !== device) {
-        // A concurrent re-add replaced this entry while discovery was in
-        // flight. Serial, platform and name cannot tell the incarnations
-        // apart — only the pool's own entry identity can — so the captured
-        // object is a previous incarnation and must not be handed out.
-        logger.debug(
-          `Rejecting superseded pooled incarnation of ${device.id} after liveness check`,
-        );
-        return false;
-      }
-      this.refreshMissingDeviceMisses.delete(device.id);
-      return true;
+      return this.confirmLivePooledDevice(device);
     }
     const replaced = await this.replaceIdlePooledDeviceForLivenessCheck(
       device,
@@ -2201,6 +2205,23 @@ export class DevicePool {
       assignmentLockHeld,
     );
     return !replaced && this.devices.get(device.id) === device;
+  }
+
+  /**
+   * Accept a pooled entry discovery just confirmed is present.
+   *
+   * Guarded on entry identity: a concurrent re-add can have replaced this entry
+   * while discovery was in flight, and serial, platform and name cannot tell the
+   * incarnations apart — only the pool's own entry object can — so the captured
+   * object would be a previous incarnation and must not be handed out.
+   */
+  private confirmLivePooledDevice(device: PooledDevice): boolean {
+    if (this.devices.get(device.id) !== device) {
+      logger.debug(`Rejecting superseded pooled incarnation of ${device.id} after liveness check`);
+      return false;
+    }
+    this.refreshMissingDeviceMisses.delete(device.id);
+    return true;
   }
 
   private async replaceIdlePooledDeviceForLivenessCheck(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5662,16 +5662,6 @@ export class DevicePool {
   }
 
   /**
-   * Whether a discovery observation describes the same runtime as a pooled
-   * entry.
-   *
-   * A discovery listing carries no connection-epoch token, so serial, platform
-   * and name are all there is to compare; the pool's own `incarnation` is the
-   * only epoch boundary, and it is minted when the pool re-creates an entry
-   * (see `daemon/deviceSessionRegistry.ts`). Name handling is delegated to
-   * {@link namesAgreeOnIdentity}.
-   */
-  /**
    * Whether this pool's entry for a serial describes the runtime a discovery
    * listing just reported on it — false when there is no entry at all.
    *
@@ -5685,6 +5675,16 @@ export class DevicePool {
     return pooled !== undefined && this.matchesRuntimeIdentity(pooled, expected);
   }
 
+  /**
+   * Whether a discovery observation describes the same runtime as a pooled
+   * entry.
+   *
+   * A discovery listing carries no connection-epoch token, so serial, platform
+   * and name are all there is to compare; the pool's own `incarnation` is the
+   * only epoch boundary, and it is minted when the pool re-creates an entry
+   * (see `daemon/deviceSessionRegistry.ts`). Name handling is delegated to
+   * {@link namesAgreeOnIdentity}.
+   */
   private matchesRuntimeIdentity(
     pooled: PooledDevice,
     expected: Pick<BootedDevice, "deviceId" | "name" | "platform">,

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -30,6 +30,7 @@ import {
 } from "./DeviceCriteriaMatcher";
 import { resetAdbDeviceListCache } from "../utils/android-cmdline-tools/AdbClient";
 import { hasMutableDisplayName, isIosPhysicalUdid } from "../utils/ios-cmdline-tools/iosDeviceType";
+import { isAndroidEmulatorSerial } from "../utils/androidSerial";
 import { didSourceSucceedForDevice, type DiscoverySource } from "../utils/discoverySource";
 import { consolePortFromSerial } from "../utils/android-cmdline-tools/EmulatorConsoleClient";
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
@@ -139,6 +140,15 @@ export type DeviceRecoveryEligibility =
  * mutex was acquired.
  */
 type MutableMetadataSource = "refresh" | "snapshot";
+
+/**
+ * The display name Android discovery falls back to when the emulator console
+ * could not answer `avd name`. It is a placeholder, not an identity claim —
+ * see {@link DevicePool.namesAgreeOnIdentity}.
+ */
+function unknownAndroidRuntimeName(deviceId: string): string {
+  return `Unknown (${deviceId})`;
+}
 
 export interface PooledDevice {
   id: string; // Device ID (e.g., "emulator-5554")
@@ -853,24 +863,18 @@ export class DevicePool {
 
   /**
    * Replace a pooled connection whose stable serial now identifies a different
-   * runtime. Preserve AutoMobile-owned emulator state because the process and
-   * AVD did not change; only the ADB connection incarnation did.
+   * runtime.
+   *
+   * Reaching here means the discovered name genuinely disagrees with the pooled
+   * one (see {@link matchesRuntimeIdentity}, which tolerates the placeholder an
+   * unreadable AVD name produces), so a different AVD has taken this serial.
+   * AutoMobile-owned emulator state belongs to the AVD that is gone and must not
+   * be carried across.
    */
   private async replacePooledDeviceForRuntimeIdentity(
     pooledDevice: PooledDevice,
     bootedDevice: BootedDevice,
   ): Promise<boolean> {
-    const preserveAutoMobileOwnership = this.hasTransportOnlyIdentityChange(
-      pooledDevice,
-      bootedDevice,
-    );
-    const sourceImage = preserveAutoMobileOwnership ? pooledDevice.androidImage : undefined;
-    const startedProcess = preserveAutoMobileOwnership
-      ? this.startedDeviceProcesses.get(pooledDevice.id)
-      : undefined;
-    const startedProcessOutput = preserveAutoMobileOwnership
-      ? this.startedDeviceProcessOutput.get(pooledDevice.id)
-      : undefined;
     await this.evictMissingPooledDevice(
       pooledDevice,
       `runtime identity changed to ${bootedDevice.platform}:${bootedDevice.name}`,
@@ -878,13 +882,7 @@ export class DevicePool {
     if (this.devices.has(bootedDevice.deviceId)) {
       return false;
     }
-    await this.addDevice(bootedDevice, sourceImage);
-    if (startedProcess) {
-      this.startedDeviceProcesses.set(bootedDevice.deviceId, startedProcess);
-    }
-    if (startedProcessOutput) {
-      this.startedDeviceProcessOutput.set(bootedDevice.deviceId, startedProcessOutput);
-    }
+    await this.addDevice(bootedDevice);
     return true;
   }
 
@@ -2128,11 +2126,16 @@ export class DevicePool {
     return evicted;
   }
 
+  /**
+   * Whether a pooled entry must be re-proved present before it is handed out.
+   *
+   * Emulator console ports are the reused identifiers: `emulator-5554` is
+   * handed to whichever AVD boots into that console slot next, so a pooled
+   * entry for one can be silently stale. A handset serial is globally unique
+   * and never reassigned, so the ordinary refresh prune is sufficient there.
+   */
   private shouldValidatePooledDevicePresence(device: PooledDevice): boolean {
-    return (
-      device.platform === "android" &&
-      (consolePortFromSerial(device.id) !== null || device.transportId !== undefined)
-    );
+    return device.platform === "android" && consolePortFromSerial(device.id) !== null;
   }
 
   private async ensurePooledDevicePresentForUse(
@@ -2154,18 +2157,8 @@ export class DevicePool {
     }
 
     const bootedDevice = discovery.devices.find((booted) => booted.deviceId === device.id);
-    if (bootedDevice && this.matchesRuntimeIdentity(device, bootedDevice)) {
-      this.refreshMissingDeviceMisses.delete(device.id);
-      return true;
-    }
-
     if (bootedDevice) {
-      const replaced = await this.replaceIdlePooledDeviceForLivenessCheck(
-        device,
-        bootedDevice,
-        assignmentLockHeld,
-      );
-      return !replaced && this.devices.get(device.id) === device;
+      return await this.reconcileDiscoveredPooledDevice(device, bootedDevice, assignmentLockHeld);
     }
 
     if (deferRecovery && this.shouldRebootDisconnectedAndroidDevice(device)) {
@@ -2180,6 +2173,38 @@ export class DevicePool {
     }
     await this.evictMissingPooledDevice(device, "not present in adb devices", true);
     return false;
+  }
+
+  /**
+   * Settle a liveness check for a serial discovery still reports as booted:
+   * either the pooled entry is the runtime that answered, or a different one
+   * has taken the serial and the entry must be replaced.
+   */
+  private async reconcileDiscoveredPooledDevice(
+    device: PooledDevice,
+    bootedDevice: BootedDevice,
+    assignmentLockHeld: boolean,
+  ): Promise<boolean> {
+    if (this.matchesRuntimeIdentity(device, bootedDevice)) {
+      if (this.devices.get(device.id) !== device) {
+        // A concurrent re-add replaced this entry while discovery was in
+        // flight. Serial, platform and name cannot tell the incarnations
+        // apart — only the pool's own entry identity can — so the captured
+        // object is a previous incarnation and must not be handed out.
+        logger.debug(
+          `Rejecting superseded pooled incarnation of ${device.id} after liveness check`,
+        );
+        return false;
+      }
+      this.refreshMissingDeviceMisses.delete(device.id);
+      return true;
+    }
+    const replaced = await this.replaceIdlePooledDeviceForLivenessCheck(
+      device,
+      bootedDevice,
+      assignmentLockHeld,
+    );
+    return !replaced && this.devices.get(device.id) === device;
   }
 
   private async replaceIdlePooledDeviceForLivenessCheck(
@@ -5003,10 +5028,7 @@ export class DevicePool {
    */
   async reserveDeviceForReadiness(
     deviceId: string,
-    expectedIdentity: Pick<
-      BootedDevice,
-      "deviceId" | "name" | "platform" | "transportId" | "observedAt"
-    >,
+    expectedIdentity: Pick<BootedDevice, "deviceId" | "name" | "platform" | "observedAt">,
     stableRuntimeName = expectedIdentity.name,
     verifiedAndroidAvdName?: string,
     autolockClient?: AutolockClient,
@@ -5027,11 +5049,7 @@ export class DevicePool {
         // Acquisition may reboot a device during readiness recovery. Prove
         // ownership before reserving it or beginning those side effects.
         this.getOwnedAutolockSession(pooled, autolockClient);
-        if (this.hasTransportOnlyIdentityChange(pooled, expectedIdentity)) {
-          await this.replacePooledDeviceForRuntimeIdentity(pooled, expectedIdentity);
-        } else {
-          this.assertRuntimeIdentity(pooled, expectedIdentity);
-        }
+        this.assertRuntimeIdentity(pooled, expectedIdentity);
       }
       throwIfRequestAborted();
       const current = this.devices.get(deviceId);
@@ -5602,9 +5620,7 @@ export class DevicePool {
 
   private assertRuntimeIdentity(
     pooled: PooledDevice,
-    expected:
-      | Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId" | "observedAt">
-      | undefined,
+    expected: Pick<BootedDevice, "deviceId" | "name" | "platform" | "observedAt"> | undefined,
   ): void {
     if (!expected || this.matchesRuntimeIdentity(pooled, expected)) {
       // A tolerated match is still an opportunity to reconcile: every caller
@@ -5618,21 +5634,64 @@ export class DevicePool {
     }
     throw new ActionableError(
       `Device pool identity mismatch for '${expected.deviceId}': ` +
-        `resolved=[${expected.name} platform=${expected.platform} transportId=${expected.transportId}] ` +
-        `pooled=[${pooled.name} platform=${pooled.platform} transportId=${pooled.transportId}].`,
+        `resolved=[${expected.name} platform=${expected.platform}] ` +
+        `pooled=[${pooled.name} platform=${pooled.platform} incarnation=${pooled.incarnation}].`,
     );
   }
 
+  /**
+   * Whether a discovery observation describes the same runtime as a pooled
+   * entry.
+   *
+   * A discovery listing carries no connection-epoch token, so serial, platform
+   * and name are all there is to compare; the pool's own `incarnation` is the
+   * only epoch boundary, and it is minted when the pool re-creates an entry
+   * (see `daemon/deviceSessionRegistry.ts`). Name handling is delegated to
+   * {@link namesAgreeOnIdentity}.
+   */
   private matchesRuntimeIdentity(
     pooled: PooledDevice,
-    expected: Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId">,
+    expected: Pick<BootedDevice, "deviceId" | "name" | "platform">,
   ): boolean {
     return (
       pooled.id === expected.deviceId &&
-      (this.hasMutableDisplayName(pooled) || pooled.name === expected.name) &&
       pooled.platform === expected.platform &&
-      (expected.transportId === undefined || pooled.transportId === expected.transportId)
+      this.namesAgreeOnIdentity(pooled, expected)
     );
+  }
+
+  /**
+   * Whether a pooled label and a freshly-discovered name can be the same
+   * runtime.
+   *
+   * Name equality is the rule, with two documented tolerances:
+   *  - a device class whose name is mutable metadata (iOS physical) never
+   *    carries identity in its name at all;
+   *  - `Unknown (<serial>)` is the placeholder Android discovery emits when the
+   *    emulator console could not answer `avd name`. It asserts nothing, so
+   *    reading it as "a different AVD took this serial" would evict a live
+   *    pooled emulator — and its AutoMobile ownership — on a transient console
+   *    read. The tolerance is guarded by {@link isAndroidEmulatorSerial}
+   *    because a handset's name is `ro.product.model`, which is not unique;
+   *    handsets stay on strict name equality behind their unique serial.
+   */
+  private namesAgreeOnIdentity(
+    pooled: PooledDevice,
+    expected: Pick<BootedDevice, "name">,
+  ): boolean {
+    if (this.hasMutableDisplayName(pooled) || pooled.name === expected.name) {
+      return true;
+    }
+    if (pooled.platform !== "android" || !isAndroidEmulatorSerial(pooled.id)) {
+      return false;
+    }
+    const placeholder = unknownAndroidRuntimeName(pooled.id);
+    if (expected.name === placeholder) {
+      return true;
+    }
+    // The pooled label is the placeholder. Accept a resolved name only when the
+    // AVD this pool started says so — never on the strength of a name alone.
+    return pooled.name === placeholder && pooled.avdName === expected.name;
   }
 
   /**
@@ -5642,6 +5701,34 @@ export class DevicePool {
    */
   private hasMutableDisplayName(pooled: PooledDevice): boolean {
     return hasMutableDisplayName(pooled.platform, pooled.id);
+  }
+
+  /**
+   * Upgrade a pooled emulator still labelled `Unknown (<serial>)` to the AVD
+   * name a later discovery managed to read.
+   *
+   * {@link namesAgreeOnIdentity} tolerates the placeholder in both directions so
+   * an unreadable console never evicts a live entry; without this the tolerated
+   * match would also leave the pooled label stuck on the placeholder, and
+   * name-based pool consumers (DeviceCriteriaMatcher.filterDevices) would never
+   * match the real AVD. Only a name the pool already vouches for through
+   * `avdName` is adopted, so this cannot rename an entry onto a different AVD.
+   */
+  private resolvePlaceholderEmulatorName(
+    pooled: PooledDevice,
+    discovered: Pick<BootedDevice, "name">,
+  ): void {
+    if (
+      pooled.platform !== "android" ||
+      !isAndroidEmulatorSerial(pooled.id) ||
+      pooled.name !== unknownAndroidRuntimeName(pooled.id) ||
+      pooled.avdName === undefined ||
+      pooled.avdName !== discovered.name
+    ) {
+      return;
+    }
+    logger.info(`Device ${pooled.id} resolved its AVD name to '${discovered.name}'`);
+    pooled.name = discovered.name;
   }
 
   /**
@@ -5655,6 +5742,7 @@ export class DevicePool {
     discovered: Pick<BootedDevice, "name" | "observedAt">,
     source: MutableMetadataSource,
   ): void {
+    this.resolvePlaceholderEmulatorName(pooled, discovered);
     if (!this.hasMutableDisplayName(pooled)) {
       return;
     }
@@ -5694,35 +5782,6 @@ export class DevicePool {
       delete pooled.nameObservedAt;
       pooled.nameRefreshGeneration = this.refreshGeneration;
     }
-  }
-
-  private hasTransportOnlyIdentityChange(
-    pooled: PooledDevice,
-    expected: Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId">,
-  ): boolean {
-    return (
-      pooled.id === expected.deviceId &&
-      pooled.platform === expected.platform &&
-      this.hasSameOrUnknownEmulatorName(pooled, expected) &&
-      !this.matchesRuntimeIdentity(pooled, expected)
-    );
-  }
-
-  private hasSameOrUnknownEmulatorName(
-    pooled: PooledDevice,
-    expected: Pick<BootedDevice, "deviceId" | "name">,
-  ): boolean {
-    if (pooled.name === expected.name) {
-      return true;
-    }
-    if (!pooled.id.startsWith("emulator-")) {
-      return false;
-    }
-    const unknownName = `Unknown (${pooled.id})`;
-    return (
-      expected.name === unknownName ||
-      (pooled.name === unknownName && pooled.avdName === expected.name)
-    );
   }
 
   /**

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2161,10 +2161,26 @@ export class DevicePool {
     return device.platform === "android" && consolePortFromSerial(device.id) !== null;
   }
 
+  /**
+   * The shared assignability gate every hand-out path runs an Android entry
+   * through: idle selection, exact `bindOrReuseDeviceSession`, autolock and the
+   * pre-allocation sweeps. It answers one question — may this entry be handed to
+   * a session right now — which is presence AND a resolved identity, since the
+   * liveness check it performs is also what ENTERS the quarantine.
+   */
   private async ensurePooledDevicePresentForUse(
     device: PooledDevice,
     deferRecovery: boolean = false,
     assignmentLockHeld: boolean = false,
+  ): Promise<boolean> {
+    const present = await this.ensurePooledDevicePresent(device, deferRecovery, assignmentLockHeld);
+    return present && this.isPooledDeviceIdentityAssignable(device);
+  }
+
+  private async ensurePooledDevicePresent(
+    device: PooledDevice,
+    deferRecovery: boolean,
+    assignmentLockHeld: boolean,
   ): Promise<boolean> {
     if (!this.shouldValidatePooledDevicePresence(device)) {
       return true;
@@ -4187,14 +4203,12 @@ export class DevicePool {
 
     while (device) {
       const skippedDeviceId = device.id;
-      if (device.identityUnresolved) {
-        // Quarantined: the serial is there, but which AVD answers on it is not
-        // known, so handing it to a session would bind that session to a runtime
-        // the pool cannot name (#6863 review).
-        logger.warn(
-          `[DevicePool] Cannot assign ${device.id}: its AVD identity is unresolved until the ` +
-            "next discovery reads a name",
-        );
+      // Quarantined: the serial is there, but which AVD answers on it is not
+      // known, so handing it to a session would bind that session to a runtime the
+      // pool cannot name. Checked here as well as inside the shared gate below so
+      // an already-quarantined entry is skipped without a discovery round trip
+      // (#6863 review).
+      if (!this.isPooledDeviceIdentityAssignable(device)) {
         candidates = candidates.filter((candidate) => candidate.id !== skippedDeviceId);
         device = this.selectIdleDevice(candidates);
         continue;
@@ -5610,6 +5624,15 @@ export class DevicePool {
     if (!replacement) {
       throw new ActionableError(unavailableMessage);
     }
+    // An exact-device request names the serial, and the quarantine is precisely
+    // the pool's inability to say which runtime answers on it — so this refuses
+    // rather than falling through to the unavailable message, which would invite
+    // a retry against the same unknown runtime (#6863 review).
+    if (replacement.identityUnresolved === true) {
+      throw new ActionableError(
+        this.describeUnresolvedPooledIdentity(replacement, "Refusing to assign device"),
+      );
+    }
     this.assertRuntimeIdentity(replacement, expectedIdentity);
     await this.assertIdleDeviceAssignable(
       replacement,
@@ -5727,6 +5750,38 @@ export class DevicePool {
    */
   isPooledIdentityUnresolved(deviceId: string): boolean {
     return this.devices.get(deviceId)?.identityUnresolved === true;
+  }
+
+  /**
+   * The single wording for every refusal the quarantine produces, so assignment,
+   * tool execution and their tests all name the same two facts: the serial, and
+   * the label the daemon can no longer tie to the runtime on it.
+   */
+  private describeUnresolvedPooledIdentity(device: PooledDevice, refusal: string): string {
+    return (
+      `${refusal} '${device.id}': this daemon has it recorded as AVD ` +
+      `'${device.avdName ?? device.name}', but discovery could not read the AVD name from the ` +
+      "runtime, so its identity is unresolved. Retry after the next device discovery resolves " +
+      "it, or re-acquire the device."
+    );
+  }
+
+  /**
+   * The quarantine half of the shared assignability gate: an entry that is — or
+   * that the liveness check just made — quarantined is not assignable, and is
+   * reported exactly as a missing device is, so the operation that ENTERS the
+   * quarantine fails at assignment instead of handing back a session that would
+   * then fail every tool at {@link assertSessionReadyForAutomation}
+   * ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+   */
+  private isPooledDeviceIdentityAssignable(device: PooledDevice): boolean {
+    if (device.identityUnresolved !== true) {
+      return true;
+    }
+    logger.warn(
+      this.describeUnresolvedPooledIdentity(device, "[DevicePool] Cannot hand out device"),
+    );
+    return false;
   }
 
   /**
@@ -6664,10 +6719,7 @@ export class DevicePool {
     const quarantined = assignedDeviceId ? this.devices.get(assignedDeviceId) : undefined;
     if (quarantined?.identityUnresolved) {
       throw new ActionableError(
-        `Refusing to run on Android emulator '${quarantined.id}': this daemon has it recorded as ` +
-          `AVD '${quarantined.avdName ?? quarantined.name}', but discovery could not read the AVD ` +
-          "name from the runtime, so its identity is unresolved. Retry after the next device " +
-          "discovery resolves it, or re-acquire the device.",
+        this.describeUnresolvedPooledIdentity(quarantined, "Refusing to run on device"),
       );
     }
     if (assignedDeviceId && this.isDeviceUnderShutdown(assignedDeviceId)) {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -733,17 +733,27 @@ export class DevicePool {
           }
           let pooledDevice = this.devices.get(device.deviceId);
           let runtimeReplaced = false;
+          let replacementDeferred = false;
           if (pooledDevice && !this.matchesRuntimeIdentity(pooledDevice, device)) {
+            const supersededDevice = pooledDevice;
             runtimeReplaced = await this.replacePooledDeviceForRuntimeIdentity(
-              pooledDevice,
+              supersededDevice,
               device,
             );
             pooledDevice = this.devices.get(device.deviceId);
+            replacementDeferred = !runtimeReplaced && pooledDevice === supersededDevice;
           }
           if (pooledDevice) {
             pooledDevice.iosVersion = device.iosVersion;
+            if (replacementDeferred) {
+              // The entry the pool still holds is the one this observation
+              // DISAGREES with, so neither its metadata nor its identity may be
+              // updated from it.
+              await this.quarantineDeferredPooledReplacement(pooledDevice, device);
+              return runtimeReplaced;
+            }
             this.applyMutableRuntimeMetadata(pooledDevice, device, "refresh");
-            this.reconcilePooledIdentityResolution(pooledDevice, device);
+            await this.reconcilePooledIdentityResolution(pooledDevice, device);
             return runtimeReplaced;
           }
           this.devices.set(device.deviceId, {
@@ -2247,7 +2257,7 @@ export class DevicePool {
     assignmentLockHeld: boolean,
   ): Promise<boolean> {
     if (this.matchesRuntimeIdentity(device, bootedDevice)) {
-      this.reconcilePooledIdentityResolution(device, bootedDevice);
+      await this.reconcilePooledIdentityResolution(device, bootedDevice);
       return this.confirmLivePooledDevice(device);
     }
     const replaced = await this.replaceIdlePooledDeviceForLivenessCheck(
@@ -5825,23 +5835,22 @@ export class DevicePool {
    * and its name (`ro.product.model`) is not identity, so there is no continuity
    * question for the placeholder to leave open.
    */
-  private reconcilePooledIdentityResolution(
+  private async reconcilePooledIdentityResolution(
     pooled: PooledDevice,
     discovered: Pick<BootedDevice, "deviceId" | "name" | "platform">,
-  ): void {
+  ): Promise<void> {
     if (!this.hasReusableSerial(pooled)) {
       return;
     }
-    const unresolved = this.hasUnresolvedEmulatorName(discovered);
-    if (unresolved === (pooled.identityUnresolved === true)) {
+    if (this.hasUnresolvedEmulatorName(discovered)) {
+      await this.enterPooledIdentityQuarantine(
+        pooled,
+        "discovery could not read the AVD name, so the pooled identity " +
+          `'${pooled.avdName ?? pooled.name}' can no longer be tied to the runtime`,
+      );
       return;
     }
-    if (unresolved) {
-      pooled.identityUnresolved = true;
-      logger.warn(
-        `[DevicePool] Quarantining ${pooled.id}: discovery could not read the AVD name, so the ` +
-          `pooled identity '${pooled.avdName ?? pooled.name}' can no longer be tied to the runtime`,
-      );
+    if (pooled.identityUnresolved !== true) {
       return;
     }
     delete pooled.identityUnresolved;
@@ -5849,6 +5858,73 @@ export class DevicePool {
       `[DevicePool] Lifting the identity quarantine on ${pooled.id}: discovery read ` +
         `'${discovered.name}'`,
     );
+  }
+
+  /**
+   * Quarantine a pooled entry whose replacement could not be installed.
+   *
+   * {@link replacePooledDeviceForRuntimeIdentity} evicts the old incarnation
+   * before adding the discovered runtime, and {@link evictMissingPooledDevice}
+   * DEFERS that eviction while killDevice holds a shutdown reservation. The
+   * refresh then reloads the same old entry, and the discovered name -- which
+   * DISAGREES with it -- would otherwise reach
+   * {@link reconcilePooledIdentityResolution} and read as proof of continuity.
+   *
+   * A disagreement is never that proof. The entry is held in quarantine until
+   * the replacement actually installs, which is the only event that retires the
+   * old session and mints the new incarnation
+   * ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+   */
+  private async quarantineDeferredPooledReplacement(
+    pooled: PooledDevice,
+    discovered: Pick<BootedDevice, "deviceId" | "name" | "platform">,
+  ): Promise<void> {
+    if (!this.hasReusableSerial(pooled)) {
+      return;
+    }
+    await this.enterPooledIdentityQuarantine(
+      pooled,
+      `discovery reports '${discovered.name}' on this serial while the pooled identity is ` +
+        `'${pooled.avdName ?? pooled.name}', and its replacement could not be installed yet`,
+    );
+  }
+
+  /**
+   * Enter the quarantine, once.
+   *
+   * The entry keeps its session and its `incarnation` -- the quarantine
+   * withholds trust, it does not retire the epoch -- but the work already IN
+   * FLIGHT on the bound session is not covered by any admission gate: those
+   * executions are registered and keep issuing serial-addressed operations that
+   * can land on whatever now answers on the serial. So they are cancelled and
+   * drained through the same injected seam the ADB-reset quarantine uses, under
+   * the device-loss reason so each one surfaces a typed `DeviceLostError`
+   * naming the serial ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863)
+   * review).
+   */
+  private async enterPooledIdentityQuarantine(
+    pooled: PooledDevice,
+    reason: string,
+  ): Promise<void> {
+    if (pooled.identityUnresolved === true) {
+      return;
+    }
+    pooled.identityUnresolved = true;
+    logger.warn(`[DevicePool] Quarantining ${pooled.id}: ${reason}`);
+    const sessionId = pooled.sessionId;
+    if (!sessionId) {
+      return;
+    }
+    const cancelled = await this.cancelDeviceSessionExecutions(
+      sessionId,
+      deviceLossCancellationReason(pooled.id),
+    );
+    if (cancelled > 0) {
+      logger.warn(
+        `[DevicePool] Cancelled ${cancelled} in-flight execution(s) on session ${sessionId} ` +
+          `while quarantining ${pooled.id}`,
+      );
+    }
   }
 
   /**

--- a/src/daemon/deviceSessionRegistry.ts
+++ b/src/daemon/deviceSessionRegistry.ts
@@ -6,11 +6,12 @@ import type { Platform } from "../models";
 /**
  * Identity of a single device *connection epoch*.
  *
- * The adb serial / simulator UDID (`deviceId`) is reused across boots and its
- * ADB `transportId` changes on reconnect, so a consumer cannot tell "same
- * device, stream continues" from "device rebooted, flush your caches" by serial
- * alone. `deviceSessionUuid` is minted once per epoch and retired when the
- * device disconnects, giving every stream a stable routing key that a reused
+ * The adb serial / simulator UDID (`deviceId`) is reused across boots, and a
+ * discovery listing carries no per-connection token at all, so a consumer cannot
+ * tell "same device, stream continues" from "device rebooted, flush your caches"
+ * by serial alone. `deviceSessionUuid` is minted once per epoch -- keyed on the
+ * pool's `incarnation`, the only epoch boundary in the model -- and retired when
+ * the device disconnects, giving every stream a stable routing key that a reused
  * serial cannot alias.
  */
 export interface DeviceSessionRecord {

--- a/src/daemon/deviceSessionResolver.ts
+++ b/src/daemon/deviceSessionResolver.ts
@@ -1,3 +1,4 @@
+import { logger } from "../utils/logger";
 import type { DeviceSessionRegistry } from "./deviceSessionRegistry";
 
 /**
@@ -16,6 +17,20 @@ export interface DeviceSessionResolver {
   resolveUuid(deviceId: string): string | null;
   /** Live serial/UDID for a `deviceSessionUuid`, or `null` when the epoch is retired/unknown. */
   resolveDeviceId(deviceSessionUuid: string): string | null;
+  /**
+   * Whether this serial currently has NO routing identity because the pool's
+   * entry for it is quarantined (`PooledDevice.identityUnresolved`): the serial
+   * answers, but which runtime answers on it is unknown, so the epoch is
+   * preserved and simply withheld.
+   *
+   * Distinguishes "quarantined" from "no live epoch", which `resolveUuid`
+   * returning `null` cannot: a device-attributed frame for a serial with no
+   * epoch is still broadcast to all-device subscribers, whereas a frame for a
+   * quarantined serial is DROPPED — attributing it to the serial is the only
+   * thing the daemon could do with it, and that attribution is exactly what is
+   * in doubt (#6863 review).
+   */
+  isRoutingSuspended(deviceId: string): boolean;
 }
 
 /**
@@ -27,15 +42,66 @@ export interface DeviceSessionResolver {
 export const nullDeviceSessionResolver: DeviceSessionResolver = {
   resolveUuid: () => null,
   resolveDeviceId: () => null,
+  isRoutingSuspended: () => false,
 };
 
-/** Adapt a {@link DeviceSessionRegistry} to the narrow {@link DeviceSessionResolver} contract. */
+/**
+ * Adapt a {@link DeviceSessionRegistry} to the narrow {@link DeviceSessionResolver}
+ * contract.
+ *
+ * `isIdentityQuarantined` is the pool's `identityUnresolved` state
+ * (`DevicePool.isPooledIdentityUnresolved`). While it holds for a serial, BOTH
+ * directions withhold the routing identity — the registry record is untouched, so
+ * a lifted quarantine resumes the same epoch — and every device-attributed frame
+ * for that serial is dropped by its push server. Omitted (direct mode, tests) means
+ * nothing is ever quarantined.
+ */
 export function createRegistryDeviceSessionResolver(
   registry: DeviceSessionRegistry,
+  isIdentityQuarantined: (deviceId: string) => boolean = () => false,
 ): DeviceSessionResolver {
+  const resolveUuid = (deviceId: string): string | null =>
+    isIdentityQuarantined(deviceId)
+      ? null
+      : (registry.getByDeviceId(deviceId)?.deviceSessionUuid ?? null);
   return {
-    resolveUuid: (deviceId: string) => registry.getByDeviceId(deviceId)?.deviceSessionUuid ?? null,
-    resolveDeviceId: (deviceSessionUuid: string) =>
-      registry.getByUuid(deviceSessionUuid)?.deviceId ?? null,
+    resolveUuid,
+    resolveDeviceId: (deviceSessionUuid: string) => {
+      const deviceId = registry.getByUuid(deviceSessionUuid)?.deviceId;
+      if (deviceId === undefined || isIdentityQuarantined(deviceId)) {
+        return null;
+      }
+      return deviceId;
+    },
+    isRoutingSuspended: (deviceId: string) => isIdentityQuarantined(deviceId),
   };
+}
+
+/**
+ * Per-server memo that keeps a suspended serial's drop notice to ONCE per
+ * quarantine instead of once per dropped frame — passive streams push
+ * continuously, so the per-frame form would bury the log it belongs in.
+ */
+export class SuspendedDeviceRoutingLog {
+  private readonly announced = new Set<string>();
+
+  /**
+   * Whether frames attributed to `deviceId` must be dropped. Logs the first drop
+   * of a quarantine and re-arms as soon as routing resumes, so a later
+   * re-quarantine of the same serial is announced again.
+   */
+  shouldDropFrame(resolver: DeviceSessionResolver, deviceId: string, serverLabel: string): boolean {
+    if (!resolver.isRoutingSuspended(deviceId)) {
+      this.announced.delete(deviceId);
+      return false;
+    }
+    if (!this.announced.has(deviceId)) {
+      this.announced.add(deviceId);
+      logger.debug(
+        `[${serverLabel}] Dropping frames for ${deviceId}: its pooled AVD identity is ` +
+          "unresolved, so there is no routing identity to attribute them to",
+      );
+    }
+    return true;
+  }
 }

--- a/src/daemon/failuresPushSocketServer.ts
+++ b/src/daemon/failuresPushSocketServer.ts
@@ -3,7 +3,11 @@ import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { PushSubscriptionSocketServer, getSocketPath } from "./socketServer/index";
 import type { FailureType, FailureSeverity } from "../server/failuresResources";
 import { FAILURES_PUSH_SOCKET_CONFIG } from "./daemonFiles";
-import { type DeviceSessionResolver, nullDeviceSessionResolver } from "./deviceSessionResolver";
+import {
+  type DeviceSessionResolver,
+  nullDeviceSessionResolver,
+  SuspendedDeviceRoutingLog,
+} from "./deviceSessionResolver";
 
 /**
  * Failure notification data pushed to clients.
@@ -61,6 +65,7 @@ export class FailuresPushSocketServer extends PushSubscriptionSocketServer<
   FailureNotificationPush
 > {
   private deviceSessionResolver: DeviceSessionResolver = nullDeviceSessionResolver;
+  private readonly suspendedRoutingLog = new SuspendedDeviceRoutingLog();
 
   constructor(
     socketPath: string = getSocketPath(FAILURES_PUSH_SOCKET_CONFIG),
@@ -80,6 +85,17 @@ export class FailuresPushSocketServer extends PushSubscriptionSocketServer<
    * the routing key reflects the device's current epoch.
    */
   pushFailure(data: FailureNotificationPush): void {
+    if (
+      data.deviceId &&
+      this.suspendedRoutingLog.shouldDropFrame(
+        this.deviceSessionResolver,
+        data.deviceId,
+        "FailuresPush",
+      )
+    ) {
+      // Quarantined pooled identity: see pushTelemetryEvent (#6863 review).
+      return;
+    }
     const deviceSessionUuid = data.deviceId
       ? this.deviceSessionResolver.resolveUuid(data.deviceId)
       : null;

--- a/src/daemon/performancePushSocketServer.ts
+++ b/src/daemon/performancePushSocketServer.ts
@@ -2,7 +2,11 @@ import { logger } from "../utils/logger";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { PushSubscriptionSocketServer, getSocketPath } from "./socketServer/index";
 import { PERFORMANCE_PUSH_SOCKET_CONFIG } from "./daemonFiles";
-import { type DeviceSessionResolver, nullDeviceSessionResolver } from "./deviceSessionResolver";
+import {
+  type DeviceSessionResolver,
+  nullDeviceSessionResolver,
+  SuspendedDeviceRoutingLog,
+} from "./deviceSessionResolver";
 
 /**
  * Performance thresholds for health status calculation
@@ -107,6 +111,7 @@ export class PerformancePushSocketServer extends PushSubscriptionSocketServer<
   LivePerformanceData
 > {
   private deviceSessionResolver: DeviceSessionResolver = nullDeviceSessionResolver;
+  private readonly suspendedRoutingLog = new SuspendedDeviceRoutingLog();
 
   constructor(
     socketPath: string = getSocketPath(PERFORMANCE_PUSH_SOCKET_CONFIG),
@@ -126,6 +131,17 @@ export class PerformancePushSocketServer extends PushSubscriptionSocketServer<
    * current epoch regardless of what the caller supplied.
    */
   pushPerformanceData(data: LivePerformanceData): void {
+    if (
+      data.deviceId &&
+      this.suspendedRoutingLog.shouldDropFrame(
+        this.deviceSessionResolver,
+        data.deviceId,
+        "PerformancePush",
+      )
+    ) {
+      // Quarantined pooled identity: see pushTelemetryEvent (#6863 review).
+      return;
+    }
     const deviceSessionUuid = data.deviceId
       ? this.deviceSessionResolver.resolveUuid(data.deviceId)
       : null;

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -3922,11 +3922,16 @@ export class UnixSocketServer {
         ? undefined
         : () => this.validateAppendFrameContext(client, frameContext, deadline, totalTimeoutMs);
     const cached = this.getAppendTextInput(targetDevice);
-    const run = async (input: AppendTextInput, pending: string, timeoutMs: number) =>
+    const run = async (
+      input: AppendTextInput,
+      pending: string,
+      timeoutMs: number,
+      validate: typeof beforeKeyEvent,
+    ) =>
       signal
-        ? await input.appendText(pending, timeoutMs, beforeKeyEvent, signal)
-        : await input.appendText(pending, timeoutMs, beforeKeyEvent);
-    const result = await run(cached.input, text, appendTimeoutMs);
+        ? await input.appendText(pending, timeoutMs, validate, signal)
+        : await input.appendText(pending, timeoutMs, validate);
+    const result = await run(cached.input, text, appendTimeoutMs, beforeKeyEvent);
     if (result.success || !cached.fromCache || signal?.aborted) {
       return result;
     }
@@ -3956,7 +3961,17 @@ export class UnixSocketServer {
     if (retryTimeoutMs <= 0) {
       return result;
     }
-    const retry = await run(this.getAppendTextInput(targetDevice).input, pending, retryTimeoutMs);
+    // No frame validator on the retry. This is the SAME logical append: the
+    // original call already validated `frameContext` before its first key event,
+    // and the confirmed prefix has since emitted TYPE_VIEW_TEXT_CHANGED, which
+    // advances the runner's frame epoch. Re-validating here would reject a
+    // suffix that is safe to type (#6863 review).
+    const retry = await run(
+      this.getAppendTextInput(targetDevice).input,
+      pending,
+      retryTimeoutMs,
+      undefined,
+    );
     // Progress accumulates across both helpers so the caller's retry boundary
     // stays an index into the ORIGINAL text; an ambiguous retry poisons the
     // whole count, so it reports no boundary at all.

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -69,6 +69,7 @@ import { InputText, type AppendKeyEventValidator } from "../features/action/Inpu
 import { getCurrentBuildIdentity } from "./buildIdentity";
 import { DaemonState } from "./daemonState";
 import { DaemonStateAccess, handleDaemonRequest } from "./daemonRequestHandlers";
+import { deviceIncarnationToken } from "../utils/deviceIncarnation";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { type IdGenerator, defaultIdGenerator } from "../utils/IdGenerator";
 import type { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
@@ -349,7 +350,14 @@ export interface AppendTextInput {
 
 interface CachedAppendTextInput {
   input: AppendTextInput;
-  transportId?: string;
+  /**
+   * Pool connection epoch this helper was built for (see
+   * `utils/deviceIncarnation.ts`). `undefined` means no pool could answer, in
+   * which case the entry is still reused -- {@link
+   * UnixSocketServer.evictDeviceInputCache} and the append self-heal are the
+   * safeguards, not a rebuild on every keystroke.
+   */
+  incarnationToken: string | undefined;
 }
 
 interface BoundMcpClient {
@@ -3853,10 +3861,27 @@ export class UnixSocketServer {
       frameContext === undefined
         ? undefined
         : () => this.validateAppendFrameContext(client, frameContext, deadline, totalTimeoutMs);
-    const input = this.getAppendTextInput(targetDevice);
-    return signal
-      ? await input.appendText(text, appendTimeoutMs, beforeKeyEvent, signal)
-      : await input.appendText(text, appendTimeoutMs, beforeKeyEvent);
+    const cached = this.getAppendTextInput(targetDevice);
+    const run = async (input: AppendTextInput, timeoutMs: number) =>
+      signal
+        ? await input.appendText(text, timeoutMs, beforeKeyEvent, signal)
+        : await input.appendText(text, timeoutMs, beforeKeyEvent);
+    const result = await run(cached.input, appendTimeoutMs);
+    if (result.success || !cached.fromCache || signal?.aborted) {
+      return result;
+    }
+    // Self-heal: without an ADB transport id there is nothing that proves a
+    // cached helper still belongs to the device now on this serial, and a
+    // restart faster than one discovery interval leaves the pool incarnation
+    // unchanged. A failure is the first evidence either way, so drop the helper
+    // and give a freshly built one exactly one attempt before surfacing the
+    // error.
+    this.evictDeviceInputCache(targetDevice.deviceId);
+    const retryTimeoutMs = deadline - this.timer.now();
+    if (retryTimeoutMs <= 0) {
+      return result;
+    }
+    return await run(this.getAppendTextInput(targetDevice).input, retryTimeoutMs);
   }
 
   private async validateAppendFrameContext(
@@ -4793,21 +4818,31 @@ export class UnixSocketServer {
     }
   }
 
-  /** Cached-per-device accessor for the append helper; see {@link appendTextInputs}. */
-  private getAppendTextInput(device: BootedDevice): AppendTextInput {
+  /**
+   * Cached-per-device accessor for the append helper; see
+   * {@link appendTextInputs}. Keyed on the pool's connection epoch so a
+   * same-serial reincarnation cannot inherit the previous device's probed API
+   * level. `fromCache` tells the caller whether a failure is worth retrying
+   * against a freshly built helper.
+   */
+  private getAppendTextInput(device: BootedDevice): {
+    input: AppendTextInput;
+    fromCache: boolean;
+  } {
+    const incarnationToken = deviceIncarnationToken(device.deviceId);
     const existing = this.appendTextInputs.get(device.deviceId);
-    if (existing?.transportId !== undefined && device.transportId === existing.transportId) {
-      return existing.input;
+    if (existing && existing.incarnationToken === incarnationToken) {
+      return { input: existing.input, fromCache: true };
     }
     if (existing) {
       logger.debug(
         `[UnixSocketServer] Rebuilding cached append helper for ${device.deviceId}: ` +
-          `ADB transport changed from ${existing.transportId} to ${device.transportId}`,
+          `pool incarnation changed from ${existing.incarnationToken} to ${incarnationToken}`,
       );
     }
     const created = this.appendTextFactory(device);
-    this.appendTextInputs.set(device.deviceId, { input: created, transportId: device.transportId });
-    return created;
+    this.appendTextInputs.set(device.deviceId, { input: created, incarnationToken });
+    return { input: created, fromCache: false };
   }
 
   /**

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -3948,24 +3948,50 @@ export class UnixSocketServer {
         ? await input.appendText(pending, timeoutMs, validate, signal)
         : await input.appendText(pending, timeoutMs, validate);
     const result = await run(cached.input, text, appendTimeoutMs, beforeKeyEvent);
-    if (result.success || !cached.fromCache || signal?.aborted) {
+    if (
+      result.success ||
+      !cached.fromCache ||
+      signal?.aborted ||
+      // A verdict from the RUNNER is not evidence about the helper. The helper
+      // worked; the device-side answer was "no" (a stale `frameContext`, say).
+      // Rebuilding and replaying would type the whole string into a UI the
+      // runner explicitly refused, so the verdict is surfaced exactly as it came
+      // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+      result.failureSource === "runner"
+    ) {
       return result;
     }
-    // A verdict from the RUNNER is not evidence about the helper. The helper
-    // worked; the device-side answer was "no" (a stale `frameContext`, say).
-    // Rebuilding and replaying would type the whole string into a UI the runner
-    // explicitly refused, so the verdict is surfaced exactly as it came
-    // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
-    if (result.failureSource === "runner") {
-      return result;
-    }
-    // Self-heal, for HELPER failures only: without an ADB transport id there is
-    // nothing that proves a cached helper still belongs to the device now on
-    // this serial, and a restart faster than one discovery interval leaves the
-    // pool incarnation unchanged. A helper failure is the first evidence either
-    // way, so drop the helper and give a freshly built one exactly one attempt
-    // before surfacing the error.
-    //
+    return await this.retryAppendTextWithRebuiltHelper(
+      targetDevice,
+      text,
+      result,
+      deadline,
+      beforeKeyEvent,
+      run,
+    );
+  }
+
+  /**
+   * Self-heal, for HELPER failures only: without an ADB transport id there is
+   * nothing that proves a cached helper still belongs to the device now on this
+   * serial, and a restart faster than one discovery interval leaves the pool
+   * incarnation unchanged. A helper failure is the first evidence either way, so
+   * drop the helper and give a freshly built one exactly one attempt before
+   * surfacing the error. A RUNNER verdict never reaches here.
+   */
+  private async retryAppendTextWithRebuiltHelper(
+    targetDevice: BootedDevice,
+    text: string,
+    result: Awaited<ReturnType<AppendTextInput["appendText"]>>,
+    deadline: number,
+    beforeKeyEvent: AppendKeyEventValidator | undefined,
+    run: (
+      input: AppendTextInput,
+      pending: string,
+      timeoutMs: number,
+      validate: AppendKeyEventValidator | undefined,
+    ) => Promise<Awaited<ReturnType<AppendTextInput["appendText"]>>>,
+  ): Promise<{ success: boolean; error?: string; charsSent?: number }> {
     // The retry resumes from the UNCONFIRMED SUFFIX only. `charsSent` is the
     // exact prefix the failed helper landed on the device, so replaying the whole
     // string would duplicate it ("AB" after "A" becomes "AAB", issue #3351). An
@@ -4012,7 +4038,7 @@ export class UnixSocketServer {
     frameContext: string,
     deadline: number,
     totalTimeoutMs: number,
-  ): Promise<{ success: boolean; error?: string }> {
+  ): Promise<{ success: boolean; error?: string; failureSource?: AppendTextFailureSource }> {
     const validationTimeoutMs = deadline - this.timer.now();
     if (validationTimeoutMs <= 0) {
       return {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -120,7 +120,12 @@ import { canonicalPixelsToPoints } from "./canonicalPixels";
 import { ActionableError, toActionableError } from "../models/ActionableError";
 import { getDeviceDataStreamServer } from "./deviceDataStreamSocketServer";
 import type { KeyValueType } from "../features/storage/storageTypes";
-import type { BootedDevice, ImeAction, ScreenScaleMetadata } from "../models";
+import type {
+  AppendTextFailureSource,
+  BootedDevice,
+  ImeAction,
+  ScreenScaleMetadata,
+} from "../models";
 import type { DeviceService } from "../features/observe/DeviceService";
 import { executionTracker } from "../server/executionTracker";
 import {
@@ -346,7 +351,18 @@ export interface AppendTextInput {
     timeoutMs?: number,
     beforeKeyEvent?: AppendKeyEventValidator,
     signal?: AbortSignal,
-  ): Promise<{ success: boolean; error?: string; charsSent?: number }>;
+  ): Promise<{
+    success: boolean;
+    error?: string;
+    charsSent?: number;
+    /**
+     * Who produced a failure -- see {@link AppendTextFailureSource}. Absent
+     * means the helper. The self-heal in
+     * {@link UnixSocketServer.executeAndroidAppendText} keys on this rather than
+     * on `charsSent === 0`, which cannot tell the two apart.
+     */
+    failureSource?: AppendTextFailureSource;
+  }>;
 }
 
 interface CachedAppendTextInput {
@@ -3935,12 +3951,20 @@ export class UnixSocketServer {
     if (result.success || !cached.fromCache || signal?.aborted) {
       return result;
     }
-    // Self-heal: without an ADB transport id there is nothing that proves a
-    // cached helper still belongs to the device now on this serial, and a
-    // restart faster than one discovery interval leaves the pool incarnation
-    // unchanged. A failure is the first evidence either way, so drop the helper
-    // and give a freshly built one exactly one attempt before surfacing the
-    // error.
+    // A verdict from the RUNNER is not evidence about the helper. The helper
+    // worked; the device-side answer was "no" (a stale `frameContext`, say).
+    // Rebuilding and replaying would type the whole string into a UI the runner
+    // explicitly refused, so the verdict is surfaced exactly as it came
+    // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+    if (result.failureSource === "runner") {
+      return result;
+    }
+    // Self-heal, for HELPER failures only: without an ADB transport id there is
+    // nothing that proves a cached helper still belongs to the device now on
+    // this serial, and a restart faster than one discovery interval leaves the
+    // pool incarnation unchanged. A helper failure is the first evidence either
+    // way, so drop the helper and give a freshly built one exactly one attempt
+    // before surfacing the error.
     //
     // The retry resumes from the UNCONFIRMED SUFFIX only. `charsSent` is the
     // exact prefix the failed helper landed on the device, so replaying the whole
@@ -3961,16 +3985,19 @@ export class UnixSocketServer {
     if (retryTimeoutMs <= 0) {
       return result;
     }
-    // No frame validator on the retry. This is the SAME logical append: the
-    // original call already validated `frameContext` before its first key event,
-    // and the confirmed prefix has since emitted TYPE_VIEW_TEXT_CHANGED, which
-    // advances the runner's frame epoch. Re-validating here would reject a
-    // suffix that is safe to type (#6863 review).
+    // The validator travels with the retry only when NOTHING was confirmed:
+    // there, no key event landed, the original validation was never spent, and
+    // the rebuilt helper is starting the same append over. Once a prefix IS
+    // confirmed this is a RESUME of the same logical append -- the original call
+    // already validated `frameContext` before its first key event, and the
+    // confirmed prefix has since emitted TYPE_VIEW_TEXT_CHANGED, which advances
+    // the runner's frame epoch, so re-validating would reject a suffix that is
+    // safe to type ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
     const retry = await run(
       this.getAppendTextInput(targetDevice).input,
       pending,
       retryTimeoutMs,
-      undefined,
+      confirmed === 0 ? beforeKeyEvent : undefined,
     );
     // Progress accumulates across both helpers so the caller's retry boundary
     // stays an index into the ORIGINAL text; an ambiguous retry poisons the
@@ -4001,6 +4028,10 @@ export class UnixSocketServer {
           error:
             validation.error ??
             "Frame context is stale or unavailable; observe a fresh frame before retrying",
+          // The runner answered, and the answer is "no". That is a verdict about
+          // the DEVICE, so the caller must not treat it as a stale helper and
+          // replay the text through a rebuilt one (#6863 review).
+          failureSource: "runner",
         };
   }
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -3922,11 +3922,11 @@ export class UnixSocketServer {
         ? undefined
         : () => this.validateAppendFrameContext(client, frameContext, deadline, totalTimeoutMs);
     const cached = this.getAppendTextInput(targetDevice);
-    const run = async (input: AppendTextInput, timeoutMs: number) =>
+    const run = async (input: AppendTextInput, pending: string, timeoutMs: number) =>
       signal
-        ? await input.appendText(text, timeoutMs, beforeKeyEvent, signal)
-        : await input.appendText(text, timeoutMs, beforeKeyEvent);
-    const result = await run(cached.input, appendTimeoutMs);
+        ? await input.appendText(pending, timeoutMs, beforeKeyEvent, signal)
+        : await input.appendText(pending, timeoutMs, beforeKeyEvent);
+    const result = await run(cached.input, text, appendTimeoutMs);
     if (result.success || !cached.fromCache || signal?.aborted) {
       return result;
     }
@@ -3936,12 +3936,33 @@ export class UnixSocketServer {
     // unchanged. A failure is the first evidence either way, so drop the helper
     // and give a freshly built one exactly one attempt before surfacing the
     // error.
+    //
+    // The retry resumes from the UNCONFIRMED SUFFIX only. `charsSent` is the
+    // exact prefix the failed helper landed on the device, so replaying the whole
+    // string would duplicate it ("AB" after "A" becomes "AAB", issue #3351). An
+    // ABSENT `charsSent` means the helper cannot say whether its in-flight key
+    // event landed (an adb timeout kills the host child, not Android's handling
+    // of the event), which makes every replay unsafe: surface the failure.
+    const confirmed = result.charsSent;
+    if (confirmed === undefined) {
+      return result;
+    }
+    const pending = text.slice(confirmed);
+    if (pending.length === 0) {
+      return result;
+    }
     this.evictDeviceInputCache(targetDevice.deviceId);
     const retryTimeoutMs = deadline - this.timer.now();
     if (retryTimeoutMs <= 0) {
       return result;
     }
-    return await run(this.getAppendTextInput(targetDevice).input, retryTimeoutMs);
+    const retry = await run(this.getAppendTextInput(targetDevice).input, pending, retryTimeoutMs);
+    // Progress accumulates across both helpers so the caller's retry boundary
+    // stays an index into the ORIGINAL text; an ambiguous retry poisons the
+    // whole count, so it reports no boundary at all.
+    return retry.charsSent === undefined
+      ? { success: retry.success, ...(retry.error !== undefined ? { error: retry.error } : {}) }
+      : { ...retry, charsSent: confirmed + retry.charsSent };
   }
 
   private async validateAppendFrameContext(

--- a/src/daemon/telemetryPushSocketServer.ts
+++ b/src/daemon/telemetryPushSocketServer.ts
@@ -15,7 +15,11 @@ import type { Kysely } from "kysely";
 import { TELEMETRY_PUSH_SOCKET_CONFIG } from "./daemonFiles";
 import { truncateBodyText, boundStructuredField } from "../utils/truncateBodyText";
 import { buildNavigationNodeScreenshotUri } from "../utils/navigationResourceUri";
-import { type DeviceSessionResolver, nullDeviceSessionResolver } from "./deviceSessionResolver";
+import {
+  type DeviceSessionResolver,
+  nullDeviceSessionResolver,
+  SuspendedDeviceRoutingLog,
+} from "./deviceSessionResolver";
 
 /**
  * Opaque plain-text fields that the backfill fans out (limit=100) and that can
@@ -115,6 +119,7 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
   TelemetryEvent
 > {
   private deviceSessionResolver: DeviceSessionResolver = nullDeviceSessionResolver;
+  private readonly suspendedRoutingLog = new SuspendedDeviceRoutingLog();
 
   constructor(
     socketPath: string = getSocketPath(TELEMETRY_PUSH_SOCKET_CONFIG),
@@ -137,6 +142,18 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
   }
 
   pushTelemetryEvent(event: TelemetryEvent): void {
+    if (
+      event.deviceId &&
+      this.suspendedRoutingLog.shouldDropFrame(
+        this.deviceSessionResolver,
+        event.deviceId,
+        "TelemetryPush",
+      )
+    ) {
+      // Quarantined pooled identity: the serial is the event's only attribution
+      // and it is exactly what is in doubt, so nobody may receive it (#6863 review).
+      return;
+    }
     const stamped = this.stampDeviceSession(event);
     const sentCount = this.pushToSubscribers(stamped);
     if (sentCount > 0) {

--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -7,7 +7,10 @@ import { AwaitIdle } from "../observe/AwaitIdle";
 import { RealObserveScreen } from "../observe/ObserveScreen";
 import type { ObserveScreen } from "../observe/interfaces/ObserveScreen";
 import { Window } from "../observe/Window";
-import { isForegroundLauncher } from "../observe/androidLauncherPackages";
+import {
+  clearResolvedHomePackageCache,
+  isForegroundLauncher,
+} from "../observe/androidLauncherPackages";
 import { logger } from "../../utils/logger";
 import { errorMessage } from "../../utils/describeUnknownError";
 import { DEFAULT_FUZZY_MATCH_TOLERANCE_PERCENT } from "../../utils/constants";
@@ -606,6 +609,32 @@ export class BaseVisualChange {
       retryDelaysMs?: readonly number[];
     } = {},
   ): Promise<boolean> {
+    const verified = await this.readAndroidHomeForeground(options);
+    if (!verified) {
+      // Self-heal a launcher cache that may no longer describe this device
+      // (issue #6863 review). The cached configured-HOME package is
+      // invalidated by a connection-epoch change, but in direct mode no
+      // incarnation resolver is registered, so a reconnect or a reused serial
+      // leaves the entry looking valid. A failed verification is the only
+      // evidence available that the cached package may be the previous
+      // runtime's, so drop it and let the next press re-resolve rather than
+      // keep reporting real Home presses as failures. A cancellation rethrows
+      // above and never reaches here -- an aborted read is not evidence.
+      clearResolvedHomePackageCache(this.device.deviceId);
+    }
+    return verified;
+  }
+
+  /**
+   * The retry loop behind {@link verifyAndroidHomeForeground}. Split out so the
+   * failure path has exactly one place to self-heal the launcher cache,
+   * regardless of which of the loop's several `return false` exits was taken.
+   */
+  private async readAndroidHomeForeground(options: {
+    signal?: AbortSignal;
+    timeoutMs?: number;
+    retryDelaysMs?: readonly number[];
+  }): Promise<boolean> {
     // Combine explicit + ambient ONCE so the reads and the abort classification
     // below observe the SAME signal (issue #6289): on the ambient-only route the
     // explicit signal is undefined, so checking it alone would miss the abort.

--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -612,7 +612,7 @@ export class BaseVisualChange {
     const verified = await this.readAndroidHomeForeground(options);
     if (!verified) {
       // Self-heal a launcher cache that may no longer describe this device
-      // (issue #6863 review). The cached configured-HOME package is
+      // (#6863 review). The cached configured-HOME package is
       // invalidated by a connection-epoch change, but in direct mode no
       // incarnation resolver is registered, so a reconnect or a reused serial
       // leaves the entry looking valid. A failed verification is the only

--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -30,6 +30,7 @@ import { sequenceBackoff } from "../../utils/Backoff";
 import { getDeviceDataStreamServer } from "../../daemon/deviceDataStreamSocketServer";
 import { shouldSkipActionObservationScreenshot } from "../observe/automaticScreenshotPolicy";
 import { serverConfig } from "../../utils/ServerConfig";
+import { deviceIncarnationToken } from "../../utils/deviceIncarnation";
 
 export interface ProgressCallback {
   (progress: number, total?: number, message?: string): Promise<void>;
@@ -642,7 +643,7 @@ export class BaseVisualChange {
           this.adb,
           this.device.deviceId,
           this.timer,
-          this.device.transportId,
+          deviceIncarnationToken(this.device.deviceId),
           signal,
           remainingMs(),
         );

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -1,6 +1,7 @@
 import { errorMessage } from "../../utils/describeUnknownError";
 import { BaseVisualChange } from "./BaseVisualChange";
 import {
+  type AppendTextFailureSource,
   BootedDevice,
   ImeAction,
   KeyboardResult,
@@ -79,9 +80,17 @@ const defaultTargetFocuserFactory: TextInputTargetFocuserFactory = (device) => (
   },
 });
 
+/**
+ * Runs once, immediately before the append's FIRST key event, to confirm the
+ * device is still in the state the caller observed.
+ *
+ * A rejection carries a {@link AppendTextFailureSource} so the caller can tell a
+ * RUNNER verdict about the device apart from a host-side failure of the check
+ * itself; the append propagates it verbatim on the failed result.
+ */
 export type AppendKeyEventValidator = (
   timeoutMs?: number,
-) => Promise<{ success: boolean; error?: string }>;
+) => Promise<{ success: boolean; error?: string; failureSource?: AppendTextFailureSource }>;
 
 interface KeyboardCloser {
   close(signal?: AbortSignal): Promise<KeyboardResult>;
@@ -636,7 +645,7 @@ export class InputText extends BaseVisualChange {
     if (typed.error) {
       // A non-timeout failure leaves an exact confirmed prefix, while a timed-out
       // key event is ambiguous: Android may have accepted it before adb was killed.
-      return this.appendFailure(text, typed.error, typed.charsSent);
+      return this.appendFailure(text, typed.error, typed.charsSent, undefined, typed.failureSource);
     }
 
     // IME action before dismiss — see the a11y path for why (issue #5887).
@@ -731,7 +740,7 @@ export class InputText extends BaseVisualChange {
     timeoutMs: number | undefined,
     beforeKeyEvents?: AppendKeyEventValidator,
     signal?: AbortSignal,
-  ): Promise<{ charsSent?: number; error?: string }> {
+  ): Promise<{ charsSent?: number; error?: string; failureSource?: AppendTextFailureSource }> {
     let charsSent = 0;
     for (const plan of plans) {
       assertInputNotAborted(signal);
@@ -740,6 +749,7 @@ export class InputText extends BaseVisualChange {
         return { charsSent, error: this.appendBudgetExceeded(timeoutMs, "typing") };
       }
       let validationError: string | undefined;
+      let validationFailureSource: AppendTextFailureSource | undefined;
       const beforeDispatch =
         charsSent === 0 && beforeKeyEvents
           ? async (remainingTimeoutMs?: number) => {
@@ -750,6 +760,7 @@ export class InputText extends BaseVisualChange {
                   validationError =
                     validation.error ??
                     "Frame context is stale or unavailable; observe a fresh frame before retrying";
+                  validationFailureSource = validation.failureSource;
                 }
               } catch (error) {
                 const message = errorMessage(error);
@@ -779,7 +790,13 @@ export class InputText extends BaseVisualChange {
       } catch (error) {
         assertInputNotAborted(signal);
         if (validationError) {
-          return { charsSent, error: validationError };
+          return {
+            charsSent,
+            error: validationError,
+            ...(validationFailureSource !== undefined
+              ? { failureSource: validationFailureSource }
+              : {}),
+          };
         }
         const message = errorMessage(error);
         logger.warn(
@@ -855,6 +872,7 @@ export class InputText extends BaseVisualChange {
     error: string,
     charsSent?: number,
     imeAction?: ImeAction,
+    failureSource?: AppendTextFailureSource,
   ): SendTextResult & { method?: InputTextMode } {
     return {
       success: false,
@@ -863,6 +881,7 @@ export class InputText extends BaseVisualChange {
       method: "append",
       ...(imeAction !== undefined ? { imeAction } : {}),
       ...(charsSent !== undefined ? { charsSent } : {}),
+      ...(failureSource !== undefined ? { failureSource } : {}),
     };
   }
 

--- a/src/features/observe/androidLauncherPackages.ts
+++ b/src/features/observe/androidLauncherPackages.ts
@@ -77,6 +77,27 @@ const FALLBACK_LAUNCHER_PACKAGES: ReadonlySet<string> = new Set([
  */
 const RESOLVED_HOME_PACKAGE_TTL_MS = 30_000;
 
+/**
+ * How long a resolved HOME launcher package stays valid when NO connection
+ * epoch token is available (issue #6863 review). The 30-second TTL above is
+ * only safe because an incarnation change invalidates the entry; outside a
+ * daemon -- direct mode, or any caller with no pool to ask -- the token is
+ * always undefined, and two undefined tokens compare equal, so a same-serial
+ * reconnect or a reused emulator serial would be served the PREVIOUS
+ * runtime's launcher for the rest of the window and report a successful Home
+ * press as failed.
+ *
+ * Rather than bypass the cache entirely (which would re-query `cmd package
+ * resolve-activity` on every verification retry, several times per Home
+ * press), an untokened entry lives only long enough to serve the retries of
+ * the single verification that resolved it: a device swap needs the old
+ * device to disconnect and a new one to boot, which is orders of magnitude
+ * slower than this. `verifyAndroidHomeForeground` additionally evicts the
+ * entry whenever a verification fails, so even within this window a stale
+ * package self-heals on the next attempt.
+ */
+const UNTOKENED_RESOLVED_HOME_PACKAGE_TTL_MS = 2_000;
+
 interface ResolvedHomePackageCacheEntry {
   packageName: string;
   resolvedAtMs: number;
@@ -126,11 +147,13 @@ function parseResolvedHomePackage(stdout: string): string | null {
 }
 
 /**
- * The cached package name, but only when it is still within
- * {@link RESOLVED_HOME_PACKAGE_TTL_MS} of `now` AND was resolved under the
- * same `incarnationToken`. Returns undefined for "no cache entry", "cache
- * entry expired", and "cache entry belongs to a superseded incarnation" --
- * the caller re-resolves in all three cases.
+ * The cached package name, but only when it is still within its lifetime
+ * ({@link RESOLVED_HOME_PACKAGE_TTL_MS}, or the much shorter
+ * {@link UNTOKENED_RESOLVED_HOME_PACKAGE_TTL_MS} when no epoch token is
+ * available) of `now` AND was resolved under the same `incarnationToken`.
+ * Returns undefined for "no cache entry", "cache entry expired", and "cache
+ * entry belongs to a superseded incarnation" -- the caller re-resolves in all
+ * three cases.
  */
 function freshCachedPackageName(
   cached: ResolvedHomePackageCacheEntry | undefined,
@@ -140,7 +163,13 @@ function freshCachedPackageName(
   if (cached === undefined || cached.incarnationToken !== incarnationToken) {
     return undefined;
   }
-  return now - cached.resolvedAtMs < RESOLVED_HOME_PACKAGE_TTL_MS ? cached.packageName : undefined;
+  // Without a token there is nothing to notice a reincarnation with, so the
+  // entry cannot be trusted for a full TTL.
+  const ttlMs =
+    incarnationToken === undefined
+      ? UNTOKENED_RESOLVED_HOME_PACKAGE_TTL_MS
+      : RESOLVED_HOME_PACKAGE_TTL_MS;
+  return now - cached.resolvedAtMs < ttlMs ? cached.packageName : undefined;
 }
 
 /**
@@ -156,10 +185,12 @@ function freshCachedPackageName(
  *   (same `deviceId`, new incarnation -- a reused Android serial such as
  *   `emulator-5554` picked up by a fresh AVD within the TTL) is treated as a
  *   cache miss and re-resolved, instead of serving the previous incarnation's
- *   launcher. Omit to keep the previous serial-only keying (e.g. callers with
- *   no incarnation info available). A restart faster than one discovery
- *   interval leaves the incarnation unchanged, so this narrows the window --
- *   it does not close it.
+ *   launcher. Omit when no incarnation info is available (direct mode, or a
+ *   caller with no pool to ask): the entry is then keyed on the serial alone
+ *   and, because nothing can notice a reincarnation, only lives for
+ *   {@link UNTOKENED_RESOLVED_HOME_PACKAGE_TTL_MS}. A restart faster than one
+ *   discovery interval leaves the incarnation unchanged, so this narrows the
+ *   window -- it does not close it.
  * @param timeoutMs - Optional remaining budget for the resolve command. When
  *   provided the ADB query is bounded to `min(RESOLVE_HOME_TIMEOUT_MS,
  *   timeoutMs)` so a caller spending a shrinking request deadline (e.g. home

--- a/src/features/observe/androidLauncherPackages.ts
+++ b/src/features/observe/androidLauncherPackages.ts
@@ -79,7 +79,7 @@ const RESOLVED_HOME_PACKAGE_TTL_MS = 30_000;
 
 /**
  * How long a resolved HOME launcher package stays valid when NO connection
- * epoch token is available (issue #6863 review). The 30-second TTL above is
+ * epoch token is available (#6863 review). The 30-second TTL above is
  * only safe because an incarnation change invalidates the entry; outside a
  * daemon -- direct mode, or any caller with no pool to ask -- the token is
  * always undefined, and two undefined tokens compare equal, so a same-serial

--- a/src/features/observe/androidLauncherPackages.ts
+++ b/src/features/observe/androidLauncherPackages.ts
@@ -238,7 +238,12 @@ export async function resolveConfiguredHomePackage(
     if (packageName) {
       resolvedHomePackageCache.set(deviceId, {
         packageName,
-        resolvedAtMs: now,
+        // Stamp the entry with the clock AFTER the resolve, never the `now`
+        // read before it: the TTL measures the age of this ANSWER. A resolve
+        // slower than the (short) untokened lifetime would otherwise write an
+        // entry that is already expired, so the next verification retry
+        // re-resolves and eats the caller's remaining deadline (#6863 review).
+        resolvedAtMs: timer.now(),
         incarnationToken,
       });
     }

--- a/src/features/observe/androidLauncherPackages.ts
+++ b/src/features/observe/androidLauncherPackages.ts
@@ -81,9 +81,10 @@ interface ResolvedHomePackageCacheEntry {
   packageName: string;
   resolvedAtMs: number;
   /**
-   * The device CONNECTION EPOCH this entry was resolved under, e.g.
-   * `BootedDevice.transportId` -- undefined when the caller has no
-   * incarnation info to offer. Android serials are reused across connection
+   * The device CONNECTION EPOCH this entry was resolved under -- the device
+   * pool's `incarnation` counter, read through
+   * `utils/deviceIncarnation.ts`; undefined when no pool can answer (direct
+   * mode, or a caller with no incarnation info to offer). Android serials are reused across connection
    * epochs (see `daemon/deviceSessionRegistry.ts`; e.g. a fresh AVD taking
    * over `emulator-5554` within the TTL below), so keying this cache on
    * `deviceId` alone lets a same-serial reincarnation serve the PREVIOUS
@@ -150,12 +151,15 @@ function freshCachedPackageName(
  * must fall back to {@link isFallbackLauncherPackage} in that case.
  *
  * @param incarnationToken - A discriminator for the device's current
- *   connection epoch, e.g. `BootedDevice.transportId`. A cached entry
- *   resolved under a DIFFERENT token (same `deviceId`, new incarnation -- a
- *   reused Android serial such as `emulator-5554` picked up by a fresh AVD
- *   within the TTL) is treated as a cache miss and re-resolved, instead of
- *   serving the previous incarnation's launcher. Omit to keep the previous
- *   serial-only keying (e.g. callers with no incarnation info available).
+ *   connection epoch: the device pool's `incarnation` counter, stringified by
+ *   `deviceIncarnationToken`. A cached entry resolved under a DIFFERENT token
+ *   (same `deviceId`, new incarnation -- a reused Android serial such as
+ *   `emulator-5554` picked up by a fresh AVD within the TTL) is treated as a
+ *   cache miss and re-resolved, instead of serving the previous incarnation's
+ *   launcher. Omit to keep the previous serial-only keying (e.g. callers with
+ *   no incarnation info available). A restart faster than one discovery
+ *   interval leaves the incarnation unchanged, so this narrows the window --
+ *   it does not close it.
  * @param timeoutMs - Optional remaining budget for the resolve command. When
  *   provided the ADB query is bounded to `min(RESOLVE_HOME_TIMEOUT_MS,
  *   timeoutMs)` so a caller spending a shrinking request deadline (e.g. home
@@ -247,9 +251,9 @@ export function isFallbackLauncherPackage(appId: string | null | undefined): boo
  * fallback launcher package otherwise.
  *
  * @param incarnationToken - Forwarded to {@link resolveConfiguredHomePackage}
- *   -- see its doc for why a device's connection-epoch discriminator (e.g.
- *   `BootedDevice.transportId`) must be supplied to avoid serving a reused
- *   serial's stale cached launcher.
+ *   -- see its doc for why a device's connection-epoch discriminator (the pool
+ *   incarnation, via `deviceIncarnationToken`) must be supplied to avoid
+ *   serving a reused serial's stale cached launcher.
  * @param timeoutMs - Optional remaining budget forwarded to
  *   {@link resolveConfiguredHomePackage} so the launcher lookup shares the
  *   caller's deadline instead of always taking the full resolve default.

--- a/src/models/DeviceInfo.ts
+++ b/src/models/DeviceInfo.ts
@@ -36,8 +36,6 @@ export interface BootedDevice {
    * stamp.
    */
   observedAt?: number;
-  /** ADB transport identity, which changes when a serial reconnects. */
-  transportId?: string;
   source?: "local";
   iosVersion?: string;
   osVersion?: string;

--- a/src/models/SendTextResult.ts
+++ b/src/models/SendTextResult.ts
@@ -1,6 +1,24 @@
 import { BaseActionResult } from "./BaseActionResult";
 
 /**
+ * WHO produced an append failure.
+ *
+ * `"runner"` -- the device-side runner answered with a VERDICT about the device
+ * (a stale `frameContext`, say). The helper worked; the answer is "no".
+ * `"helper"` -- the host-side helper could not complete the call at all (it
+ * threw, its transport died, or it is a stale cached helper bound to a device
+ * that is no longer there). Absent means the same as `"helper"`.
+ *
+ * The daemon's cached-helper self-heal (`UnixSocketServer.executeAndroidAppendText`)
+ * turns on exactly this distinction: a HELPER failure is the first evidence the
+ * cached helper is stale, so it is evicted, rebuilt and given one more attempt;
+ * a RUNNER verdict is about the device state, and rebuilding and replaying would
+ * type into a UI the runner explicitly refused
+ * ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+ */
+export type AppendTextFailureSource = "runner" | "helper";
+
+/**
  * Result of a send text operation
  */
 export interface SendTextResult extends BaseActionResult {
@@ -20,4 +38,9 @@ export interface SendTextResult extends BaseActionResult {
    * (== full length) and some failed append results; omitted by non-append modes.
    */
   charsSent?: number;
+  /**
+   * For the Android `append` mode only: who produced this failure. See
+   * {@link AppendTextFailureSource}; omitted on success and by non-append modes.
+   */
+  failureSource?: AppendTextFailureSource;
 }

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -175,8 +175,9 @@ interface PoolDeviceInfo {
   recoveryEligibility: DeviceRecoveryEligibility;
   /**
    * The AVD this pool started on the serial, and the epoch of that allocation.
-   * Both are present ONLY when the pooled entry describes the runtime discovery
-   * just reported on the serial; see {@link getPoolDeviceInfo}.
+   * The whole {@link PoolDeviceContext} -- these two included -- exists ONLY
+   * when the pooled entry describes the runtime discovery just reported on the
+   * serial; see {@link resolvePoolDeviceContext}.
    */
   avdName?: string;
   incarnation?: number;
@@ -311,10 +312,9 @@ async function getDeviceLockStates(): Promise<ResourceContent> {
 // Convert BootedDevice to BootedDeviceInfo
 function toBootedDeviceInfo(
   device: BootedDevice,
-  poolInfo?: PoolDeviceInfo,
-  sessionInfo?: DeviceSessionInfo,
-  deviceSessionUuid?: string | null,
+  poolContext?: PoolDeviceContext,
 ): BootedDeviceInfo {
+  const poolInfo = poolContext?.poolInfo;
   const isVirtual = isVirtualDevice(device);
   const runtime = device.iosVersion ?? device.osVersion;
   const info: BootedDeviceInfo = {
@@ -330,8 +330,8 @@ function toBootedDeviceInfo(
     capabilities: { automation: null },
   };
 
-  if (deviceSessionUuid) {
-    info.deviceSessionUuid = deviceSessionUuid;
+  if (poolContext?.deviceSessionUuid) {
+    info.deviceSessionUuid = poolContext.deviceSessionUuid;
   }
   if (runtime) {
     info.runtime = runtime;
@@ -344,8 +344,8 @@ function toBootedDeviceInfo(
     info.assignedSession = poolInfo.assignedSession;
     info.recoveryEligibility = poolInfo.recoveryEligibility;
   }
-  if (sessionInfo) {
-    info.session = sessionInfo;
+  if (poolContext?.sessionInfo) {
+    info.session = poolContext.sessionInfo;
   }
   return info;
 }
@@ -386,39 +386,56 @@ function isVirtualDevice(device: BootedDevice): boolean {
   return device.deviceId.includes("-") && device.deviceId.length > 30;
 }
 
-function getPoolDeviceInfo(
+/**
+ * Everything the resource publishes about WHICH RUNTIME is on a serial, resolved
+ * as ONE unit so it can be withheld as one.
+ *
+ * The join to daemon state is by serial alone, and a different device can hold
+ * that serial before the pool refreshes -- or the emulator console can have gone
+ * quiet, leaving discovery with the `Unknown (<serial>)` placeholder, which
+ * asserts nothing either way. Naming the retired entry's epoch would tell
+ * consumers to keep state exactly when the new epoch is supposed to make them
+ * flush it; naming its AVD would publish the previous occupant's label as this
+ * runtime's `stableId`; and handing out the retired `deviceSessionUuid` would
+ * have the desktop subscribe to this runtime's streams under a dead epoch. So
+ * `describesPooledRuntime` gates the pool entry, the session and the registry
+ * epoch TOGETHER: on a mismatch the entry carries no pool context at all and its
+ * identity is built purely from discovery (#6863 review).
+ */
+interface PoolDeviceContext {
+  poolInfo: PoolDeviceInfo;
+  sessionInfo?: DeviceSessionInfo;
+  deviceSessionUuid?: string;
+}
+
+function resolvePoolDeviceContext(
   devicePool: DevicePool | null,
   device: BootedDevice,
-): PoolDeviceInfo | undefined {
+  sessionInfoByDeviceId: Map<string, DeviceSessionInfo> | null,
+  resolveDeviceSessionUuid: (deviceId: string) => string | null,
+): PoolDeviceContext | undefined {
   if (!devicePool) {
     return undefined;
   }
 
   const pooledDevice = devicePool.getDevice(device.deviceId);
-  if (!pooledDevice) {
+  if (!pooledDevice || !devicePool.describesPooledRuntime(device)) {
     return undefined;
   }
 
   const poolStatus: PoolDeviceStatus =
     pooledDevice.status === "busy" ? "assigned" : pooledDevice.status;
 
-  // Everything this entry claims about WHICH runtime is on the serial is
-  // published only when the entry describes the runtime discovery just reported
-  // there. The join is by serial alone, and a different device can hold that
-  // serial before the pool refreshes -- or the emulator console can have gone
-  // quiet, leaving discovery with the `Unknown (<serial>)` placeholder, which
-  // asserts nothing either way. Naming the retired entry's epoch would tell
-  // consumers to keep state exactly when the new epoch is supposed to make them
-  // flush it, and naming its AVD would publish the previous occupant's label as
-  // this runtime's `stableId` (#6863 review).
-  const describesRuntime = devicePool.describesPooledRuntime(device);
-
   return {
-    poolStatus,
-    assignedSession: pooledDevice.sessionId || undefined,
-    recoveryEligibility: devicePool.getRecoveryEligibility(device.deviceId),
-    avdName: describesRuntime ? pooledDevice.avdName : undefined,
-    incarnation: describesRuntime ? pooledDevice.incarnation : undefined,
+    poolInfo: {
+      poolStatus,
+      assignedSession: pooledDevice.sessionId || undefined,
+      recoveryEligibility: devicePool.getRecoveryEligibility(device.deviceId),
+      avdName: pooledDevice.avdName,
+      incarnation: pooledDevice.incarnation,
+    },
+    sessionInfo: sessionInfoByDeviceId?.get(device.deviceId),
+    deviceSessionUuid: resolveDeviceSessionUuid(device.deviceId) ?? undefined,
   };
 }
 
@@ -541,9 +558,12 @@ async function discoverBootedDevicesForPlatform(
       devices: discovery.devices.map((device) =>
         toBootedDeviceInfo(
           device,
-          getPoolDeviceInfo(devicePool, device),
-          sessionInfoByDeviceId?.get(device.deviceId),
-          resolveDeviceSessionUuid(device.deviceId),
+          resolvePoolDeviceContext(
+            devicePool,
+            device,
+            sessionInfoByDeviceId,
+            resolveDeviceSessionUuid,
+          ),
         ),
       ),
       succeededPlatforms: complete ? new Set([platform]) : new Set(),

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -74,8 +74,11 @@ interface DeviceIdentity {
    * Key for THIS connection epoch of the device. An adb serial is reused across
    * boots, so the serial alone cannot tell a consumer "same device, stream
    * continues" from "device rebooted, flush your state". When the pool knows the
-   * device's `incarnation` this is `<deviceId>#<incarnation>`; otherwise the
-   * serial alone, which callers must read as "no epoch information".
+   * device's `incarnation` AND that pooled entry describes the runtime this
+   * discovery just reported on the serial, this is `<deviceId>#<incarnation>`;
+   * otherwise the serial alone, which callers must read as "no epoch
+   * information". The identity check matters because the pool join is by serial:
+   * an unchecked join could publish a retired entry's epoch for a new runtime.
    */
   connectionId: string;
 }
@@ -369,13 +372,13 @@ function isVirtualDevice(device: BootedDevice): boolean {
 
 function getPoolDeviceInfo(
   devicePool: DevicePool | null,
-  deviceId: string,
+  device: BootedDevice,
 ): PoolDeviceInfo | undefined {
   if (!devicePool) {
     return undefined;
   }
 
-  const pooledDevice = devicePool.getDevice(deviceId);
+  const pooledDevice = devicePool.getDevice(device.deviceId);
   if (!pooledDevice) {
     return undefined;
   }
@@ -386,9 +389,14 @@ function getPoolDeviceInfo(
   return {
     poolStatus,
     assignedSession: pooledDevice.sessionId || undefined,
-    recoveryEligibility: devicePool.getRecoveryEligibility(deviceId),
+    recoveryEligibility: devicePool.getRecoveryEligibility(device.deviceId),
     avdName: pooledDevice.avdName,
-    incarnation: pooledDevice.incarnation,
+    // The epoch is published ONLY when this entry describes the runtime
+    // discovery just reported on the serial. The join is by serial alone, and a
+    // different device can hold that serial before the pool refreshes; naming
+    // the retired entry's epoch would tell consumers to keep state exactly when
+    // the new epoch is supposed to make them flush it.
+    incarnation: devicePool.describesPooledRuntime(device) ? pooledDevice.incarnation : undefined,
   };
 }
 
@@ -511,7 +519,7 @@ async function discoverBootedDevicesForPlatform(
       devices: discovery.devices.map((device) =>
         toBootedDeviceInfo(
           device,
-          getPoolDeviceInfo(devicePool, device.deviceId),
+          getPoolDeviceInfo(devicePool, device),
           sessionInfoByDeviceId?.get(device.deviceId),
           resolveDeviceSessionUuid(device.deviceId),
         ),

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -70,8 +70,14 @@ export interface DeviceServiceStatus {
 
 interface DeviceIdentity {
   stableId: string;
+  /**
+   * Key for THIS connection epoch of the device. An adb serial is reused across
+   * boots, so the serial alone cannot tell a consumer "same device, stream
+   * continues" from "device rebooted, flush your state". When the pool knows the
+   * device's `incarnation` this is `<deviceId>#<incarnation>`; otherwise the
+   * serial alone, which callers must read as "no epoch information".
+   */
   connectionId: string;
-  transportId?: string;
 }
 
 interface DeviceReadiness {
@@ -165,6 +171,7 @@ interface PoolDeviceInfo {
   assignedSession?: string;
   recoveryEligibility: DeviceRecoveryEligibility;
   avdName?: string;
+  incarnation?: number;
 }
 
 /**
@@ -340,17 +347,16 @@ function toDeviceIdentity(
   poolInfo: PoolDeviceInfo | undefined,
   isVirtual: boolean,
 ): DeviceIdentity {
-  const identity: DeviceIdentity = {
+  return {
     stableId:
       device.platform === "android" && isVirtual
         ? (poolInfo?.avdName ?? device.name)
         : device.deviceId,
-    connectionId: device.transportId ?? device.deviceId,
+    connectionId:
+      poolInfo?.incarnation === undefined
+        ? device.deviceId
+        : `${device.deviceId}#${poolInfo.incarnation}`,
   };
-  if (device.transportId) {
-    identity.transportId = device.transportId;
-  }
-  return identity;
 }
 
 function isVirtualDevice(device: BootedDevice): boolean {
@@ -382,6 +388,7 @@ function getPoolDeviceInfo(
     assignedSession: pooledDevice.sessionId || undefined,
     recoveryEligibility: devicePool.getRecoveryEligibility(deviceId),
     avdName: pooledDevice.avdName,
+    incarnation: pooledDevice.incarnation,
   };
 }
 

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -173,6 +173,11 @@ interface PoolDeviceInfo {
   poolStatus: PoolDeviceStatus;
   assignedSession?: string;
   recoveryEligibility: DeviceRecoveryEligibility;
+  /**
+   * The AVD this pool started on the serial, and the epoch of that allocation.
+   * Both are present ONLY when the pooled entry describes the runtime discovery
+   * just reported on the serial; see {@link getPoolDeviceInfo}.
+   */
   avdName?: string;
   incarnation?: number;
 }
@@ -345,6 +350,17 @@ function toBootedDeviceInfo(
   return info;
 }
 
+/**
+ * The two identities a consumer needs: WHICH device (`stableId`, the AVD name
+ * for an emulator because a serial is reused across boots) and WHICH RUN of it
+ * (`connectionId`, the pool's per-allocation incarnation).
+ *
+ * Both fall back to discovery's own answer when the pool has nothing to say
+ * about this runtime -- including when discovery reports `Unknown (<serial>)`,
+ * where the pooled AVD label could belong to the previous occupant of the
+ * serial. A caller that needs the real AVD name in that case must re-resolve it
+ * from the runtime rather than read it here (#6863 review).
+ */
 function toDeviceIdentity(
   device: BootedDevice,
   poolInfo: PoolDeviceInfo | undefined,
@@ -386,17 +402,23 @@ function getPoolDeviceInfo(
   const poolStatus: PoolDeviceStatus =
     pooledDevice.status === "busy" ? "assigned" : pooledDevice.status;
 
+  // Everything this entry claims about WHICH runtime is on the serial is
+  // published only when the entry describes the runtime discovery just reported
+  // there. The join is by serial alone, and a different device can hold that
+  // serial before the pool refreshes -- or the emulator console can have gone
+  // quiet, leaving discovery with the `Unknown (<serial>)` placeholder, which
+  // asserts nothing either way. Naming the retired entry's epoch would tell
+  // consumers to keep state exactly when the new epoch is supposed to make them
+  // flush it, and naming its AVD would publish the previous occupant's label as
+  // this runtime's `stableId` (#6863 review).
+  const describesRuntime = devicePool.describesPooledRuntime(device);
+
   return {
     poolStatus,
     assignedSession: pooledDevice.sessionId || undefined,
     recoveryEligibility: devicePool.getRecoveryEligibility(device.deviceId),
-    avdName: pooledDevice.avdName,
-    // The epoch is published ONLY when this entry describes the runtime
-    // discovery just reported on the serial. The join is by serial alone, and a
-    // different device can hold that serial before the pool refreshes; naming
-    // the retired entry's epoch would tell consumers to keep state exactly when
-    // the new epoch is supposed to make them flush it.
-    incarnation: devicePool.describesPooledRuntime(device) ? pooledDevice.incarnation : undefined,
+    avdName: describesRuntime ? pooledDevice.avdName : undefined,
+    incarnation: describesRuntime ? pooledDevice.incarnation : undefined,
   };
 }
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2490,10 +2490,7 @@ async function verifyPooledAndroidAvdName(
     : { reason: "conflict", pooledAvdName, runtimeAvdName };
 }
 
-function pooledAvdNameRefusalMessage(
-  device: BootedDevice,
-  refusal: PooledAvdNameRefusal,
-): string {
+function pooledAvdNameRefusalMessage(device: BootedDevice, refusal: PooledAvdNameRefusal): string {
   if (refusal.reason === "conflict") {
     return (
       `Refusing to act on Android emulator '${device.deviceId}': this daemon has it recorded as ` +

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2264,10 +2264,6 @@ type TeardownResolvedTarget =
       bootedDevice: BootedDevice;
     };
 
-function isAndroidEmulatorSerial(deviceId: string): boolean {
-  return deviceId.startsWith("emulator-");
-}
-
 function isVirtualAndroidDevice(device: BootedDevice): boolean {
   return device.platform === "android" && isAndroidEmulatorSerial(device.deviceId);
 }

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -852,7 +852,12 @@ function releaseProvisionDeviceWaiter(
  */
 const POOLED_AVD_NAME_VERIFICATION_TIMEOUT_MS = 3_000;
 
-async function defaultResolveRunningAndroidAvdName(
+/**
+ * Exported for tests only: the DEFAULT {@link
+ * DeviceToolsDependencies.resolveRunningAndroidAvdName}. Production callers
+ * reach it through `getDeviceToolsDependencies()`.
+ */
+export async function defaultResolveRunningAndroidAvdName(
   device: BootedDevice,
   timeoutMs: number,
   signal?: AbortSignal,
@@ -862,6 +867,13 @@ async function defaultResolveRunningAndroidAvdName(
       await import("../utils/android-cmdline-tools/AndroidEmulatorClient");
     return await new AndroidEmulatorClient().resolveRunningAvdName(device, timeoutMs, signal);
   } catch (error) {
+    if (signal?.aborted) {
+      // Cancellation is not evidence about the runtime's identity, and reporting
+      // it as "unresolved" would make killDevice raise an identity refusal --
+      // and deleteDevice answer `target_identity_unresolved` -- for an action the
+      // CALLER stopped. Propagate the cancellation instead (#6863 review).
+      throw signal.reason ?? error;
+    }
     // An unreachable console is one of the three expected outcomes of this
     // probe; "could not resolve" makes the caller REFUSE the destructive action,
     // so this is a warn-and-report-unresolved, never a swallow that proceeds.

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -778,6 +778,16 @@ export interface DeviceToolsDependencies {
   idGenerator: IdGenerator;
   timer: Timer;
   lifecycleCoordinator: VirtualDeviceLifecycleCoordinator;
+  /**
+   * Re-resolve an emulator's AVD name from the RUNTIME rather than from any
+   * host-side cache (`emu avd name`). Resolves to undefined when the emulator
+   * console cannot answer inside `timeoutMs`. See
+   * {@link verifyPooledAndroidAvdName}.
+   */
+  resolveRunningAndroidAvdName: (
+    device: BootedDevice,
+    timeoutMs: number,
+  ) => Promise<string | undefined>;
 }
 
 /**
@@ -829,6 +839,34 @@ function releaseProvisionDeviceWaiter(
     ),
   );
   return true;
+}
+
+/**
+ * How long the runtime gets to name itself before a destructive action gives up
+ * on verification. Short on purpose: the caller is holding a lifecycle lease and
+ * a wedged console must not turn a kill into a hang — an unanswered probe is a
+ * logged warning, not a failure (see {@link verifyPooledAndroidAvdName}).
+ */
+const POOLED_AVD_NAME_VERIFICATION_TIMEOUT_MS = 3_000;
+
+async function defaultResolveRunningAndroidAvdName(
+  device: BootedDevice,
+  timeoutMs: number,
+): Promise<string | undefined> {
+  try {
+    const { AndroidEmulatorClient } = await import(
+      "../utils/android-cmdline-tools/AndroidEmulatorClient"
+    );
+    return await new AndroidEmulatorClient().resolveRunningAvdName(device, timeoutMs);
+  } catch (error) {
+    // An unreachable console is one of the three expected outcomes of this
+    // probe; the caller treats "could not resolve" as its documented blind spot.
+    logger.warn(
+      `[DeviceTools] Could not re-resolve the AVD name for ${device.deviceId}: ${errorMessage(error)}`,
+      error,
+    );
+    return undefined;
+  }
 }
 
 async function defaultNotifyResourcesChanged(): Promise<void> {
@@ -2300,11 +2338,12 @@ function resolveKillDeviceStableTarget(
  *  3. that entry must carry an `avdName`, which the pool writes only from the
  *     AVD it itself started (`recordSourceAndroidAvd`), never from discovery.
  *
- * Blind spot, accepted deliberately: a same-serial restart faster than one
- * discovery interval never reaches the pool, so the cached AVD name can name
- * the previous occupant. Callers must therefore treat this as a best-effort
- * label and re-resolve the runtime name (`emu avd name`) rather than take it as
- * proof of identity before a destructive action.
+ * This is a best-effort LABEL, never proof of identity: a same-serial restart
+ * faster than one discovery interval never reaches the pool, so the cached name
+ * can belong to the previous occupant of the serial. Every DESTRUCTIVE caller
+ * (killDevice, deleteDevice) must therefore run {@link
+ * verifyPooledAndroidAvdName} first, which re-resolves the name from the
+ * runtime and fails closed on a mismatch.
  */
 function getValidatedPooledAndroidAvdName(
   device: BootedDevice,
@@ -2320,6 +2359,65 @@ function getValidatedPooledAndroidAvdName(
   }
   const pooled = devicePool?.getDevice(device.deviceId);
   return pooled?.avdName;
+}
+
+interface PooledAvdNameConflict {
+  pooledAvdName: string;
+  runtimeAvdName: string;
+}
+
+/**
+ * Fail closed before a destructive action on an emulator whose discovered name
+ * is `Unknown (<serial>)` and whose AVD name therefore comes from the pool.
+ *
+ * A different AVD can take over a reused serial before discovery observes the
+ * previous one disappear, leaving the pool holding the OLD label — and a kill or
+ * delete issued against that label would stop the NEW emulator (#6863 review).
+ * So ask the runtime itself:
+ *  - it names a DIFFERENT AVD -> return the conflict; the caller refuses;
+ *  - it names the SAME AVD -> identity verified, proceed;
+ *  - it cannot answer inside the bounded timeout -> proceed on the pooled name
+ *    and warn. That is the whole of the remaining blind spot, narrowed from
+ *    "any restart faster than one discovery interval" to "the emulator console
+ *    is unavailable at the moment of the destructive action".
+ *
+ * Physical handsets never reach the probe: {@link
+ * getValidatedPooledAndroidAvdName} returns nothing for a non-emulator serial,
+ * because `ro.product.model` is not an AVD name and is not unique.
+ */
+async function verifyPooledAndroidAvdName(
+  device: BootedDevice,
+  devicePool: DevicePool | undefined,
+  resolveRunningAvdName: DeviceToolsDependencies["resolveRunningAndroidAvdName"],
+): Promise<PooledAvdNameConflict | undefined> {
+  const pooledAvdName = getValidatedPooledAndroidAvdName(device, devicePool);
+  if (!pooledAvdName) {
+    return undefined;
+  }
+  const runtimeAvdName = await resolveRunningAvdName(
+    device,
+    POOLED_AVD_NAME_VERIFICATION_TIMEOUT_MS,
+  );
+  if (runtimeAvdName === undefined) {
+    logger.warn(
+      `[DeviceTools] Could not confirm that ${device.deviceId} is still AVD '${pooledAvdName}': ` +
+        "the emulator console did not report a name. Proceeding on the pooled name.",
+    );
+    return undefined;
+  }
+  return runtimeAvdName === pooledAvdName ? undefined : { pooledAvdName, runtimeAvdName };
+}
+
+function pooledAvdNameConflictMessage(
+  device: BootedDevice,
+  conflict: PooledAvdNameConflict,
+): string {
+  return (
+    `Refusing to act on Android emulator '${device.deviceId}': this daemon has it recorded as ` +
+    `AVD '${conflict.pooledAvdName}', but the emulator now running on that serial reports ` +
+    `AVD '${conflict.runtimeAvdName}'. The serial was reused by a different AVD; re-resolve the ` +
+    "target and retry."
+  );
 }
 
 function getBootedAndroidStableName(
@@ -2814,6 +2912,26 @@ async function resolveTeardownTarget(context: TeardownContext): Promise<Teardown
   }
   const daemonState = DaemonState.getInstance();
   const devicePool = daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
+  // A booted emulator only matches this teardown by its POOLED AVD name when its
+  // runtime name is unknown; make the runtime confirm that name before the stop
+  // and the delete act on it (#6863 review).
+  for (const candidate of findMatchingBootedTeardownDevices(booted, context.args, devicePool)) {
+    const conflict = await verifyPooledAndroidAvdName(
+      candidate,
+      devicePool,
+      getDeviceToolsDependencies().resolveRunningAndroidAvdName,
+    );
+    if (conflict) {
+      return {
+        response: createTeardownFailureResponse(
+          context.args,
+          "precondition",
+          "target_identity_unresolved",
+          pooledAvdNameConflictMessage(candidate, conflict),
+        ),
+      };
+    }
+  }
   const bootedTarget = findBootedTeardownTarget(booted, context.args, devicePool);
   if (bootedTarget.conflict) {
     return {
@@ -3157,6 +3275,7 @@ function getDeviceToolsDependencies(): DeviceToolsDependencies {
       idGenerator: defaultIdGenerator,
       timer: defaultTimer,
       lifecycleCoordinator: getVirtualDeviceLifecycleCoordinator(),
+      resolveRunningAndroidAvdName: defaultResolveRunningAndroidAvdName,
     };
   }
   return moduleDependencies;
@@ -3214,6 +3333,8 @@ export function setDeviceToolsDependencies(deps: Partial<DeviceToolsDependencies
     idGenerator: deps.idGenerator ?? currentDeps.idGenerator,
     timer: deps.timer ?? currentDeps.timer,
     lifecycleCoordinator: resolveDeviceToolsLifecycleCoordinator(deps, currentDeps),
+    resolveRunningAndroidAvdName:
+      deps.resolveRunningAndroidAvdName ?? currentDeps.resolveRunningAndroidAvdName,
   };
 }
 
@@ -6881,6 +7002,16 @@ export function registerDeviceTools() {
     const deadlineMs = deps.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
     const daemonState = DaemonState.getInstance();
     const devicePool = daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
+    // Before anything destructive: if this target's AVD name comes from the pool
+    // rather than from the runtime, make the runtime confirm it (#6863 review).
+    const avdNameConflict = await verifyPooledAndroidAvdName(
+      args.device,
+      devicePool,
+      deps.resolveRunningAndroidAvdName,
+    );
+    if (avdNameConflict) {
+      throw new ActionableError(pooledAvdNameConflictMessage(args.device, avdNameConflict));
+    }
     const stableTarget = resolveKillDeviceStableTarget(args.device, devicePool);
     const lifecycleLease = stableTarget
       ? await reserveStableDeviceLifecycle(

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1560,7 +1560,7 @@ async function waitForDeviceShutdown(
     if (platformWasDiscovered && !matchingDevice) {
       return undefined;
     }
-    if (matchingDevice && !isSameBootedDeviceIdentity(device, matchingDevice)) {
+    if (matchingDevice && isConfirmedDeviceReplacement(device, matchingDevice)) {
       return matchingDevice;
     }
 
@@ -1576,7 +1576,9 @@ async function waitForDeviceShutdown(
 }
 
 /**
- * Whether two discovery observations describe the same booted runtime.
+ * Whether two discovery observations are positive evidence of the same booted
+ * runtime -- the CONTINUITY question, asked by callers deciding whether to
+ * retain live state (an attached observer, a bound session).
  *
  * A discovery listing carries no connection-epoch token, so this is platform +
  * serial + name and nothing more. An Android emulator serial is reused across
@@ -1586,12 +1588,61 @@ async function waitForDeviceShutdown(
  * leaves is deliberate: a same-serial restart of the SAME AVD between two
  * observations reads as continuity, so callers relying on this must self-heal
  * on failure rather than trust it as proof of an unbroken connection.
+ *
+ * An `Unknown (<serial>)` name is not an answer to this question. It means the
+ * emulator console did not report a name, so it is never evidence of continuity
+ * -- and, symmetrically, never evidence of a replacement (see
+ * {@link isConfirmedDeviceReplacement}). This is the uniform rule for the
+ * placeholder; a tool-level `force` escape hatch for callers that want to act
+ * without resolved identity is tracked as a separate follow-up.
  */
 function isSameBootedDeviceIdentity(device: BootedDevice, candidate: BootedDevice): boolean {
   return (
     device.platform === candidate.platform &&
     device.deviceId === candidate.deviceId &&
-    device.name === candidate.name
+    device.name === candidate.name &&
+    !hasUnresolvedEmulatorRuntimeName(device) &&
+    !hasUnresolvedEmulatorRuntimeName(candidate)
+  );
+}
+
+/**
+ * Whether a device rediscovered on a serial is positive evidence that a
+ * DIFFERENT runtime now holds it -- the REPLACEMENT question, asked by the
+ * shutdown wait before it stops waiting and rebuilds the pool around the
+ * newcomer.
+ *
+ * Only a RESOLVED, different name declares a replacement. While an emulator
+ * shuts down, `adb devices` can keep listing its serial after the console has
+ * stopped answering `avd name`, so the device that is still present gets
+ * labelled `Unknown (<serial>)`; classifying that as a replacement would end the
+ * shutdown wait before disappearance and retirement, releasing the session and
+ * rebuilding the pool around a device that is still going away (#6863 review).
+ *
+ * This is NOT the negation of {@link isSameBootedDeviceIdentity}: an unresolved
+ * name answers neither question, so both predicates return false for it.
+ */
+function isConfirmedDeviceReplacement(device: BootedDevice, candidate: BootedDevice): boolean {
+  if (device.platform !== candidate.platform || device.deviceId !== candidate.deviceId) {
+    return false;
+  }
+  if (hasUnresolvedEmulatorRuntimeName(device) || hasUnresolvedEmulatorRuntimeName(candidate)) {
+    return false;
+  }
+  return device.name !== candidate.name;
+}
+
+/**
+ * Whether this observation's name is the `Unknown (<serial>)` placeholder rather
+ * than a name read from the runtime. Guarded by {@link isAndroidEmulatorSerial}:
+ * a handset's name is `ro.product.model`, which is not unique and carries no
+ * identity anyway, so handsets keep serial-only identity.
+ */
+function hasUnresolvedEmulatorRuntimeName(device: BootedDevice): boolean {
+  return (
+    device.platform === "android" &&
+    isAndroidEmulatorSerial(device.deviceId) &&
+    isUnknownAndroidRuntimeName(device)
   );
 }
 
@@ -1664,7 +1715,7 @@ async function findReplacementAfterSessionRelease(
   const replacement = findDiscoveredDevice(discovery, device);
   if (
     replacement &&
-    (device.platform === "ios" || !isSameBootedDeviceIdentity(device, replacement))
+    (device.platform === "ios" || isConfirmedDeviceReplacement(device, replacement))
   ) {
     return replacement;
   }

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -141,6 +141,7 @@ import {
 import { DeviceTeardownService, type DeviceTeardownPhase } from "../utils/deviceTeardownService";
 import { DeviceShutdownService } from "../utils/deviceShutdownService";
 import { hasMutableDisplayName } from "../utils/ios-cmdline-tools/iosDeviceType";
+import { isAndroidEmulatorSerial } from "../utils/androidSerial";
 import { classifyDisplayCutout, DISPLAY_CUTOUT_PREFERENCES } from "../utils/displayCutout";
 
 // Schema definitions
@@ -1030,12 +1031,7 @@ async function stopAndroidCtrlProxyBeforeShutdown(
   const observerState: AndroidObserverShutdownState = {
     hadActiveObserver: activeObserver !== null,
     boundSessionId: activeObserver?.getBoundSessionId() ?? null,
-    deviceIdentity: activeDeviceIdentity
-      ? {
-          ...activeDeviceIdentity,
-          transportId: activeDeviceIdentity.transportId ?? context.device.transportId,
-        }
-      : null,
+    deviceIdentity: activeDeviceIdentity ?? null,
   };
   let stop: Promise<void> | undefined;
   perf.startOperation("stopAndroidCtrlProxy");
@@ -1225,8 +1221,7 @@ async function revalidateReconnectedAndroidObserver(
     const reconnectedDevice = findDiscoveredDevice(discovery, device);
     return (
       reconnectedDevice !== undefined &&
-      observerState.deviceIdentity?.transportId !== undefined &&
-      reconnectedDevice.transportId !== undefined &&
+      observerState.deviceIdentity !== null &&
       isSameBootedDeviceIdentity(observerState.deviceIdentity, reconnectedDevice)
     );
   } catch (error) {
@@ -1269,8 +1264,7 @@ async function restoreAndroidObserverAfterCommandFailure(
     const survivingDevice = findDiscoveredDevice(discovery, device);
     if (
       survivingDevice &&
-      observerState.deviceIdentity?.transportId !== undefined &&
-      survivingDevice.transportId !== undefined &&
+      observerState.deviceIdentity !== null &&
       isSameBootedDeviceIdentity(observerState.deviceIdentity, survivingDevice)
     ) {
       const observer = AndroidCtrlProxyClient.getInstance(survivingDevice);
@@ -1546,18 +1540,24 @@ async function waitForDeviceShutdown(
   }
 }
 
+/**
+ * Whether two discovery observations describe the same booted runtime.
+ *
+ * A discovery listing carries no connection-epoch token, so this is platform +
+ * serial + name and nothing more. An Android emulator serial is reused across
+ * boots, and its AVD name is what distinguishes one occupant of that serial
+ * from the next; a handset serial is globally unique, so its (non-unique)
+ * `ro.product.model` name can never conflate two handsets. The blind spot this
+ * leaves is deliberate: a same-serial restart of the SAME AVD between two
+ * observations reads as continuity, so callers relying on this must self-heal
+ * on failure rather than trust it as proof of an unbroken connection.
+ */
 function isSameBootedDeviceIdentity(device: BootedDevice, candidate: BootedDevice): boolean {
-  if (device.platform !== candidate.platform || device.deviceId !== candidate.deviceId) {
-    return false;
-  }
-  if (
-    device.platform === "android" &&
-    device.transportId !== undefined &&
-    candidate.transportId !== undefined
-  ) {
-    return device.transportId === candidate.transportId;
-  }
-  return device.name === candidate.name;
+  return (
+    device.platform === candidate.platform &&
+    device.deviceId === candidate.deviceId &&
+    device.name === candidate.name
+  );
 }
 
 function findDiscoveredDevice(
@@ -2287,6 +2287,27 @@ function resolveKillDeviceStableTarget(
   return pooledAvdName ? { platform: "android", stableId: pooledAvdName } : undefined;
 }
 
+/**
+ * The AVD name the pool holds for an emulator whose runtime name could not be
+ * read (`Unknown (<serial>)`), or undefined when the pool cannot vouch for one.
+ *
+ * The rule, now that the identity model has no ADB transport id:
+ *  1. the serial must be an emulator serial (`isAndroidEmulatorSerial`) — a
+ *     handset's name is `ro.product.model` and there is no AVD to substitute;
+ *  2. the pool must still hold a LIVE entry for that serial. The pool evicts an
+ *     entry the moment discovery observes the serial disappear and re-adds it
+ *     under a fresh `incarnation`, so a surviving entry is the pool's statement
+ *     that it has observed no boundary for this serial — the only continuity
+ *     evidence left;
+ *  3. that entry must carry an `avdName`, which the pool writes only from the
+ *     AVD it itself started (`recordSourceAndroidAvd`), never from discovery.
+ *
+ * Blind spot, accepted deliberately: a same-serial restart faster than one
+ * discovery interval never reaches the pool, so the cached AVD name can name
+ * the previous occupant. Callers must therefore treat this as a best-effort
+ * label and re-resolve the runtime name (`emu avd name`) rather than take it as
+ * proof of identity before a destructive action.
+ */
 function getValidatedPooledAndroidAvdName(
   device: BootedDevice,
   devicePool: DevicePool | undefined,
@@ -2294,16 +2315,13 @@ function getValidatedPooledAndroidAvdName(
   if (device.platform !== "android" || !isUnknownAndroidRuntimeName(device)) {
     return undefined;
   }
-  const pooled = devicePool?.getDevice(device.deviceId);
-  if (
-    !pooled?.avdName ||
-    !pooled.transportId ||
-    !device.transportId ||
-    pooled.transportId !== device.transportId
-  ) {
+  if (!isAndroidEmulatorSerial(device.deviceId)) {
+    // A handset's name is `ro.product.model`, not an AVD; there is nothing to
+    // substitute and nothing that would make a pooled label trustworthy.
     return undefined;
   }
-  return pooled.avdName;
+  const pooled = devicePool?.getDevice(device.deviceId);
+  return pooled?.avdName;
 }
 
 function getBootedAndroidStableName(
@@ -2909,7 +2927,6 @@ async function retireTeardownPooledOwnership(
     platform: expectedPooledDevice.platform,
     name,
     deviceId: expectedPooledDevice.id,
-    ...(expectedPooledDevice.transportId ? { transportId: expectedPooledDevice.transportId } : {}),
   };
   try {
     await stopVideoRecordingsBeforeShutdown(

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2096,9 +2096,17 @@ async function retireShutdownOwnership(
  *
  * Without a pooled capture that is the caller's own target. With one -- an
  * emulator whose discovered name is `Unknown (<serial>)` -- the captured epoch
- * is re-confirmed and the runtime is asked to name itself HERE, immediately
- * before the kill, and the kill runs under the name the runtime gave. Any
- * refusal throws: nothing destructive has run yet at this point.
+ * is re-confirmed and the runtime is asked to name itself, and the kill runs
+ * under the name the runtime gave.
+ *
+ * Called FIRST inside the shutdown's execute step, after the shutdown
+ * reservation (so the pool cannot evict the captured entry mid-check) but
+ * BEFORE any of the shutdown's preparation side effects. A refusal here is a
+ * statement that this daemon may not touch the device at all, so it must not
+ * arrive with the device's recordings already stopped, its CtrlProxy singleton
+ * closed and removed, and its passive observers detached -- those are not
+ * rolled back, and the device is still running
+ * ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
  */
 async function resolvePooledAvdKillTarget(
   dependencies: DeviceToolsDependencies,
@@ -2140,21 +2148,9 @@ async function killProcessAndRetireOwnership(
   ) => void,
   strictDeadline = false,
   timeoutMs = DEVICE_SHUTDOWN_TIMEOUT_MS,
-  pooledAvdCapture?: PooledAvdCapture,
+  killTarget: BootedDevice = device,
 ): Promise<string | undefined> {
   const deviceManager = dependencies.deviceManagerFactory();
-  // LAST thing before anything destructive: re-confirm the captured epoch and
-  // make the runtime name itself, then kill under the name it gave (#6863
-  // review). Ahead of `markIntentionalShutdown`, so a refusal leaves no marker
-  // behind on a device this daemon did not touch.
-  const killTarget = await resolvePooledAvdKillTarget(
-    dependencies,
-    device,
-    pooledAvdCapture,
-    devicePool,
-    shutdownDeadlineMs,
-    requestAbortSignal,
-  );
   if (device.platform === "android") {
     devicePool?.markIntentionalShutdown(device.deviceId);
   }
@@ -2328,6 +2324,15 @@ async function shutdownDevice(
         requestAbortSignal,
         retainReservationUntil: retainShutdownUntil,
       };
+      // Identity first: a refusal must leave a still-running device untouched.
+      const killTarget = await resolvePooledAvdKillTarget(
+        dependencies,
+        device,
+        pooledAvdCapture,
+        devicePool,
+        shutdownDeadlineMs,
+        requestAbortSignal,
+      );
       await stopVideoRecordingsBeforeShutdown(shutdownContext, perf);
       await stopIosCtrlProxyBeforeShutdown(shutdownContext, perf);
       const androidObserverState = await stopAndroidCtrlProxyBeforeShutdown(
@@ -2351,7 +2356,7 @@ async function shutdownDevice(
         },
         strictDeadline,
         timeoutMs,
-        pooledAvdCapture,
+        killTarget,
       );
 
       if (alreadyStoppedMessage !== undefined) {
@@ -2458,7 +2463,14 @@ function resolveKillDeviceStableTarget(
  *     under a fresh `incarnation`, so a surviving entry is the pool's statement
  *     that it has observed no boundary for this serial — the only continuity
  *     evidence left;
- *  3. that entry must carry an `avdName`, which the pool writes only from the
+ *  3. that entry must not be QUARANTINED. Once a discovery sweep observes the
+ *     `Unknown (<serial>)` placeholder on a live entry, the pool flags it
+ *     `identityUnresolved` (`DevicePool.isPooledIdentityUnresolved`) and its
+ *     label stops standing for the runtime: the serial may have been taken over
+ *     by a different AVD that simply cannot name itself either. Returning the
+ *     cached label there is what let a teardown of the NEW AVD miss the booted
+ *     runtime and fall through to the stopped-image inventory path;
+ *  4. that entry must carry an `avdName`, which the pool writes only from the
  *     AVD it itself started (`recordSourceAndroidAvd`), never from discovery.
  *
  * This is a best-effort LABEL, never proof of identity: a same-serial restart
@@ -2480,6 +2492,9 @@ function getValidatedPooledAndroidEntry(
   if (!isAndroidEmulatorSerial(device.deviceId)) {
     // A handset's name is `ro.product.model`, not an AVD; there is nothing to
     // substitute and nothing that would make a pooled label trustworthy.
+    return undefined;
+  }
+  if (devicePool?.isPooledIdentityUnresolved(device.deviceId)) {
     return undefined;
   }
   return devicePool?.getDevice(device.deviceId) ?? undefined;

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2501,7 +2501,11 @@ function resolveKillDeviceStableTarget(
  *     label stops standing for the runtime: the serial may have been taken over
  *     by a different AVD that simply cannot name itself either. Returning the
  *     cached label there is what let a teardown of the NEW AVD miss the booted
- *     runtime and fall through to the stopped-image inventory path;
+ *     runtime and fall through to the stopped-image inventory path. The one
+ *     caller that must still SEE a quarantined entry is the destructive
+ *     identity check, which reads it through
+ *     {@link getPooledAndroidEntryForIdentityCheck} and turns it into a
+ *     `quarantined` capture whose runtime confirmation is mandatory;
  *  4. that entry must carry an `avdName`, which the pool writes only from the
  *     AVD it itself started (`recordSourceAndroidAvd`), never from discovery.
  *
@@ -2518,15 +2522,37 @@ function getValidatedPooledAndroidEntry(
   device: BootedDevice,
   devicePool: DevicePool | undefined,
 ): PooledDevice | undefined {
+  if (devicePool?.isPooledIdentityUnresolved(device.deviceId)) {
+    return undefined;
+  }
+  return getPooledAndroidEntryForIdentityCheck(device, devicePool);
+}
+
+/**
+ * The same lookup WITHOUT rule 3, for the one caller that must still see a
+ * QUARANTINED entry: the destructive identity check.
+ *
+ * Every other consumer reads a quarantined entry as "no label" and stops there,
+ * which is right for routing, publishing and matching. A kill cannot stop
+ * there: dropping the entry also dropped the CONFIRMATION the label exists to
+ * trigger, so the quarantined emulator fell back to the same unchecked path as
+ * a runtime that named itself and a sessionless `killDevice` carrying
+ * `Unknown (<serial>)` reached `AndroidEmulatorClient.killDevice` on nothing
+ * but that placeholder. Quarantine is the state in which the runtime MUST be
+ * made to name itself, so the check takes the entry and
+ * {@link capturePooledAvdIdentity} marks the capture `quarantined`
+ * ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+ */
+function getPooledAndroidEntryForIdentityCheck(
+  device: BootedDevice,
+  devicePool: DevicePool | undefined,
+): PooledDevice | undefined {
   if (device.platform !== "android" || !isUnknownAndroidRuntimeName(device)) {
     return undefined;
   }
   if (!isAndroidEmulatorSerial(device.deviceId)) {
     // A handset's name is `ro.product.model`, not an AVD; there is nothing to
     // substitute and nothing that would make a pooled label trustworthy.
-    return undefined;
-  }
-  if (devicePool?.isPooledIdentityUnresolved(device.deviceId)) {
     return undefined;
   }
   return devicePool?.getDevice(device.deviceId) ?? undefined;
@@ -2558,12 +2584,33 @@ type PooledAvdNameRefusal =
 interface PooledAvdCapture {
   avdName: string;
   incarnation: number;
+  /**
+   * The pooled entry was QUARANTINED at capture time
+   * (`DevicePool.isPooledIdentityUnresolved`), so the label is not the pool's
+   * statement about the runtime -- it is only the last name this daemon saw on
+   * the serial. The confirmation is therefore mandatory rather than merely
+   * corroborating: without a name from the runtime there is no identity at all.
+   */
+  quarantined?: true;
 }
 
 type PooledAvdCaptureResult =
   | { kind: "none" }
   | { kind: "capture"; capture: PooledAvdCapture }
+  | { kind: "quarantined"; capture: PooledAvdCapture }
   | { kind: "refusal"; refusal: PooledAvdNameRefusal };
+
+/**
+ * The capture a destructive action must carry into
+ * {@link confirmPooledAvdIdentity}, for the two kinds that require the runtime
+ * to name itself before the platform kill. `none` -- a runtime that named
+ * itself, and every physical handset -- carries nothing.
+ */
+function pooledAvdCaptureRequiringConfirmation(
+  result: PooledAvdCaptureResult,
+): PooledAvdCapture | undefined {
+  return result.kind === "capture" || result.kind === "quarantined" ? result.capture : undefined;
+}
 
 /**
  * An identity refusal raised from inside the shutdown path. It is an
@@ -2601,7 +2648,7 @@ function capturePooledAvdIdentity(
   devicePool: DevicePool | undefined,
   budget: PooledAvdNameProbeBudget,
 ): PooledAvdCaptureResult {
-  const pooled = getValidatedPooledAndroidEntry(device, devicePool);
+  const pooled = getPooledAndroidEntryForIdentityCheck(device, devicePool);
   const avdName = pooled?.avdName;
   if (!pooled || !avdName) {
     return { kind: "none" };
@@ -2609,13 +2656,21 @@ function capturePooledAvdIdentity(
   if (budget.deadlineMs - budget.timer.now() <= 0) {
     return { kind: "refusal", refusal: { reason: "unresolved", pooledAvdName: avdName } };
   }
-  return { kind: "capture", capture: { avdName, incarnation: pooled.incarnation } };
+  const quarantined = devicePool?.isPooledIdentityUnresolved(device.deviceId) === true;
+  return quarantined
+    ? {
+        kind: "quarantined",
+        capture: { avdName, incarnation: pooled.incarnation, quarantined: true },
+      }
+    : { kind: "capture", capture: { avdName, incarnation: pooled.incarnation } };
 }
 
 /**
  * KILL-TIME half of the identity check, run immediately before the platform
  * kill on an emulator whose discovered name is `Unknown (<serial>)` and whose
- * AVD name therefore comes from the pool.
+ * AVD name therefore comes from the pool -- including a pool entry that is
+ * QUARANTINED, where the label is not the pool's statement about the runtime
+ * and this probe is the only identity evidence there is.
  *
  * Two things must still hold:
  *  - the pool must still hold the CAPTURED incarnation under that label. A new
@@ -2658,6 +2713,15 @@ async function confirmPooledAvdIdentity(
         `${device.deviceId} under AVD '${pooledAvdName}'; refusing the destructive action.`,
     );
     return { refusal: { reason: "moved", pooledAvdName } };
+  }
+  if (capture.quarantined) {
+    // Not an extra check, a louder one: for a quarantined entry the probe is the
+    // ONLY identity evidence there is, and a refusal here is the fail-closed
+    // outcome rather than a surprising one (#6863 review).
+    logger.warn(
+      `[DeviceTools] The pooled identity of ${device.deviceId} is quarantined; the runtime must ` +
+        `name itself before this action may act on '${pooledAvdName}'.`,
+    );
   }
   const remainingMs = budget.deadlineMs - budget.timer.now();
   if (remainingMs <= 0) {
@@ -3296,9 +3360,10 @@ async function resolveTeardownTarget(context: TeardownContext): Promise<Teardown
     };
   }
   if (bootedTarget.target) {
+    const captureRequiringConfirmation = pooledAvdCaptureRequiringConfirmation(pooledAvdCapture);
     const resolvedTarget: TeardownResolvedTarget =
-      bootedTarget.target.wasBooted && pooledAvdCapture.kind === "capture"
-        ? { ...bootedTarget.target, pooledAvdCapture: pooledAvdCapture.capture }
+      bootedTarget.target.wasBooted && captureRequiringConfirmation
+        ? { ...bootedTarget.target, pooledAvdCapture: captureRequiringConfirmation }
         : bootedTarget.target;
     return await finalizeIosNameResolvedTeardownTarget(context, resolvedTarget);
   }
@@ -7406,7 +7471,7 @@ export function registerDeviceTools() {
         false,
         DEVICE_SHUTDOWN_TIMEOUT_MS,
         retainLifecycleUntil,
-        pooledAvdCapture.kind === "capture" ? pooledAvdCapture.capture : undefined,
+        pooledAvdCaptureRequiringConfirmation(pooledAvdCapture),
       );
       return createKillDeviceResponse(args, result.timing, result.alreadyStoppedMessage);
     } finally {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2148,7 +2148,7 @@ async function killProcessAndRetireOwnership(
   ) => void,
   strictDeadline = false,
   timeoutMs = DEVICE_SHUTDOWN_TIMEOUT_MS,
-  killTarget: BootedDevice = device,
+  killTarget: BootedDevice,
 ): Promise<string | undefined> {
   const deviceManager = dependencies.deviceManagerFactory();
   if (device.platform === "android") {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -863,7 +863,8 @@ async function defaultResolveRunningAndroidAvdName(
     return await new AndroidEmulatorClient().resolveRunningAvdName(device, timeoutMs, signal);
   } catch (error) {
     // An unreachable console is one of the three expected outcomes of this
-    // probe; the caller treats "could not resolve" as its documented blind spot.
+    // probe; "could not resolve" makes the caller REFUSE the destructive action,
+    // so this is a warn-and-report-unresolved, never a swallow that proceeds.
     logger.warn(
       `[DeviceTools] Could not re-resolve the AVD name for ${device.deviceId}: ${errorMessage(error)}`,
       error,

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -3367,12 +3367,24 @@ async function resolveTeardownTarget(context: TeardownContext): Promise<Teardown
         : bootedTarget.target;
     return await finalizeIosNameResolvedTeardownTarget(context, resolvedTarget);
   }
+  // Nothing booted matched this teardown, so the next step is the STOPPED-image
+  // inventory path -- and a booted emulator that could not name itself may be
+  // the very AVD whose image is about to be destroyed.
+  //
+  // The question is answered from THIS discovery, not from the pool. The pool's
+  // quarantine encodes exactly this observation, but only from the sweep that
+  // FOLLOWS it: on the first discovery after a different AVD takes a pooled
+  // serial, the pool still holds the previous occupant's label and reading it
+  // here would treat the placeholder as resolved -- which is what let a
+  // teardown of the new AVD miss the booted runtime and destroy its image while
+  // it was running. The teardown's own observation is the newer evidence of the
+  // two, so it decides ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863)
+  // review).
   const unresolvedAndroidRuntime = booted.devices.find(
     (device) =>
       device.platform === "android" &&
       isVirtualAndroidDevice(device) &&
-      isUnknownAndroidRuntimeName(device) &&
-      !getValidatedPooledAndroidAvdName(device, devicePool),
+      isUnknownAndroidRuntimeName(device),
   );
   if (unresolvedAndroidRuntime) {
     return {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -854,9 +854,8 @@ async function defaultResolveRunningAndroidAvdName(
   timeoutMs: number,
 ): Promise<string | undefined> {
   try {
-    const { AndroidEmulatorClient } = await import(
-      "../utils/android-cmdline-tools/AndroidEmulatorClient"
-    );
+    const { AndroidEmulatorClient } =
+      await import("../utils/android-cmdline-tools/AndroidEmulatorClient");
     return await new AndroidEmulatorClient().resolveRunningAvdName(device, timeoutMs);
   } catch (error) {
     // An unreachable console is one of the three expected outcomes of this

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -782,7 +782,7 @@ export interface DeviceToolsDependencies {
    * Re-resolve an emulator's AVD name from the RUNTIME rather than from any
    * host-side cache (`emu avd name`). Resolves to undefined when the emulator
    * console cannot answer inside `timeoutMs`, which is the caller's REMAINING
-   * deadline, not an independent budget. See {@link verifyPooledAndroidAvdName}.
+   * deadline, not an independent budget. See {@link confirmPooledAvdIdentity}.
    */
   resolveRunningAndroidAvdName: (
     device: BootedDevice,
@@ -848,7 +848,7 @@ function releaseProvisionDeviceWaiter(
  * lifecycle lease and a wedged console must not turn a kill into a hang. It is a
  * ceiling and never a floor — the probe is bounded by whichever is smaller, this
  * or the caller's remaining teardown/kill deadline, and an unanswered probe
- * REFUSES the action (see {@link verifyPooledAndroidAvdName}).
+ * REFUSES the action (see {@link confirmPooledAvdIdentity}).
  */
 const POOLED_AVD_NAME_VERIFICATION_TIMEOUT_MS = 3_000;
 
@@ -2079,6 +2079,39 @@ async function retireShutdownOwnership(
   }
 }
 
+/**
+ * Resolve the device the platform kill command is actually issued against.
+ *
+ * Without a pooled capture that is the caller's own target. With one -- an
+ * emulator whose discovered name is `Unknown (<serial>)` -- the captured epoch
+ * is re-confirmed and the runtime is asked to name itself HERE, immediately
+ * before the kill, and the kill runs under the name the runtime gave. Any
+ * refusal throws: nothing destructive has run yet at this point.
+ */
+async function resolvePooledAvdKillTarget(
+  dependencies: DeviceToolsDependencies,
+  device: BootedDevice,
+  pooledAvdCapture: PooledAvdCapture | undefined,
+  devicePool: DevicePool | undefined,
+  shutdownDeadlineMs: number,
+  requestAbortSignal: AbortSignal | undefined,
+): Promise<BootedDevice> {
+  if (!pooledAvdCapture) {
+    return device;
+  }
+  const confirmation = await confirmPooledAvdIdentity(
+    device,
+    pooledAvdCapture,
+    devicePool,
+    dependencies.resolveRunningAndroidAvdName,
+    { timer: dependencies.timer, deadlineMs: shutdownDeadlineMs, signal: requestAbortSignal },
+  );
+  if ("refusal" in confirmation) {
+    throw new PooledAvdIdentityError(pooledAvdNameRefusalMessage(device, confirmation.refusal));
+  }
+  return { ...device, name: confirmation.confirmedAvdName };
+}
+
 async function killProcessAndRetireOwnership(
   dependencies: DeviceToolsDependencies,
   device: BootedDevice,
@@ -2095,8 +2128,21 @@ async function killProcessAndRetireOwnership(
   ) => void,
   strictDeadline = false,
   timeoutMs = DEVICE_SHUTDOWN_TIMEOUT_MS,
+  pooledAvdCapture?: PooledAvdCapture,
 ): Promise<string | undefined> {
   const deviceManager = dependencies.deviceManagerFactory();
+  // LAST thing before anything destructive: re-confirm the captured epoch and
+  // make the runtime name itself, then kill under the name it gave (#6863
+  // review). Ahead of `markIntentionalShutdown`, so a refusal leaves no marker
+  // behind on a device this daemon did not touch.
+  const killTarget = await resolvePooledAvdKillTarget(
+    dependencies,
+    device,
+    pooledAvdCapture,
+    devicePool,
+    shutdownDeadlineMs,
+    requestAbortSignal,
+  );
   if (device.platform === "android") {
     devicePool?.markIntentionalShutdown(device.deviceId);
   }
@@ -2114,9 +2160,11 @@ async function killProcessAndRetireOwnership(
       "platform shutdown command did not complete",
       requestAbortSignal,
       async (signal, timeoutMs) => {
-        platformShutdown = deviceManager.killDevice(device, { signal, timeoutMs }).finally(() => {
-          platformShutdownSettled = true;
-        });
+        platformShutdown = deviceManager
+          .killDevice(killTarget, { signal, timeoutMs })
+          .finally(() => {
+            platformShutdownSettled = true;
+          });
         return await platformShutdown;
       },
       timeoutMs,
@@ -2230,6 +2278,7 @@ async function shutdownDevice(
   strictDeadline = false,
   timeoutMs = DEVICE_SHUTDOWN_TIMEOUT_MS,
   retainLifecycleUntil?: (operation: Promise<unknown>) => void,
+  pooledAvdCapture?: PooledAvdCapture,
 ): Promise<ShutdownResult> {
   const perf = createPerformanceTracker(true);
   perf.serial(operationName);
@@ -2290,6 +2339,7 @@ async function shutdownDevice(
         },
         strictDeadline,
         timeoutMs,
+        pooledAvdCapture,
       );
 
       if (alreadyStoppedMessage !== undefined) {
@@ -2355,6 +2405,12 @@ type TeardownResolvedTarget =
       device: DeviceInfo;
       wasBooted: true;
       bootedDevice: BootedDevice;
+      /**
+       * The pooled AVD label + epoch captured at preflight, when this target was
+       * matched by a label the pool supplied rather than by a name the runtime
+       * gave. Re-confirmed immediately before the platform kill (#6863 review).
+       */
+      pooledAvdCapture?: PooledAvdCapture;
     };
 
 function isVirtualAndroidDevice(device: BootedDevice): boolean {
@@ -2397,14 +2453,15 @@ function resolveKillDeviceStableTarget(
  * faster than one discovery interval never reaches the pool, so the cached name
  * can belong to the previous occupant of the serial. Every DESTRUCTIVE caller
  * (killDevice, deleteDevice) must therefore run {@link
- * verifyPooledAndroidAvdName} first, which re-resolves the name from the
+ * capturePooledAvdIdentity} at preflight and {@link confirmPooledAvdIdentity}
+ * immediately before the platform kill, which re-resolves the name from the
  * runtime and fails closed on a mismatch -- and on a probe that does not
  * answer.
  */
-function getValidatedPooledAndroidAvdName(
+function getValidatedPooledAndroidEntry(
   device: BootedDevice,
   devicePool: DevicePool | undefined,
-): string | undefined {
+): PooledDevice | undefined {
   if (device.platform !== "android" || !isUnknownAndroidRuntimeName(device)) {
     return undefined;
   }
@@ -2413,13 +2470,49 @@ function getValidatedPooledAndroidAvdName(
     // substitute and nothing that would make a pooled label trustworthy.
     return undefined;
   }
-  const pooled = devicePool?.getDevice(device.deviceId);
-  return pooled?.avdName;
+  return devicePool?.getDevice(device.deviceId) ?? undefined;
+}
+
+function getValidatedPooledAndroidAvdName(
+  device: BootedDevice,
+  devicePool: DevicePool | undefined,
+): string | undefined {
+  return getValidatedPooledAndroidEntry(device, devicePool)?.avdName;
 }
 
 type PooledAvdNameRefusal =
   | { reason: "conflict"; pooledAvdName: string; runtimeAvdName: string }
-  | { reason: "unresolved"; pooledAvdName: string };
+  | { reason: "unresolved"; pooledAvdName: string }
+  | { reason: "moved"; pooledAvdName: string };
+
+/**
+ * The pooled AVD label a destructive action would otherwise act on, pinned to
+ * the pool INCARNATION that label belongs to.
+ *
+ * Captured at PREFLIGHT and re-confirmed immediately before the platform kill.
+ * `reserveDeviceForShutdown` protects the captured entry from pool eviction,
+ * but it cannot stop the emulator behind the serial from disappearing and being
+ * replaced before discovery notices, so the epoch is re-read at the last
+ * possible moment and the runtime is asked to name itself there rather than at
+ * preflight (#6863 review).
+ */
+interface PooledAvdCapture {
+  avdName: string;
+  incarnation: number;
+}
+
+type PooledAvdCaptureResult =
+  | { kind: "none" }
+  | { kind: "capture"; capture: PooledAvdCapture }
+  | { kind: "refusal"; refusal: PooledAvdNameRefusal };
+
+/**
+ * An identity refusal raised from inside the shutdown path. It is an
+ * {@link ActionableError} so it travels through `rethrowShutdownFailure`
+ * unwrapped, and its own type lets `deleteDevice` report it as
+ * `target_identity_unresolved` instead of a generic operation failure.
+ */
+class PooledAvdIdentityError extends ActionableError {}
 
 /**
  * The caller's own deadline for the destructive action, which the verification
@@ -2432,20 +2525,56 @@ interface PooledAvdNameProbeBudget {
 }
 
 /**
- * Fail closed before a destructive action on an emulator whose discovered name
- * is `Unknown (<serial>)` and whose AVD name therefore comes from the pool.
+ * PREFLIGHT half of the identity check: pin the pooled label to its epoch.
  *
- * A different AVD can take over a reused serial before discovery observes the
- * previous one disappear, leaving the pool holding the OLD label — and a kill or
- * delete issued against that label would stop the NEW emulator (#6863 review).
- * So ask the runtime itself:
- *  - it names the SAME AVD -> identity verified, proceed;
- *  - it names a DIFFERENT AVD -> `conflict`; the caller refuses;
- *  - it cannot answer inside the bounded budget -> `unresolved`; the caller
- *    refuses too.
+ * Returns `none` for every target whose name did NOT come from the pool -- a
+ * runtime that named itself, and every physical handset, because
+ * `ro.product.model` is not an AVD name and is not unique.
+ *
+ * A budget that is already spent refuses right here: with no time left the
+ * runtime can never be asked to name itself, so the label can never be tied to
+ * the emulator running on the serial, and refusing with the identity message is
+ * strictly more actionable than the shutdown timeout that would otherwise
+ * follow.
+ */
+function capturePooledAvdIdentity(
+  device: BootedDevice,
+  devicePool: DevicePool | undefined,
+  budget: PooledAvdNameProbeBudget,
+): PooledAvdCaptureResult {
+  const pooled = getValidatedPooledAndroidEntry(device, devicePool);
+  const avdName = pooled?.avdName;
+  if (!pooled || !avdName) {
+    return { kind: "none" };
+  }
+  if (budget.deadlineMs - budget.timer.now() <= 0) {
+    return { kind: "refusal", refusal: { reason: "unresolved", pooledAvdName: avdName } };
+  }
+  return { kind: "capture", capture: { avdName, incarnation: pooled.incarnation } };
+}
+
+/**
+ * KILL-TIME half of the identity check, run immediately before the platform
+ * kill on an emulator whose discovered name is `Unknown (<serial>)` and whose
+ * AVD name therefore comes from the pool.
+ *
+ * Two things must still hold:
+ *  - the pool must still hold the CAPTURED incarnation under that label. A new
+ *    incarnation means the serial was re-allocated while this shutdown was
+ *    being set up, so the captured label no longer describes the target;
+ *  - the runtime must name the SAME AVD. A different AVD can take over a reused
+ *    serial before discovery observes the previous one disappear, leaving the
+ *    pool holding the OLD label -- and a kill issued against that label would
+ *    stop the NEW emulator (#6863 review).
+ *
+ * Returns the CONFIRMED name so the caller can put it in the kill target:
+ * `AndroidEmulatorClient.killDevice` re-discovers the serial and refuses a
+ * target whose name differs from the discovered one, so handing it the
+ * `Unknown (<serial>)` placeholder would throw away the proof this probe just
+ * obtained.
  *
  * There is no fail-open branch. `Unknown (<serial>)` means "no information", and
- * a probe that does not answer leaves it that way — acting anyway would be
+ * a probe that does not answer leaves it that way -- acting anyway would be
  * acting on a label this daemon cannot tie to the runtime. The cost is that an
  * emulator whose console has wedged is not killable through the tool; the
  * message names `adb -s <serial> emu kill` as the manual escape, and a
@@ -2454,25 +2583,26 @@ interface PooledAvdNameProbeBudget {
  * The probe is bounded by whichever is smaller, the verification ceiling or the
  * caller's REMAINING deadline: it runs inside a lifecycle lease that is already
  * on the clock, so it must never start an independent timer that can outlast it.
- * A budget that is already spent refuses immediately without probing at all.
- *
- * Physical handsets never reach the probe: {@link
- * getValidatedPooledAndroidAvdName} returns nothing for a non-emulator serial,
- * because `ro.product.model` is not an AVD name and is not unique.
  */
-async function verifyPooledAndroidAvdName(
+async function confirmPooledAvdIdentity(
   device: BootedDevice,
+  capture: PooledAvdCapture,
   devicePool: DevicePool | undefined,
   resolveRunningAvdName: DeviceToolsDependencies["resolveRunningAndroidAvdName"],
   budget: PooledAvdNameProbeBudget,
-): Promise<PooledAvdNameRefusal | undefined> {
-  const pooledAvdName = getValidatedPooledAndroidAvdName(device, devicePool);
-  if (!pooledAvdName) {
-    return undefined;
+): Promise<{ confirmedAvdName: string } | { refusal: PooledAvdNameRefusal }> {
+  const pooledAvdName = capture.avdName;
+  const pooled = devicePool?.getDevice(device.deviceId);
+  if (!pooled || pooled.incarnation !== capture.incarnation || pooled.avdName !== pooledAvdName) {
+    logger.warn(
+      `[DeviceTools] The pool no longer holds incarnation ${capture.incarnation} of ` +
+        `${device.deviceId} under AVD '${pooledAvdName}'; refusing the destructive action.`,
+    );
+    return { refusal: { reason: "moved", pooledAvdName } };
   }
   const remainingMs = budget.deadlineMs - budget.timer.now();
   if (remainingMs <= 0) {
-    return { reason: "unresolved", pooledAvdName };
+    return { refusal: { reason: "unresolved", pooledAvdName } };
   }
   const runtimeAvdName = await resolveRunningAvdName(
     device,
@@ -2484,14 +2614,22 @@ async function verifyPooledAndroidAvdName(
       `[DeviceTools] Could not confirm that ${device.deviceId} is still AVD '${pooledAvdName}': ` +
         "the emulator console did not report a name.",
     );
-    return { reason: "unresolved", pooledAvdName };
+    return { refusal: { reason: "unresolved", pooledAvdName } };
   }
   return runtimeAvdName === pooledAvdName
-    ? undefined
-    : { reason: "conflict", pooledAvdName, runtimeAvdName };
+    ? { confirmedAvdName: runtimeAvdName }
+    : { refusal: { reason: "conflict", pooledAvdName, runtimeAvdName } };
 }
 
 function pooledAvdNameRefusalMessage(device: BootedDevice, refusal: PooledAvdNameRefusal): string {
+  if (refusal.reason === "moved") {
+    return (
+      `Refusing to act on Android emulator '${device.deviceId}': this daemon had it recorded as ` +
+      `AVD '${refusal.pooledAvdName}', but that connection epoch was retired while this action ` +
+      "was being prepared, so the emulator now on that serial is a different run. Re-resolve " +
+      "the target and retry."
+    );
+  }
   if (refusal.reason === "conflict") {
     return (
       `Refusing to act on Android emulator '${device.deviceId}': this daemon has it recorded as ` +
@@ -3002,29 +3140,31 @@ async function resolveTeardownTarget(context: TeardownContext): Promise<Teardown
   const daemonState = DaemonState.getInstance();
   const devicePool = daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
   // A booted emulator only matches this teardown by its POOLED AVD name when its
-  // runtime name is unknown; make the runtime confirm that name before the stop
-  // and the delete act on it (#6863 review).
-  for (const candidate of findMatchingBootedTeardownDevices(booted, context.args, devicePool)) {
-    const refusal = await verifyPooledAndroidAvdName(
-      candidate,
-      devicePool,
-      getDeviceToolsDependencies().resolveRunningAndroidAvdName,
-      {
+  // runtime name is unknown. Pin that label to its epoch here; the runtime is
+  // made to confirm it immediately before the stop's platform kill, which is
+  // also where `createBootedTeardownTarget` has already rewritten the target's
+  // name to the pooled label (#6863 review).
+  const [matchedBootedCandidate] = findMatchingBootedTeardownDevices(
+    booted,
+    context.args,
+    devicePool,
+  );
+  const pooledAvdCapture: PooledAvdCaptureResult = matchedBootedCandidate
+    ? capturePooledAvdIdentity(matchedBootedCandidate, devicePool, {
         timer: context.dependencies.timer,
         deadlineMs: context.deadlineMs,
         signal: context.requestAbortSignal,
-      },
-    );
-    if (refusal) {
-      return {
-        response: createTeardownFailureResponse(
-          context.args,
-          "precondition",
-          "target_identity_unresolved",
-          pooledAvdNameRefusalMessage(candidate, refusal),
-        ),
-      };
-    }
+      })
+    : { kind: "none" };
+  if (matchedBootedCandidate && pooledAvdCapture.kind === "refusal") {
+    return {
+      response: createTeardownFailureResponse(
+        context.args,
+        "precondition",
+        "target_identity_unresolved",
+        pooledAvdNameRefusalMessage(matchedBootedCandidate, pooledAvdCapture.refusal),
+      ),
+    };
   }
   const bootedTarget = findBootedTeardownTarget(booted, context.args, devicePool);
   if (bootedTarget.conflict) {
@@ -3048,7 +3188,11 @@ async function resolveTeardownTarget(context: TeardownContext): Promise<Teardown
     };
   }
   if (bootedTarget.target) {
-    return await finalizeIosNameResolvedTeardownTarget(context, bootedTarget.target);
+    const resolvedTarget: TeardownResolvedTarget =
+      bootedTarget.target.wasBooted && pooledAvdCapture.kind === "capture"
+        ? { ...bootedTarget.target, pooledAvdCapture: pooledAvdCapture.capture }
+        : bootedTarget.target;
+    return await finalizeIosNameResolvedTeardownTarget(context, resolvedTarget);
   }
   const unresolvedAndroidRuntime = booted.devices.find(
     (device) =>
@@ -7096,16 +7240,18 @@ export function registerDeviceTools() {
     const deadlineMs = deps.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
     const daemonState = DaemonState.getInstance();
     const devicePool = daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
-    // Before anything destructive: if this target's AVD name comes from the pool
-    // rather than from the runtime, make the runtime confirm it (#6863 review).
-    const avdNameRefusal = await verifyPooledAndroidAvdName(
-      args.device,
-      devicePool,
-      deps.resolveRunningAndroidAvdName,
-      { timer: deps.timer, deadlineMs, signal: requestAbortSignal },
-    );
-    if (avdNameRefusal) {
-      throw new ActionableError(pooledAvdNameRefusalMessage(args.device, avdNameRefusal));
+    // Preflight: if this target's AVD name comes from the pool rather than from
+    // the runtime, pin the label to its epoch. The runtime is made to confirm it
+    // immediately before the platform kill, not here (#6863 review).
+    const pooledAvdCapture = capturePooledAvdIdentity(args.device, devicePool, {
+      timer: deps.timer,
+      deadlineMs,
+      signal: requestAbortSignal,
+    });
+    if (pooledAvdCapture.kind === "refusal") {
+      throw new PooledAvdIdentityError(
+        pooledAvdNameRefusalMessage(args.device, pooledAvdCapture.refusal),
+      );
     }
     const stableTarget = resolveKillDeviceStableTarget(args.device, devicePool);
     const lifecycleLease = stableTarget
@@ -7144,6 +7290,7 @@ export function registerDeviceTools() {
         false,
         DEVICE_SHUTDOWN_TIMEOUT_MS,
         retainLifecycleUntil,
+        pooledAvdCapture.kind === "capture" ? pooledAvdCapture.capture : undefined,
       );
       return createKillDeviceResponse(args, result.timing, result.alreadyStoppedMessage);
     } finally {
@@ -7212,6 +7359,7 @@ export function registerDeviceTools() {
                 true,
                 context.timeoutMs,
                 retainLeaseUntil,
+                target.pooledAvdCapture,
               );
               stop = stopped.alreadyStoppedMessage ? "not_required" : "accepted";
             } else {
@@ -7270,7 +7418,12 @@ export function registerDeviceTools() {
             return createTeardownFailureResponse(
               args,
               phase,
-              "operation_failed",
+              // The last-moment identity check refuses a target this daemon
+              // cannot tie to the runtime; that is an identity outcome, not a
+              // generic operation failure (#6863 review).
+              effectiveError instanceof PooledAvdIdentityError
+                ? "target_identity_unresolved"
+                : "operation_failed",
               String(effectiveError instanceof Error ? effectiveError.message : effectiveError),
               state?.target.device,
             );

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -781,12 +781,13 @@ export interface DeviceToolsDependencies {
   /**
    * Re-resolve an emulator's AVD name from the RUNTIME rather than from any
    * host-side cache (`emu avd name`). Resolves to undefined when the emulator
-   * console cannot answer inside `timeoutMs`. See
-   * {@link verifyPooledAndroidAvdName}.
+   * console cannot answer inside `timeoutMs`, which is the caller's REMAINING
+   * deadline, not an independent budget. See {@link verifyPooledAndroidAvdName}.
    */
   resolveRunningAndroidAvdName: (
     device: BootedDevice,
     timeoutMs: number,
+    signal?: AbortSignal,
   ) => Promise<string | undefined>;
 }
 
@@ -842,21 +843,24 @@ function releaseProvisionDeviceWaiter(
 }
 
 /**
- * How long the runtime gets to name itself before a destructive action gives up
- * on verification. Short on purpose: the caller is holding a lifecycle lease and
- * a wedged console must not turn a kill into a hang — an unanswered probe is a
- * logged warning, not a failure (see {@link verifyPooledAndroidAvdName}).
+ * The CEILING on how long the runtime gets to name itself before a destructive
+ * action gives up on verification. Short on purpose: the caller is holding a
+ * lifecycle lease and a wedged console must not turn a kill into a hang. It is a
+ * ceiling and never a floor — the probe is bounded by whichever is smaller, this
+ * or the caller's remaining teardown/kill deadline, and an unanswered probe
+ * REFUSES the action (see {@link verifyPooledAndroidAvdName}).
  */
 const POOLED_AVD_NAME_VERIFICATION_TIMEOUT_MS = 3_000;
 
 async function defaultResolveRunningAndroidAvdName(
   device: BootedDevice,
   timeoutMs: number,
+  signal?: AbortSignal,
 ): Promise<string | undefined> {
   try {
     const { AndroidEmulatorClient } =
       await import("../utils/android-cmdline-tools/AndroidEmulatorClient");
-    return await new AndroidEmulatorClient().resolveRunningAvdName(device, timeoutMs);
+    return await new AndroidEmulatorClient().resolveRunningAvdName(device, timeoutMs, signal);
   } catch (error) {
     // An unreachable console is one of the three expected outcomes of this
     // probe; the caller treats "could not resolve" as its documented blind spot.
@@ -2393,7 +2397,8 @@ function resolveKillDeviceStableTarget(
  * can belong to the previous occupant of the serial. Every DESTRUCTIVE caller
  * (killDevice, deleteDevice) must therefore run {@link
  * verifyPooledAndroidAvdName} first, which re-resolves the name from the
- * runtime and fails closed on a mismatch.
+ * runtime and fails closed on a mismatch -- and on a probe that does not
+ * answer.
  */
 function getValidatedPooledAndroidAvdName(
   device: BootedDevice,
@@ -2411,9 +2416,18 @@ function getValidatedPooledAndroidAvdName(
   return pooled?.avdName;
 }
 
-interface PooledAvdNameConflict {
-  pooledAvdName: string;
-  runtimeAvdName: string;
+type PooledAvdNameRefusal =
+  | { reason: "conflict"; pooledAvdName: string; runtimeAvdName: string }
+  | { reason: "unresolved"; pooledAvdName: string };
+
+/**
+ * The caller's own deadline for the destructive action, which the verification
+ * probe borrows rather than starting a timer of its own.
+ */
+interface PooledAvdNameProbeBudget {
+  timer: Timer;
+  deadlineMs: number;
+  signal?: AbortSignal;
 }
 
 /**
@@ -2424,12 +2438,22 @@ interface PooledAvdNameConflict {
  * previous one disappear, leaving the pool holding the OLD label — and a kill or
  * delete issued against that label would stop the NEW emulator (#6863 review).
  * So ask the runtime itself:
- *  - it names a DIFFERENT AVD -> return the conflict; the caller refuses;
  *  - it names the SAME AVD -> identity verified, proceed;
- *  - it cannot answer inside the bounded timeout -> proceed on the pooled name
- *    and warn. That is the whole of the remaining blind spot, narrowed from
- *    "any restart faster than one discovery interval" to "the emulator console
- *    is unavailable at the moment of the destructive action".
+ *  - it names a DIFFERENT AVD -> `conflict`; the caller refuses;
+ *  - it cannot answer inside the bounded budget -> `unresolved`; the caller
+ *    refuses too.
+ *
+ * There is no fail-open branch. `Unknown (<serial>)` means "no information", and
+ * a probe that does not answer leaves it that way — acting anyway would be
+ * acting on a label this daemon cannot tie to the runtime. The cost is that an
+ * emulator whose console has wedged is not killable through the tool; the
+ * message names `adb -s <serial> emu kill` as the manual escape, and a
+ * tool-level `force` option is tracked as a separate follow-up.
+ *
+ * The probe is bounded by whichever is smaller, the verification ceiling or the
+ * caller's REMAINING deadline: it runs inside a lifecycle lease that is already
+ * on the clock, so it must never start an independent timer that can outlast it.
+ * A budget that is already spent refuses immediately without probing at all.
  *
  * Physical handsets never reach the probe: {@link
  * getValidatedPooledAndroidAvdName} returns nothing for a non-emulator serial,
@@ -2439,34 +2463,51 @@ async function verifyPooledAndroidAvdName(
   device: BootedDevice,
   devicePool: DevicePool | undefined,
   resolveRunningAvdName: DeviceToolsDependencies["resolveRunningAndroidAvdName"],
-): Promise<PooledAvdNameConflict | undefined> {
+  budget: PooledAvdNameProbeBudget,
+): Promise<PooledAvdNameRefusal | undefined> {
   const pooledAvdName = getValidatedPooledAndroidAvdName(device, devicePool);
   if (!pooledAvdName) {
     return undefined;
   }
+  const remainingMs = budget.deadlineMs - budget.timer.now();
+  if (remainingMs <= 0) {
+    return { reason: "unresolved", pooledAvdName };
+  }
   const runtimeAvdName = await resolveRunningAvdName(
     device,
-    POOLED_AVD_NAME_VERIFICATION_TIMEOUT_MS,
+    Math.min(POOLED_AVD_NAME_VERIFICATION_TIMEOUT_MS, remainingMs),
+    budget.signal,
   );
   if (runtimeAvdName === undefined) {
     logger.warn(
       `[DeviceTools] Could not confirm that ${device.deviceId} is still AVD '${pooledAvdName}': ` +
-        "the emulator console did not report a name. Proceeding on the pooled name.",
+        "the emulator console did not report a name.",
     );
-    return undefined;
+    return { reason: "unresolved", pooledAvdName };
   }
-  return runtimeAvdName === pooledAvdName ? undefined : { pooledAvdName, runtimeAvdName };
+  return runtimeAvdName === pooledAvdName
+    ? undefined
+    : { reason: "conflict", pooledAvdName, runtimeAvdName };
 }
 
-function pooledAvdNameConflictMessage(
+function pooledAvdNameRefusalMessage(
   device: BootedDevice,
-  conflict: PooledAvdNameConflict,
+  refusal: PooledAvdNameRefusal,
 ): string {
+  if (refusal.reason === "conflict") {
+    return (
+      `Refusing to act on Android emulator '${device.deviceId}': this daemon has it recorded as ` +
+      `AVD '${refusal.pooledAvdName}', but the emulator now running on that serial reports ` +
+      `AVD '${refusal.runtimeAvdName}'. The serial was reused by a different AVD; re-resolve ` +
+      "the target and retry."
+    );
+  }
   return (
     `Refusing to act on Android emulator '${device.deviceId}': this daemon has it recorded as ` +
-    `AVD '${conflict.pooledAvdName}', but the emulator now running on that serial reports ` +
-    `AVD '${conflict.runtimeAvdName}'. The serial was reused by a different AVD; re-resolve the ` +
-    "target and retry."
+    `AVD '${refusal.pooledAvdName}', but the emulator console on that serial did not answer, so ` +
+    "the AVD actually running there could not be confirmed. Acting on the recorded name could " +
+    "stop a different emulator that took the serial. Resolve the target and retry, or stop it " +
+    `by hand with \`adb -s ${device.deviceId} emu kill\`.`
   );
 }
 
@@ -2966,18 +3007,23 @@ async function resolveTeardownTarget(context: TeardownContext): Promise<Teardown
   // runtime name is unknown; make the runtime confirm that name before the stop
   // and the delete act on it (#6863 review).
   for (const candidate of findMatchingBootedTeardownDevices(booted, context.args, devicePool)) {
-    const conflict = await verifyPooledAndroidAvdName(
+    const refusal = await verifyPooledAndroidAvdName(
       candidate,
       devicePool,
       getDeviceToolsDependencies().resolveRunningAndroidAvdName,
+      {
+        timer: context.dependencies.timer,
+        deadlineMs: context.deadlineMs,
+        signal: context.requestAbortSignal,
+      },
     );
-    if (conflict) {
+    if (refusal) {
       return {
         response: createTeardownFailureResponse(
           context.args,
           "precondition",
           "target_identity_unresolved",
-          pooledAvdNameConflictMessage(candidate, conflict),
+          pooledAvdNameRefusalMessage(candidate, refusal),
         ),
       };
     }
@@ -7054,13 +7100,14 @@ export function registerDeviceTools() {
     const devicePool = daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
     // Before anything destructive: if this target's AVD name comes from the pool
     // rather than from the runtime, make the runtime confirm it (#6863 review).
-    const avdNameConflict = await verifyPooledAndroidAvdName(
+    const avdNameRefusal = await verifyPooledAndroidAvdName(
       args.device,
       devicePool,
       deps.resolveRunningAndroidAvdName,
+      { timer: deps.timer, deadlineMs, signal: requestAbortSignal },
     );
-    if (avdNameConflict) {
-      throw new ActionableError(pooledAvdNameConflictMessage(args.device, avdNameConflict));
+    if (avdNameRefusal) {
+      throw new ActionableError(pooledAvdNameRefusalMessage(args.device, avdNameRefusal));
     }
     const stableTarget = resolveKillDeviceStableTarget(args.device, devicePool);
     const lifecycleLease = stableTarget

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -468,7 +468,6 @@ export const killDeviceSchema = z.object({
     name: z.string().describe("Device image name"),
     deviceId: z.string(),
     platform: platformSchema,
-    transportId: z.string().optional(),
   }),
 });
 
@@ -741,7 +740,6 @@ function deviceIdentityPayload(
       avdName: sourceImage?.platform === "android" ? sourceImage.name : device.name,
       adbSerial: device.deviceId,
       emulatorConsolePort: portMatch ? Number(portMatch[1]) : null,
-      adbTransportId: device.transportId ?? null,
     };
   }
 

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -1198,20 +1198,20 @@ export class AdbClient implements AdbExecutor {
     const devices = lines
       .filter((line) => line.trim().length > 0)
       .flatMap((line) => {
-        const [deviceId, state, ...details] = line.trim().split(/\s+/);
+        const [deviceId, state] = line.trim().split(/\s+/);
         if (!deviceId || state !== "device") {
           return [];
         }
-        const transportId = details
-          .find((detail) => detail.startsWith("transport_id:"))
-          ?.slice("transport_id:".length);
+        // `adb devices -l` also reports `transport_id:`, deliberately not read:
+        // it is a per-connection handle, and a device identity that carried it
+        // invited callers to treat "transport unchanged" as proof of an unbroken
+        // connection. The pool's `incarnation` is the one epoch token.
         return [
           {
             name: deviceId,
             platform: "android",
             deviceId,
             observedAt,
-            ...(transportId ? { transportId } : {}),
           } satisfies BootedDevice,
         ];
       });

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1395,6 +1395,15 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     return name === "" ? undefined : name;
   }
 
+  /**
+   * `infoTimeoutMs` is the TOTAL budget for naming this runtime, not a per-command
+   * allowance. The console probe and the `getprop` fallback run sequentially, so
+   * giving each its own full budget would let two stalled commands take twice the
+   * timeout the caller asked for -- and this resolver runs inside a destructive
+   * action that is already holding a lifecycle lease against a deadline (#6863
+   * review). They share one deadline; the fallback gets only what is left of it,
+   * and is skipped when nothing is.
+   */
   private async getRunningAVDName(
     device: BootedDevice,
     infoTimeoutMs: number,
@@ -1402,6 +1411,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   ): Promise<{ name: string; diagnostic?: ReadinessDiagnostic }> {
     const deviceId = device.deviceId;
     const adbWithDevice = this.adbFactory.create(device);
+    const deadlineMs = this.timer.now() + infoTimeoutMs;
     let diagnostic: ReadinessDiagnostic | undefined;
     try {
       const result = await adbWithDevice.executeCommand(
@@ -1424,10 +1434,18 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       logger.debug(`Failed to get AVD name for ${deviceId}: ${error}`);
     }
 
+    const remainingMs = deadlineMs - this.timer.now();
+    if (remainingMs <= 0) {
+      logger.debug(
+        `AVD name resolution for ${deviceId} spent its ${infoTimeoutMs}ms budget on the console probe; skipping the property fallback`,
+      );
+      return { name: "", diagnostic };
+    }
+
     try {
       const result = await adbWithDevice.executeCommand(
         "shell getprop ro.boot.qemu.avd_name",
-        infoTimeoutMs,
+        remainingMs,
         undefined,
         true,
         signal,

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -2258,6 +2258,25 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       );
     }
 
+    // Two unknowns are not an equality. `Unknown (<serial>)` on either side is
+    // the absence of a name, so a request carrying the placeholder that meets a
+    // discovery carrying the placeholder has matched on nothing -- and the
+    // emulator answering on the serial now may be a replacement of the one the
+    // caller resolved. Callers that legitimately target an emulator whose
+    // console is mute resolve its AVD name first and put THAT in the target
+    // (`deviceTools.confirmPooledAvdIdentity`), so reaching here with two
+    // placeholders means no identity was ever established (#6863 review).
+    if (
+      this.isUnknownEmulatorName(device.name, device.deviceId) &&
+      this.isUnknownEmulatorName(emulator.name, emulator.deviceId)
+    ) {
+      throw new ActionableError(
+        `Refusing to kill '${device.deviceId}': the emulator could not name itself, so this ` +
+          "daemon cannot tell it apart from a replacement that took the serial. Resolve its AVD " +
+          `name and retry, or stop it by hand with \`adb -s ${device.deviceId} emu kill\`.`,
+      );
+    }
+
     // Terminate through the emulator console `emu kill`. Only the console
     // shutdown lets the emulator write its quick-boot snapshot on exit; a guest
     // `shell reboot -p` halts the OS without it, so the next quick-boot of the

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1376,6 +1376,25 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
   }
 
+  /**
+   * Ask the RUNTIME on this serial which AVD it is (`emu avd name`, with the
+   * `ro.boot.qemu.avd_name` property as fallback).
+   *
+   * Public because identity now has no ADB transport id: a caller about to do
+   * something destructive to an emulator whose discovered name is
+   * `Unknown (<serial>)` must be able to re-resolve that name from the device
+   * itself rather than trust a host-side cache (#6863). Returns undefined when
+   * the runtime cannot answer inside `timeoutMs`.
+   */
+  async resolveRunningAvdName(
+    device: BootedDevice,
+    timeoutMs: number,
+    signal?: AbortSignal,
+  ): Promise<string | undefined> {
+    const { name } = await this.getRunningAVDName(device, timeoutMs, signal);
+    return name === "" ? undefined : name;
+  }
+
   private async getRunningAVDName(
     device: BootedDevice,
     infoTimeoutMs: number,

--- a/src/utils/androidSerial.ts
+++ b/src/utils/androidSerial.ts
@@ -1,0 +1,12 @@
+/**
+ * adb reserves the `emulator-<port>` serial shape for locally-running Android
+ * emulators; every other serial belongs to a physical handset. Several call
+ * sites had grown their own copy of this predicate, so keep exactly one
+ * spelling here (issue #6850 review).
+ */
+const ANDROID_EMULATOR_SERIAL_PATTERN = /^emulator-\d+$/;
+
+/** True when `deviceId` is an adb emulator serial (e.g. `emulator-5554`). */
+export function isAndroidEmulatorSerial(deviceId: string): boolean {
+  return ANDROID_EMULATOR_SERIAL_PATTERN.test(deviceId);
+}

--- a/src/utils/deviceIncarnation.ts
+++ b/src/utils/deviceIncarnation.ts
@@ -1,0 +1,39 @@
+/**
+ * Process-local access to the device pool's connection-epoch counter.
+ *
+ * `PooledDevice.incarnation` is the ONLY epoch token in the device identity
+ * model: an adb serial is reused across boots, and a discovery listing carries
+ * nothing that distinguishes one occupant of `emulator-5554` from the next.
+ * Anything that caches per-device state keyed on the serial therefore has to key
+ * on the incarnation as well, or a same-serial reincarnation silently inherits
+ * the previous device's cached state (issue #3351).
+ *
+ * Feature code must not reach into the daemon to ask, so the daemon registers a
+ * resolver here when it wires its pool (`DaemonState.initialize`) and callers
+ * read the token through {@link deviceIncarnationToken}. Outside a daemon -- a
+ * direct-mode invocation, or a unit test that never built a pool -- no resolver
+ * is registered and the token is `undefined`, which every consumer must treat as
+ * "no epoch information", never as an epoch of its own.
+ */
+export type DeviceIncarnationResolver = (deviceId: string) => number | undefined;
+
+let resolver: DeviceIncarnationResolver | undefined;
+
+/**
+ * Register (or, with `undefined`, clear) the process-wide resolver. The daemon
+ * calls this once with its pool; tests call it to control the epoch explicitly
+ * and must clear it again so the token does not leak between cases.
+ */
+export function setDeviceIncarnationResolver(next: DeviceIncarnationResolver | undefined): void {
+  resolver = next;
+}
+
+/**
+ * The current connection-epoch token for `deviceId`, or `undefined` when no
+ * resolver is registered or the device is not pooled. Stringified so consumers
+ * can compare and log it without caring that it is a counter.
+ */
+export function deviceIncarnationToken(deviceId: string): string | undefined {
+  const incarnation = resolver?.(deviceId);
+  return incarnation === undefined ? undefined : String(incarnation);
+}

--- a/test/daemon/daemonDevicePoolStartup.test.ts
+++ b/test/daemon/daemonDevicePoolStartup.test.ts
@@ -21,10 +21,18 @@ class DeferredDiscoveryDeviceManager extends FakeDeviceManager {
   private readonly started = Promise.withResolvers<void>();
   private readonly release = Promise.withResolvers<void>();
 
+  private discoveryCount = 0;
+
   override async getBootedDevicesDetailed(platform: SomePlatform) {
     this.discoveryStarted = true;
     this.started.resolve();
-    await this.release.promise;
+    this.discoveryCount++;
+    // Only the FIRST discovery is the deferred startup one. Later callers (the
+    // pool re-proving an idle entry present before it is assigned) must not be
+    // parked behind it, the way a real adb would not be.
+    if (this.discoveryCount === 1) {
+      await this.release.promise;
+    }
     return await super.getBootedDevicesDetailed(platform);
   }
 

--- a/test/daemon/daemonSessionReleaseSignal.integration.test.ts
+++ b/test/daemon/daemonSessionReleaseSignal.integration.test.ts
@@ -9,6 +9,9 @@ import { SessionReleaseBroadcaster } from "../../src/server/sessionReleaseBroadc
 import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
 import { createTestDatabase } from "../db/testDbHelper";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
+import type { DevicePool } from "../../src/daemon/devicePool";
+import type { BootedDevice } from "../../src/models";
 
 // Issue #4610: the daemon registers a release callback (next to the nav-graph /
 // observe-cache cleanup) that fans the released session key out to the
@@ -22,6 +25,18 @@ interface DaemonHeartbeatMonitorInternals {
 
 interface DaemonSessionReleaseInternals {
   cancelAndReleaseSession(sessionId: string, releaseReason: string): Promise<void>;
+}
+
+/**
+ * Point a daemon-owned pool's discovery at a fake that lists exactly these
+ * devices. A pooled Android entry is re-proved present against discovery before
+ * it is handed out (handsets included), and the daemon builds its pool with the
+ * real device manager, which would shell out to adb.
+ */
+function stubPoolDiscovery(devicePool: DevicePool, devices: BootedDevice[]): void {
+  const deviceManager = new FakeDeviceManager();
+  deviceManager.bootedDevices = [...devices];
+  Object.assign(devicePool, { deviceManager });
 }
 
 describe("Daemon session-release signal wiring", () => {
@@ -118,13 +133,9 @@ describe("Daemon session-release signal wiring", () => {
     );
 
     try {
-      await devicePool.initializeWithDevices([
-        {
-          name: "Pixel",
-          deviceId,
-          platform: "android",
-        },
-      ]);
+      const device: BootedDevice = { name: "Pixel", deviceId, platform: "android" };
+      stubPoolDiscovery(devicePool, [device]);
+      await devicePool.initializeWithDevices([device]);
       await devicePool.assignDeviceToSession(sessionId, "android");
 
       await expect(

--- a/test/daemon/daemonShutdownSessionRelease.test.ts
+++ b/test/daemon/daemonShutdownSessionRelease.test.ts
@@ -18,7 +18,10 @@ import {
 } from "../../src/utils/KeepScreenAwakeManager";
 import { logger } from "../../src/utils/logger";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import type { DevicePool } from "../../src/daemon/devicePool";
+import type { BootedDevice } from "../../src/models";
 
 class FakeDeviceSessionRepository {
   readonly events: string[] = [];
@@ -60,6 +63,18 @@ interface DaemonSocketServerInternals {
     drainSessionReleaseNotifications(): Promise<void>;
     close(): Promise<void>;
   } | null;
+}
+
+/**
+ * Point a daemon-owned pool's discovery at a fake that lists exactly these
+ * devices. A pooled Android entry is re-proved present against discovery before
+ * it is handed out (handsets included), and the daemon builds its pool with the
+ * real device manager, which would shell out to adb.
+ */
+function stubPoolDiscovery(devicePool: DevicePool, devices: BootedDevice[]): void {
+  const deviceManager = new FakeDeviceManager();
+  deviceManager.bootedDevices = [...devices];
+  Object.assign(devicePool, { deviceManager });
 }
 
 describe("Daemon shutdown session release (issue #5303)", () => {
@@ -105,13 +120,11 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     });
 
     try {
-      await devicePool.initializeWithDevices([
-        {
-          name: "Physical Android",
-          deviceId,
-          platform: "android",
-        },
-      ]);
+      const pooledDevices: BootedDevice[] = [
+        { name: "Physical Android", deviceId, platform: "android" },
+      ];
+      stubPoolDiscovery(devicePool, pooledDevices);
+      await devicePool.initializeWithDevices(pooledDevices);
       await devicePool.assignDeviceToSession(sessionId, "android");
       sessionManager.setKeepScreenAwake(sessionId, keepAwakeState);
       sessionManager.onSessionRelease((releasedSessionId, releasedDeviceId) => {
@@ -168,13 +181,11 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     });
 
     try {
-      await devicePool.initializeWithDevices([
-        {
-          name: "Managed Android",
-          deviceId: "managed-physical-device",
-          platform: "android",
-        },
-      ]);
+      const pooledDevices: BootedDevice[] = [
+        { name: "Managed Android", deviceId: "managed-physical-device", platform: "android" },
+      ];
+      stubPoolDiscovery(devicePool, pooledDevices);
+      await devicePool.initializeWithDevices(pooledDevices);
       await devicePool.assignDeviceToSession("managed-adb-session", "android");
 
       await daemon.stop();
@@ -248,10 +259,12 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
 
     try {
-      await devicePool.initializeWithDevices([
+      const pooledDevices: BootedDevice[] = [
         { name: "Broken Android", deviceId: "broken-device", platform: "android" },
         { name: "Healthy Android", deviceId: "healthy-device", platform: "android" },
-      ]);
+      ];
+      stubPoolDiscovery(devicePool, pooledDevices);
+      await devicePool.initializeWithDevices(pooledDevices);
       await devicePool.assignDeviceToSession(brokenSessionId, "android");
       await devicePool.assignDeviceToSession(healthySessionId, "android");
       sessionManager.setKeepScreenAwake(brokenSessionId, {
@@ -663,13 +676,11 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
 
     try {
-      await devicePool.initializeWithDevices([
-        {
-          name: "Expired Android",
-          deviceId,
-          platform: "android",
-        },
-      ]);
+      const pooledDevices: BootedDevice[] = [
+        { name: "Expired Android", deviceId, platform: "android" },
+      ];
+      stubPoolDiscovery(devicePool, pooledDevices);
+      await devicePool.initializeWithDevices(pooledDevices);
       await devicePool.assignDeviceToSession(sessionId, "android");
       sessionManager.setKeepScreenAwake(sessionId, keepAwakeState);
       sessionManager.onSessionRelease((releasedSessionId) =>

--- a/test/daemon/daemonStreamWiring.integration.test.ts
+++ b/test/daemon/daemonStreamWiring.integration.test.ts
@@ -26,6 +26,7 @@ interface RoutingTargets {
 }
 
 interface DaemonStreamInternals {
+  devicePool: { isPooledIdentityUnresolved(deviceId: string): boolean };
   observationStreamHealth: {
     isHealthy(): boolean;
     recover(): Promise<void>;
@@ -170,6 +171,50 @@ describe("Daemon stream wiring", () => {
       expect(replacementStream.observationCallbackInstalled).toBe(true);
       expect(replacementStream.navigationRequestCallbackInstalled).toBe(true);
       expect(replacementStream.storageSubscriptionCallbackInstalled).toBe(true);
+    } finally {
+      daemon.getSessionManager().stopCleanupTimer();
+    }
+  });
+
+  // The resolver handed to every push server reads the POOL's quarantine, not just
+  // the registry, so a serial whose AVD identity is unresolved has no routing
+  // identity in either direction while the epoch itself is preserved (#6863 review).
+  test("withholds routing identity for a pool-quarantined serial", async () => {
+    const timer = new FakeTimer();
+    const db = await createTestDatabase();
+    const daemon = new Daemon(
+      {},
+      undefined,
+      timer,
+      new DeviceSessionRepository(db),
+      new CountingIdGenerator("device-session"),
+    );
+    const internals = daemon as unknown as DaemonStreamInternals;
+    const stream = new FakeDeviceDataStreamServer();
+    internals.getDeviceSessionRoutingTargets = () => targets(stream);
+    let quarantined = false;
+    internals.devicePool.isPooledIdentityUnresolved = (deviceId: string) =>
+      quarantined && deviceId === "emulator-5554";
+
+    try {
+      internals.setupDeviceSessionRouting();
+      const record = internals.deviceSessionRegistry.onDeviceConnected({
+        deviceId: "emulator-5554",
+        platform: "android",
+        incarnation: 1,
+      });
+      expect(stream.resolver?.resolveUuid("emulator-5554")).toBe(record.deviceSessionUuid);
+
+      quarantined = true;
+
+      expect(stream.resolver?.resolveUuid("emulator-5554")).toBeNull();
+      expect(stream.resolver?.resolveDeviceId(record.deviceSessionUuid)).toBeNull();
+      expect(stream.resolver?.isRoutingSuspended("emulator-5554")).toBe(true);
+
+      quarantined = false;
+
+      // The epoch was preserved underneath, so routing resumes on the SAME uuid.
+      expect(stream.resolver?.resolveUuid("emulator-5554")).toBe(record.deviceSessionUuid);
     } finally {
       daemon.getSessionManager().stopCleanupTimer();
     }

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -2930,4 +2930,55 @@ describe("DeviceDataStreamSocketServer", () => {
       });
     });
   });
+  // Stream routing while the pool cannot say WHICH AVD is on a serial (#6863
+  // review). The pooled entry keeps its session and its epoch, but a possible
+  // replacement's passive frames must not reach the previous AVD's subscribers —
+  // nor anyone else, since the serial they are attributed to is the only thing
+  // the daemon still knows about them.
+  describe("unresolved pooled identity", () => {
+    const frame = (text: string) =>
+      ({ hierarchy: { node: { $: { class: "Root", text } } } }) as any;
+
+    it("drops device-attributed frames while routing is suspended", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "device-1" });
+      server.sessionResolver.quarantine("device-1");
+
+      server.pushHierarchyUpdate("device-1", frame("a"));
+
+      expect(socket.getWrittenMessages()).toHaveLength(0);
+    });
+
+    it("drops them for all-device subscribers too, not just the previous epoch's", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "device-1" });
+      const all = server.simulateSubscription({});
+      server.sessionResolver.quarantine("device-1");
+
+      server.pushHierarchyUpdate("device-1", frame("a"));
+
+      expect(socket.getWrittenMessages()).toHaveLength(0);
+      expect(all.socket.getWrittenMessages()).toHaveLength(0);
+    });
+
+    it("keeps routing every other device's frames", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "device-2" });
+      server.sessionResolver.quarantine("device-1");
+
+      server.pushHierarchyUpdate("device-2", frame("a"));
+
+      expect(socket.getWrittenMessages()).toHaveLength(1);
+    });
+
+    it("resumes routing under the same uuid once the quarantine lifts", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "device-1" });
+      server.sessionResolver.quarantine("device-1");
+      server.pushHierarchyUpdate("device-1", frame("a"));
+
+      server.sessionResolver.resolveIdentity("device-1");
+      server.pushHierarchyUpdate("device-1", frame("b"));
+
+      const messages = socket.getWrittenMessages<{ type: string; deviceSessionUuid: string }>();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].deviceSessionUuid).toBe(sessionUuidFor("device-1"));
+    });
+  });
 });

--- a/test/daemon/devicePool.recoveryShutdown.test.ts
+++ b/test/daemon/devicePool.recoveryShutdown.test.ts
@@ -13,7 +13,6 @@ const original: BootedDevice = {
   name: "Pixel_8_API_35",
   platform: "android",
   deviceId: "emulator-5554",
-  transportId: "1",
 };
 const image: DeviceInfo = {
   name: original.name,
@@ -28,7 +27,7 @@ class LaggingShutdownManager extends FakeDeviceManager {
   }
   override async startDevice(device: DeviceInfo): Promise<ChildProcess> {
     this.startedDevices.push(device);
-    this.bootedDevices = [{ ...original, deviceId: "emulator-5560", transportId: "2" }];
+    this.bootedDevices = [{ ...original, deviceId: "emulator-5560" }];
     return { pid: 0 } as ChildProcess;
   }
   override async waitForDeviceReady(): Promise<BootedDevice> {
@@ -172,7 +171,7 @@ test("a different AVD reusing the serial is preserved after shutdown", async () 
     );
     await manager.killAccepted.promise;
     await flush();
-    manager.bootedDevices = [{ ...original, name: "Pixel_9", transportId: "new" }];
+    manager.bootedDevices = [{ ...original, name: "Pixel_9" }];
     timer.advanceTime(1_000);
     expect(await recovery).toBe(true);
     expect(killCalls).toBe(1);

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -6698,6 +6698,72 @@ describe("DevicePool", () => {
       expect(devicePool.getDevice("emulator-5554")?.sessionId).toBeNull();
     });
 
+    // The quarantine can be ENTERED by the assignment-time liveness check itself,
+    // with no refresh sweep in between. The operation that enters it must fail at
+    // assignment rather than hand back a session that then fails every tool
+    // (#6863 review).
+    test("does not assign an emulator the assignment-time liveness check just quarantined", async () => {
+      await initializeLiveDevices([
+        poolDevice("emulator-5554", "Pixel_8_API_35"),
+        poolDevice("emulator-5556", "Pixel_7_API_34"),
+      ]);
+      // No refresh: the placeholder is what the assignment's own discovery reads.
+      fakeDeviceManager.bootedDevices = [
+        unresolved("emulator-5554"),
+        poolDevice("emulator-5556", "Pixel_7_API_34"),
+      ];
+
+      const assigned = await devicePool.assignDeviceToSession("session-1");
+
+      expect(devicePool.isPooledIdentityUnresolved("emulator-5554")).toBe(true);
+      expect(assigned).toBe("emulator-5556");
+      expect(devicePool.getDevice("emulator-5554")?.sessionId).toBeNull();
+    });
+
+    test("assigns the entry again once a later sweep resolves the name", async () => {
+      const device = poolDevice("emulator-5554", "Pixel_8_API_35");
+      await initializeLiveDevices([device]);
+      await refreshWith([unresolved("emulator-5554")]);
+      expect(devicePool.isPooledIdentityUnresolved("emulator-5554")).toBe(true);
+
+      await refreshWith([device]);
+      const assigned = await devicePool.assignDeviceToSession("session-1");
+
+      expect(assigned).toBe("emulator-5554");
+    });
+
+    test("refuses an exact bind whose liveness check finds an unresolved identity", async () => {
+      const device = poolDevice("emulator-5554", "Pixel_8_API_35");
+      await initializeLiveDevices([device]);
+      fakeDeviceManager.bootedDevices = [unresolved("emulator-5554")];
+
+      await expect(
+        devicePool.bindOrReuseDeviceSession("session-1", "emulator-5554", "android", androidImage),
+      ).rejects.toThrow(/emulator-5554[\s\S]*identity is unresolved/);
+      expect(devicePool.getDevice("emulator-5554")?.sessionId).toBeNull();
+    });
+
+    test("refuses an autolock whose liveness check finds an unresolved identity", async () => {
+      const originalAutolock = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+      process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+      try {
+        const device = poolDevice("emulator-5554", "Pixel_8_API_35");
+        await initializeLiveDevices([device]);
+        fakeDeviceManager.bootedDevices = [unresolved("emulator-5554")];
+
+        await expect(
+          devicePool.autolockDevice("emulator-5554", "android", "mcp-session-1"),
+        ).rejects.toThrow(/emulator-5554[\s\S]*identity is unresolved/);
+        expect(devicePool.getDevice("emulator-5554")?.sessionId).toBeNull();
+      } finally {
+        if (originalAutolock === undefined) {
+          delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+        } else {
+          process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = originalAutolock;
+        }
+      }
+    });
+
     test("refuses tool execution for a session bound to an unresolved emulator", async () => {
       const device = poolDevice("emulator-5554", "Pixel_8_API_35");
       fakeDeviceManager.bootedDevices = [device];

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -6798,6 +6798,103 @@ describe("DevicePool", () => {
       expect(devicePool.describesPooledRuntime(device)).toBe(false);
     });
 
+    // A resolved name that DISAGREES is a replacement, and the pool installs it
+    // by evicting the old incarnation. `evictMissingPooledDevice` deliberately
+    // DEFERS that eviction while killDevice holds a shutdown reservation, so the
+    // refresh reloads the very entry the discovered runtime disagrees with. That
+    // entry must stay quarantined until the replacement actually installs --
+    // otherwise the disagreeing name reads as proof of continuity and re-admits
+    // the old session's tools and stream routing to a different AVD
+    // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+    test("keeps the quarantine when a differing name arrives while eviction is deferred", async () => {
+      const device = poolDevice("emulator-5554", "Pixel_8_API_35");
+      await initializeLiveDevices([device]);
+      const incarnation = devicePool.getDevice("emulator-5554")!.incarnation;
+      await refreshWith([unresolved("emulator-5554")]);
+      expect(devicePool.isPooledIdentityUnresolved("emulator-5554")).toBe(true);
+      const reservation = await devicePool.reserveDeviceForShutdown("emulator-5554");
+      expect(reservation).toBeDefined();
+
+      await refreshWith([poolDevice("emulator-5554", "Pixel_7_API_34")]);
+
+      // Eviction was deferred, so this is still the OLD incarnation -- and it is
+      // still untrusted.
+      expect(devicePool.getDevice("emulator-5554")?.incarnation).toBe(incarnation);
+      expect(devicePool.isPooledIdentityUnresolved("emulator-5554")).toBe(true);
+
+      await reservation!.release();
+      await refreshWith([poolDevice("emulator-5554", "Pixel_7_API_34")]);
+
+      const replacement = devicePool.getDevice("emulator-5554");
+      expect(replacement?.name).toBe("Pixel_7_API_34");
+      expect(replacement?.incarnation).toBeGreaterThan(incarnation);
+      expect(devicePool.isPooledIdentityUnresolved("emulator-5554")).toBe(false);
+    });
+
+    // Same deferral, but the entry was NOT quarantined beforehand: the
+    // disagreement itself is what makes the pooled label untrustworthy.
+    test("quarantines a live entry whose deferred replacement disagrees with it", async () => {
+      const device = poolDevice("emulator-5554", "Pixel_8_API_35");
+      await initializeLiveDevices([device]);
+      const incarnation = devicePool.getDevice("emulator-5554")!.incarnation;
+      const reservation = await devicePool.reserveDeviceForShutdown("emulator-5554");
+
+      await refreshWith([poolDevice("emulator-5554", "Pixel_7_API_34")]);
+
+      expect(devicePool.getDevice("emulator-5554")?.incarnation).toBe(incarnation);
+      expect(devicePool.getDevice("emulator-5554")?.name).toBe("Pixel_8_API_35");
+      expect(devicePool.isPooledIdentityUnresolved("emulator-5554")).toBe(true);
+      await reservation!.release();
+    });
+
+    // Entering the quarantine must also stop the work already in flight on the
+    // bound session. The admission gate only refuses LATER calls, while an
+    // execution already registered in `executionTracker` keeps issuing
+    // serial-addressed operations that can land on a replacement AVD
+    // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+    test("cancels the bound session's in-flight executions when entering quarantine", async () => {
+      const cancellations: { sessionId: string; reason: string }[] = [];
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        async (sessionId, reason) => {
+          cancellations.push({ sessionId, reason });
+          return 1;
+        },
+      );
+      const device = poolDevice("emulator-5554", "Pixel_8_API_35");
+      await initializeLiveDevices([device]);
+      await devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        "emulator-5554",
+        "android",
+        androidImage,
+      );
+      const incarnation = devicePool.getDevice("emulator-5554")!.incarnation;
+
+      await refreshWith([unresolved("emulator-5554")]);
+
+      expect(cancellations.map((entry) => entry.sessionId)).toEqual(["owner-session"]);
+      expect(cancellations[0]?.reason).toContain("emulator-5554");
+      // Session and incarnation survive the quarantine: it withholds trust, it
+      // does not retire the epoch.
+      const quarantined = devicePool.getDevice("emulator-5554");
+      expect(quarantined?.sessionId).toBe("owner-session");
+      expect(quarantined?.incarnation).toBe(incarnation);
+    });
+
     test("never quarantines a handset, whose name is not its identity", async () => {
       const handset = createBootedDevice("R5CT10ABCDE", "android", "Pixel 8");
       await initializeLiveDevices([handset]);

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -265,6 +265,10 @@ describe("DevicePool", () => {
       this.resolveDiscoveryRelease();
     }
 
+    addToConcurrentSnapshot(device: BootedDevice): void {
+      this.concurrentSnapshot.push(device);
+    }
+
     private discoveryFor(devices: BootedDevice[], platform: SomePlatform) {
       const platforms: Platform[] = platform === "either" ? ["android", "ios"] : [platform];
       return {
@@ -3489,6 +3493,21 @@ describe("DevicePool", () => {
       expect(devicePool.getDevice("sim-new")?.sessionId).toBe("session-2");
     });
 
+    // A handset serial is unique, so it never needs the emulator's identity
+    // reconciliation — but it still has to be PRESENT. Unplugging one after the
+    // last refresh must not leave it assignable (#6863 review).
+    test("does not assign a pooled physical handset that was unplugged after the last refresh", async () => {
+      await devicePool.initializeWithDevices([
+        createBootedDevice("R5CT10ABCDE", "android", "SM-S911B"),
+      ]);
+      fakeDeviceManager.bootedDevices = [];
+
+      await expect(devicePool.assignDeviceToSession("session-1", "android")).rejects.toThrow();
+
+      expect(devicePool.getDevice("R5CT10ABCDE")).toBeNull();
+      expect(sessionManager.getSession("session-1")).toBeNull();
+    });
+
     test("does not assign but retains a pooled iOS simulator when liveness discovery fails", async () => {
       await devicePool.initializeWithDevices([createBootedDevice("sim-1", "ios", "iPhone 15")]);
       fakeDeviceManager.bootedDevices = [];
@@ -3880,7 +3899,11 @@ describe("DevicePool", () => {
       await deferredDeviceManager.waitForDiscoveryStart();
 
       await devicePool.assignDeviceToSession("concurrent-session", "android");
-      await devicePool.addDevice(createBootedDevice("R5CT654321", "android", "Pixel 9"));
+      const spareHandset = createBootedDevice("R5CT654321", "android", "Pixel 9");
+      // The handset has to be discoverable too: a pooled Android entry is
+      // re-proved present before it is handed out, handsets included.
+      deferredDeviceManager.addToConcurrentSnapshot(spareHandset);
+      await devicePool.addDevice(spareHandset);
       deferredDeviceManager.releaseDiscovery();
       await preflightAllocation;
 
@@ -6352,7 +6375,7 @@ describe("DevicePool", () => {
       // tryAssignDeviceWithCriteria (issue #2656). Criteria-based allocation
       // must distribute load to the least-recently-used idle device, the same
       // way platform-based allocation does.
-      await devicePool.initializeWithDevices([
+      await initializeLiveDevices([
         createBootedDevice("dev-a", "android"),
         createBootedDevice("dev-b", "android"),
         createBootedDevice("dev-c", "android"),

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1477,11 +1477,8 @@ describe("DevicePool", () => {
       });
     });
 
-    test("assigns a fresh incarnation per pooled connection and keeps it across a same-transport refresh", async () => {
-      const device = {
-        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
-        transportId: "1",
-      };
+    test("assigns a fresh incarnation per pooled connection and keeps it across a rediscovery", async () => {
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
       await initializeLiveDevices([device]);
       const first = devicePool.getDevice("emulator-5554");
       if (!first) {
@@ -1489,8 +1486,8 @@ describe("DevicePool", () => {
       }
       const firstIncarnation = first.incarnation;
 
-      // A refresh that rediscovers the same serial and transport reuses the
-      // entry — same incarnation, so an existing mark for it still applies.
+      // A refresh that rediscovers the same serial reuses the entry — same
+      // incarnation, so an existing mark for it still applies.
       await devicePool.refreshDevices();
       expect(devicePool.getDevice("emulator-5554")?.incarnation).toBe(firstIncarnation);
 
@@ -1504,7 +1501,7 @@ describe("DevicePool", () => {
       expect(second!.incarnation).toBeGreaterThan(firstIncarnation);
     });
 
-    test("replaces a fast same-serial transport reconnect with a new device session epoch", async () => {
+    test("mints a new device session epoch when a serial disappears and returns", async () => {
       const registry = new DeviceSessionRegistry(
         fakeTimer,
         new FakeIdGenerator(["uuid-a", "uuid-b"]),
@@ -1535,11 +1532,8 @@ describe("DevicePool", () => {
         undefined,
         (deviceId) => registry.onDeviceDisconnected(deviceId),
       );
-      const firstConnection = {
-        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
-        transportId: "1",
-      };
-      const reconnected = { ...firstConnection, transportId: "2" };
+      const firstConnection = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const reconnected = { ...firstConnection };
       await initializeLiveDevices([firstConnection]);
       devicePool.notifyDeviceReady(firstConnection.deviceId);
       const firstEpoch = registry.getByDeviceId(firstConnection.deviceId);
@@ -1548,6 +1542,10 @@ describe("DevicePool", () => {
         throw new Error("expected the first pooled connection epoch");
       }
 
+      // The pool observing the serial leave is the epoch boundary; the serial
+      // returning afterwards is a new incarnation even though adb reports the
+      // identical listing.
+      await devicePool.removeDevice(firstConnection.deviceId);
       fakeDeviceManager.bootedDevices = [reconnected];
 
       const added = await devicePool.refreshDevices();
@@ -1565,7 +1563,7 @@ describe("DevicePool", () => {
       ]);
     });
 
-    test("rekeys a same-serial transport reconnect before assigning an idle device", async () => {
+    test("rekeys a same-serial AVD replacement before assigning an idle device", async () => {
       const registry = new DeviceSessionRegistry(
         fakeTimer,
         new FakeIdGenerator(["uuid-a", "uuid-b"]),
@@ -1595,11 +1593,8 @@ describe("DevicePool", () => {
         undefined,
         (deviceId) => registry.onDeviceDisconnected(deviceId),
       );
-      const firstConnection = {
-        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
-        transportId: "1",
-      };
-      const reconnected = { ...firstConnection, transportId: "2" };
+      const firstConnection = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const reconnected = { ...firstConnection, name: "Pixel 9" };
       await initializeLiveDevices([firstConnection]);
       devicePool.notifyDeviceReady(firstConnection.deviceId);
       const firstEpoch = registry.getByDeviceId(firstConnection.deviceId);
@@ -1610,19 +1605,16 @@ describe("DevicePool", () => {
       );
 
       expect(devicePool.getDevice(reconnected.deviceId)).toMatchObject({
-        transportId: "2",
+        name: "Pixel 9",
         sessionId: "session-1",
       });
       expect(registry.getByDeviceId(reconnected.deviceId)?.deviceSessionUuid).toBe("uuid-b");
       expect(registry.getByUuid(firstEpoch!.deviceSessionUuid)).toBeUndefined();
     });
 
-    test("discards an older refresh snapshot after a newer transport replacement", async () => {
-      const firstConnection = {
-        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
-        transportId: "1",
-      };
-      const reconnected = { ...firstConnection, transportId: "2" };
+    test("discards an older refresh snapshot after a newer same-serial replacement", async () => {
+      const firstConnection = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const reconnected = { ...firstConnection, name: "Pixel 9" };
       const outOfOrderManager = new OutOfOrderRefreshFakeDeviceManager(
         [firstConnection],
         [reconnected],
@@ -1644,28 +1636,26 @@ describe("DevicePool", () => {
       outOfOrderManager.releaseFirstDiscovery();
       await olderRefresh;
 
-      expect(devicePool.getDevice(reconnected.deviceId)?.transportId).toBe("2");
+      expect(devicePool.getDevice(reconnected.deviceId)?.name).toBe("Pixel 9");
     });
 
-    test("preserves AutoMobile-owned emulator metadata across a transport rekey", async () => {
+    test("preserves AutoMobile-owned emulator metadata across a same-serial rediscovery", async () => {
       const sourceImage: DeviceInfo = {
         name: "Pixel 8",
         platform: "android",
         isRunning: false,
         source: "local",
       };
-      const firstConnection = {
-        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
-        transportId: "1",
-      };
-      const reconnected = { ...firstConnection, transportId: "2" };
+      const firstConnection = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const reconnected = { ...firstConnection };
       await devicePool.addDevice(firstConnection, sourceImage);
+      const incarnation = devicePool.getDevice(firstConnection.deviceId)?.incarnation;
       fakeDeviceManager.bootedDevices = [reconnected];
 
       await devicePool.refreshDevices();
 
       expect(devicePool.getDevice(reconnected.deviceId)).toMatchObject({
-        transportId: "2",
+        incarnation,
         avdName: "Pixel 8",
         androidImage: sourceImage,
       });
@@ -1678,24 +1668,14 @@ describe("DevicePool", () => {
         isRunning: false,
         source: "local",
       };
-      const firstConnection = {
-        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
-        transportId: "1",
-      };
-      const replacement = {
-        ...firstConnection,
-        name: "Pixel 9",
-        transportId: "2",
-      };
+      const firstConnection = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const replacement = { ...firstConnection, name: "Pixel 9" };
       await devicePool.addDevice(firstConnection, sourceImage);
       fakeDeviceManager.bootedDevices = [replacement];
 
       await devicePool.refreshDevices();
 
-      expect(devicePool.getDevice(replacement.deviceId)).toMatchObject({
-        name: "Pixel 9",
-        transportId: "2",
-      });
+      expect(devicePool.getDevice(replacement.deviceId)).toMatchObject({ name: "Pixel 9" });
       expect(devicePool.getDevice(replacement.deviceId)?.androidImage).toBeUndefined();
       expect(devicePool.getDevice(replacement.deviceId)?.avdName).toBeUndefined();
     });
@@ -1707,23 +1687,22 @@ describe("DevicePool", () => {
         isRunning: false,
         source: "local",
       };
-      const firstConnection = {
-        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
-        transportId: "1",
-      };
+      const firstConnection = createBootedDevice("emulator-5554", "android", "Pixel 8");
       const rediscoveredWithUnknownName = {
         ...firstConnection,
         name: "Unknown (emulator-5554)",
-        transportId: "2",
       };
       await devicePool.addDevice(firstConnection, sourceImage);
+      const incarnation = devicePool.getDevice(firstConnection.deviceId)?.incarnation;
       fakeDeviceManager.bootedDevices = [rediscoveredWithUnknownName];
 
       await devicePool.refreshDevices();
 
+      // The placeholder asserts nothing, so it neither evicts the live entry,
+      // starts a new epoch, nor overwrites the known AVD label.
       expect(devicePool.getDevice(firstConnection.deviceId)).toMatchObject({
-        name: "Unknown (emulator-5554)",
-        transportId: "2",
+        name: "Pixel 8",
+        incarnation,
         androidImage: sourceImage,
         avdName: "Pixel 8",
       });
@@ -1736,20 +1715,12 @@ describe("DevicePool", () => {
         isRunning: false,
         source: "local",
       };
-      const firstConnection = {
-        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
-        transportId: "1",
-      };
+      const firstConnection = createBootedDevice("emulator-5554", "android", "Pixel 8");
       const rediscoveredWithUnknownName = {
         ...firstConnection,
         name: "Unknown (emulator-5554)",
-        transportId: "2",
       };
-      const differentAvd = {
-        ...firstConnection,
-        name: "Pixel 9",
-        transportId: "3",
-      };
+      const differentAvd = { ...firstConnection, name: "Pixel 9" };
       await devicePool.addDevice(firstConnection, sourceImage);
       fakeDeviceManager.bootedDevices = [rediscoveredWithUnknownName];
       await devicePool.refreshDevices();
@@ -1757,46 +1728,45 @@ describe("DevicePool", () => {
 
       await devicePool.refreshDevices();
 
-      expect(devicePool.getDevice(differentAvd.deviceId)).toMatchObject({
-        name: "Pixel 9",
-        transportId: "3",
-      });
+      expect(devicePool.getDevice(differentAvd.deviceId)).toMatchObject({ name: "Pixel 9" });
       expect(devicePool.getDevice(differentAvd.deviceId)?.androidImage).toBeUndefined();
       expect(devicePool.getDevice(differentAvd.deviceId)?.avdName).toBeUndefined();
     });
 
-    test("rekeys a transport-only mismatch before reserving startDevice readiness", async () => {
-      const firstConnection = {
-        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
-        transportId: "1",
-      };
-      const reconnected = { ...firstConnection, transportId: "2" };
+    test("reserves startDevice readiness for a runtime whose AVD name could not be read", async () => {
+      const firstConnection = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const unreadable = { ...firstConnection, name: "Unknown (emulator-5554)" };
       await initializeLiveDevices([firstConnection]);
+      const incarnation = devicePool.getDevice(firstConnection.deviceId)?.incarnation;
 
       const releaseReservation = await devicePool.reserveDeviceForReadiness(
-        reconnected.deviceId,
-        reconnected,
+        unreadable.deviceId,
+        unreadable,
       );
 
-      expect(devicePool.getDevice(reconnected.deviceId)?.transportId).toBe("2");
+      // The placeholder must not read as an identity mismatch, and must not
+      // evict the entry whose readiness is being reserved.
+      expect(devicePool.getDevice(firstConnection.deviceId)).toMatchObject({
+        name: "Pixel 8",
+        incarnation,
+      });
       await releaseReservation();
     });
 
-    test("rekeys a non-emulator Android transport reconnect before allocation", async () => {
-      const firstConnection = {
-        ...createBootedDevice("R5CT123456", "android", "Pixel 8"),
-        transportId: "1",
-      };
-      const reconnected = { ...firstConnection, transportId: "2" };
+    test("allocates a rediscovered handset on its unique serial alone", async () => {
+      const firstConnection = createBootedDevice("R5CT123456", "android", "Pixel 8");
+      const reconnected = { ...firstConnection };
       await initializeLiveDevices([firstConnection]);
+      const incarnation = devicePool.getDevice(firstConnection.deviceId)?.incarnation;
       fakeDeviceManager.bootedDevices = [reconnected];
 
       await expect(devicePool.assignDeviceToSession("session-usb", "android")).resolves.toBe(
         reconnected.deviceId,
       );
 
+      // A handset serial is never reassigned, so rediscovery is continuity.
       expect(devicePool.getDevice(reconnected.deviceId)).toMatchObject({
-        transportId: "2",
+        incarnation,
         sessionId: "session-usb",
       });
     });
@@ -1819,6 +1789,96 @@ describe("DevicePool", () => {
       } finally {
         await releaseReservation();
       }
+    });
+
+    test("adopts the started AVD name once discovery replaces the unknown-name placeholder", async () => {
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      const started = createBootedDevice("emulator-5554", "android", "Unknown (emulator-5554)");
+      await devicePool.addDevice(started, sourceImage);
+      const incarnation = devicePool.getDevice(started.deviceId)?.incarnation;
+      fakeDeviceManager.bootedDevices = [{ ...started, name: "Pixel 8" }];
+
+      await devicePool.refreshDevices();
+
+      expect(devicePool.getDevice(started.deviceId)).toMatchObject({
+        name: "Pixel 8",
+        avdName: "Pixel 8",
+        incarnation,
+      });
+    });
+
+    test("does not adopt a resolved name that contradicts the AVD this pool started", async () => {
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      const started = createBootedDevice("emulator-5554", "android", "Unknown (emulator-5554)");
+      await devicePool.addDevice(started, sourceImage);
+      const incarnation = devicePool.getDevice(started.deviceId)?.incarnation;
+      fakeDeviceManager.bootedDevices = [{ ...started, name: "Pixel 9" }];
+
+      await devicePool.refreshDevices();
+
+      const replaced = devicePool.getDevice(started.deviceId);
+      expect(replaced?.name).toBe("Pixel 9");
+      expect(replaced?.incarnation).not.toBe(incarnation);
+      expect(replaced?.androidImage).toBeUndefined();
+      expect(replaced?.avdName).toBeUndefined();
+    });
+
+    test("documented blind spot: a same-serial restart inside one discovery interval keeps its incarnation", async () => {
+      // Without a discovery-level epoch token there is nothing in an adb
+      // listing that distinguishes "still the same emulator process" from "the
+      // same AVD restarted between two discovery sweeps". The pool never
+      // observed the disappearance, so the incarnation — the only epoch token
+      // left — is unchanged, and every cache keyed on it must self-heal on use
+      // rather than rely on invalidation. Asserted here so the gap stays
+      // deliberate instead of becoming a surprise.
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      await initializeLiveDevices([device]);
+      const incarnation = devicePool.getDevice(device.deviceId)?.incarnation;
+
+      fakeDeviceManager.bootedDevices = [{ ...device }];
+      await devicePool.refreshDevices();
+
+      expect(devicePool.getDevice(device.deviceId)?.incarnation).toBe(incarnation);
+    });
+
+    test("starts a new incarnation once the serial is observed to disappear and return", async () => {
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      await initializeLiveDevices([device]);
+      const incarnation = devicePool.getDevice(device.deviceId)?.incarnation;
+
+      await devicePool.removeDevice(device.deviceId);
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.refreshDevices();
+
+      expect(devicePool.getDevice(device.deviceId)?.incarnation).toBeGreaterThan(incarnation!);
+    });
+
+    test("never conflates two same-model handsets that share a display name", async () => {
+      const firstPhone = createBootedDevice("R5CT123456", "android", "Pixel 8");
+      const secondPhone = createBootedDevice("R5CT654321", "android", "Pixel 8");
+      await initializeLiveDevices([firstPhone, secondPhone]);
+      const firstIncarnation = devicePool.getDevice(firstPhone.deviceId)?.incarnation;
+      const secondIncarnation = devicePool.getDevice(secondPhone.deviceId)?.incarnation;
+
+      // Handset names are `ro.product.model` and are not unique, so identity
+      // for a non-emulator serial stays serial-only.
+      expect(firstIncarnation).not.toBe(secondIncarnation);
+      await devicePool.removeDevice(firstPhone.deviceId);
+      fakeDeviceManager.bootedDevices = [secondPhone];
+      await devicePool.refreshDevices();
+
+      expect(devicePool.getDevice(firstPhone.deviceId)).toBeNull();
+      expect(devicePool.getDevice(secondPhone.deviceId)?.incarnation).toBe(secondIncarnation);
     });
 
     test("reserves a verified AVD name when the running emulator lacks AVD metadata", async () => {
@@ -1935,7 +1995,7 @@ describe("DevicePool", () => {
       const originalIncarnation = devicePool.getDevice(original.deviceId)?.incarnation;
 
       await devicePool.removeDevice(original.deviceId);
-      const replacement = { ...original, transportId: "2" };
+      const replacement = { ...original };
       fakeDeviceManager.bootedDevices = [replacement];
       await devicePool.addDevice(replacement, sourceImage);
 
@@ -3619,13 +3679,11 @@ describe("DevicePool", () => {
       expect(sessionManager.getSession("session-1")?.assignedDevice).toBe("emulator-new");
     });
 
-    test("binds a same-serial transport reconnect without requiring a retry", async () => {
-      const firstConnection = {
-        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
-        transportId: "1",
-      };
-      const reconnected = { ...firstConnection, transportId: "2" };
+    test("binds a rediscovered same-serial emulator without requiring a retry", async () => {
+      const firstConnection = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const reconnected = { ...firstConnection };
       await initializeLiveDevices([firstConnection]);
+      const incarnation = devicePool.getDevice(firstConnection.deviceId)?.incarnation;
       fakeDeviceManager.bootedDevices = [reconnected];
 
       await expect(
@@ -3633,20 +3691,17 @@ describe("DevicePool", () => {
       ).resolves.toBe("session-1");
 
       expect(devicePool.getDevice(reconnected.deviceId)).toMatchObject({
-        transportId: "2",
+        incarnation,
         sessionId: "session-1",
         status: "busy",
       });
       expect(sessionManager.getSession("session-1")?.assignedDevice).toBe(reconnected.deviceId);
     });
 
-    test("autolocks a same-serial transport reconnect without reacquiring the assignment mutex", async () => {
+    test("autolocks a rediscovered same-serial emulator without reacquiring the assignment mutex", async () => {
       const originalAutolock = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
-      const firstConnection = {
-        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
-        transportId: "1",
-      };
-      const reconnected = { ...firstConnection, transportId: "2" };
+      const firstConnection = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const reconnected = { ...firstConnection };
       try {
         process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
         await initializeLiveDevices([firstConnection]);
@@ -3656,10 +3711,7 @@ describe("DevicePool", () => {
           devicePool.autolockDevice(reconnected.deviceId, "android", "mcp-session-1"),
         ).resolves.toBeDefined();
 
-        expect(devicePool.getDevice(reconnected.deviceId)).toMatchObject({
-          transportId: "2",
-          status: "busy",
-        });
+        expect(devicePool.getDevice(reconnected.deviceId)).toMatchObject({ status: "busy" });
       } finally {
         if (originalAutolock === undefined) {
           delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
@@ -3670,11 +3722,8 @@ describe("DevicePool", () => {
     });
 
     test("assigns the current replacement after liveness discovery supersedes a captured device", async () => {
-      const firstConnection = {
-        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
-        transportId: "1",
-      };
-      const reconnected = { ...firstConnection, transportId: "2" };
+      const firstConnection = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const reconnected = { ...firstConnection };
       const manager = new DeferredReconnectionDiscoveryFakeDeviceManager(
         [reconnected],
         [reconnected],
@@ -3698,7 +3747,6 @@ describe("DevicePool", () => {
 
       await expect(assignment).resolves.toBe(reconnected.deviceId);
       expect(devicePool.getDevice(reconnected.deviceId)).toMatchObject({
-        transportId: "2",
         sessionId: "session-1",
         status: "busy",
       });
@@ -3807,11 +3855,8 @@ describe("DevicePool", () => {
 
   describe("assignMultipleDevices", () => {
     test("does not evict a session claimed while preflight reconnect discovery is pending", async () => {
-      const firstConnection = {
-        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
-        transportId: "1",
-      };
-      const reconnected = { ...firstConnection, transportId: "2" };
+      const firstConnection = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const reconnected = { ...firstConnection };
       const deferredDeviceManager = new DeferredReconnectionDiscoveryFakeDeviceManager(
         [reconnected],
         [firstConnection],
@@ -3845,7 +3890,6 @@ describe("DevicePool", () => {
       expect(devicePool.getDevice(firstConnection.deviceId)).toMatchObject({
         sessionId: "concurrent-session",
         status: "busy",
-        transportId: "1",
       });
     });
 

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -6615,4 +6615,130 @@ describe("DevicePool", () => {
       expect(sessionManager.getDeviceReadiness("session-first")).toBe("automationReady");
     });
   });
+
+  // A pooled emulator entry whose LATEST discovery observation carries the
+  // `Unknown (<serial>)` placeholder is not evicted -- the placeholder is not
+  // evidence that a different AVD took the serial -- but it is no longer
+  // evidence of continuity either. Between those two, the entry is QUARANTINED:
+  // kept (session and incarnation intact) but withheld from assignment, from
+  // serial-addressed tool execution and from anything the pool publishes, until
+  // a resolved name proves which runtime is actually on the serial
+  // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+  describe("unresolved emulator identity quarantine", () => {
+    const androidImage: DeviceInfo = {
+      name: "Pixel_8_API_35",
+      platform: "android",
+      isRunning: false,
+      source: "local",
+    };
+
+    const poolDevice = (deviceId: string, name: string): BootedDevice =>
+      createBootedDevice(deviceId, "android", name);
+
+    const unresolved = (deviceId: string): BootedDevice =>
+      createBootedDevice(deviceId, "android", `Unknown (${deviceId})`);
+
+    const refreshWith = async (devices: BootedDevice[]): Promise<void> => {
+      fakeDeviceManager.bootedDevices = [...devices];
+      await devicePool.refreshDevices();
+    };
+
+    test("quarantines a live entry whose latest observation is the placeholder", async () => {
+      const device = poolDevice("emulator-5554", "Pixel_8_API_35");
+      await initializeLiveDevices([device]);
+      const incarnation = devicePool.getDevice("emulator-5554")?.incarnation;
+
+      await refreshWith([unresolved("emulator-5554")]);
+
+      expect(devicePool.isPooledIdentityUnresolved("emulator-5554")).toBe(true);
+      // Kept, not evicted: same entry, same incarnation.
+      expect(devicePool.getDevice("emulator-5554")?.incarnation).toBe(incarnation!);
+    });
+
+    test("restores a quarantined entry when the same AVD name is read again", async () => {
+      const device = poolDevice("emulator-5554", "Pixel_8_API_35");
+      await initializeLiveDevices([device]);
+      const incarnation = devicePool.getDevice("emulator-5554")?.incarnation;
+      await refreshWith([unresolved("emulator-5554")]);
+      expect(devicePool.isPooledIdentityUnresolved("emulator-5554")).toBe(true);
+
+      await refreshWith([device]);
+
+      expect(devicePool.isPooledIdentityUnresolved("emulator-5554")).toBe(false);
+      expect(devicePool.getDevice("emulator-5554")?.incarnation).toBe(incarnation!);
+    });
+
+    test("replaces a quarantined entry when a different AVD name is read", async () => {
+      const device = poolDevice("emulator-5554", "Pixel_8_API_35");
+      await initializeLiveDevices([device]);
+      const incarnation = devicePool.getDevice("emulator-5554")!.incarnation;
+      await refreshWith([unresolved("emulator-5554")]);
+
+      await refreshWith([poolDevice("emulator-5554", "Pixel_7_API_34")]);
+
+      const replacement = devicePool.getDevice("emulator-5554");
+      expect(replacement?.name).toBe("Pixel_7_API_34");
+      expect(replacement?.incarnation).toBeGreaterThan(incarnation);
+      expect(devicePool.isPooledIdentityUnresolved("emulator-5554")).toBe(false);
+    });
+
+    test("does not assign an idle emulator while its identity is unresolved", async () => {
+      await initializeLiveDevices([
+        poolDevice("emulator-5554", "Pixel_8_API_35"),
+        poolDevice("emulator-5556", "Pixel_7_API_34"),
+      ]);
+      await refreshWith([
+        unresolved("emulator-5554"),
+        poolDevice("emulator-5556", "Pixel_7_API_34"),
+      ]);
+
+      const assigned = await devicePool.assignDeviceToSession("session-1");
+
+      expect(assigned).toBe("emulator-5556");
+      expect(devicePool.getDevice("emulator-5554")?.sessionId).toBeNull();
+    });
+
+    test("refuses tool execution for a session bound to an unresolved emulator", async () => {
+      const device = poolDevice("emulator-5554", "Pixel_8_API_35");
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+      await devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        "emulator-5554",
+        "android",
+        androidImage,
+      );
+      expect(() => devicePool.assertSessionReadyForAutomation("owner-session")).not.toThrow();
+
+      await refreshWith([unresolved("emulator-5554")]);
+
+      expect(() => devicePool.assertSessionReadyForAutomation("owner-session")).toThrow(
+        /emulator-5554/,
+      );
+      expect(() => devicePool.assertSessionReadyForAutomation("owner-session")).toThrow(
+        /Pixel_8_API_35/,
+      );
+      // The session survives the quarantine: it is refused, not released.
+      expect(devicePool.getDevice("emulator-5554")?.sessionId).toBe("owner-session");
+    });
+
+    test("withholds published pool context while the identity is unresolved", async () => {
+      const device = poolDevice("emulator-5554", "Pixel_8_API_35");
+      await initializeLiveDevices([device]);
+      await refreshWith([unresolved("emulator-5554")]);
+
+      // Even a later observation that HAPPENS to carry the pooled name cannot
+      // publish pool context until a discovery sweep lifts the quarantine.
+      expect(devicePool.describesPooledRuntime(device)).toBe(false);
+    });
+
+    test("never quarantines a handset, whose name is not its identity", async () => {
+      const handset = createBootedDevice("R5CT10ABCDE", "android", "Pixel 8");
+      await initializeLiveDevices([handset]);
+
+      await refreshWith([createBootedDevice("R5CT10ABCDE", "android", "Unknown (R5CT10ABCDE)")]);
+
+      expect(devicePool.isPooledIdentityUnresolved("R5CT10ABCDE")).toBe(false);
+    });
+  });
 });

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1712,6 +1712,32 @@ describe("DevicePool", () => {
       });
     });
 
+    // `Unknown (<serial>)` asserts nothing, so it is neither evidence that a
+    // different AVD took the serial (the entry survives) nor evidence that the
+    // pooled entry describes what is running now (#6863 review). Consumers that
+    // publish pool-derived epoch information must therefore not treat it as a
+    // match.
+    test("does not claim a pooled entry describes a placeholder-named runtime", async () => {
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      const firstConnection = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      await devicePool.addDevice(firstConnection, sourceImage);
+
+      expect(devicePool.describesPooledRuntime(firstConnection)).toBe(true);
+      expect(
+        devicePool.describesPooledRuntime({
+          ...firstConnection,
+          name: "Unknown (emulator-5554)",
+        }),
+      ).toBe(false);
+      // The entry itself is untouched: the placeholder is not a replacement.
+      expect(devicePool.getDevice(firstConnection.deviceId)).toMatchObject({ name: "Pixel 8" });
+    });
+
     test("does not transfer ownership from an unknown-name emulator to a different known AVD", async () => {
       const sourceImage: DeviceInfo = {
         name: "Pixel 8",

--- a/test/daemon/deviceSessionResolver.test.ts
+++ b/test/daemon/deviceSessionResolver.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+import { DeviceSessionRegistry } from "../../src/daemon/deviceSessionRegistry";
+import {
+  createRegistryDeviceSessionResolver,
+  nullDeviceSessionResolver,
+} from "../../src/daemon/deviceSessionResolver";
+import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+function makeRegistry(scripted?: string[]): DeviceSessionRegistry {
+  return new DeviceSessionRegistry(new FakeTimer(), new FakeIdGenerator(scripted));
+}
+
+describe("createRegistryDeviceSessionResolver", () => {
+  it("resolves both directions for a live epoch", () => {
+    const registry = makeRegistry(["uuid-a"]);
+    registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+    const resolver = createRegistryDeviceSessionResolver(registry);
+
+    expect(resolver.resolveUuid("emulator-5554")).toBe("uuid-a");
+    expect(resolver.resolveDeviceId("uuid-a")).toBe("emulator-5554");
+    expect(resolver.isRoutingSuspended("emulator-5554")).toBe(false);
+  });
+
+  // The quarantine (#6863 review): the pool keeps the entry, its session and its
+  // epoch intact, but nothing may ACT on or ROUTE BY the pooled identity until
+  // discovery reads a name again.
+  describe("while the pooled identity is quarantined", () => {
+    const quarantinedResolver = (registry: DeviceSessionRegistry, quarantined: Set<string>) =>
+      createRegistryDeviceSessionResolver(registry, (deviceId) => quarantined.has(deviceId));
+
+    it("withholds the routing identity in both directions", () => {
+      const registry = makeRegistry(["uuid-a"]);
+      registry.onDeviceConnected({
+        deviceId: "emulator-5554",
+        platform: "android",
+        incarnation: 1,
+      });
+      const resolver = quarantinedResolver(registry, new Set(["emulator-5554"]));
+
+      expect(resolver.resolveUuid("emulator-5554")).toBeNull();
+      expect(resolver.resolveDeviceId("uuid-a")).toBeNull();
+      expect(resolver.isRoutingSuspended("emulator-5554")).toBe(true);
+    });
+
+    it("leaves an unrelated device routing normally", () => {
+      const registry = makeRegistry(["uuid-a", "uuid-b"]);
+      registry.onDeviceConnected({
+        deviceId: "emulator-5554",
+        platform: "android",
+        incarnation: 1,
+      });
+      registry.onDeviceConnected({
+        deviceId: "emulator-5556",
+        platform: "android",
+        incarnation: 1,
+      });
+      const resolver = quarantinedResolver(registry, new Set(["emulator-5554"]));
+
+      expect(resolver.resolveUuid("emulator-5556")).toBe("uuid-b");
+      expect(resolver.resolveDeviceId("uuid-b")).toBe("emulator-5556");
+      expect(resolver.isRoutingSuspended("emulator-5556")).toBe(false);
+    });
+
+    it("restores the SAME uuid once the quarantine lifts", () => {
+      const registry = makeRegistry(["uuid-a"]);
+      registry.onDeviceConnected({
+        deviceId: "emulator-5554",
+        platform: "android",
+        incarnation: 1,
+      });
+      const quarantined = new Set(["emulator-5554"]);
+      const resolver = quarantinedResolver(registry, quarantined);
+      expect(resolver.resolveUuid("emulator-5554")).toBeNull();
+
+      quarantined.delete("emulator-5554");
+
+      expect(resolver.resolveUuid("emulator-5554")).toBe("uuid-a");
+      expect(resolver.resolveDeviceId("uuid-a")).toBe("emulator-5554");
+      expect(resolver.isRoutingSuspended("emulator-5554")).toBe(false);
+    });
+
+    it("routes the replacement's uuid, never the retired one, after a reincarnation", () => {
+      const registry = makeRegistry(["uuid-a", "uuid-b"]);
+      registry.onDeviceConnected({
+        deviceId: "emulator-5554",
+        platform: "android",
+        incarnation: 1,
+      });
+      const quarantined = new Set(["emulator-5554"]);
+      const resolver = quarantinedResolver(registry, quarantined);
+
+      // Discovery finally reads a DIFFERENT AVD name: the pool replaces the entry
+      // under a fresh incarnation, retiring the old epoch and minting a new one.
+      registry.onDeviceConnected({
+        deviceId: "emulator-5554",
+        platform: "android",
+        incarnation: 2,
+      });
+      quarantined.delete("emulator-5554");
+
+      expect(resolver.resolveUuid("emulator-5554")).toBe("uuid-b");
+      expect(resolver.resolveDeviceId("uuid-b")).toBe("emulator-5554");
+      expect(resolver.resolveDeviceId("uuid-a")).toBeNull();
+    });
+  });
+
+  it("never suspends routing without a quarantine predicate", () => {
+    const registry = makeRegistry(["uuid-a"]);
+    registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+    const resolver = createRegistryDeviceSessionResolver(registry);
+
+    expect(resolver.isRoutingSuspended("emulator-5554")).toBe(false);
+  });
+});
+
+describe("nullDeviceSessionResolver", () => {
+  it("misses every lookup and suspends nothing", () => {
+    expect(nullDeviceSessionResolver.resolveUuid("emulator-5554")).toBeNull();
+    expect(nullDeviceSessionResolver.resolveDeviceId("uuid-a")).toBeNull();
+    expect(nullDeviceSessionResolver.isRoutingSuspended("emulator-5554")).toBe(false);
+  });
+});

--- a/test/daemon/failuresPushSocketServer.test.ts
+++ b/test/daemon/failuresPushSocketServer.test.ts
@@ -142,4 +142,29 @@ describe("FailuresPushSocketServer device-session attribution (#5259)", () => {
     expect(msgs[0].data.deviceId).toBeNull();
     expect(msgs[0].data.deviceSessionUuid).toBeNull();
   });
+  // The pooled entry keeps its epoch while its AVD identity is unresolved, but a
+  // possible replacement's failures must not be attributed to the previous AVD —
+  // nor broadcast under a serial the pool can no longer tie to a runtime
+  // (#6863 review).
+  it("drops a failure for a device whose pooled identity is quarantined", () => {
+    const scoped = server.simulateSubscription({ deviceSessionUuid: "uuid-a" });
+    const all = server.simulateSubscription({ deviceSessionUuid: null });
+    resolver.quarantine("emulator-5554");
+
+    server.pushFailure(notification({ deviceId: "emulator-5554" }));
+
+    expect(pushed(scoped.socket)).toHaveLength(0);
+    expect(pushed(all.socket)).toHaveLength(0);
+  });
+
+  it("resumes failure delivery under the same uuid once the quarantine lifts", () => {
+    const { socket } = server.simulateSubscription({ deviceSessionUuid: "uuid-a" });
+    resolver.quarantine("emulator-5554");
+    server.pushFailure(notification({ occurrenceId: "occ-dropped", deviceId: "emulator-5554" }));
+
+    resolver.resolveIdentity("emulator-5554");
+    server.pushFailure(notification({ occurrenceId: "occ-kept", deviceId: "emulator-5554" }));
+
+    expect(pushed(socket).map((m) => m.data.occurrenceId)).toEqual(["occ-kept"]);
+  });
 });

--- a/test/daemon/integration/parallelExecution.integration.test.ts
+++ b/test/daemon/integration/parallelExecution.integration.test.ts
@@ -3,6 +3,7 @@ import { SessionManager } from "../../../src/daemon/sessionManager";
 import { DevicePool } from "../../../src/daemon/devicePool";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeDeviceSessionPersistence } from "../../fakes/FakeDeviceSessionPersistence";
+import { FakeDeviceManager } from "../../fakes/FakeDeviceManager";
 import { FakeInstalledAppsRepository } from "../../fakes/FakeInstalledAppsRepository";
 import { BootedDevice } from "../../../src/models";
 import { DefaultRetryExecutor } from "../../../src/utils/retry/RetryExecutor";
@@ -25,19 +26,25 @@ describe("Parallel Execution Across Multiple Devices", function () {
     fakeAppsRepo = new FakeInstalledAppsRepository();
     // Create a RetryExecutor that uses the fakeTimer so time advancement works correctly
     const retryExecutor = new DefaultRetryExecutor(fakeTimer);
+    const devices = [
+      createBootedDevice("device-1"),
+      createBootedDevice("device-2"),
+      createBootedDevice("device-3"),
+    ];
+    // An injected device manager, not the real one: a pooled Android entry is
+    // re-proved present against discovery before it is assigned, and the default
+    // manager would shell out to a real adb for that.
+    const fakeDeviceManager = new FakeDeviceManager();
+    fakeDeviceManager.bootedDevices = [...devices];
     devicePool = new DevicePool(
       sessionManager,
       "test-daemon-session-id",
       fakeTimer,
       fakeAppsRepo,
-      undefined,
+      fakeDeviceManager,
       retryExecutor,
     );
-    await devicePool.initializeWithDevices([
-      createBootedDevice("device-1"),
-      createBootedDevice("device-2"),
-      createBootedDevice("device-3"),
-    ]);
+    await devicePool.initializeWithDevices(devices);
   });
 
   afterEach(function () {

--- a/test/daemon/performancePushSocketServer.test.ts
+++ b/test/daemon/performancePushSocketServer.test.ts
@@ -118,6 +118,27 @@ describe("PerformancePushSocketServer", () => {
     await server.startFake();
   });
 
+  const performanceData = (deviceId: string): LivePerformanceData => ({
+    deviceId,
+    deviceSessionUuid: null,
+    packageName: "com.example.app",
+    timestamp: 1000,
+    nodeId: null,
+    screenName: null,
+    metrics: {
+      fps: 60,
+      frameTimeMs: 16,
+      jankFrames: 0,
+      touchLatencyMs: null,
+      ttffMs: null,
+      ttiMs: null,
+      cpuUsagePercent: null,
+      memoryUsageMb: null,
+    },
+    thresholds: DEFAULT_THRESHOLDS,
+    health: "healthy",
+  });
+
   it("tracks subscriber count correctly", () => {
     expect(server.getSubscriberCount()).toBe(0);
 
@@ -212,6 +233,33 @@ describe("PerformancePushSocketServer", () => {
 
     expect(msgs1).toHaveLength(1);
     expect(msgs2).toHaveLength(0);
+  });
+
+  // While the pool cannot say which AVD is on the serial, the entry's epoch is
+  // preserved but withheld: a possible replacement's metrics must not land on the
+  // previous AVD's pane, nor on an all-device one (#6863 review).
+  it("drops performance data while the device's pooled identity is quarantined", () => {
+    const scoped = server.simulateSubscription({ deviceSessionUuid: "uuid-1" });
+    const all = server.simulateSubscription({});
+    resolver.quarantine("device-1");
+
+    server.pushPerformanceData(performanceData("device-1"));
+
+    expect(scoped.socket.getWrittenMessages()).toHaveLength(0);
+    expect(all.socket.getWrittenMessages()).toHaveLength(0);
+  });
+
+  it("resumes performance delivery under the same uuid once the quarantine lifts", () => {
+    const { socket } = server.simulateSubscription({ deviceSessionUuid: "uuid-1" });
+    resolver.quarantine("device-1");
+    server.pushPerformanceData(performanceData("device-1"));
+
+    resolver.resolveIdentity("device-1");
+    server.pushPerformanceData(performanceData("device-1"));
+
+    const msgs = socket.getWrittenMessages<{ data?: LivePerformanceData }>();
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].data?.deviceSessionUuid).toBe("uuid-1");
   });
 
   it("yields zero events to a stale/retired deviceSessionUuid filter (AC4)", async () => {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -1501,17 +1501,20 @@ describe("SessionManager", () => {
           },
         }),
       );
+      const device = { name: "device-1", deviceId: "device-1", platform: "android" as const };
+      const deviceManager = new FakeDeviceManager();
+      // A pooled Android entry is re-proved present against discovery before it
+      // is handed out, handsets included, so discovery has to list it.
+      deviceManager.bootedDevices = [device];
       const pool = new DevicePool(
         manager,
         "test-daemon",
         fakeTimer,
         new FakeInstalledAppsRepository(),
-        new FakeDeviceManager(),
+        deviceManager,
       );
       try {
-        await pool.initializeWithDevices([
-          { name: "device-1", deviceId: "device-1", platform: "android" },
-        ]);
+        await pool.initializeWithDevices([device]);
         await pool.assignDeviceToSession("s1", "android");
         manager.setKeepScreenAwake("s1", { applied: true, method: "svc", svcWasEnabled: false });
 

--- a/test/daemon/socketServerInputTypeText.integration.test.ts
+++ b/test/daemon/socketServerInputTypeText.integration.test.ts
@@ -1201,6 +1201,91 @@ describe("UnixSocketServer input/typeText", () => {
     expect(deviceField).toBe("xABCDE");
   });
 
+  // The self-heal retry resumes the SAME logical append: the original call
+  // already validated the frame context before its first key event, and the
+  // confirmed prefix has since emitted TYPE_VIEW_TEXT_CHANGED, which advances the
+  // runner's frame epoch. Re-running the validator on the rebuilt helper would
+  // therefore reject a suffix that is perfectly safe to type
+  // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+  test("does not re-validate the frame context when resuming a self-healed append", async () => {
+    let validationCalls = 0;
+    const validateFrameContext = mock(async () => {
+      validationCalls += 1;
+      // The confirmed prefix advanced the frame epoch, so any validation after
+      // the original append's own one is answered "stale".
+      return validationCalls > 2
+        ? { success: false, error: "Stale frame context; observe a fresh frame before retrying" }
+        : { success: true };
+    });
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      validateFrameContext,
+      requestImeAction: mock(async () => ({ success: true, totalTimeMs: 1 })),
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    setDeviceIncarnationResolver(() => 7);
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(),
+      fakeTimer,
+    );
+    (server as unknown as { requireCurrentFrameContext: () => void }).requireCurrentFrameContext =
+      () => {};
+    let deviceField = "";
+    const validatorsReceived: Array<unknown> = [];
+    let factoryCalls = 0;
+    server.appendTextFactory = () => {
+      factoryCalls++;
+      const helper = factoryCalls;
+      let helperCalls = 0;
+      return {
+        appendText: async (
+          text: string,
+          _timeoutMs: number,
+          beforeKeyEvent?: () => Promise<{ success: boolean; error?: string }>,
+        ) => {
+          helperCalls++;
+          validatorsReceived.push(beforeKeyEvent);
+          if (beforeKeyEvent) {
+            const validation = await beforeKeyEvent();
+            if (!validation.success) {
+              return { success: false, error: validation.error, charsSent: 0 };
+            }
+          }
+          if (helper === 1 && helperCalls === 2) {
+            deviceField += text.slice(0, 2);
+            return { success: false, error: "helper died mid-append", charsSent: 2 };
+          }
+          deviceField += text;
+          return { success: true, charsSent: text.length };
+        },
+      } as unknown as InputText;
+    };
+    await server.start();
+
+    const append = (text: string, frameContext: string) =>
+      sendRequest(
+        socketPath,
+        "input/typeText",
+        { platform: "android", deviceId: "emulator-5554", text, mode: "append", frameContext },
+        1234,
+      );
+
+    expect((await append("x", "epoch:1")).success).toBe(true);
+    expect(factoryCalls).toBe(1);
+
+    const response = await append("ABCDE", "epoch:2");
+
+    expect(response.success).toBe(true);
+    expect(factoryCalls).toBe(2);
+    // The rebuilt helper resumes the suffix with NO validator of its own.
+    expect(validatorsReceived).toHaveLength(3);
+    expect(validatorsReceived[2]).toBeUndefined();
+    // One validation per logical append; the retry adds none.
+    expect(validationCalls).toBe(2);
+    expect(deviceField).toBe("xABCDE");
+  });
+
   // An omitted `charsSent` means the helper cannot say whether the in-flight key
   // event landed (an adb timeout kills the host child, not the device's handling
   // of it). Replaying anything there can duplicate a character, so the failure is

--- a/test/daemon/socketServerInputTypeText.integration.test.ts
+++ b/test/daemon/socketServerInputTypeText.integration.test.ts
@@ -1286,6 +1286,171 @@ describe("UnixSocketServer input/typeText", () => {
     expect(deviceField).toBe("xABCDE");
   });
 
+  // Two very different things can make a cached-helper append fail, and only one
+  // of them is evidence that the HELPER is stale. When the RUNNER answers with a
+  // verdict about the device -- a stale `frameContext`, say -- that verdict is
+  // about the device state, not about the helper: rebuilding and replaying would
+  // type into a UI the runner just refused. The verdict is surfaced as-is
+  // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+  test("surfaces a runner rejection instead of self-healing the helper", async () => {
+    const validateFrameContext = mock(async () => ({
+      success: false,
+      error: "Stale frame context; observe a fresh frame before retrying",
+    }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      validateFrameContext,
+      requestImeAction: mock(async () => ({ success: true, totalTimeMs: 1 })),
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    setDeviceIncarnationResolver(() => 7);
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(),
+      fakeTimer,
+    );
+    (server as unknown as { requireCurrentFrameContext: () => void }).requireCurrentFrameContext =
+      () => {};
+    let deviceField = "";
+    let factoryCalls = 0;
+    server.appendTextFactory = () => {
+      factoryCalls++;
+      return {
+        // Mirrors the real helper: a validator rejection becomes a failed append
+        // with zero characters sent, tagged as the RUNNER's verdict.
+        appendText: async (
+          text: string,
+          _timeoutMs: number,
+          beforeKeyEvent?: () => Promise<{
+            success: boolean;
+            error?: string;
+            failureSource?: "runner" | "helper";
+          }>,
+        ) => {
+          if (beforeKeyEvent) {
+            const validation = await beforeKeyEvent();
+            if (!validation.success) {
+              return {
+                success: false,
+                error: validation.error,
+                charsSent: 0,
+                failureSource: validation.failureSource,
+              };
+            }
+          }
+          deviceField += text;
+          return { success: true, charsSent: text.length };
+        },
+      } as unknown as InputText;
+    };
+    await server.start();
+
+    const append = (text: string, frameContext?: string) =>
+      sendRequest(
+        socketPath,
+        "input/typeText",
+        {
+          platform: "android",
+          deviceId: "emulator-5554",
+          text,
+          mode: "append",
+          ...(frameContext ? { frameContext } : {}),
+        },
+        1234,
+      );
+
+    // Warm the cache so the next append is "from cache" and self-heal eligible.
+    expect((await append("x")).success).toBe(true);
+    expect(factoryCalls).toBe(1);
+
+    const response = await append("AB", "epoch:1");
+
+    expect(response.success).toBe(false);
+    expect(String(response.error)).toContain("Stale frame context");
+    expect(response.charsSent).toBe(0);
+    // No rebuild and no replay: the device receives nothing after the warm-up.
+    expect(factoryCalls).toBe(1);
+    expect(deviceField).toBe("x");
+  });
+
+  // A HELPER failure with zero confirmed characters is the other shape: nothing
+  // was validated-and-sent, so the rebuilt helper starts the append over --
+  // including the original frame-context validation, which has not yet been
+  // spent on a key event that landed
+  // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+  test("replays the whole text WITH its validator when nothing was confirmed", async () => {
+    const validateFrameContext = mock(async () => ({ success: true }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      validateFrameContext,
+      requestImeAction: mock(async () => ({ success: true, totalTimeMs: 1 })),
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    setDeviceIncarnationResolver(() => 7);
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(),
+      fakeTimer,
+    );
+    (server as unknown as { requireCurrentFrameContext: () => void }).requireCurrentFrameContext =
+      () => {};
+    let deviceField = "";
+    const validatorsReceived: Array<unknown> = [];
+    let factoryCalls = 0;
+    server.appendTextFactory = () => {
+      factoryCalls++;
+      const helper = factoryCalls;
+      let helperCalls = 0;
+      return {
+        appendText: async (
+          text: string,
+          _timeoutMs: number,
+          beforeKeyEvent?: () => Promise<{ success: boolean; error?: string }>,
+        ) => {
+          helperCalls++;
+          validatorsReceived.push(beforeKeyEvent);
+          if (beforeKeyEvent) {
+            const validation = await beforeKeyEvent();
+            if (!validation.success) {
+              return { success: false, error: validation.error, charsSent: 0 };
+            }
+          }
+          if (helper === 1 && helperCalls === 2) {
+            // The helper itself dies before any key event lands.
+            return {
+              success: false,
+              error: "helper died before the first key event",
+              charsSent: 0,
+            };
+          }
+          deviceField += text;
+          return { success: true, charsSent: text.length };
+        },
+      } as unknown as InputText;
+    };
+    await server.start();
+
+    const append = (text: string, frameContext: string) =>
+      sendRequest(
+        socketPath,
+        "input/typeText",
+        { platform: "android", deviceId: "emulator-5554", text, mode: "append", frameContext },
+        1234,
+      );
+
+    expect((await append("x", "epoch:1")).success).toBe(true);
+    expect(factoryCalls).toBe(1);
+
+    const response = await append("ABC", "epoch:2");
+
+    expect(response.success).toBe(true);
+    expect(factoryCalls).toBe(2);
+    // The rebuilt helper retries the whole text, and it keeps the validator.
+    expect(validatorsReceived).toHaveLength(3);
+    expect(validatorsReceived[2]).toBeDefined();
+    expect(deviceField).toBe("xABC");
+  });
+
   // An omitted `charsSent` means the helper cannot say whether the in-flight key
   // event landed (an adb timeout kills the host child, not the device's handling
   // of it). Replaying anything there can duplicate a character, so the failure is

--- a/test/daemon/socketServerInputTypeText.integration.test.ts
+++ b/test/daemon/socketServerInputTypeText.integration.test.ts
@@ -16,6 +16,10 @@ import { defaultTimer } from "../../src/utils/SystemTimer";
 import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
 import { IOSCtrlProxyClient } from "../../src/features/observe/ios";
 import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
+import {
+  deviceIncarnationToken,
+  setDeviceIncarnationResolver,
+} from "../../src/utils/deviceIncarnation";
 import { executionTracker } from "../../src/server/executionTracker";
 import { FakeTimer } from "../fakes/FakeTimer";
 import {
@@ -184,6 +188,7 @@ describe("UnixSocketServer input/typeText", () => {
     PlatformDeviceManagerFactory.reset();
     AndroidCtrlProxyClient.resetInstances();
     IOSCtrlProxyClient.resetInstances();
+    setDeviceIncarnationResolver(undefined);
   });
 
   test("routes Android text input through existing platform input infrastructure", async () => {
@@ -678,9 +683,7 @@ describe("UnixSocketServer input/typeText", () => {
       requestSetText,
       requestImeAction,
     })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
-    PlatformDeviceManagerFactory.setInstance(
-      createFakeDeviceManager([{ ...androidDevice, transportId: "1" }]),
-    );
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
@@ -730,9 +733,7 @@ describe("UnixSocketServer input/typeText", () => {
       requestSetText,
       requestImeAction,
     })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
-    PlatformDeviceManagerFactory.setInstance(
-      createFakeDeviceManager([{ ...androidDevice, transportId: "1" }]),
-    );
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
@@ -765,9 +766,7 @@ describe("UnixSocketServer input/typeText", () => {
   });
 
   test("evicts the cached append helper after a session MCP forward succeeds it in the device queue", async () => {
-    PlatformDeviceManagerFactory.setInstance(
-      createFakeDeviceManager([{ ...androidDevice, transportId: "1" }]),
-    );
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
     const sessions = new Map([
       ["session-a", createFakeSession("session-a", androidDevice.deviceId, "android")],
     ]);
@@ -897,17 +896,16 @@ describe("UnixSocketServer input/typeText", () => {
     expect(adb.probeCalls.length).toBe(2);
   });
 
-  test("re-probes append input when direct discovery reports a new connection incarnation", async () => {
+  test("re-probes append input when the pool reports a new connection incarnation", async () => {
     const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
     const requestImeAction = mock(async () => ({ success: true, totalTimeMs: 1 }));
     AndroidCtrlProxyClient.getInstance = mock(() => ({
       requestSetText,
       requestImeAction,
     })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
-    let discoveredDevice = {
-      ...androidDevice,
-      transportId: "1",
-    } as BootedDevice;
+    const discoveredDevice = androidDevice;
+    let incarnation = 1;
+    setDeviceIncarnationResolver(() => incarnation);
     let bypassedAndroidDeviceListCache = false;
     PlatformDeviceManagerFactory.setInstance({
       getBootedDevicesDetailed: async (
@@ -949,10 +947,7 @@ describe("UnixSocketServer input/typeText", () => {
       );
 
     expect((await append()).success).toBe(true);
-    discoveredDevice = {
-      ...androidDevice,
-      transportId: "2",
-    } as BootedDevice;
+    incarnation = 2;
     expect((await append()).success).toBe(true);
 
     expect(factoryCalls).toBe(2);
@@ -960,14 +955,16 @@ describe("UnixSocketServer input/typeText", () => {
     expect(bypassedAndroidDeviceListCache).toBe(true);
   });
 
-  test("revalidates append transport identity after waiting behind same-device input", async () => {
+  test("revalidates append device identity after waiting behind same-device input", async () => {
     const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
     const requestImeAction = mock(async () => ({ success: true, totalTimeMs: 1 }));
     AndroidCtrlProxyClient.getInstance = mock(() => ({
       requestSetText,
       requestImeAction,
     })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
-    let discoveredDevice = { ...androidDevice, transportId: "1" } as BootedDevice;
+    const discoveredDevice = androidDevice;
+    let incarnation = 1;
+    setDeviceIncarnationResolver(() => incarnation);
     let discoveryCalls = 0;
     PlatformDeviceManagerFactory.setInstance({
       getBootedDevicesDetailed: async () => {
@@ -992,12 +989,12 @@ describe("UnixSocketServer input/typeText", () => {
     const firstAppendStarted = new Promise<void>((resolve) => {
       signalFirstAppendStarted = resolve;
     });
-    const createdForTransportIds: Array<string | undefined> = [];
+    const createdForIncarnations: Array<string | undefined> = [];
     server.appendTextFactory = (device) => {
-      createdForTransportIds.push(device.transportId);
+      createdForIncarnations.push(deviceIncarnationToken(device.deviceId));
       return {
         appendText: async () => {
-          if (createdForTransportIds.length === 1) {
+          if (createdForIncarnations.length === 1) {
             signalFirstAppendStarted?.();
             await firstAppendReleased;
           }
@@ -1027,17 +1024,17 @@ describe("UnixSocketServer input/typeText", () => {
     expect(discoveryCalls).toBe(3);
 
     // The second request was resolved before the replacement, then waited in
-    // the same-device queue. Its queued revalidation must see the new transport.
-    discoveredDevice = { ...androidDevice, transportId: "2" } as BootedDevice;
+    // the same-device queue. Its queued revalidation must see the new epoch.
+    incarnation = 2;
     releaseFirstAppend?.();
 
     expect((await first).success).toBe(true);
     expect((await second).success).toBe(true);
-    expect(createdForTransportIds).toEqual(["1", "2"]);
+    expect(createdForIncarnations).toEqual(["1", "2"]);
     expect(discoveryCalls).toBe(4);
   });
 
-  test("does not reuse append input when direct discovery omits transport identity", async () => {
+  test("documented blind spot: with no pool incarnation the cached append helper is reused", async () => {
     const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
     const requestImeAction = mock(async () => ({ success: true, totalTimeMs: 1 }));
     AndroidCtrlProxyClient.getInstance = mock(() => ({
@@ -1072,11 +1069,67 @@ describe("UnixSocketServer input/typeText", () => {
         1234,
       );
 
+    // Nothing in a discovery listing distinguishes one occupant of a reused
+    // serial from the next, so with no pool to name the epoch the helper is
+    // reused rather than rebuilt on every keystroke (#1099). The safeguards are
+    // `evictDeviceInputCache` on the pool's own lifecycle events and the
+    // append self-heal below, not this comparison.
     expect((await append()).success).toBe(true);
     expect((await append()).success).toBe(true);
 
+    expect(factoryCalls).toBe(1);
+    expect(adb.probeCalls.length).toBe(1);
+  });
+
+  test("rebuilds a cached append helper once when its first use fails", async () => {
+    const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    const requestImeAction = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestSetText,
+      requestImeAction,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    setDeviceIncarnationResolver(() => 7);
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(),
+      fakeTimer,
+    );
+    let factoryCalls = 0;
+    server.appendTextFactory = () => {
+      factoryCalls++;
+      const call = factoryCalls;
+      return {
+        appendText: async () =>
+          call === 1 ? { success: false, error: "stale helper" } : { success: true, charsSent: 1 },
+      } as unknown as InputText;
+    };
+    await server.start();
+
+    const append = () =>
+      sendRequest(
+        socketPath,
+        "input/typeText",
+        {
+          platform: "android",
+          deviceId: "emulator-5554",
+          text: "A",
+          mode: "append",
+        },
+        1234,
+      );
+
+    // First call builds the helper and caches it; it is not "from cache", so
+    // its failure is surfaced as-is.
+    expect((await append()).success).toBe(false);
+    expect(factoryCalls).toBe(1);
+
+    // The second call takes the cached helper. There is no epoch change to
+    // detect a same-serial reincarnation, so the failure itself is the signal:
+    // evict, rebuild once, and the retry succeeds.
+    expect((await append()).success).toBe(true);
     expect(factoryCalls).toBe(2);
-    expect(adb.probeCalls.length).toBe(2);
   });
 
   // The client forwards every printable ASCII character, but uppercase and shifted

--- a/test/daemon/socketServerInputTypeText.integration.test.ts
+++ b/test/daemon/socketServerInputTypeText.integration.test.ts
@@ -1101,8 +1101,13 @@ describe("UnixSocketServer input/typeText", () => {
       factoryCalls++;
       const call = factoryCalls;
       return {
+        // charsSent: 0 is what the real helper reports when it fails before any
+        // key event lands, and it is the only failure shape whose whole string
+        // may be replayed (see the two tests below for the other two shapes).
         appendText: async () =>
-          call === 1 ? { success: false, error: "stale helper" } : { success: true, charsSent: 1 },
+          call === 1
+            ? { success: false, error: "stale helper", charsSent: 0 }
+            : { success: true, charsSent: 1 },
       } as unknown as InputText;
     };
     await server.start();
@@ -1130,6 +1135,126 @@ describe("UnixSocketServer input/typeText", () => {
     // evict, rebuild once, and the retry succeeds.
     expect((await append()).success).toBe(true);
     expect(factoryCalls).toBe(2);
+  });
+
+  // The self-heal rebuild must not re-type what already landed: `charsSent` is the
+  // confirmed prefix, so the rebuilt helper resumes from `text.slice(charsSent)`.
+  // Replaying the whole string would turn "AB" after "A" into "AAB" (issue #3351).
+  test("retries only the unconfirmed suffix after a cached helper appends part of the text", async () => {
+    const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    const requestImeAction = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestSetText,
+      requestImeAction,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    setDeviceIncarnationResolver(() => 7);
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(),
+      fakeTimer,
+    );
+    // What the device's focused field would hold after these appends.
+    let deviceField = "";
+    const textsReceived: string[] = [];
+    let factoryCalls = 0;
+    server.appendTextFactory = () => {
+      factoryCalls++;
+      const helper = factoryCalls;
+      let helperCalls = 0;
+      return {
+        appendText: async (text: string) => {
+          helperCalls++;
+          textsReceived.push(text);
+          if (helper === 1 && helperCalls === 2) {
+            // The cached use dies halfway: two characters landed, the third did not.
+            deviceField += text.slice(0, 2);
+            return { success: false, error: "helper died mid-append", charsSent: 2 };
+          }
+          deviceField += text;
+          return { success: true, charsSent: text.length };
+        },
+      } as unknown as InputText;
+    };
+    await server.start();
+
+    const append = (text: string) =>
+      sendRequest(
+        socketPath,
+        "input/typeText",
+        { platform: "android", deviceId: "emulator-5554", text, mode: "append" },
+        1234,
+      );
+
+    // Warm the cache with a successful append so the next one is "from cache".
+    expect((await append("x")).success).toBe(true);
+    expect(factoryCalls).toBe(1);
+
+    const response = await append("ABCDE");
+
+    expect(response.success).toBe(true);
+    expect(factoryCalls).toBe(2);
+    // The rebuilt helper gets the suffix only...
+    expect(textsReceived).toEqual(["x", "ABCDE", "CDE"]);
+    // ...so every character reaches the device exactly once.
+    expect(deviceField).toBe("xABCDE");
+  });
+
+  // An omitted `charsSent` means the helper cannot say whether the in-flight key
+  // event landed (an adb timeout kills the host child, not the device's handling
+  // of it). Replaying anything there can duplicate a character, so the failure is
+  // surfaced instead of self-healed.
+  test("does not replay an append whose confirmed prefix is unknown", async () => {
+    const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    const requestImeAction = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestSetText,
+      requestImeAction,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    setDeviceIncarnationResolver(() => 7);
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(),
+      fakeTimer,
+    );
+    const textsReceived: string[] = [];
+    let factoryCalls = 0;
+    server.appendTextFactory = () => {
+      factoryCalls++;
+      let helperCalls = 0;
+      return {
+        appendText: async (text: string) => {
+          helperCalls++;
+          textsReceived.push(text);
+          return helperCalls === 1
+            ? { success: true, charsSent: text.length }
+            : { success: false, error: "append key event failed: timeout" };
+        },
+      } as unknown as InputText;
+    };
+    await server.start();
+
+    const append = (text: string) =>
+      sendRequest(
+        socketPath,
+        "input/typeText",
+        { platform: "android", deviceId: "emulator-5554", text, mode: "append" },
+        1234,
+      );
+
+    expect((await append("x")).success).toBe(true);
+
+    const response = await append("AB");
+
+    expect(response.success).toBe(false);
+    expect(String(response.error)).toContain("append key event failed");
+    expect(response.charsSent).toBeUndefined();
+    // No rebuild, no replay.
+    expect(factoryCalls).toBe(1);
+    expect(textsReceived).toEqual(["x", "AB"]);
   });
 
   // The client forwards every printable ASCII character, but uppercase and shifted

--- a/test/daemon/telemetryPushSocketServer.integration.test.ts
+++ b/test/daemon/telemetryPushSocketServer.integration.test.ts
@@ -255,6 +255,7 @@ describe("TelemetryPushSocketServer", () => {
     category: "network",
     timestamp: 1000,
     deviceId,
+    sessionId: null,
     data: { method: "GET", url: "/users", statusCode: 200, durationMs: 42 },
   });
 

--- a/test/daemon/telemetryPushSocketServer.integration.test.ts
+++ b/test/daemon/telemetryPushSocketServer.integration.test.ts
@@ -251,6 +251,40 @@ describe("TelemetryPushSocketServer", () => {
     await server.startFake();
   });
 
+  const telemetryEvent = (deviceId: string): TelemetryEvent => ({
+    category: "network",
+    timestamp: 1000,
+    deviceId,
+    data: { method: "GET", url: "/users", statusCode: 200, durationMs: 42 },
+  });
+
+  // The epoch survives the quarantine but is withheld, and the event is dropped
+  // rather than broadcast under a serial the pool can no longer tie to a runtime
+  // (#6863 review).
+  it("drops telemetry while the device's pooled identity is quarantined", () => {
+    const scoped = server.simulateSubscription({ deviceSessionUuid: "uuid-1" });
+    const all = server.simulateSubscription({});
+    resolver.quarantine("device-1");
+
+    server.pushTelemetryEvent(telemetryEvent("device-1"));
+
+    expect(scoped.socket.getWrittenMessages()).toHaveLength(0);
+    expect(all.socket.getWrittenMessages()).toHaveLength(0);
+  });
+
+  it("resumes telemetry delivery under the same uuid once the quarantine lifts", () => {
+    const { socket } = server.simulateSubscription({ deviceSessionUuid: "uuid-1" });
+    resolver.quarantine("device-1");
+    server.pushTelemetryEvent(telemetryEvent("device-1"));
+
+    resolver.resolveIdentity("device-1");
+    server.pushTelemetryEvent(telemetryEvent("device-1"));
+
+    const msgs = socket.getWrittenMessages<{ data?: TelemetryEvent }>();
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].data?.deviceSessionUuid).toBe("uuid-1");
+  });
+
   it("tracks subscriber count correctly", () => {
     expect(server.getSubscriberCount()).toBe(0);
 

--- a/test/fakes/FakeDeviceSessionResolver.ts
+++ b/test/fakes/FakeDeviceSessionResolver.ts
@@ -4,10 +4,15 @@ import type { DeviceSessionResolver } from "../../src/daemon/deviceSessionResolv
  * In-memory {@link DeviceSessionResolver} for unit tests. Seed live serial↔uuid
  * pairs with {@link bind}; {@link retire} drops a pair so both directions miss
  * (mirroring a disconnected epoch). Unknown ids resolve to `null`.
+ *
+ * {@link quarantine} models the pool's `identityUnresolved` state: the pair is
+ * KEPT (so {@link resolveIdentity} resumes the same epoch) but withheld from both
+ * directions, and routing for that serial reports as suspended.
  */
 export class FakeDeviceSessionResolver implements DeviceSessionResolver {
   private readonly deviceIdToUuid = new Map<string, string>();
   private readonly uuidToDeviceId = new Map<string, string>();
+  private readonly quarantined = new Set<string>();
 
   bind(deviceId: string, deviceSessionUuid: string): this {
     const previousUuid = this.deviceIdToUuid.get(deviceId);
@@ -28,11 +33,34 @@ export class FakeDeviceSessionResolver implements DeviceSessionResolver {
     return this;
   }
 
+  /** Withhold this serial's routing identity, as the pool's quarantine does. */
+  quarantine(deviceId: string): this {
+    this.quarantined.add(deviceId);
+    return this;
+  }
+
+  /** Lift {@link quarantine}, restoring the epoch that was preserved underneath it. */
+  resolveIdentity(deviceId: string): this {
+    this.quarantined.delete(deviceId);
+    return this;
+  }
+
   resolveUuid(deviceId: string): string | null {
+    if (this.quarantined.has(deviceId)) {
+      return null;
+    }
     return this.deviceIdToUuid.get(deviceId) ?? null;
   }
 
   resolveDeviceId(deviceSessionUuid: string): string | null {
-    return this.uuidToDeviceId.get(deviceSessionUuid) ?? null;
+    const deviceId = this.uuidToDeviceId.get(deviceSessionUuid);
+    if (deviceId === undefined || this.quarantined.has(deviceId)) {
+      return null;
+    }
+    return deviceId;
+  }
+
+  isRoutingSuspended(deviceId: string): boolean {
+    return this.quarantined.has(deviceId);
   }
 }

--- a/test/features/action/PressButton.android.test.ts
+++ b/test/features/action/PressButton.android.test.ts
@@ -233,7 +233,7 @@ describe("PressButton Android keycode dispatch", () => {
   // into the ADB keyevent fallback and the home-foreground verification reads.
   // A failed verification is the only signal available that the cached
   // configured-HOME package may no longer describe the device in front of us
-  // (issue #6863 review): in direct mode there is no incarnation token, so a
+  // (#6863 review): in direct mode there is no incarnation token, so a
   // reconnect or a reused serial leaves the cache looking valid. Evicting on
   // failure lets the next attempt re-resolve instead of reporting a real Home
   // press as failed for the rest of the cache window.

--- a/test/features/action/PressButton.android.test.ts
+++ b/test/features/action/PressButton.android.test.ts
@@ -5,6 +5,11 @@ import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeWindow } from "../../fakes/FakeWindow";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { runWithAbortSignal } from "../../../src/utils/AbortContext";
+import {
+  clearResolvedHomePackageCache,
+  resolveConfiguredHomePackage,
+} from "../../../src/features/observe/androidLauncherPackages";
+import { setDeviceIncarnationResolver } from "../../../src/utils/deviceIncarnation";
 import { OPERATION_CANCELLED_MESSAGE } from "../../../src/utils/constants";
 import type { BootedDevice } from "../../../src/models";
 import type { ActiveWindowInfo } from "../../../src/models/ActiveWindowInfo";
@@ -53,11 +58,14 @@ describe("PressButton Android keycode dispatch", () => {
     fakeAdb = new FakeAdbExecutor();
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
+    clearResolvedHomePackageCache();
   });
 
   afterEach(() => {
     getInstanceSpy?.mockRestore();
     getInstanceSpy = null;
+    setDeviceIncarnationResolver(undefined);
+    clearResolvedHomePackageCache();
   });
 
   const press = (button: string, window?: WindowInterface) => {
@@ -223,6 +231,69 @@ describe("PressButton Android keycode dispatch", () => {
 
   // Deadline/abort plumbing (issue #6289): press() accepts a signal, threaded
   // into the ADB keyevent fallback and the home-foreground verification reads.
+  // A failed verification is the only signal available that the cached
+  // configured-HOME package may no longer describe the device in front of us
+  // (issue #6863 review): in direct mode there is no incarnation token, so a
+  // reconnect or a reused serial leaves the cache looking valid. Evicting on
+  // failure lets the next attempt re-resolve instead of reporting a real Home
+  // press as failed for the rest of the cache window.
+  describe("home verification self-heals a stale launcher cache", () => {
+    const verifier = (window: WindowInterface): PressButton => {
+      const pressButton = Object.create(PressButton.prototype) as PressButton;
+      (pressButton as any).timer = fakeTimer;
+      (pressButton as any).adb = fakeAdb;
+      (pressButton as any).device = androidDevice;
+      (pressButton as any).window = window;
+      return pressButton;
+    };
+
+    test("evicts the cached HOME package when verification fails", async () => {
+      // An epoch token is registered, so the entry would otherwise survive the
+      // full TTL -- only the failure eviction can make the next call re-resolve.
+      setDeviceIncarnationResolver(() => 1);
+      fakeAdb.setCommandResponse("resolve-activity", {
+        stdout: "com.launcher.a/.Main",
+        stderr: "",
+      });
+
+      await expect(
+        (verifier(sequencedWindow(["com.other.app"])) as any).verifyAndroidHomeForeground({
+          retryDelaysMs: [],
+        }),
+      ).resolves.toBe(false);
+
+      fakeAdb.setCommandResponse("resolve-activity", {
+        stdout: "com.launcher.b/.Main",
+        stderr: "",
+      });
+      expect(
+        await resolveConfiguredHomePackage(fakeAdb, androidDevice.deviceId, fakeTimer, "1"),
+      ).toBe("com.launcher.b");
+    });
+
+    test("keeps the cached HOME package when verification succeeds", async () => {
+      setDeviceIncarnationResolver(() => 1);
+      fakeAdb.setCommandResponse("resolve-activity", {
+        stdout: "com.launcher.a/.Main",
+        stderr: "",
+      });
+
+      await expect(
+        (verifier(sequencedWindow(["com.launcher.a"])) as any).verifyAndroidHomeForeground({
+          retryDelaysMs: [],
+        }),
+      ).resolves.toBe(true);
+
+      fakeAdb.setCommandResponse("resolve-activity", {
+        stdout: "com.launcher.b/.Main",
+        stderr: "",
+      });
+      expect(
+        await resolveConfiguredHomePackage(fakeAdb, androidDevice.deviceId, fakeTimer, "1"),
+      ).toBe("com.launcher.a");
+    });
+  });
+
   describe("AbortSignal propagation (issue #6289)", () => {
     test("forwards the signal into the ADB keyevent fallback and home verification", async () => {
       getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({

--- a/test/features/observe/androidLauncherPackages.test.ts
+++ b/test/features/observe/androidLauncherPackages.test.ts
@@ -173,7 +173,8 @@ describe("androidLauncherPackages", () => {
 
   // A process-lifetime cache means a user who changes their default HOME app
   // never sees it reflected until the daemon restarts. A bounded TTL fixes
-  // that.
+  // that. These cases all pass an incarnation token, so they exercise the
+  // FULL TTL -- the shorter untokened lifetime has its own describe below.
   describe("resolveConfiguredHomePackage cache TTL", () => {
     test("serves the cached package within the TTL window", async () => {
       const fakeTimer = new FakeTimer();
@@ -183,9 +184,9 @@ describe("androidLauncherPackages", () => {
         stderr: "",
       });
 
-      const first = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer);
+      const first = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer, "epoch-1");
       fakeTimer.setCurrentTime(29_000);
-      const second = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer);
+      const second = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer, "epoch-1");
 
       expect(first).toBe("com.launcher.a");
       expect(second).toBe("com.launcher.a");
@@ -201,7 +202,7 @@ describe("androidLauncherPackages", () => {
         stdout: "com.launcher.a/.Main",
         stderr: "",
       });
-      const first = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer);
+      const first = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer, "epoch-1");
 
       // The user changes their default HOME app while the daemon keeps
       // running.
@@ -210,7 +211,7 @@ describe("androidLauncherPackages", () => {
         stderr: "",
       });
       fakeTimer.setCurrentTime(30_001);
-      const second = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer);
+      const second = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer, "epoch-1");
 
       expect(first).toBe("com.launcher.a");
       expect(second).toBe("com.launcher.b");
@@ -226,12 +227,12 @@ describe("androidLauncherPackages", () => {
         stdout: "com.launcher.a/.Main",
         stderr: "",
       });
-      expect(await isForegroundLauncher("com.launcher.a", fakeAdb, "device-1", fakeTimer)).toBe(
-        true,
-      );
-      expect(await isForegroundLauncher("com.launcher.b", fakeAdb, "device-1", fakeTimer)).toBe(
-        false,
-      );
+      expect(
+        await isForegroundLauncher("com.launcher.a", fakeAdb, "device-1", fakeTimer, "epoch-1"),
+      ).toBe(true);
+      expect(
+        await isForegroundLauncher("com.launcher.b", fakeAdb, "device-1", fakeTimer, "epoch-1"),
+      ).toBe(false);
 
       fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
         stdout: "com.launcher.b/.Main",
@@ -239,18 +240,88 @@ describe("androidLauncherPackages", () => {
       });
       // Still within the TTL -- the stale cached value ("a") is still served.
       fakeTimer.setCurrentTime(10_000);
-      expect(await isForegroundLauncher("com.launcher.b", fakeAdb, "device-1", fakeTimer)).toBe(
-        false,
-      );
+      expect(
+        await isForegroundLauncher("com.launcher.b", fakeAdb, "device-1", fakeTimer, "epoch-1"),
+      ).toBe(false);
 
       // Past the TTL -- the new default HOME launcher ("b") is now accepted.
       fakeTimer.setCurrentTime(30_001);
-      expect(await isForegroundLauncher("com.launcher.b", fakeAdb, "device-1", fakeTimer)).toBe(
-        true,
-      );
-      expect(await isForegroundLauncher("com.launcher.a", fakeAdb, "device-1", fakeTimer)).toBe(
-        false,
-      );
+      expect(
+        await isForegroundLauncher("com.launcher.b", fakeAdb, "device-1", fakeTimer, "epoch-1"),
+      ).toBe(true);
+      expect(
+        await isForegroundLauncher("com.launcher.a", fakeAdb, "device-1", fakeTimer, "epoch-1"),
+      ).toBe(false);
+    });
+  });
+
+  // Direct mode (and any caller outside a daemon) registers no incarnation
+  // resolver, so the token is always undefined and two undefined tokens
+  // compare equal -- i.e. a same-serial reconnect within the full TTL would
+  // be served the PREVIOUS runtime's launcher. Without an epoch token the
+  // entry therefore only lives long enough to serve the retries of a single
+  // home-press verification.
+  describe("untokened cache lifetime", () => {
+    test("serves the cache across one verification's retries when no epoch token is available", async () => {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.setCurrentTime(0);
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.launcher.a/.Main",
+        stderr: "",
+      });
+
+      const first = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer);
+      fakeTimer.setCurrentTime(1_500);
+      const second = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer);
+
+      expect(first).toBe("com.launcher.a");
+      expect(second).toBe("com.launcher.a");
+      expect(
+        fakeAdb.getExecutedCommands().filter((cmd) => cmd.includes(RESOLVE_HOME_PATTERN)).length,
+      ).toBe(1);
+    });
+
+    test("re-resolves well before the full TTL when no epoch token is available", async () => {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.setCurrentTime(0);
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.launcher.a/.Main",
+        stderr: "",
+      });
+      const first = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer);
+
+      // A reconnect (or a reused serial) hands the same deviceId to a
+      // different runtime. With no epoch token to notice it, only the short
+      // lifetime prevents the previous runtime's launcher being served.
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.launcher.b/.Main",
+        stderr: "",
+      });
+      fakeTimer.setCurrentTime(2_001);
+      const second = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer);
+
+      expect(first).toBe("com.launcher.a");
+      expect(second).toBe("com.launcher.b");
+      expect(
+        fakeAdb.getExecutedCommands().filter((cmd) => cmd.includes(RESOLVE_HOME_PATTERN)).length,
+      ).toBe(2);
+    });
+
+    test("keeps the full TTL once an epoch token IS available", async () => {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.setCurrentTime(0);
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.launcher.a/.Main",
+        stderr: "",
+      });
+      await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer, "epoch-1");
+      fakeTimer.setCurrentTime(2_001);
+      const second = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer, "epoch-1");
+
+      expect(second).toBe("com.launcher.a");
+      expect(
+        fakeAdb.getExecutedCommands().filter((cmd) => cmd.includes(RESOLVE_HOME_PATTERN)).length,
+      ).toBe(1);
     });
   });
 

--- a/test/features/observe/androidLauncherPackages.test.ts
+++ b/test/features/observe/androidLauncherPackages.test.ts
@@ -7,10 +7,35 @@ import {
 } from "../../../src/features/observe/androidLauncherPackages";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import type { ExecResult } from "../../../src/models";
 import { runWithAbortSignal } from "../../../src/utils/AbortContext";
 import { OPERATION_CANCELLED_MESSAGE } from "../../../src/utils/constants";
 
 const RESOLVE_HOME_PATTERN = "resolve-activity";
+
+/**
+ * An adb executor whose resolve takes measurable device time, so a test can
+ * tell whether a cache entry is stamped before or after the command completes.
+ */
+class SlowResolveAdbExecutor extends FakeAdbExecutor {
+  constructor(
+    private readonly clock: FakeTimer,
+    private readonly elapsedMs: number,
+  ) {
+    super();
+  }
+
+  override async executeCommand(
+    command: string,
+    timeoutMs?: number,
+    maxBuffer?: number,
+    noRetry?: boolean,
+    signal?: AbortSignal,
+  ): Promise<ExecResult> {
+    this.clock.setCurrentTime(this.clock.now() + this.elapsedMs);
+    return await super.executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
+  }
+}
 
 describe("androidLauncherPackages", () => {
   let fakeAdb: FakeAdbExecutor;
@@ -305,6 +330,34 @@ describe("androidLauncherPackages", () => {
       expect(
         fakeAdb.getExecutedCommands().filter((cmd) => cmd.includes(RESOLVE_HOME_PATTERN)).length,
       ).toBe(2);
+    });
+
+    // The TTL must measure the age of the ANSWER, not of the call that went
+    // looking for it. Stamping the entry with the pre-resolve clock makes a slow
+    // adb resolve produce an entry that is already expired by the time it is
+    // written, so the very next verification retry re-resolves and burns more of
+    // the caller's deadline ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863)
+    // review).
+    test("starts the untokened lifetime when the resolve completes, not when it began", async () => {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.setCurrentTime(0);
+      const slowAdb = new SlowResolveAdbExecutor(fakeTimer, 1_900);
+      slowAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.launcher.a/.Main",
+        stderr: "",
+      });
+
+      const first = await resolveConfiguredHomePackage(slowAdb, "device-1", fakeTimer);
+      // The resolve itself consumed 1,900ms, so the entry is 0ms old here and
+      // 1,100ms old at 3,000 -- inside the short untokened lifetime either way.
+      fakeTimer.setCurrentTime(3_000);
+      const second = await resolveConfiguredHomePackage(slowAdb, "device-1", fakeTimer);
+
+      expect(first).toBe("com.launcher.a");
+      expect(second).toBe("com.launcher.a");
+      expect(
+        slowAdb.getExecutedCommands().filter((cmd) => cmd.includes(RESOLVE_HOME_PATTERN)).length,
+      ).toBe(1);
     });
 
     test("keeps the full TTL once an epoch token IS available", async () => {

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -51,6 +51,9 @@ describe("ToolExecutionContext", () => {
       fakeAppsRepo,
       fakeDeviceManager,
     );
+    // Discovery has to list the pooled device: an idle Android entry is
+    // re-proved present before it is assigned, handsets included.
+    fakeDeviceManager.bootedDevices = [createBootedDevice("device-1")];
     await devicePool.initializeWithDevices([createBootedDevice("device-1")]);
     originalGetInstance = AndroidCtrlProxyManager.getInstance;
     originalClientGetInstance = AndroidCtrlProxyClient.getInstance;
@@ -1461,12 +1464,14 @@ describe("ToolExecutionContext", () => {
       async markReleased(): Promise<void> {},
       async markStaleActiveSessionsExpired(): Promise<void> {},
     });
+    const boundedDeviceManager = new FakeDeviceManager();
+    boundedDeviceManager.bootedDevices = [createBootedDevice("device-1")];
     const boundedPool = new DevicePool(
       boundedSessionManager,
       "test-daemon-session-id",
       boundedTimer,
       fakeAppsRepo,
-      new FakeDeviceManager(),
+      boundedDeviceManager,
     );
     await boundedPool.initializeWithDevices([createBootedDevice("device-1")]);
     let finishSetup!: () => void;

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -461,8 +461,14 @@ describe("killDevice handler", () => {
   const originalAlias = process.env.AUTO_MOBILE_ANDROID_REBOOT_ON_DEATH;
   let sessionManager: SessionManager;
   let manager: FailingKillDeviceManager;
+  // What `emu avd name` answers for a serial whose discovered runtime name is
+  // `Unknown (<serial>)`. undefined == the console did not answer.
+  let runtimeAvdNames: Map<string, string | undefined>;
+  let runtimeAvdNameProbes: string[];
 
   beforeEach(async () => {
+    runtimeAvdNames = new Map();
+    runtimeAvdNameProbes = [];
     process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = "1";
     delete process.env.AUTO_MOBILE_ANDROID_REBOOT_ON_DEATH;
     manager = new FailingKillDeviceManager();
@@ -481,6 +487,10 @@ describe("killDevice handler", () => {
       notifyResourcesChanged: async () => {},
       ensureCtrlProxyReady: async () => {},
       clearInstalledAppsForDevice: async () => {},
+      resolveRunningAndroidAvdName: async (device) => {
+        runtimeAvdNameProbes.push(device.deviceId);
+        return runtimeAvdNames.get(device.deviceId);
+      },
     });
     registerDeviceTools();
   });
@@ -501,6 +511,103 @@ describe("killDevice handler", () => {
     } else {
       process.env.AUTO_MOBILE_ANDROID_REBOOT_ON_DEATH = originalAlias;
     }
+  });
+
+  /**
+   * The pooled AVD name is a host-side label, not proof of identity: a different
+   * AVD can take over a reused serial before discovery observes the previous one
+   * disappear. Killing on that stale label would stop the emulator running NOW,
+   * so the runtime is asked to confirm the name first (#6863 review).
+   */
+  describe("pooled AVD name verification before a kill", () => {
+    async function poolWithUnknownRuntime(
+      booted: BootedDevice,
+      pooledAvdName: string,
+    ): Promise<void> {
+      const timer = new FakeTimer();
+      sessionManager = new SessionManager(timer, new FakeDeviceSessionRepository());
+      const pool = new DevicePool(
+        sessionManager,
+        "daemon-session",
+        timer,
+        new FakeInstalledAppsRepository(),
+        manager,
+        new DefaultRetryExecutor(timer),
+        new FakeDeviceSessionRepository(),
+      );
+      DaemonState.getInstance().initialize(sessionManager, pool);
+      await pool.addDevice(booted, {
+        platform: "android",
+        name: pooledAvdName,
+        isRunning: true,
+      });
+      manager.setBootedDevices("android", [booted]);
+    }
+
+    function killTool() {
+      const tool = ToolRegistry.getTool("killDevice");
+      if (!tool) {
+        throw new Error("killDevice not registered");
+      }
+      return tool;
+    }
+
+    const unknownEmulator: BootedDevice = {
+      platform: "android",
+      name: "Unknown (emulator-5554)",
+      deviceId: "emulator-5554",
+    };
+
+    test("refuses when the runtime names a different AVD than the pool", async () => {
+      manager = new SuccessfulKillDeviceManager();
+      setDeviceToolsDependencies({ deviceManagerFactory: () => manager });
+      await poolWithUnknownRuntime(unknownEmulator, "Pixel_8_Old");
+      runtimeAvdNames.set("emulator-5554", "Pixel_9_New");
+
+      await expect(killTool().handler({ device: unknownEmulator })).rejects.toThrow(
+        /Pixel_8_Old[\s\S]*Pixel_9_New/,
+      );
+      expect(manager.wasMethodCalled("killDevice")).toBe(false);
+    });
+
+    test("proceeds when the runtime confirms the pooled AVD name", async () => {
+      manager = new SuccessfulKillDeviceManager();
+      setDeviceToolsDependencies({ deviceManagerFactory: () => manager });
+      await poolWithUnknownRuntime(unknownEmulator, "Pixel_8_Old");
+      runtimeAvdNames.set("emulator-5554", "Pixel_8_Old");
+
+      await expect(killTool().handler({ device: unknownEmulator })).resolves.toBeDefined();
+      expect(runtimeAvdNameProbes).toEqual(["emulator-5554"]);
+    });
+
+    // The documented blind spot, now narrowed to "the console is unavailable at
+    // the moment of the kill": proceed on the pooled name rather than leaving an
+    // emulator un-killable because its console stopped answering.
+    test("proceeds on the pooled name when the runtime cannot answer", async () => {
+      manager = new SuccessfulKillDeviceManager();
+      setDeviceToolsDependencies({ deviceManagerFactory: () => manager });
+      await poolWithUnknownRuntime(unknownEmulator, "Pixel_8_Old");
+
+      await expect(killTool().handler({ device: unknownEmulator })).resolves.toBeDefined();
+      expect(runtimeAvdNameProbes).toEqual(["emulator-5554"]);
+    });
+
+    // A handset's name is `ro.product.model`, not an AVD, and two handsets of the
+    // same model share it — there is no AVD name to verify and nothing an
+    // emulator console could answer.
+    test("never probes a physical handset", async () => {
+      manager = new SuccessfulKillDeviceManager();
+      setDeviceToolsDependencies({ deviceManagerFactory: () => manager });
+      const handset: BootedDevice = {
+        platform: "android",
+        name: "Unknown (R5CT10ABCDE)",
+        deviceId: "R5CT10ABCDE",
+      };
+      await poolWithUnknownRuntime(handset, "Pixel 8");
+
+      await expect(killTool().handler({ device: handset })).resolves.toBeDefined();
+      expect(runtimeAvdNameProbes).toEqual([]);
+    });
   });
 
   test("a failed explicit shutdown remains eligible for later crash recovery", async () => {

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -2553,7 +2553,6 @@ describe("killDevice handler", () => {
           name: image.name,
           platform: "android",
           deviceId: image.deviceId!,
-          transportId: "1",
         },
       }),
     );
@@ -3043,7 +3042,6 @@ describe("killDevice handler", () => {
         name: "Pixel 8",
         platform: "android",
         deviceId: "emulator-5554",
-        transportId: "1",
       };
       manager.setBootedDevices("android", [device]);
       const deviceSessionRepository = new FakeDeviceSessionRepository();
@@ -3077,7 +3075,7 @@ describe("killDevice handler", () => {
       // An active observation-stream subscriber has already caused this singleton
       // to exist. Its cadence callback later resolves only an existing instance.
       const activeObserver = AndroidCtrlProxyClient.getInstance(
-        { ...device, transportId: undefined },
+        { ...device },
         new FakeAdbClientFactory(),
       );
       activeObserver.bindSession("session-5503");
@@ -3125,7 +3123,6 @@ describe("killDevice handler", () => {
         name: "Pixel 8",
         platform: "android",
         deviceId: "emulator-5554",
-        transportId: "1",
       };
       manager.setBootedDevices("android", [device]);
       setDeviceToolsDependencies({
@@ -3183,7 +3180,6 @@ describe("killDevice handler", () => {
         name: "Pixel 8",
         platform: "android",
         deviceId: "emulator-5554",
-        transportId: "1",
       };
       // A different AVD taking the serial is the detectable replacement now
       // that the identity model carries no ADB transport id.
@@ -3242,7 +3238,6 @@ describe("killDevice handler", () => {
         name: "Pixel 8",
         platform: "android",
         deviceId: "emulator-5554",
-        transportId: "1",
       };
       const incompleteManager = new IncompleteThenBootedDiscoveryKillDeviceManager(device);
       manager = incompleteManager;
@@ -3292,7 +3287,6 @@ describe("killDevice handler", () => {
         name: "Pixel 8",
         platform: "android",
         deviceId: "emulator-5554",
-        transportId: "1",
       };
       manager.setBootedDevices("android", [device]);
       setDeviceToolsDependencies({
@@ -3375,7 +3369,6 @@ describe("killDevice handler", () => {
         name: "Pixel 8",
         platform: "android",
         deviceId: "emulator-5554",
-        transportId: "1",
       };
       manager.setBootedDevices("android", [device]);
       setDeviceToolsDependencies({
@@ -3413,7 +3406,6 @@ describe("killDevice handler", () => {
       };
       const observedDevice: BootedDevice = {
         ...requestedDevice,
-        transportId: "1",
       };
       manager.setBootedDevices("android", [observedDevice]);
       setDeviceToolsDependencies({

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -673,6 +673,61 @@ describe("killDevice handler", () => {
       expect(manager.killedDeviceTargets.map((device) => device.name)).toEqual(["Pixel_8_Old"]);
     });
 
+    // A QUARANTINED pooled entry is the state in which confirmation matters
+    // most: the pool has observed the placeholder on this serial and can no
+    // longer say which AVD answers there. It used to produce no capture at all
+    // (`getValidatedPooledAndroidEntry` returns undefined), which skipped the
+    // runtime confirmation entirely and let a sessionless kill carrying
+    // `Unknown (<serial>)` run against whatever holds the serial now
+    // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+    async function quarantinePooledIdentity(): Promise<void> {
+      const pool = DaemonState.getInstance().getDevicePool();
+      await pool.refreshDevices();
+      expect(pool.isPooledIdentityUnresolved("emulator-5554")).toBe(true);
+    }
+
+    test("refuses a kill on a quarantined entry when the runtime cannot answer", async () => {
+      manager = new SuccessfulKillDeviceManager();
+      setDeviceToolsDependencies({ deviceManagerFactory: () => manager });
+      await poolWithUnknownRuntime(unknownEmulator, "Pixel_8_Old");
+      await quarantinePooledIdentity();
+
+      await expect(killTool().handler({ device: unknownEmulator })).rejects.toThrow(
+        /emulator-5554[\s\S]*did not answer/,
+      );
+      expect(runtimeAvdNameProbes).toEqual(["emulator-5554"]);
+      expect(manager.killedDeviceIds).toEqual([]);
+    });
+
+    test("kills a quarantined entry under the name the runtime confirms", async () => {
+      manager = new SuccessfulKillDeviceManager();
+      setDeviceToolsDependencies({ deviceManagerFactory: () => manager });
+      await poolWithUnknownRuntime(unknownEmulator, "Pixel_8_Old");
+      await quarantinePooledIdentity();
+      runtimeAvdNames.set("emulator-5554", "Pixel_8_Old");
+
+      await expect(killTool().handler({ device: unknownEmulator })).resolves.toBeDefined();
+
+      expect(runtimeAvdNameProbes).toEqual(["emulator-5554"]);
+      expect(manager.killedDeviceTargets.map((device) => device.name)).toEqual(["Pixel_8_Old"]);
+    });
+
+    // The quarantine is not proof of a replacement either: a runtime that names
+    // a DIFFERENT AVD than the pooled label is, and the kill is refused rather
+    // than retargeted.
+    test("refuses a quarantined entry whose runtime names a different AVD", async () => {
+      manager = new SuccessfulKillDeviceManager();
+      setDeviceToolsDependencies({ deviceManagerFactory: () => manager });
+      await poolWithUnknownRuntime(unknownEmulator, "Pixel_8_Old");
+      await quarantinePooledIdentity();
+      runtimeAvdNames.set("emulator-5554", "Pixel_9_New");
+
+      await expect(killTool().handler({ device: unknownEmulator })).rejects.toThrow(
+        /Pixel_8_Old[\s\S]*Pixel_9_New/,
+      );
+      expect(manager.killedDeviceIds).toEqual([]);
+    });
+
     // The shutdown reservation protects the CAPTURED pool entry from eviction,
     // but it cannot stop the emulator behind the serial from going away and
     // being replaced. Re-read the epoch at the confirm and refuse when a

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -82,7 +82,7 @@ class ShutdownDiscoveryOptionsDeviceManager extends SuccessfulKillDeviceManager 
   }
 }
 
-class CurrentTransportKillDeviceManager extends FailingKillDeviceManager {
+class CurrentRuntimeKillDeviceManager extends FailingKillDeviceManager {
   private shutdownPollsStarted = false;
   private shutdownPollCount = 0;
 
@@ -1050,7 +1050,7 @@ describe("killDevice handler", () => {
     );
   });
 
-  test("waits for the transport that the Android kill preflight actually selected", async () => {
+  test("waits for the runtime the Android kill preflight actually resolved", async () => {
     const timer = new FakeTimer();
     const image: DeviceInfo = {
       name: "Pixel 8",
@@ -1063,26 +1063,25 @@ describe("killDevice handler", () => {
       name: image.name,
       platform: "android",
       deviceId: image.deviceId!,
-      transportId: "2",
     };
-    const currentTransportManager = new CurrentTransportKillDeviceManager(currentDevice);
-    manager = currentTransportManager;
+    const currentRuntimeManager = new CurrentRuntimeKillDeviceManager(currentDevice);
+    manager = currentRuntimeManager;
     const deviceSessionRepository = new FakeDeviceSessionRepository();
     setDeviceToolsDependencies({
-      deviceManagerFactory: () => currentTransportManager,
+      deviceManagerFactory: () => currentRuntimeManager,
       notifyResourcesChanged: async () => {},
       ensureCtrlProxyReady: async () => {},
       clearInstalledAppsForDevice: async () => {},
       timer,
     });
     sessionManager = new SessionManager(timer, deviceSessionRepository);
-    currentTransportManager.setDeviceImages("android", [image]);
+    currentRuntimeManager.setDeviceImages("android", [image]);
     const pool = new DevicePool(
       sessionManager,
       "daemon-session",
       timer,
       new FakeInstalledAppsRepository(),
-      currentTransportManager,
+      currentRuntimeManager,
       new DefaultRetryExecutor(timer),
       deviceSessionRepository,
     );
@@ -1093,14 +1092,17 @@ describe("killDevice handler", () => {
       throw new Error("killDevice not registered");
     }
 
-    currentTransportManager.beginShutdownPolls();
+    currentRuntimeManager.beginShutdownPolls();
+    // The caller's identity is stale: killDevice resolves the live runtime and
+    // must wait for THAT one to leave. Waiting on the caller's stale name would
+    // read the very first poll as "something else already took this serial" and
+    // retire the pool entry before the device physically exited.
     const result = tool.handler(
       tool.schema.parse({
         device: {
-          name: image.name,
+          name: "Stale AVD",
           platform: "android",
           deviceId: image.deviceId!,
-          transportId: "1",
         },
       }),
     );
@@ -1486,7 +1488,6 @@ describe("killDevice handler", () => {
       name: "Pixel 8",
       platform: "android",
       deviceId: "emulator-5554",
-      transportId: "1",
     };
     delayedManager.setBootedDevices("android", [device]);
     const tool = ToolRegistry.getTool("killDevice");
@@ -1567,7 +1568,6 @@ describe("killDevice handler", () => {
       name: "Pixel 8",
       platform: "android",
       deviceId: "emulator-5554",
-      transportId: "1",
     };
     const transientManager = new TransientAbsenceThenSameIncarnationDeviceManager(device);
     manager = transientManager;
@@ -1837,7 +1837,6 @@ describe("killDevice handler", () => {
       name: "Current AVD",
       platform: "android",
       deviceId: "emulator-5554",
-      transportId: "2",
     };
     const tool = ToolRegistry.getTool("killDevice");
     if (!tool) {
@@ -2244,7 +2243,6 @@ describe("killDevice handler", () => {
       name: "Pixel 8 replacement",
       platform: "android",
       deviceId: image.deviceId!,
-      transportId: "2",
     };
     const replacementManager = new FirstReplacementThenEmptyDeviceManager(replacement);
     manager = replacementManager;
@@ -2286,7 +2284,7 @@ describe("killDevice handler", () => {
 
     const result = tool.handler(
       tool.schema.parse({
-        device: { ...image, transportId: "1" },
+        device: { ...image },
       }),
     );
     await cleanupStarted;
@@ -2375,7 +2373,6 @@ describe("killDevice handler", () => {
       name: image.name,
       platform: "android",
       deviceId: image.deviceId!,
-      transportId: "2",
     };
     const replacementManager = new ReplacementBeforeShutdownWaitDeviceManager(replacement);
     manager = replacementManager;
@@ -2415,14 +2412,17 @@ describe("killDevice handler", () => {
       throw new Error("killDevice not registered");
     }
 
+    // With no ADB transport id in the identity model, a same-serial
+    // replacement is recognized by its runtime name. The caller's pre-kill
+    // observation could not read the AVD name, so the resolved replacement
+    // name differs from it and the handoff is detected.
     await expect(
       tool.handler(
         tool.schema.parse({
           device: {
-            name: image.name,
+            name: `Unknown (${image.deviceId!})`,
             platform: "android",
             deviceId: image.deviceId!,
-            transportId: "1",
           },
         }),
       ),
@@ -2453,7 +2453,6 @@ describe("killDevice handler", () => {
       name: "Pixel 8 replacement",
       platform: "android",
       deviceId: image.deviceId!,
-      transportId: "2",
     };
     const replacementManager = new FirstReplacementThenEmptyDeviceManager(replacement);
     manager = replacementManager;
@@ -2486,7 +2485,7 @@ describe("killDevice handler", () => {
     await expect(
       tool.handler(
         tool.schema.parse({
-          device: { ...image, transportId: "1" },
+          device: { ...image },
         }),
       ),
     ).resolves.toBeDefined();
@@ -2508,7 +2507,6 @@ describe("killDevice handler", () => {
       name: "Pixel 8 replacement",
       platform: "android",
       deviceId: image.deviceId!,
-      transportId: "2",
     };
     const replacementManager = new FailedDiscoveryThenReplacementDeviceManager(replacement);
     manager = replacementManager;
@@ -2647,7 +2645,6 @@ describe("killDevice handler", () => {
       name: "Pixel 8 replacement",
       platform: "android",
       deviceId: image.deviceId!,
-      transportId: "2",
     };
     const deviceSessionRepository = new ReplacingDeviceSessionRepository(async () => {
       deadlineManager.setBootedDevices("android", [replacement]);
@@ -3188,7 +3185,9 @@ describe("killDevice handler", () => {
         deviceId: "emulator-5554",
         transportId: "1",
       };
-      const replacement: BootedDevice = { ...device, transportId: "2" };
+      // A different AVD taking the serial is the detectable replacement now
+      // that the identity model carries no ADB transport id.
+      const replacement: BootedDevice = { ...device, name: "Pixel 9" };
       const replacementManager = new ReplacementAfterObserverReconnectDeviceManager(
         device,
         replacement,
@@ -3459,7 +3458,7 @@ describe("killDevice handler", () => {
   );
 
   test.skipIf(process.platform === "win32")(
-    "does not restore an observer onto a same-ID Android replacement when the original transport is unknown",
+    "does not restore an observer onto a different AVD that took the same serial",
     async () => {
       const timer = new FakeTimer();
       const device: BootedDevice = {
@@ -3467,10 +3466,7 @@ describe("killDevice handler", () => {
         platform: "android",
         deviceId: "emulator-5554",
       };
-      const replacement: BootedDevice = {
-        ...device,
-        transportId: "2",
-      };
+      const replacement: BootedDevice = { ...device, name: "Pixel 9" };
       manager.setBootedDevices("android", [replacement]);
       setDeviceToolsDependencies({
         deviceManagerFactory: () => manager,
@@ -3493,6 +3489,52 @@ describe("killDevice handler", () => {
         expect(closeSpy).toHaveBeenCalledTimes(1);
         expect(getInstanceSpy).not.toHaveBeenCalled();
         expect(AndroidCtrlProxyClient.getExistingInstance(device.deviceId)).toBeNull();
+      } finally {
+        getInstanceSpy.mockRestore();
+        closeSpy.mockRestore();
+      }
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "documented blind spot: a same-AVD restart on the same serial reads as the surviving incarnation",
+    async () => {
+      // Identity is platform + serial + name, so an emulator that restarted the
+      // SAME AVD under the same serial between two observations is
+      // indistinguishable from one that never left. The observer is restored
+      // onto it; recovery depends on the observer's own post-connect identity
+      // check and its reconnect failures, not on this comparison. Asserted so
+      // the gap stays deliberate rather than becoming a surprise.
+      const timer = new FakeTimer();
+      const device: BootedDevice = {
+        name: "Pixel 8",
+        platform: "android",
+        deviceId: "emulator-5554",
+      };
+      const restarted: BootedDevice = { ...device };
+      manager.setBootedDevices("android", [restarted]);
+      setDeviceToolsDependencies({
+        deviceManagerFactory: () => manager,
+        notifyResourcesChanged: async () => {},
+        ensureCtrlProxyReady: async () => {},
+        clearInstalledAppsForDevice: async () => {},
+        timer,
+      });
+      const observer = AndroidCtrlProxyClient.getInstance(device, new FakeAdbClientFactory());
+      const closeSpy = spyOn(observer, "close").mockResolvedValue(undefined);
+      const originalGetInstance = AndroidCtrlProxyClient.getInstance;
+      const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockImplementation(
+        (target) => originalGetInstance(target, new FakeAdbClientFactory()),
+      );
+      try {
+        const tool = ToolRegistry.getTool("killDevice");
+        if (!tool) {
+          throw new Error("killDevice not registered");
+        }
+
+        await expect(tool.handler({ device })).rejects.toThrow("adb emu kill failed");
+
+        expect(getInstanceSpy).toHaveBeenCalled();
       } finally {
         getInstanceSpy.mockRestore();
         closeSpy.mockRestore();

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -44,6 +44,8 @@ class FailingKillDeviceManager extends FakeDeviceUtils {
    * vacuously true. Assert against this instead.
    */
   readonly killedDeviceIds: string[] = [];
+  /** The full targets handed to the platform kill, so a test can assert the NAME it was given. */
+  readonly killedDeviceTargets: BootedDevice[] = [];
 
   constructor() {
     super();
@@ -62,6 +64,7 @@ class FailingKillDeviceManager extends FakeDeviceUtils {
 
   override async killDevice(device: BootedDevice): Promise<void> {
     this.killedDeviceIds.push(device.deviceId);
+    this.killedDeviceTargets.push(device);
     throw new Error("adb emu kill failed");
   }
 }
@@ -91,6 +94,7 @@ class DeadlineSpendingFakeTimer extends FakeTimer {
 class SuccessfulKillDeviceManager extends FailingKillDeviceManager {
   override async killDevice(device: BootedDevice): Promise<void> {
     this.killedDeviceIds.push(device.deviceId);
+    this.killedDeviceTargets.push(device);
     this.setBootedDevices(device.platform, []);
   }
 }
@@ -646,6 +650,51 @@ describe("killDevice handler", () => {
         /did not answer/,
       );
       expect(runtimeAvdNameProbes).toEqual([]);
+      expect(manager.killedDeviceIds).toEqual([]);
+    });
+
+    // Confirming the runtime's AVD name and then killing under the
+    // `Unknown (<serial>)` placeholder throws the proof away:
+    // `AndroidEmulatorClient.killDevice` re-discovers the serial and refuses to
+    // kill when the discovered name differs from the target's. The verified
+    // name has to travel into the kill target
+    // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+    test("hands the CONFIRMED AVD name to the platform kill", async () => {
+      manager = new SuccessfulKillDeviceManager();
+      setDeviceToolsDependencies({ deviceManagerFactory: () => manager });
+      await poolWithUnknownRuntime(unknownEmulator, "Pixel_8_Old");
+      runtimeAvdNames.set("emulator-5554", "Pixel_8_Old");
+
+      await expect(killTool().handler({ device: unknownEmulator })).resolves.toBeDefined();
+
+      expect(manager.killedDeviceTargets.map((device) => device.name)).toEqual(["Pixel_8_Old"]);
+    });
+
+    // The shutdown reservation protects the CAPTURED pool entry from eviction,
+    // but it cannot stop the emulator behind the serial from going away and
+    // being replaced. Re-read the epoch immediately before the platform kill and
+    // refuse when a different incarnation now holds the serial
+    // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+    test("refuses when the pooled incarnation moves between preflight and the kill", async () => {
+      manager = new SuccessfulKillDeviceManager();
+      await poolWithUnknownRuntime(unknownEmulator, "Pixel_8_Old");
+      runtimeAvdNames.set("emulator-5554", "Pixel_8_Old");
+      const pool = DaemonState.getInstance().getDevicePool();
+      setDeviceToolsDependencies({
+        deviceManagerFactory: () => manager,
+        // Runs immediately before the platform kill, which is where a
+        // same-serial replacement would land in production.
+        stopAndroidObservers: async () => {
+          const pooled = pool.getDevice("emulator-5554");
+          if (pooled) {
+            pooled.incarnation += 1;
+          }
+        },
+      });
+
+      await expect(killTool().handler({ device: unknownEmulator })).rejects.toThrow(
+        /emulator-5554[\s\S]*Pixel_8_Old/,
+      );
       expect(manager.killedDeviceIds).toEqual([]);
     });
 

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -6,10 +6,12 @@ import { DevicePool } from "../../src/daemon/devicePool";
 import { DeviceSessionRegistry } from "../../src/daemon/deviceSessionRegistry";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import {
+  defaultResolveRunningAndroidAvdName,
   registerDeviceTools,
   resetDeviceToolsDependencies,
   setDeviceToolsDependencies,
 } from "../../src/server/deviceTools";
+import { ActionableError } from "../../src/models/ActionableError";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import {
   resetVideoRecordingManagerDependencies,
@@ -695,6 +697,43 @@ describe("killDevice handler", () => {
       await expect(killTool().handler({ device: unknownEmulator })).rejects.toThrow(
         /emulator-5554[\s\S]*Pixel_8_Old/,
       );
+      expect(manager.killedDeviceIds).toEqual([]);
+    });
+
+    // Cancellation is not evidence about the runtime's identity. Swallowing an
+    // abort into "unresolved" would make a caller who stopped waiting see an
+    // identity refusal naming a manual `emu kill` escape
+    // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+    test("the default AVD resolver rethrows caller cancellation instead of reporting unresolved", async () => {
+      const controller = new AbortController();
+      const reason = new ActionableError("Operation cancelled by the caller");
+      controller.abort(reason);
+
+      await expect(
+        defaultResolveRunningAndroidAvdName(unknownEmulator, 1_000, controller.signal),
+      ).rejects.toBe(reason);
+    });
+
+    test("killDevice surfaces a cancelled AVD probe instead of an identity refusal", async () => {
+      manager = new SuccessfulKillDeviceManager();
+      const reason = new ActionableError("Operation cancelled by the caller");
+      setDeviceToolsDependencies({
+        deviceManagerFactory: () => manager,
+        resolveRunningAndroidAvdName: async () => {
+          throw reason;
+        },
+      });
+      await poolWithUnknownRuntime(unknownEmulator, "Pixel_8_Old");
+
+      const rejection = await killTool()
+        .handler({ device: unknownEmulator })
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+
+      expect(String(rejection)).toContain("cancelled");
+      expect(String(rejection)).not.toContain("did not answer");
       expect(manager.killedDeviceIds).toEqual([]);
     });
 

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -36,6 +36,14 @@ import { InMemoryVirtualDeviceLifecycleCoordinator } from "../../src/utils/virtu
 
 class FailingKillDeviceManager extends FakeDeviceUtils {
   readonly childProcess = new EventEmitter() as ChildProcess;
+  /**
+   * Serials this manager was actually asked to kill. `FakeDeviceUtils` records
+   * operations in its own `killDevice`, which every subclass here overrides, so
+   * `wasMethodCalled("killDevice")` would answer `false` even for a kill that
+   * DID reach the device manager -- making a "the kill was refused" assertion
+   * vacuously true. Assert against this instead.
+   */
+  readonly killedDeviceIds: string[] = [];
 
   constructor() {
     super();
@@ -52,13 +60,15 @@ class FailingKillDeviceManager extends FakeDeviceUtils {
     return this.childProcess;
   }
 
-  override async killDevice(): Promise<void> {
+  override async killDevice(device: BootedDevice): Promise<void> {
+    this.killedDeviceIds.push(device.deviceId);
     throw new Error("adb emu kill failed");
   }
 }
 
 class SuccessfulKillDeviceManager extends FailingKillDeviceManager {
   override async killDevice(device: BootedDevice): Promise<void> {
+    this.killedDeviceIds.push(device.deviceId);
     this.setBootedDevices(device.platform, []);
   }
 }
@@ -567,7 +577,7 @@ describe("killDevice handler", () => {
       await expect(killTool().handler({ device: unknownEmulator })).rejects.toThrow(
         /Pixel_8_Old[\s\S]*Pixel_9_New/,
       );
-      expect(manager.wasMethodCalled("killDevice")).toBe(false);
+      expect(manager.killedDeviceIds).toEqual([]);
     });
 
     test("proceeds when the runtime confirms the pooled AVD name", async () => {
@@ -578,11 +588,15 @@ describe("killDevice handler", () => {
 
       await expect(killTool().handler({ device: unknownEmulator })).resolves.toBeDefined();
       expect(runtimeAvdNameProbes).toEqual(["emulator-5554"]);
+      expect(manager.killedDeviceIds).toEqual(["emulator-5554"]);
     });
 
     // The documented blind spot, now narrowed to "the console is unavailable at
     // the moment of the kill": proceed on the pooled name rather than leaving an
-    // emulator un-killable because its console stopped answering.
+    // emulator un-killable because its console stopped answering. The kill
+    // REACHING the device manager is the point of the choice, so assert it
+    // explicitly -- whichever way the open fail-open/fail-closed question is
+    // decided, this test is where the answer is written down.
     test("proceeds on the pooled name when the runtime cannot answer", async () => {
       manager = new SuccessfulKillDeviceManager();
       setDeviceToolsDependencies({ deviceManagerFactory: () => manager });
@@ -590,6 +604,7 @@ describe("killDevice handler", () => {
 
       await expect(killTool().handler({ device: unknownEmulator })).resolves.toBeDefined();
       expect(runtimeAvdNameProbes).toEqual(["emulator-5554"]);
+      expect(manager.killedDeviceIds).toEqual(["emulator-5554"]);
     });
 
     // A handset's name is `ro.product.model`, not an AVD, and two handsets of the

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -674,24 +674,32 @@ describe("killDevice handler", () => {
 
     // The shutdown reservation protects the CAPTURED pool entry from eviction,
     // but it cannot stop the emulator behind the serial from going away and
-    // being replaced. Re-read the epoch immediately before the platform kill and
-    // refuse when a different incarnation now holds the serial
+    // being replaced. Re-read the epoch at the confirm and refuse when a
+    // different incarnation now holds the serial
     // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
     test("refuses when the pooled incarnation moves between preflight and the kill", async () => {
       manager = new SuccessfulKillDeviceManager();
       await poolWithUnknownRuntime(unknownEmulator, "Pixel_8_Old");
       runtimeAvdNames.set("emulator-5554", "Pixel_8_Old");
       const pool = DaemonState.getInstance().getDevicePool();
-      setDeviceToolsDependencies({
-        deviceManagerFactory: () => manager,
-        // Runs immediately before the platform kill, which is where a
-        // same-serial replacement would land in production.
-        stopAndroidObservers: async () => {
+      // The lifecycle reservation is taken after the preflight capture and
+      // before the confirm, which is the window a same-serial replacement lands
+      // in production.
+      class ReplacingLifecycleCoordinator extends InMemoryVirtualDeviceLifecycleCoordinator {
+        override async reserve(
+          identity: Parameters<InMemoryVirtualDeviceLifecycleCoordinator["reserve"]>[0],
+          options: Parameters<InMemoryVirtualDeviceLifecycleCoordinator["reserve"]>[1],
+        ) {
           const pooled = pool.getDevice("emulator-5554");
           if (pooled) {
             pooled.incarnation += 1;
           }
-        },
+          return await super.reserve(identity, options);
+        }
+      }
+      setDeviceToolsDependencies({
+        deviceManagerFactory: () => manager,
+        lifecycleCoordinator: new ReplacingLifecycleCoordinator(new FakeTimer()),
       });
 
       await expect(killTool().handler({ device: unknownEmulator })).rejects.toThrow(
@@ -752,6 +760,65 @@ describe("killDevice handler", () => {
 
       await expect(killTool().handler({ device: handset })).resolves.toBeDefined();
       expect(runtimeAvdNameProbes).toEqual([]);
+    });
+
+    // The verifier is the LAST gate before anything destructive, but it used to
+    // sit downstream of `shutdownDevice`'s preparation: by the time it refused,
+    // recordings had been stopped, the Android CtrlProxy singleton had been
+    // closed and removed, and passive observers had been detached -- on a device
+    // that is still running and that the daemon just decided it may not touch.
+    // A refusal must leave that device exactly as it found it
+    // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+    test("leaves a still-running device fully intact when it refuses", async () => {
+      manager = new SuccessfulKillDeviceManager();
+      const stoppedRecordings: string[] = [];
+      const stoppedObserverDeviceIds: string[] = [];
+      await setVideoRecordingManagerDependencies({
+        videoRecorderService: {
+          // Records the call and then fails; the shutdown path logs and moves
+          // on, so what this test pins is whether the call happened at all.
+          stopRecording: async (recordingId: string) => {
+            stoppedRecordings.push(recordingId);
+            throw new Error("recording teardown unavailable");
+          },
+          listActiveRecordingIds: () => [],
+        } as never,
+        recordingRepository: {
+          // Only the shutdown path's per-device query answers with an active
+          // recording; the manager's own startup scan must stay empty.
+          listRecordings: async (filter?: { deviceId?: string }) =>
+            filter?.deviceId ? [{ recordingId: "recording-1" }] : [],
+          getRecording: async () => undefined,
+        } as never,
+        configRepository: {} as never,
+        highlightClient: {} as never,
+        timer: new FakeTimer(),
+        now: () => new Date(0),
+      });
+      setDeviceToolsDependencies({
+        deviceManagerFactory: () => manager,
+        stopAndroidObservers: async (target) => {
+          stoppedObserverDeviceIds.push(target.deviceId);
+        },
+      });
+      await poolWithUnknownRuntime(unknownEmulator, "Pixel_8_Old");
+      // A passive observation subscriber already owns the per-device singleton.
+      const activeObserver = AndroidCtrlProxyClient.getInstance(
+        { ...unknownEmulator },
+        new FakeAdbClientFactory(),
+      );
+      // The console does not answer, so the identity is never confirmed.
+
+      await expect(killTool().handler({ device: unknownEmulator })).rejects.toThrow(
+        /did not answer/,
+      );
+
+      expect(manager.killedDeviceIds).toEqual([]);
+      expect(stoppedRecordings).toEqual([]);
+      expect(stoppedObserverDeviceIds).toEqual([]);
+      expect(AndroidCtrlProxyClient.getExistingInstance(unknownEmulator.deviceId)).toBe(
+        activeObserver,
+      );
     });
   });
 

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -66,6 +66,28 @@ class FailingKillDeviceManager extends FakeDeviceUtils {
   }
 }
 
+/**
+ * A clock that jumps a full shutdown budget forward the next time it is read,
+ * so a test can model "the caller's deadline was already consumed by the work
+ * that ran before this point" without sleeping.
+ */
+class DeadlineSpendingFakeTimer extends FakeTimer {
+  private spendOnNextRead = false;
+
+  spendDeadlineOnNextRead(): void {
+    this.spendOnNextRead = true;
+  }
+
+  override now(): number {
+    const value = super.now();
+    if (this.spendOnNextRead) {
+      this.spendOnNextRead = false;
+      super.advanceTime(60_000);
+    }
+    return value;
+  }
+}
+
 class SuccessfulKillDeviceManager extends FailingKillDeviceManager {
   override async killDevice(device: BootedDevice): Promise<void> {
     this.killedDeviceIds.push(device.deviceId);
@@ -591,20 +613,40 @@ describe("killDevice handler", () => {
       expect(manager.killedDeviceIds).toEqual(["emulator-5554"]);
     });
 
-    // The documented blind spot, now narrowed to "the console is unavailable at
-    // the moment of the kill": proceed on the pooled name rather than leaving an
-    // emulator un-killable because its console stopped answering. The kill
-    // REACHING the device manager is the point of the choice, so assert it
-    // explicitly -- whichever way the open fail-open/fail-closed question is
-    // decided, this test is where the answer is written down.
-    test("proceeds on the pooled name when the runtime cannot answer", async () => {
+    // `Unknown (<serial>)` means "no information", and a probe that does not
+    // answer leaves it that way. A kill issued on nothing but the pooled label
+    // could stop a different AVD that took the serial, so the tool refuses and
+    // says how to do it by hand. Nothing destructive may reach the device
+    // manager (#6863 review).
+    test("refuses the kill when the runtime cannot answer", async () => {
       manager = new SuccessfulKillDeviceManager();
       setDeviceToolsDependencies({ deviceManagerFactory: () => manager });
       await poolWithUnknownRuntime(unknownEmulator, "Pixel_8_Old");
 
-      await expect(killTool().handler({ device: unknownEmulator })).resolves.toBeDefined();
+      await expect(killTool().handler({ device: unknownEmulator })).rejects.toThrow(
+        /emulator-5554[\s\S]*Pixel_8_Old[\s\S]*adb -s emulator-5554 emu kill/,
+      );
       expect(runtimeAvdNameProbes).toEqual(["emulator-5554"]);
-      expect(manager.killedDeviceIds).toEqual(["emulator-5554"]);
+      expect(manager.killedDeviceIds).toEqual([]);
+    });
+
+    // The probe borrows the kill's deadline. When that deadline is already spent
+    // by the time verification runs, there is no budget to probe with and no way
+    // to identify the target, so the refusal is immediate and the console is
+    // never contacted (#6863 review).
+    test("refuses without probing when the kill deadline is already spent", async () => {
+      manager = new SuccessfulKillDeviceManager();
+      const timer = new DeadlineSpendingFakeTimer();
+      setDeviceToolsDependencies({ deviceManagerFactory: () => manager, timer });
+      await poolWithUnknownRuntime(unknownEmulator, "Pixel_8_Old");
+      runtimeAvdNames.set("emulator-5554", "Pixel_8_Old");
+      timer.spendDeadlineOnNextRead();
+
+      await expect(killTool().handler({ device: unknownEmulator })).rejects.toThrow(
+        /did not answer/,
+      );
+      expect(runtimeAvdNameProbes).toEqual([]);
+      expect(manager.killedDeviceIds).toEqual([]);
     });
 
     // A handset's name is `ro.product.model`, not an AVD, and two handsets of the

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -2352,6 +2352,64 @@ describe("killDevice handler", () => {
     expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();
   });
 
+  // While an emulator shuts down, `adb devices` can keep listing its serial after
+  // the console has stopped answering `avd name`, so discovery labels the device
+  // that is STILL THERE `Unknown (<serial>)`. That placeholder is not evidence
+  // that a different AVD took the serial: reading it as a replacement would end
+  // the shutdown wait early and rebuild the pool around a device that is still
+  // going away (#6863 review).
+  test("does not treat an unresolved name during shutdown as a same-ID replacement", async () => {
+    const timer = new FakeTimer();
+    // The wait has to poll again instead of returning on the first observation,
+    // so the fake clock has to keep moving for the second discovery to happen.
+    timer.enableAutoAdvance();
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    const stillShuttingDown: BootedDevice = {
+      name: `Unknown (${image.deviceId!})`,
+      platform: "android",
+      deviceId: image.deviceId!,
+    };
+    const shutdownManager = new FirstReplacementThenEmptyDeviceManager(stillShuttingDown);
+    manager = shutdownManager;
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => shutdownManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    shutdownManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      shutdownManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    await expect(tool.handler(tool.schema.parse({ device: { ...image } }))).resolves.toBeDefined();
+
+    // The wait ran on to actual absence, so the device is retired rather than
+    // rebuilt under a fresh incarnation labelled with the placeholder.
+    expect(pool.getDevice(image.deviceId!)).toBeNull();
+  });
+
   test("releases the shutdown reservation before post-shutdown cleanup", async () => {
     const timer = new FakeTimer();
     const image: DeviceInfo = {
@@ -2491,6 +2549,8 @@ describe("killDevice handler", () => {
       isRunning: false,
       source: "local",
     };
+    // The AVD this pool started, rediscovered on the serial after the kill --
+    // a different runtime from the one the caller observed before it.
     const replacement: BootedDevice = {
       name: image.name,
       platform: "android",
@@ -2534,15 +2594,18 @@ describe("killDevice handler", () => {
       throw new Error("killDevice not registered");
     }
 
-    // With no ADB transport id in the identity model, a same-serial
-    // replacement is recognized by its runtime name. The caller's pre-kill
-    // observation could not read the AVD name, so the resolved replacement
-    // name differs from it and the handoff is detected.
+    // With no ADB transport id in the identity model, a same-serial replacement
+    // is recognized by its runtime name -- and only by a RESOLVED one on both
+    // sides. Here the caller's pre-kill observation and the device found on the
+    // serial afterwards both name an AVD, and they differ, so the handoff is
+    // detected before the first shutdown poll. An `Unknown (<serial>)` on either
+    // side would assert nothing and the wait would run on instead (#6863
+    // review).
     await expect(
       tool.handler(
         tool.schema.parse({
           device: {
-            name: `Unknown (${image.deviceId!})`,
+            name: "Pixel 7 API 34",
             platform: "android",
             deviceId: image.deviceId!,
           },

--- a/test/server/deviceTools.platformPreparation.test.ts
+++ b/test/server/deviceTools.platformPreparation.test.ts
@@ -156,7 +156,6 @@ describe("platform device preparation tools", () => {
       platform: "android",
       name: "Pixel_9_API_36",
       deviceId: "emulator-5562",
-      transportId: "17",
     };
     deviceUtils.setBootedDevices("android", [emulator]);
     matcher.setBootedResult(emulator);
@@ -172,7 +171,6 @@ describe("platform device preparation tools", () => {
       avdName: "Pixel_9_API_36",
       adbSerial: "emulator-5562",
       emulatorConsolePort: 5562,
-      adbTransportId: "17",
     });
   });
 

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -350,7 +350,7 @@ describe("startDevice handler", () => {
     );
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
 
-    const discoveredDevice = { ...androidDevice, transportId: "23" };
+    const discoveredDevice = { ...androidDevice };
     const coldBootImage = { ...androidImage, deviceId: androidDevice.deviceId };
     const childProcess = new FakeExitChildProcess();
     fakeDeviceUtils.setBootedDevices("android", [discoveredDevice]);
@@ -367,7 +367,6 @@ describe("startDevice handler", () => {
     expect(result.source).toBe("cold-boot");
     expect(result.sessionUuid).toBeDefined();
     expect(pool.getDevice(androidDevice.deviceId)).toMatchObject({
-      transportId: "23",
       sessionId: result.sessionUuid,
     });
     expect(childProcess.killed).toBe(false);
@@ -1934,7 +1933,6 @@ describe("startDevice handler", () => {
       platform: "android",
       name: "Pixel 8",
       deviceId: "R5CT123456A",
-      transportId: "42",
     };
     fakeDeviceUtils.setBootedDevices("android", [physicalDevice]);
     fakeDeviceUtils.getDeviceImagesDetailed = async () => ({

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -606,21 +606,22 @@ describe("startDevice handler", () => {
       ...androidImage,
       deviceId: "emulator-5556",
     };
-    const unknownRuntimeDevice = {
-      ...androidDevice,
-      name: `Unknown (${androidDevice.deviceId})`,
-    };
-    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
-    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    // The pooled entry carries a RESOLVED AVD name. An entry whose discovery name
+    // is the `Unknown (<serial>)` placeholder is quarantined and refused at
+    // assignment (#6863 review) — a different scenario, covered by "does not guess
+    // an AVD when an unknown Android runtime needs System UI recovery".
+    const pooledAnrDevice = { ...androidDevice };
+    fakeDeviceUtils.setBootedDevices("android", [pooledAnrDevice]);
+    await pool.initializeWithDevices([pooledAnrDevice]);
     await pool.bindOrReuseDeviceSession(
       "owner-session",
-      unknownRuntimeDevice.deviceId,
+      pooledAnrDevice.deviceId,
       "android",
       recoveryImage,
     );
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
     fakeDeviceUtils.setDeviceImages("android", [recoveryImage]);
-    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setBootedResult(pooledAnrDevice);
     fakeMatcher.setImageResult(recoveryImage);
     const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
     fakeDeviceUtils.killDevice = async (device, options) => {
@@ -643,7 +644,7 @@ describe("startDevice handler", () => {
 
     expect(result.deviceId).toBe("emulator-5556");
     expect(result.sessionUuid).toBe("owner-session");
-    expect(fakeDeviceUtils.getExecutedOperations()).toContain("killDevice:Unknown (emulator-5554)");
+    expect(fakeDeviceUtils.getExecutedOperations()).toContain("killDevice:Pixel_7_API_34");
     expect(fakeDeviceUtils.getExecutedOperations()).toContain("startDevice:Pixel_7_API_34:360000");
     expect(pool.getDevice("emulator-5556")).toMatchObject({
       sessionId: "owner-session",
@@ -755,21 +756,22 @@ describe("startDevice handler", () => {
       ...androidImage,
       deviceId: "emulator-5556",
     };
-    const unknownRuntimeDevice = {
-      ...androidDevice,
-      name: `Unknown (${androidDevice.deviceId})`,
-    };
-    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
-    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    // The pooled entry carries a RESOLVED AVD name. An entry whose discovery name
+    // is the `Unknown (<serial>)` placeholder is quarantined and refused at
+    // assignment (#6863 review) — a different scenario, covered by "does not guess
+    // an AVD when an unknown Android runtime needs System UI recovery".
+    const pooledAnrDevice = { ...androidDevice };
+    fakeDeviceUtils.setBootedDevices("android", [pooledAnrDevice]);
+    await pool.initializeWithDevices([pooledAnrDevice]);
     await pool.bindOrReuseDeviceSession(
       "owner-session",
-      unknownRuntimeDevice.deviceId,
+      pooledAnrDevice.deviceId,
       "android",
       recoveryImage,
     );
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
     fakeDeviceUtils.setDeviceImages("android", [recoveryImage]);
-    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setBootedResult(pooledAnrDevice);
     fakeMatcher.setImageResult(recoveryImage);
     const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
     fakeDeviceUtils.killDevice = async (device, options) => {
@@ -814,14 +816,15 @@ describe("startDevice handler", () => {
       ...androidImage,
       deviceId: "emulator-5556",
     };
-    const unknownRuntimeDevice = {
-      ...androidDevice,
-      name: `Unknown (${androidDevice.deviceId})`,
-    };
-    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
-    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    // The pooled entry carries a RESOLVED AVD name. An entry whose discovery name
+    // is the `Unknown (<serial>)` placeholder is quarantined and refused at
+    // assignment (#6863 review) — a different scenario, covered by "does not guess
+    // an AVD when an unknown Android runtime needs System UI recovery".
+    const pooledAnrDevice = { ...androidDevice };
+    fakeDeviceUtils.setBootedDevices("android", [pooledAnrDevice]);
+    await pool.initializeWithDevices([pooledAnrDevice]);
     const preservedSessionId = await pool.autolockDevice(
-      unknownRuntimeDevice.deviceId,
+      pooledAnrDevice.deviceId,
       "android",
       "mcp-client",
       recoveryImage,
@@ -829,7 +832,7 @@ describe("startDevice handler", () => {
     expect(preservedSessionId).toBeDefined();
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
     fakeDeviceUtils.setDeviceImages("android", [recoveryImage]);
-    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setBootedResult(pooledAnrDevice);
     fakeMatcher.setImageResult(recoveryImage);
     const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
     fakeDeviceUtils.killDevice = async (device, options) => {
@@ -929,16 +932,17 @@ describe("startDevice handler", () => {
       ...androidImage,
       deviceId: "emulator-5556",
     };
-    const unknownRuntimeDevice = {
-      ...androidDevice,
-      name: `Unknown (${androidDevice.deviceId})`,
-    };
+    // The pooled entry carries a RESOLVED AVD name. An entry whose discovery name
+    // is the `Unknown (<serial>)` placeholder is quarantined and refused at
+    // assignment (#6863 review) — a different scenario, covered by "does not guess
+    // an AVD when an unknown Android runtime needs System UI recovery".
+    const pooledAnrDevice = { ...androidDevice };
     const replacementProcess = new FakeExitChildProcess();
-    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
-    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    fakeDeviceUtils.setBootedDevices("android", [pooledAnrDevice]);
+    await pool.initializeWithDevices([pooledAnrDevice]);
     await pool.bindOrReuseDeviceSession(
       "owner-session",
-      unknownRuntimeDevice.deviceId,
+      pooledAnrDevice.deviceId,
       "android",
       recoveryImage,
     );
@@ -948,7 +952,7 @@ describe("startDevice handler", () => {
       recoveryImage.name,
       replacementProcess as unknown as ChildProcess,
     );
-    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setBootedResult(pooledAnrDevice);
     fakeMatcher.setImageResult(recoveryImage);
     const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
     fakeDeviceUtils.killDevice = async (device, options) => {
@@ -968,7 +972,7 @@ describe("startDevice handler", () => {
     );
 
     expect(replacementProcess.killed).toBe(true);
-    expect(pool.getDevice(unknownRuntimeDevice.deviceId)).toBeNull();
+    expect(pool.getDevice(pooledAnrDevice.deviceId)).toBeNull();
     expect(pool.getDevice(recoveryImage.deviceId!)).toBeNull();
     expect(pool.getIdleDevices()).toEqual([]);
     expect(daemonSessionManager.getSession("owner-session")).toBeNull();
@@ -993,16 +997,17 @@ describe("startDevice handler", () => {
       ...androidImage,
       deviceId: "emulator-5556",
     };
-    const unknownRuntimeDevice = {
-      ...androidDevice,
-      name: `Unknown (${androidDevice.deviceId})`,
-    };
+    // The pooled entry carries a RESOLVED AVD name. An entry whose discovery name
+    // is the `Unknown (<serial>)` placeholder is quarantined and refused at
+    // assignment (#6863 review) — a different scenario, covered by "does not guess
+    // an AVD when an unknown Android runtime needs System UI recovery".
+    const pooledAnrDevice = { ...androidDevice };
     const replacementProcess = new FakeExitChildProcess();
-    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
-    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    fakeDeviceUtils.setBootedDevices("android", [pooledAnrDevice]);
+    await pool.initializeWithDevices([pooledAnrDevice]);
     await pool.bindOrReuseDeviceSession(
       "owner-session",
-      unknownRuntimeDevice.deviceId,
+      pooledAnrDevice.deviceId,
       "android",
       recoveryImage,
     );
@@ -1012,7 +1017,7 @@ describe("startDevice handler", () => {
       recoveryImage.name,
       replacementProcess as unknown as ChildProcess,
     );
-    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setBootedResult(pooledAnrDevice);
     fakeMatcher.setImageResult(recoveryImage);
     const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
     fakeDeviceUtils.killDevice = async (device, options) => {
@@ -1066,16 +1071,17 @@ describe("startDevice handler", () => {
       ...androidImage,
       deviceId: "emulator-5556",
     };
-    const unknownRuntimeDevice = {
-      ...androidDevice,
-      name: `Unknown (${androidDevice.deviceId})`,
-    };
+    // The pooled entry carries a RESOLVED AVD name. An entry whose discovery name
+    // is the `Unknown (<serial>)` placeholder is quarantined and refused at
+    // assignment (#6863 review) — a different scenario, covered by "does not guess
+    // an AVD when an unknown Android runtime needs System UI recovery".
+    const pooledAnrDevice = { ...androidDevice };
     const replacementProcess = new FakeExitChildProcess();
-    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
-    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    fakeDeviceUtils.setBootedDevices("android", [pooledAnrDevice]);
+    await pool.initializeWithDevices([pooledAnrDevice]);
     await pool.bindOrReuseDeviceSession(
       "owner-session",
-      unknownRuntimeDevice.deviceId,
+      pooledAnrDevice.deviceId,
       "android",
       recoveryImage,
     );
@@ -1085,7 +1091,7 @@ describe("startDevice handler", () => {
       recoveryImage.name,
       replacementProcess as unknown as ChildProcess,
     );
-    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setBootedResult(pooledAnrDevice);
     fakeMatcher.setImageResult(recoveryImage);
     const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
     fakeDeviceUtils.killDevice = async (device, options) => {
@@ -1118,7 +1124,7 @@ describe("startDevice handler", () => {
     );
 
     expect(replacementProcess.killed).toBe(true);
-    expect(pool.getDevice(unknownRuntimeDevice.deviceId)).toBeNull();
+    expect(pool.getDevice(pooledAnrDevice.deviceId)).toBeNull();
     expect(pool.getDevice(recoveryImage.deviceId!)).toBeNull();
     expect(pool.getIdleDevices()).toEqual([]);
     expect(daemonSessionManager.getSession("owner-session")).toBeNull();
@@ -1144,16 +1150,17 @@ describe("startDevice handler", () => {
       ...androidImage,
       deviceId: "emulator-5556",
     };
-    const unknownRuntimeDevice = {
-      ...androidDevice,
-      name: `Unknown (${androidDevice.deviceId})`,
-    };
+    // The pooled entry carries a RESOLVED AVD name. An entry whose discovery name
+    // is the `Unknown (<serial>)` placeholder is quarantined and refused at
+    // assignment (#6863 review) — a different scenario, covered by "does not guess
+    // an AVD when an unknown Android runtime needs System UI recovery".
+    const pooledAnrDevice = { ...androidDevice };
     const replacementProcess = new FakeExitChildProcess();
-    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
-    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    fakeDeviceUtils.setBootedDevices("android", [pooledAnrDevice]);
+    await pool.initializeWithDevices([pooledAnrDevice]);
     await pool.bindOrReuseDeviceSession(
       "owner-session",
-      unknownRuntimeDevice.deviceId,
+      pooledAnrDevice.deviceId,
       "android",
       recoveryImage,
     );
@@ -1163,7 +1170,7 @@ describe("startDevice handler", () => {
       recoveryImage.name,
       replacementProcess as unknown as ChildProcess,
     );
-    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setBootedResult(pooledAnrDevice);
     fakeMatcher.setImageResult(recoveryImage);
     const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
     fakeDeviceUtils.killDevice = async (device, options) => {
@@ -1205,16 +1212,17 @@ describe("startDevice handler", () => {
       ...androidImage,
       deviceId: "emulator-5556",
     };
-    const unknownRuntimeDevice = {
-      ...androidDevice,
-      name: `Unknown (${androidDevice.deviceId})`,
-    };
+    // The pooled entry carries a RESOLVED AVD name. An entry whose discovery name
+    // is the `Unknown (<serial>)` placeholder is quarantined and refused at
+    // assignment (#6863 review) — a different scenario, covered by "does not guess
+    // an AVD when an unknown Android runtime needs System UI recovery".
+    const pooledAnrDevice = { ...androidDevice };
     const replacementProcess = new FakeExitChildProcess();
-    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
-    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    fakeDeviceUtils.setBootedDevices("android", [pooledAnrDevice]);
+    await pool.initializeWithDevices([pooledAnrDevice]);
     await pool.bindOrReuseDeviceSession(
       "owner-session",
-      unknownRuntimeDevice.deviceId,
+      pooledAnrDevice.deviceId,
       "android",
       recoveryImage,
     );
@@ -1224,7 +1232,7 @@ describe("startDevice handler", () => {
       recoveryImage.name,
       replacementProcess as unknown as ChildProcess,
     );
-    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setBootedResult(pooledAnrDevice);
     fakeMatcher.setImageResult(recoveryImage);
     const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
     fakeDeviceUtils.killDevice = async (device, options) => {

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -389,7 +389,7 @@ describe("startDevice handler", () => {
     );
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
 
-    const discoveredDevice = { ...androidDevice, transportId: "23" };
+    const discoveredDevice = { ...androidDevice };
     const coldBootImage = { ...androidImage, deviceId: androidDevice.deviceId };
     const childProcess = new FakeExitChildProcess();
     fakeDeviceUtils.setBootedDevices("android", [discoveredDevice]);

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -1651,6 +1651,54 @@ describe("deleteDevice handler", () => {
     expect(manager.destroyRequests).toEqual([]);
   });
 
+  // The same takeover, one sweep EARLIER: the teardown's own discovery is the
+  // first to observe `Unknown (<serial>)`, so the pool has not quarantined
+  // anything yet and A's label still reads as resolved. The teardown's CURRENT
+  // observation is the newer evidence of the two, and the unresolved-runtime
+  // guard consults it directly rather than the pool's not-yet-updated label
+  // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+  test("refuses the inventory path on its OWN unresolved discovery, before the pool refreshes", async () => {
+    const timer = new FakeTimer();
+    const pooledAvdName = "Pixel_8_API_35";
+    const pooledImage: DeviceInfo = {
+      platform: "android",
+      name: pooledAvdName,
+      isRunning: true,
+    };
+    const sessionManager = new SessionManager(timer);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    // The pool started AVD A on this serial and still labels it A: no refresh
+    // has run since AVD B took the serial.
+    await pool.addDevice(
+      { platform: "android", name: pooledAvdName, deviceId: "emulator-5556" },
+      pooledImage,
+    );
+    expect(pool.isPooledIdentityUnresolved("emulator-5556")).toBe(false);
+    manager.setBootedDevices("android", [
+      { platform: "android", name: "Unknown (emulator-5556)", deviceId: "emulator-5556" },
+    ]);
+    manager.setDeviceImages("android", [
+      pooledImage,
+      { platform: "android", name: "Pixel_7_API_34", isRunning: false },
+    ]);
+
+    const body = responseBody(
+      await teardownTool().handler(request("android", "Pixel_7_API_34", "Pixel_7_API_34")),
+    );
+
+    expect(body.state).toBe("failed");
+    expect(body.failure).toEqual(expect.objectContaining({ code: "target_identity_unresolved" }));
+    expect(manager.destroyRequests).toEqual([]);
+  });
+
   test("does not delete an AVD when stableId and stableName identify different targets", async () => {
     manager.setBootedDevices("android", [
       {

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -1251,6 +1251,59 @@ describe("deleteDevice handler", () => {
     ]);
   });
 
+  // A caller who stops waiting must not be told the TARGET could not be
+  // identified: cancellation says nothing about which AVD is on the serial, and
+  // `target_identity_unresolved` points the user at a manual `emu kill` for an
+  // action they themselves cancelled
+  // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+  test("reports a cancelled AVD probe as cancellation, not unresolved identity", async () => {
+    const timer = new FakeTimer();
+    const pooledAvdName = "Pixel_8_API_35";
+    const booted: BootedDevice = {
+      platform: "android",
+      name: "Unknown (emulator-5556)",
+      deviceId: "emulator-5556",
+    };
+    const image: DeviceInfo = { platform: "android", name: pooledAvdName, isRunning: true };
+    const sessionManager = new SessionManager(timer);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.addDevice(booted, image);
+    manager.setBootedDevices("android", [booted]);
+    manager.setDeviceImages("android", [image]);
+
+    const controller = new AbortController();
+    // Exactly what the default resolver does once the caller aborts: rethrow the
+    // abort reason rather than answering "no name".
+    setDeviceToolsDependencies({
+      resolveRunningAndroidAvdName: async (_device, _timeoutMs, signal) => {
+        controller.abort(new Error("deleteDevice caller stopped waiting"));
+        throw signal?.reason ?? new Error("deleteDevice caller stopped waiting");
+      },
+    });
+
+    const body = responseBody(
+      await teardownTool().handler(
+        request("android", pooledAvdName, pooledAvdName),
+        undefined,
+        controller.signal,
+      ),
+    );
+
+    expect(body.state).toBe("failed");
+    const failure = body.failure as Record<string, unknown>;
+    expect(failure.code).toBe("operation_cancelled");
+    expect(manager.killedDevices).toEqual([]);
+    expect(manager.destroyRequests).toEqual([]);
+  });
+
   test("rejects a stopped-image teardown when a running Android AVD name is unresolved", async () => {
     const booted: BootedDevice = {
       platform: "android",

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -169,9 +169,16 @@ function request(
 describe("deleteDevice handler", () => {
   let manager: TeardownDeviceManager;
   let teardownOperationStore: FakeDeviceTeardownOperationStore;
+  // What `emu avd name` answers for a serial whose discovered runtime name is
+  // `Unknown (<serial>)`. undefined == the console did not answer, which is the
+  // documented blind spot: teardown proceeds on the pooled name.
+  let runtimeAvdNames: Map<string, string | undefined>;
+  let runtimeAvdNameProbes: string[];
 
   beforeEach(async () => {
     DaemonState.getInstance().reset();
+    runtimeAvdNames = new Map();
+    runtimeAvdNameProbes = [];
     manager = new TeardownDeviceManager();
     teardownOperationStore = new FakeDeviceTeardownOperationStore();
     await setVideoRecordingManagerDependencies({
@@ -191,6 +198,10 @@ describe("deleteDevice handler", () => {
       clearInstalledAppsForDevice: async () => {},
       teardownDeviceOperationStoreFactory: () => teardownOperationStore,
       timer: new FakeTimer(),
+      resolveRunningAndroidAvdName: async (device) => {
+        runtimeAvdNameProbes.push(device.deviceId);
+        return runtimeAvdNames.get(device.deviceId);
+      },
     });
     registerDeviceTools();
   });
@@ -998,6 +1009,88 @@ describe("deleteDevice handler", () => {
         }),
       }),
     ]);
+  });
+
+  // A different AVD can take over a reused serial before discovery observes the
+  // previous one disappear, leaving the pool holding the OLD label. Acting on
+  // that label would stop the emulator that is running NOW, so teardown asks the
+  // runtime first and refuses when the answers disagree (#6863 review).
+  test("refuses teardown when the runtime names a different AVD than the pool", async () => {
+    const timer = new FakeTimer();
+    const staleAvdName = "Pixel_8_API_35";
+    const booted: BootedDevice = {
+      platform: "android",
+      name: "Unknown (emulator-5556)",
+      deviceId: "emulator-5556",
+    };
+    const image: DeviceInfo = {
+      platform: "android",
+      name: staleAvdName,
+      isRunning: true,
+    };
+    const sessionManager = new SessionManager(timer);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.addDevice(booted, image);
+    manager.setBootedDevices("android", [booted]);
+    manager.setDeviceImages("android", [image]);
+    runtimeAvdNames.set("emulator-5556", "Pixel_9_API_36");
+
+    const body = responseBody(
+      await teardownTool().handler(request("android", staleAvdName, staleAvdName)),
+    );
+
+    expect(body.state).toBe("failed");
+    expect((body.failure as Record<string, unknown>).code).toBe("target_identity_unresolved");
+    expect(String((body.failure as Record<string, unknown>).message)).toContain(staleAvdName);
+    expect(String((body.failure as Record<string, unknown>).message)).toContain("Pixel_9_API_36");
+    // Nothing destructive ran against the emulator that is actually booted.
+    expect(manager.killedDevices).toEqual([]);
+    expect(manager.destroyRequests).toEqual([]);
+  });
+
+  test("proceeds when the runtime confirms the pooled AVD name", async () => {
+    const timer = new FakeTimer();
+    const stableAvdName = "Pixel_8_API_35";
+    const booted: BootedDevice = {
+      platform: "android",
+      name: "Unknown (emulator-5556)",
+      deviceId: "emulator-5556",
+    };
+    const image: DeviceInfo = {
+      platform: "android",
+      name: stableAvdName,
+      isRunning: true,
+    };
+    const sessionManager = new SessionManager(timer);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.addDevice(booted, image);
+    manager.setBootedDevices("android", [booted]);
+    manager.setDeviceImages("android", [image]);
+    runtimeAvdNames.set("emulator-5556", stableAvdName);
+
+    const body = responseBody(
+      await teardownTool().handler(request("android", stableAvdName, stableAvdName)),
+    );
+
+    expect(body.state).toBe("destroyed");
+    expect(runtimeAvdNameProbes).toContain("emulator-5556");
+    expect(manager.wasMethodCalled("killDevice")).toBe(true);
   });
 
   test("does not stop a freshly discovered AVD that replaced stale same-serial pool state", async () => {

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -194,15 +194,20 @@ describe("deleteDevice handler", () => {
   let manager: TeardownDeviceManager;
   let teardownOperationStore: FakeDeviceTeardownOperationStore;
   // What `emu avd name` answers for a serial whose discovered runtime name is
-  // `Unknown (<serial>)`. undefined == the console did not answer, which is the
-  // documented blind spot: teardown proceeds on the pooled name.
+  // `Unknown (<serial>)`. undefined == the console did not answer, which leaves
+  // the target unidentified: teardown refuses rather than acting on the pooled
+  // label alone.
   let runtimeAvdNames: Map<string, string | undefined>;
   let runtimeAvdNameProbes: string[];
+  // The bounded budget each probe was given, so a test can pin that it comes
+  // from the caller's deadline rather than an independent timer.
+  let runtimeAvdNameProbeTimeouts: number[];
 
   beforeEach(async () => {
     DaemonState.getInstance().reset();
     runtimeAvdNames = new Map();
     runtimeAvdNameProbes = [];
+    runtimeAvdNameProbeTimeouts = [];
     manager = new TeardownDeviceManager();
     teardownOperationStore = new FakeDeviceTeardownOperationStore();
     await setVideoRecordingManagerDependencies({
@@ -222,8 +227,9 @@ describe("deleteDevice handler", () => {
       clearInstalledAppsForDevice: async () => {},
       teardownDeviceOperationStoreFactory: () => teardownOperationStore,
       timer: new FakeTimer(),
-      resolveRunningAndroidAvdName: async (device) => {
+      resolveRunningAndroidAvdName: async (device, timeoutMs) => {
         runtimeAvdNameProbes.push(device.deviceId);
+        runtimeAvdNameProbeTimeouts.push(timeoutMs);
         return runtimeAvdNames.get(device.deviceId);
       },
     });
@@ -1019,6 +1025,9 @@ describe("deleteDevice handler", () => {
     await pool.addDevice(booted, image);
     manager.setBootedDevices("android", [booted]);
     manager.setDeviceImages("android", [image]);
+    // The pooled label is only a label; the runtime has to confirm it before
+    // anything destructive runs (#6863 review).
+    runtimeAvdNames.set("emulator-5556", stableAvdName);
 
     const response = await teardownTool().handler(request("android", stableAvdName, stableAvdName));
     const body = responseBody(response);
@@ -1033,6 +1042,89 @@ describe("deleteDevice handler", () => {
         }),
       }),
     ]);
+  });
+
+  // A probe that does not answer leaves the target unidentified, and the pooled
+  // label alone is not enough to stop and delete an AVD: the serial could have
+  // been taken over by a different one. Teardown refuses, names the manual
+  // escape, and nothing destructive runs (#6863 review).
+  test("refuses teardown when the runtime cannot confirm the pooled AVD name", async () => {
+    const timer = new FakeTimer();
+    const pooledAvdName = "Pixel_8_API_35";
+    const booted: BootedDevice = {
+      platform: "android",
+      name: "Unknown (emulator-5556)",
+      deviceId: "emulator-5556",
+    };
+    const image: DeviceInfo = {
+      platform: "android",
+      name: pooledAvdName,
+      isRunning: true,
+    };
+    const sessionManager = new SessionManager(timer);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.addDevice(booted, image);
+    manager.setBootedDevices("android", [booted]);
+    manager.setDeviceImages("android", [image]);
+
+    const body = responseBody(
+      await teardownTool().handler(request("android", pooledAvdName, pooledAvdName)),
+    );
+
+    expect(body.state).toBe("failed");
+    const failure = body.failure as Record<string, unknown>;
+    expect(failure.code).toBe("target_identity_unresolved");
+    expect(String(failure.message)).toContain("emulator-5556");
+    expect(String(failure.message)).toContain(pooledAvdName);
+    expect(String(failure.message)).toContain("adb -s emulator-5556 emu kill");
+    expect(manager.killedDevices).toEqual([]);
+    expect(manager.destroyRequests).toEqual([]);
+  });
+
+  // The probe runs inside a lifecycle lease that is already on a deadline, so it
+  // must borrow that deadline instead of starting its own timer (#6863 review).
+  test("bounds the AVD name probe by the caller's remaining teardown deadline", async () => {
+    const timer = new FakeTimer();
+    const pooledAvdName = "Pixel_8_API_35";
+    const booted: BootedDevice = {
+      platform: "android",
+      name: "Unknown (emulator-5556)",
+      deviceId: "emulator-5556",
+    };
+    const image: DeviceInfo = {
+      platform: "android",
+      name: pooledAvdName,
+      isRunning: true,
+    };
+    const sessionManager = new SessionManager(timer);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.addDevice(booted, image);
+    manager.setBootedDevices("android", [booted]);
+    manager.setDeviceImages("android", [image]);
+    runtimeAvdNames.set("emulator-5556", pooledAvdName);
+
+    await teardownTool().handler({
+      ...request("android", pooledAvdName, pooledAvdName),
+      timeoutMs: 400,
+    });
+
+    expect(runtimeAvdNameProbeTimeouts).toEqual([400]);
   });
 
   // A different AVD can take over a reused serial before discovery observes the

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -80,9 +80,7 @@ class TeardownDeviceManager extends FakeDeviceUtils {
 
   private discoveriesSinceKill: number | undefined;
 
-  override async getBootedDevicesDetailed(
-    platform: SomePlatform,
-  ): Promise<BootedDeviceDiscovery> {
+  override async getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery> {
     if (
       this.discoveriesSinceKill !== undefined &&
       this.clearBootedDevicesAfterDiscoveries !== undefined

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -928,7 +928,6 @@ describe("deleteDevice handler", () => {
       platform: "android",
       name: "Pixel_8_API_35",
       deviceId: "emulator-5556",
-      transportId: "7",
     };
     manager.setBootedDevices("android", [device]);
     manager.setDeviceImages("android", [
@@ -946,7 +945,7 @@ describe("deleteDevice handler", () => {
     expect(manager.wasMethodCalled("killDevice")).toBe(true);
     expect(manager.killedDevices).toEqual([
       expect.objectContaining({
-        transportId: device.transportId,
+        deviceId: device.deviceId,
       }),
     ]);
     expect(manager.destroyRequests).toEqual([
@@ -966,7 +965,6 @@ describe("deleteDevice handler", () => {
       platform: "android",
       name: "Unknown (emulator-5556)",
       deviceId: "emulator-5556",
-      transportId: "42",
     };
     const image: DeviceInfo = {
       platform: "android",
@@ -1009,7 +1007,6 @@ describe("deleteDevice handler", () => {
       platform: "android",
       name: "Pixel_8_New",
       deviceId: "emulator-5556",
-      transportId: "43",
     };
     const sessionManager = new SessionManager(timer);
     const pool = new DevicePool(
@@ -1025,7 +1022,6 @@ describe("deleteDevice handler", () => {
       {
         ...replacement,
         name: "Unknown (emulator-5556)",
-        transportId: "42",
       },
       { platform: "android", name: staleAvdName, isRunning: true },
     );
@@ -1117,12 +1113,10 @@ describe("deleteDevice handler", () => {
       platform: "android",
       name: "Pixel_8_API_35",
       deviceId: "emulator-5554",
-      transportId: "1",
     };
     manager.replacementAfterKill = {
       ...device,
       deviceId: "emulator-5556",
-      transportId: "2",
     };
     manager.setBootedDevices("android", [device]);
     manager.setDeviceImages("android", [
@@ -1151,13 +1145,11 @@ describe("deleteDevice handler", () => {
       platform: "android",
       name: "Pixel_8_API_35",
       deviceId: "emulator-5554",
-      transportId: "1",
     };
     manager.replacementAfterKill = {
       ...device,
       name: "Unknown (emulator-5556)",
       deviceId: "emulator-5556",
-      transportId: "2",
     };
     manager.setBootedDevices("android", [device]);
     manager.setDeviceImages("android", [
@@ -1184,12 +1176,10 @@ describe("deleteDevice handler", () => {
       platform: "android",
       name: "Pixel_8_API_35",
       deviceId: "emulator-5554",
-      transportId: "1",
     };
     manager.replacementAfterKill = {
       ...device,
       name: "Unknown (emulator-5554)",
-      transportId: "2",
     };
     manager.setBootedDevices("android", [device]);
     manager.setDeviceImages("android", [

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -1500,6 +1500,60 @@ describe("deleteDevice handler", () => {
     expect(manager.destroyRequests).toEqual([]);
   });
 
+  // AVD B has taken over the serial AVD A was pooled on, and discovery can only
+  // report `Unknown (<serial>)` for it. The pool quarantines its entry for that
+  // serial, so the cached label stops standing in for a resolved AVD name --
+  // which is what previously let a teardown of B miss the booted runtime, skip
+  // the unresolved-runtime guard on the strength of A's label, and destroy B's
+  // image through the STOPPED-image inventory path while B was running
+  // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+  test("refuses to delete an inventory image while the serial's runtime is unresolved", async () => {
+    const timer = new FakeTimer();
+    const pooledAvdName = "Pixel_8_API_35";
+    const reusedSerialRuntime: BootedDevice = {
+      platform: "android",
+      name: `Unknown (emulator-5556)`,
+      deviceId: "emulator-5556",
+    };
+    const pooledImage: DeviceInfo = {
+      platform: "android",
+      name: pooledAvdName,
+      isRunning: true,
+    };
+    const sessionManager = new SessionManager(timer);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    // The pool started AVD A on this serial and knows it by name.
+    await pool.addDevice(
+      { platform: "android", name: pooledAvdName, deviceId: "emulator-5556" },
+      pooledImage,
+    );
+    // A discovery sweep can no longer read a name off that serial.
+    manager.setBootedDevices("android", [reusedSerialRuntime]);
+    await pool.refreshDevices();
+    manager.setDeviceImages("android", [
+      pooledImage,
+      // AVD B looks stopped to the inventory, because the runtime on the serial
+      // could not name itself.
+      { platform: "android", name: "Pixel_7_API_34", isRunning: false },
+    ]);
+
+    const body = responseBody(
+      await teardownTool().handler(request("android", "Pixel_7_API_34", "Pixel_7_API_34")),
+    );
+
+    expect(body.state).toBe("failed");
+    expect(body.failure).toEqual(expect.objectContaining({ code: "target_identity_unresolved" }));
+    expect(manager.destroyRequests).toEqual([]);
+  });
+
   test("does not delete an AVD when stableId and stableName identify different targets", async () => {
     manager.setBootedDevices("android", [
       {

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -66,14 +66,38 @@ class TeardownDeviceManager extends FakeDeviceUtils {
   destroyError?: Error;
   killError?: Error;
   replacementAfterKill?: BootedDevice;
+  /**
+   * Drop the booted list after this many discoveries following the kill, so a
+   * test can model a device that is still listed for a poll or two while it
+   * winds down and then really goes away.
+   */
+  clearBootedDevicesAfterDiscoveries?: number;
   killGate?: Promise<void>;
   killStarted?: () => void;
   destroyGate?: Promise<void>;
   destroyStarted?: () => void;
   private readonly destroyedIdentities = new Set<string>();
 
+  private discoveriesSinceKill: number | undefined;
+
+  override async getBootedDevicesDetailed(
+    platform: SomePlatform,
+  ): Promise<BootedDeviceDiscovery> {
+    if (
+      this.discoveriesSinceKill !== undefined &&
+      this.clearBootedDevicesAfterDiscoveries !== undefined
+    ) {
+      if (this.discoveriesSinceKill >= this.clearBootedDevicesAfterDiscoveries) {
+        this.setBootedDevices("android", []);
+      }
+      this.discoveriesSinceKill++;
+    }
+    return await super.getBootedDevicesDetailed(platform);
+  }
+
   override async killDevice(device: BootedDevice): Promise<void> {
     this.killedDevices.push(device);
+    this.discoveriesSinceKill = 0;
     this.killStarted?.();
     await this.killGate;
     this.setBootedDevices(
@@ -1264,7 +1288,51 @@ describe("deleteDevice handler", () => {
     expect(manager.destroyRequests).toEqual([]);
   });
 
-  test("fails closed when an unresolved Android replacement reuses the target serial", async () => {
+  // An emulator winding down keeps its serial in `adb devices` after the console
+  // has stopped answering `avd name`, so discovery labels the device that is
+  // STILL THERE `Unknown (<serial>)`. That placeholder is not evidence that a
+  // different AVD took the serial, so the stop phase keeps waiting for the
+  // serial to clear instead of refusing on a newcomer that does not exist
+  // (#6863 review).
+  test("keeps waiting when the target serial is still listed under an unresolved name", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    setDeviceToolsDependencies({ timer });
+    const device: BootedDevice = {
+      platform: "android",
+      name: "Pixel_8_API_35",
+      deviceId: "emulator-5554",
+    };
+    manager.replacementAfterKill = {
+      ...device,
+      name: "Unknown (emulator-5554)",
+    };
+    manager.clearBootedDevicesAfterDiscoveries = 1;
+    manager.setBootedDevices("android", [device]);
+    manager.setDeviceImages("android", [
+      {
+        platform: "android",
+        name: device.name,
+        isRunning: true,
+      },
+    ]);
+
+    const response = await teardownTool().handler(request("android", device.name, device.name));
+
+    expect(responseBody(response).state).toBe("destroyed");
+    expect(manager.destroyRequests).toEqual([
+      expect.objectContaining({
+        device: expect.objectContaining({ name: device.name }),
+      }),
+    ]);
+  });
+
+  // And when the serial never clears, teardown still fails closed: an unresolved
+  // name is never taken as proof that the target stopped either.
+  test("fails closed when a serial that never clears keeps an unresolved name", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    setDeviceToolsDependencies({ timer });
     const device: BootedDevice = {
       platform: "android",
       name: "Pixel_8_API_35",
@@ -1285,12 +1353,7 @@ describe("deleteDevice handler", () => {
 
     const response = await teardownTool().handler(request("android", device.name, device.name));
 
-    expect(responseBody(response).failure).toEqual(
-      expect.objectContaining({
-        phase: "stop",
-        code: "target_identity_unresolved",
-      }),
-    );
+    expect(responseBody(response).state).toBe("failed");
     expect(manager.destroyRequests).toEqual([]);
   });
 

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -708,6 +708,61 @@ describe("MCP Booted Device Resources", () => {
       sessionManager.stopCleanupTimer();
     });
 
+    // The resource joins discovery to pool state by SERIAL. A different AVD can
+    // take over a reused serial before the next pool refresh, and publishing the
+    // old entry's epoch as the new runtime's `connectionId` would tell consumers
+    // to KEEP state exactly when they must flush it (#6863 review).
+    test("omits the pool epoch when the discovered runtime disagrees with the pooled entry", async function () {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
+      const { FakeInstalledAppsRepository } =
+        await import("../../fakes/FakeInstalledAppsRepository");
+      const devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        new FakeInstalledAppsRepository(),
+        fakeDeviceUtils,
+      );
+      await devicePool.initializeWithDevices([mockAndroidDevice1, mockAndroidDevice2]);
+      DaemonState.getInstance().initialize(sessionManager, devicePool);
+
+      // emulator-5554 is now a DIFFERENT AVD; the pool has not refreshed yet.
+      const replacement: BootedDevice = { ...mockAndroidDevice1, name: "Pixel_9_API_36" };
+      fakeDeviceUtils.setBootedDevices("android", [replacement, mockAndroidDevice2]);
+
+      const { client } = fixture.getContext();
+      const readResourceResponseSchema = z.object({
+        contents: z.array(
+          z.object({
+            uri: z.string(),
+            mimeType: z.string().optional(),
+            text: z.string().optional(),
+            blob: z.string().optional(),
+          }),
+        ),
+      });
+      const result = await client.request(
+        { method: "resources/read", params: { uri: "automobile:devices/booted" } },
+        readResourceResponseSchema,
+      );
+      const data: BootedDevicesResourceContent = JSON.parse(result.contents[0].text!);
+
+      const reusedSerial = data.devices.find((device) => device.deviceId === "emulator-5554");
+      expect(reusedSerial?.identity?.connectionId).toBe("emulator-5554");
+
+      // The entry whose identity still agrees keeps its epoch.
+      const agreeing = data.devices.find(
+        (device) => device.deviceId === mockAndroidDevice2.deviceId,
+      );
+      expect(agreeing?.identity?.connectionId).toBe(
+        `${mockAndroidDevice2.deviceId}#${devicePool.getDeviceIncarnation(mockAndroidDevice2.deviceId)}`,
+      );
+
+      sessionManager.stopCleanupTimer();
+    });
+
     test("exposes the registry epoch UUID for each live device", async function () {
       fakeDeviceUtils.setBootedDevices("android", [mockAndroidDevice1]);
 

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -39,7 +39,6 @@ describe("MCP Booted Device Resources", () => {
     name: "Pixel_7_API_34",
     platform: "android",
     deviceId: "emulator-5554",
-    transportId: "1",
     source: "local",
   };
 
@@ -242,11 +241,12 @@ describe("MCP Booted Device Resources", () => {
         android: { observationComplete: true },
         ios: { observationComplete: true },
       });
+      // No pool is wired in this fixture, so there is no incarnation to name
+      // the epoch and `connectionId` falls back to the bare serial.
       expect(data.devices[0]).toMatchObject({
         identity: {
           stableId: "Pixel_7_API_34",
-          connectionId: "1",
-          transportId: "1",
+          connectionId: "emulator-5554",
         },
         lifecycleState: "booted",
         readiness: { state: "unknown" },
@@ -694,6 +694,15 @@ describe("MCP Booted Device Resources", () => {
       );
       expect(idleDevice).toBeDefined();
       expect(idleDevice?.poolStatus).toBe("idle");
+
+      // With a pool wired, `connectionId` names THIS connection epoch: a reused
+      // serial alone cannot tell a consumer whether to flush its per-device
+      // state, so the pool's incarnation is appended.
+      const pooledIncarnation = devicePool.getDeviceIncarnation(assignedDevice!.deviceId);
+      expect(pooledIncarnation).toBeDefined();
+      expect(assignedDevice?.identity?.connectionId).toBe(
+        `${assignedDevice!.deviceId}#${pooledIncarnation}`,
+      );
 
       // Clean up SessionManager timer to prevent process hang
       sessionManager.stopCleanupTimer();

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -763,6 +763,63 @@ describe("MCP Booted Device Resources", () => {
       sessionManager.stopCleanupTimer();
     });
 
+    // Gating pool-derived fields one at a time leaves the ones resolved
+    // SEPARATELY by serial -- the session and the registry's epoch UUID --
+    // ungated, so the resource advertises the new runtime under the RETIRED
+    // epoch's UUID and the desktop subscribes to streams with it. On a mismatch
+    // the resource must attach no pool context at all
+    // ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+    test("attaches no pool-derived context at all when the runtime disagrees", async function () {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
+      const { FakeInstalledAppsRepository } =
+        await import("../../fakes/FakeInstalledAppsRepository");
+      const devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        new FakeInstalledAppsRepository(),
+        fakeDeviceUtils,
+      );
+      fakeDeviceUtils.setBootedDevices("android", [mockAndroidDevice1]);
+      await devicePool.initializeWithDevices([mockAndroidDevice1]);
+      const sessionId = await devicePool.assignDeviceToSession("session-stale");
+      expect(sessionId).toBe(mockAndroidDevice1.deviceId);
+      const registry = new DeviceSessionRegistry(fakeTimer);
+      registry.onDeviceConnected({
+        deviceId: mockAndroidDevice1.deviceId,
+        platform: "android",
+        incarnation: 1,
+      });
+      DaemonState.getInstance().initialize(sessionManager, devicePool, registry);
+
+      // A different AVD now holds the serial; the pool has not refreshed yet.
+      fakeDeviceUtils.setBootedDevices("android", [
+        { ...mockAndroidDevice1, name: "Pixel_9_API_36" },
+      ]);
+
+      try {
+        const { client } = fixture.getContext();
+        const result = await client.readResource({ uri: "automobile:devices/booted" });
+        const data: BootedDevicesResourceContent = JSON.parse(result.contents[0].text!);
+        const entry = data.devices.find(
+          (device) => device.deviceId === mockAndroidDevice1.deviceId,
+        );
+
+        expect(entry).toBeDefined();
+        expect(entry?.deviceSessionUuid).toBeUndefined();
+        expect(entry?.session).toBeUndefined();
+        expect(entry?.poolStatus).toBeUndefined();
+        expect(entry?.assignedSession).toBeUndefined();
+        // Identity is built purely from discovery.
+        expect(entry?.identity?.stableId).toBe("Pixel_9_API_36");
+        expect(entry?.identity?.connectionId).toBe(mockAndroidDevice1.deviceId);
+      } finally {
+        sessionManager.stopCleanupTimer();
+      }
+    });
+
     // `Unknown (<serial>)` is the placeholder Android discovery emits when the
     // emulator console could not answer `avd name`. It asserts nothing, so it
     // is not agreement with the pooled entry: publishing that entry's epoch

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -763,6 +763,52 @@ describe("MCP Booted Device Resources", () => {
       sessionManager.stopCleanupTimer();
     });
 
+    // `Unknown (<serial>)` is the placeholder Android discovery emits when the
+    // emulator console could not answer `avd name`. It asserts nothing, so it
+    // is not agreement with the pooled entry: publishing that entry's epoch
+    // would tell consumers to keep state across a possible serial reuse, and
+    // publishing its AVD label as `stableId` would name a device that may no
+    // longer be the one running (#6863 review).
+    test("withholds the pool epoch and the pooled AVD name for an unresolved runtime name", async function () {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
+      const { FakeInstalledAppsRepository } =
+        await import("../../fakes/FakeInstalledAppsRepository");
+      const devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        new FakeInstalledAppsRepository(),
+        fakeDeviceUtils,
+      );
+      // `addDevice` records the AVD this pool started, which is what would be
+      // published as `stableId` for an emulator whose runtime name is unknown.
+      await devicePool.addDevice(mockAndroidDevice1, {
+        name: mockAndroidDevice1.name,
+        platform: "android",
+        isRunning: true,
+        source: "local",
+      });
+      DaemonState.getInstance().initialize(sessionManager, devicePool);
+
+      const unresolved: BootedDevice = {
+        ...mockAndroidDevice1,
+        name: `Unknown (${mockAndroidDevice1.deviceId})`,
+      };
+      fakeDeviceUtils.setBootedDevices("android", [unresolved]);
+
+      const { client } = fixture.getContext();
+      const result = await client.readResource({ uri: "automobile:devices/booted" });
+      const data: BootedDevicesResourceContent = JSON.parse(result.contents[0].text!);
+      const device = data.devices.find((entry) => entry.deviceId === unresolved.deviceId);
+
+      expect(device?.identity?.connectionId).toBe(unresolved.deviceId);
+      expect(device?.identity?.stableId).toBe(unresolved.name);
+
+      sessionManager.stopCleanupTimer();
+    });
+
     test("exposes the registry epoch UUID for each live device", async function () {
       fakeDeviceUtils.setBootedDevices("android", [mockAndroidDevice1]);
 

--- a/test/server/sessionToolSelection.integration.test.ts
+++ b/test/server/sessionToolSelection.integration.test.ts
@@ -850,19 +850,17 @@ describe("post-handler cancellation guard scope", () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const pool = new DevicePool(
-      sessionManager,
-      "daemon-test",
-      timer,
-      undefined,
-      new FakeDeviceUtils(),
-    );
+    const deviceUtils = new FakeDeviceUtils();
+    const pool = new DevicePool(sessionManager, "daemon-test", timer, undefined, deviceUtils);
     DaemonState.getInstance().initialize(sessionManager, pool);
     const device = {
       name: "Pixel 8",
       platform: "android" as const,
       deviceId: "reused-after-mint-android-1",
     };
+    // An idle Android entry is re-proved present against discovery before it is
+    // assigned, handsets included, so discovery has to list it.
+    deviceUtils.setBootedDevices("android", [device]);
     await pool.initializeWithDevices([device]);
     pool.notifyDeviceReady(device.deviceId);
 
@@ -934,15 +932,13 @@ describe("post-handler cancellation guard scope", () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const pool = new DevicePool(
-      sessionManager,
-      "daemon-test",
-      timer,
-      undefined,
-      new FakeDeviceUtils(),
-    );
+    const deviceUtils = new FakeDeviceUtils();
+    const pool = new DevicePool(sessionManager, "daemon-test", timer, undefined, deviceUtils);
     DaemonState.getInstance().initialize(sessionManager, pool);
     const device = { name: "Pixel 8", platform: "android" as const, deviceId: "reap-android-1" };
+    // An idle Android entry is re-proved present against discovery before it is
+    // assigned, handsets included, so discovery has to list it.
+    deviceUtils.setBootedDevices("android", [device]);
     await pool.initializeWithDevices([device]);
     pool.notifyDeviceReady(device.deviceId);
 

--- a/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
@@ -82,7 +82,6 @@ describe("AdbClient.getBootedAndroidDevices", () => {
         platform: "android",
         deviceId: "emulator-5554",
         observedAt: 1,
-        transportId: "42",
       },
     ]);
   });
@@ -118,13 +117,13 @@ describe("AdbClient.getBootedAndroidDevices", () => {
       }
       calls++;
       return createExecResult(
-        ["List of devices attached", `emulator-5554\tdevice transport_id:${calls}`, ""].join("\n"),
+        ["List of devices attached", `emulator-555${calls}\tdevice`, ""].join("\n"),
       );
     });
 
-    expect(await adb.getBootedAndroidDevices()).toMatchObject([{ transportId: "1" }]);
+    expect(await adb.getBootedAndroidDevices()).toMatchObject([{ deviceId: "emulator-5551" }]);
     expect(await adb.getBootedAndroidDevices({ bypassCache: true })).toMatchObject([
-      { transportId: "2" },
+      { deviceId: "emulator-5552" },
     ]);
     expect(calls).toBe(2);
   });

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-getBootedDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-getBootedDevices.test.ts
@@ -76,14 +76,13 @@ describe("AndroidEmulatorClient.getBootedDevicesChecked", () => {
     ]);
   });
 
-  test("preserves transport identity when AVD-name lookup fails", async () => {
+  test("falls back to a placeholder name when AVD-name lookup fails", async () => {
     const adb = new FakeAdbExecutor();
     adb.setDevices([
       {
         name: "ignored",
         platform: "android",
         deviceId: "emulator-5554",
-        transportId: "42",
       } satisfies BootedDevice,
     ]);
     adb.setCommandError("emu avd name", new Error("emulator console unavailable"));
@@ -99,7 +98,6 @@ describe("AndroidEmulatorClient.getBootedDevicesChecked", () => {
         name: "Unknown (emulator-5554)",
         platform: "android",
         deviceId: "emulator-5554",
-        transportId: "42",
         source: "local",
       },
     ]);

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-killIdentity.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-killIdentity.test.ts
@@ -28,7 +28,6 @@ const original: BootedDevice = {
   name: "Pixel_8",
   platform: "android",
   deviceId: "emulator-5554",
-  transportId: "1",
 };
 
 function execResult(stdout: string) {
@@ -137,12 +136,12 @@ test("with two booted emulators each kill selects only its own serial", async ()
   const { factory, commands, timer } = recordingFactory(["emulator-5554", "emulator-5556"]);
   const client = new AndroidEmulatorClient(null, null, timer, factory);
 
-  await client.killDevice({ ...original, deviceId: "emulator-5554", transportId: "1" });
+  await client.killDevice({ ...original, deviceId: "emulator-5554" });
   expect(commands.filter((args) => args.slice(-2).join(" ") === "emu kill")).toEqual([
     ["-s", "emulator-5554", "emu", "kill"],
   ]);
 
-  await client.killDevice({ ...original, deviceId: "emulator-5556", transportId: "2" });
+  await client.killDevice({ ...original, deviceId: "emulator-5556" });
   expect(commands.filter((args) => args.slice(-2).join(" ") === "emu kill")).toEqual([
     ["-s", "emulator-5554", "emu", "kill"],
     ["-s", "emulator-5556", "emu", "kill"],
@@ -174,16 +173,15 @@ test("refuses when the expected emulator is no longer running", async () => {
   expect(adb.getExecutedCommands().some((command) => command.endsWith("emu kill"))).toBe(false);
 });
 
-for (const observedTransport of ["2", undefined]) {
-  test(`a differing discovered transport id (${observedTransport}) no longer blocks the kill`, async () => {
-    // Transport ids are not part of the kill identity: serial + AVD name +
-    // platform are. A transport that moved (or was never reported) must not
-    // strand a teardown.
-    const { client, adb } = fixture({ ...original, transportId: observedTransport });
+test("an adb listing that still reports transport_id does not affect the kill identity", () => {
+  // `adb devices -l` keeps printing a `transport_id:` column; discovery no
+  // longer parses it, and the kill identity is serial + AVD name + platform.
+  const { client, adb } = fixture(original);
+  return (async () => {
     await expect(client.killDevice(original)).resolves.toMatchObject({
       deviceId: original.deviceId,
     });
     expect(adb.getExecutedCommands().some((command) => command.endsWith("emu kill"))).toBe(true);
     expectNoTransportOrRebootCommand(adb.getExecutedArgv());
-  });
-}
+  })();
+});

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-killIdentity.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-killIdentity.test.ts
@@ -167,6 +167,22 @@ test("refuses a discovered replacement AVD on the expected serial", async () => 
   expectNoTransportOrRebootCommand(adb.getExecutedArgv());
 });
 
+// Two unknowns are not an equality. When the requested target's name is the
+// `Unknown (<serial>)` placeholder AND the fresh discovery reports the same
+// placeholder, the check above passes on nothing: neither side names an AVD, so
+// a replacement emulator that also cannot name itself would be killed under the
+// previous occupant's request
+// ([#6863](https://github.com/kaeawc/auto-mobile/pull/6863) review).
+test("refuses when both the requested and the discovered name are the placeholder", async () => {
+  const placeholder: BootedDevice = {
+    ...original,
+    name: "Unknown (emulator-5554)",
+  };
+  const { client, adb } = fixture(placeholder);
+  await expect(client.killDevice(placeholder)).rejects.toThrow(/could not name itself/);
+  expect(adb.getExecutedCommands().some((command) => command.endsWith("emu kill"))).toBe(false);
+});
+
 test("refuses when the expected emulator is no longer running", async () => {
   const { client, adb } = fixture({ ...original, deviceId: "emulator-5556" });
   await expect(client.killDevice(original)).rejects.toThrow("is not running");

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-resolveRunningAvdName.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-resolveRunningAvdName.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { AndroidEmulatorClient } from "../../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import type { BootedDevice } from "../../../src/models";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import type { ExecResult } from "../../../src/models";
+
+/**
+ * Burns wall-clock (fake) time on every adb command and then fails it, the way
+ * a wedged emulator console does: the command sits until its own timeout and
+ * reports nothing.
+ */
+class StallingAdbExecutor extends FakeAdbExecutor {
+  readonly calls: Array<{ command: string; timeoutMs: number | undefined }> = [];
+
+  constructor(
+    private readonly timer: FakeTimer,
+    private readonly elapsePerCommandMs: number,
+  ) {
+    super();
+  }
+
+  override async executeCommand(command: string, timeoutMs?: number): Promise<ExecResult> {
+    this.calls.push({ command, timeoutMs });
+    this.timer.advanceTime(this.elapsePerCommandMs);
+    throw new Error("adb command timed out");
+  }
+}
+
+const device: BootedDevice = {
+  name: "Unknown (emulator-5554)",
+  platform: "android",
+  deviceId: "emulator-5554",
+};
+
+/**
+ * `resolveRunningAvdName` is called by destructive actions that are already
+ * holding a lifecycle lease against a deadline, so its budget is a TOTAL, not a
+ * per-command allowance: `emu avd name` and the `getprop` fallback run
+ * sequentially and must share it (#6863 review).
+ */
+describe("AndroidEmulatorClient.resolveRunningAvdName", () => {
+  test("shares one deadline between the console probe and the property fallback", async () => {
+    const timer = new FakeTimer();
+    const adb = new StallingAdbExecutor(timer, 2_000);
+    const client = new AndroidEmulatorClient(null, null, timer, new FakeAdbClientFactory(adb));
+
+    await expect(client.resolveRunningAvdName(device, 3_000)).resolves.toBeUndefined();
+
+    expect(adb.calls.map((call) => call.command)).toEqual([
+      "emu avd name",
+      "shell getprop ro.boot.qemu.avd_name",
+    ]);
+    expect(adb.calls[0].timeoutMs).toBe(3_000);
+    // Only what is left of the shared budget, never a second full one.
+    expect(adb.calls[1].timeoutMs).toBe(1_000);
+  });
+
+  test("skips the fallback entirely once the shared deadline is spent", async () => {
+    const timer = new FakeTimer();
+    const adb = new StallingAdbExecutor(timer, 3_500);
+    const client = new AndroidEmulatorClient(null, null, timer, new FakeAdbClientFactory(adb));
+
+    await expect(client.resolveRunningAvdName(device, 3_000)).resolves.toBeUndefined();
+
+    expect(adb.calls).toHaveLength(1);
+  });
+});

--- a/test/utils/deviceIncarnation.test.ts
+++ b/test/utils/deviceIncarnation.test.ts
@@ -13,8 +13,12 @@ import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
 import type { BootedDevice } from "../../src/models";
 
 describe("deviceIncarnationToken", () => {
+  // Reset the whole singleton, not just the resolver: a test that fails after
+  // initializing a pool would otherwise leave DaemonState holding that pool and
+  // session manager, and bun shares singleton state across test files, so a
+  // later file would observe it. `reset` clears the resolver too.
   afterEach(() => {
-    setDeviceIncarnationResolver(undefined);
+    DaemonState.getInstance().reset();
   });
 
   test("is undefined with no resolver registered", () => {

--- a/test/utils/deviceIncarnation.test.ts
+++ b/test/utils/deviceIncarnation.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  deviceIncarnationToken,
+  setDeviceIncarnationResolver,
+} from "../../src/utils/deviceIncarnation";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
+import type { BootedDevice } from "../../src/models";
+
+describe("deviceIncarnationToken", () => {
+  afterEach(() => {
+    setDeviceIncarnationResolver(undefined);
+  });
+
+  test("is undefined with no resolver registered", () => {
+    setDeviceIncarnationResolver(undefined);
+    expect(deviceIncarnationToken("emulator-5554")).toBeUndefined();
+  });
+
+  test("stringifies whatever the registered resolver answers", () => {
+    setDeviceIncarnationResolver((deviceId) => (deviceId === "emulator-5554" ? 3 : undefined));
+    expect(deviceIncarnationToken("emulator-5554")).toBe("3");
+    expect(deviceIncarnationToken("emulator-5556")).toBeUndefined();
+  });
+
+  test("follows the pool's incarnation once the daemon publishes its pool", async () => {
+    const timer = new FakeTimer();
+    const deviceManager = new FakeDeviceManager();
+    const sessionManager = new SessionManager(timer);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      deviceManager,
+      new DefaultRetryExecutor(timer),
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    const device: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+    };
+    deviceManager.bootedDevices = [device];
+    await pool.initializeWithDevices([device]);
+
+    const first = deviceIncarnationToken(device.deviceId);
+    expect(first).toBeDefined();
+
+    // A new pooled connection is a new epoch, and the published token must move
+    // with it — it is the only thing a per-device cache can key on.
+    await pool.removeDevice(device.deviceId);
+    expect(deviceIncarnationToken(device.deviceId)).toBeUndefined();
+    await pool.refreshDevices();
+    expect(deviceIncarnationToken(device.deviceId)).not.toBe(first);
+  });
+});

--- a/test/utils/deviceIncarnation.test.ts
+++ b/test/utils/deviceIncarnation.test.ts
@@ -28,6 +28,51 @@ describe("deviceIncarnationToken", () => {
     expect(deviceIncarnationToken("emulator-5556")).toBeUndefined();
   });
 
+  // The resolver is a module global closed over ONE pool. A daemon-state reset
+  // (shutdown, or a test moving on) retires that pool, and leaving the closure
+  // installed would keep the retired pool alive and keep answering direct-mode
+  // callers with its epochs (#6863 review).
+  test("stops answering after the daemon state that installed it is reset", async () => {
+    const timer = new FakeTimer();
+    const deviceManager = new FakeDeviceManager();
+    const sessionManager = new SessionManager(timer);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      deviceManager,
+      new DefaultRetryExecutor(timer),
+    );
+    const device: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+    };
+    deviceManager.bootedDevices = [device];
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.initializeWithDevices([device]);
+    expect(deviceIncarnationToken(device.deviceId)).toBeDefined();
+
+    DaemonState.getInstance().reset();
+
+    expect(deviceIncarnationToken(device.deviceId)).toBeUndefined();
+
+    // A fresh initialize installs a resolver for the NEW pool.
+    const replacementPool = new DevicePool(
+      sessionManager,
+      "daemon-session-2",
+      timer,
+      new FakeInstalledAppsRepository(),
+      deviceManager,
+      new DefaultRetryExecutor(timer),
+    );
+    DaemonState.getInstance().initialize(sessionManager, replacementPool);
+    await replacementPool.initializeWithDevices([device]);
+    expect(deviceIncarnationToken(device.deviceId)).toBeDefined();
+    DaemonState.getInstance().reset();
+  });
+
   test("follows the pool's incarnation once the daemon publishes its pool", async () => {
     const timer = new FakeTimer();
     const deviceManager = new FakeDeviceManager();


### PR DESCRIPTION
## Summary

Removes `transportId` from the Android device identity model entirely. Follows [#6853](https://github.com/kaeawc/auto-mobile/pull/6853), which already dropped it from the kill path.

Identity is now two questions. Which device: the adb serial for addressing, plus the AVD name for stable routing across restarts. Which run of it: `PooledDevice.incarnation`, the pool's existing per-allocation counter that already mints the per-epoch device-session UUID. Nothing replaces the transport id at discovery level on purpose: a per-connection handle in the device model invited callers to read "transport unchanged" as proof of an unbroken connection, which it never was once adb reconnected for its own reasons.

## Changes

- Identity comparisons in `DevicePool` and `deviceTools` become platform + serial + name, with two documented name tolerances (iOS physical names are mutable metadata; `Unknown (<serial>)` is a placeholder that asserts nothing). Both are guarded by `isAndroidEmulatorSerial` so a handset's non-unique `ro.product.model` can never conflate two devices. `hasTransportOnlyIdentityChange` is gone; a same-serial reallocation is detected by observed disappearance plus the boot-ready boundary, which already bumps the incarnation.
- `getValidatedPooledAndroidAvdName` trusts the pool's cached AVD name for an `Unknown (<serial>)` runtime only when the serial is emulator-shaped, the pool still holds a live entry for it, and that entry carries an `avdName` the pool itself recorded. Otherwise it returns undefined and the caller falls back.
- Caches keyed on the transport (the daemon's append-text helper, the resolved HOME-package cache) now key on the pool incarnation through a single resolver in `src/utils/deviceIncarnation.ts`, so feature code does not import the daemon. The append path self-heals by evicting and rebuilding once on a cached helper's first failure.
- A latent bug surfaced and fixed: `ensurePooledDevicePresentForUse` could return true for a captured `PooledDevice` that a concurrent re-add had superseded; it now checks pool-entry identity.
- Accepted blind spot, asserted by name in three tests: a same-serial restart faster than one discovery interval reads as continuity.

## Breaking on the wire

`killDevice`'s `device.transportId` argument, `deviceIdentity.adbTransportId`, and `identity.transportId` on `automobile:devices/booted` are removed. `identity.connectionId` now spells the epoch as `<deviceId>#<incarnation>` when the pool knows the device, bare serial otherwise. The only external consumer, the desktop client's `DeviceIdentity` model (never read the field), is updated here. `schemas/tool-definitions.json` regenerated.

## Validation

typecheck gate clean (143 baseline), format:check clean, oxlint diff vs main empty, `bun test test/daemon test/server test/utils test/db test/features` 16122 pass / 0 fail with zero new names vs main, `bun run build` ok, `./gradlew :desktop-core:test --tests "*DeviceResourceParserTest*"` ok. `grep -rn transportId src test schemas docs android ios` returns nothing.

## Unresolved emulator identities are quarantined in the pool

When a discovery sweep can only report `Unknown (<serial>)` for a live pooled Android emulator, the pool records that on the entry (`PooledDevice.identityUnresolved`) instead of choosing between two wrong answers. The placeholder is not evidence that a different AVD took the serial, and it is not evidence of continuity either. The entry is kept with session and incarnation intact, but everything that would act on the pooled identity is withheld: it is not assignable, serial-addressed tool execution is refused at the single admission choke point with an error naming the serial and the pooled AVD label, the booted-devices resource publishes no pool context for it, and no destructive path can read its cached AVD name. That last point closes the deleteDevice inventory bypass, where a teardown of the AVD that had actually taken the serial could previously destroy the running image as a stopped one. The quarantine lifts on the next discovery that reads a name: the pooled label restores the entry unchanged, and a different name is a replacement with a fresh incarnation and the old session retired. Handsets never enter the state.

The append-text self-heal is likewise narrowed: a runner verdict (a stale frame-context rejection) is surfaced as-is with no rebuild or replay; only a helper failure triggers rebuild-and-resume.

## Two funnels enforce the quarantine

Every Android discovery observation enters the pool through one method, `DevicePool.reconcileDiscoveryObservation`, which owns the quarantine transitions (enter on the placeholder, restore on a matching resolved name, quarantine a disagreeing one and leave replacement to the allocation-owning paths). Every device-addressed operation at the daemon boundary, session or sessionless, input or observation, passes one gate, `DevicePool.assertDeviceActionable`. Two lint tests pin this: `test/lint/deviceDiscoveryReconcileFunnel.test.ts` inventories all 49 discovery call sites with a reason for each that cannot reconcile, and `test/lint/deviceAddressedAdmissionGate.test.ts` fails any socket handler that resolves an incoming deviceId without the gate.