### PR TITLE
chore(lint): brace one-line bodies in TTLCache so oxlint --fix stops dirtying the tree

### DIFF
--- a/src/utils/cache/Cache.ts
+++ b/src/utils/cache/Cache.ts
@@ -346,8 +346,12 @@ export class TTLCache<K, V> implements Cache<K, V> {
         continue;
       }
       if (now - entry.createdAt < this.ttlMs) {
-        if (!fullScan) break;
-        if (entry.createdAt < previousLiveTimestamp) survivingDisorder = true;
+        if (!fullScan) {
+          break;
+        }
+        if (entry.createdAt < previousLiveTimestamp) {
+          survivingDisorder = true;
+        }
         previousLiveTimestamp = Math.max(previousLiveTimestamp, entry.createdAt);
         continue;
       }

--- a/test/utils/cache/Cache.test.ts
+++ b/test/utils/cache/Cache.test.ts
@@ -412,7 +412,9 @@ describe("TTLCache", () => {
       };
       const cacheWithWallClock = new TTLCache<string, string>(wallClock, { ttlMs: 1_000 });
 
-      for (let i = 0; i < 1000; i++) cacheWithWallClock.set(`live-${i}`, "live");
+      for (let i = 0; i < 1000; i++) {
+        cacheWithWallClock.set(`live-${i}`, "live");
+      }
       cacheWithWallClock.set("live-first", "live");
       wallTime = 500; // a backwards Date.now() step before the next insert
       cacheWithWallClock.set("expired-second", "expired");


### PR DESCRIPTION
## Why

Since [#6755](https://github.com/kaeawc/auto-mobile/pull/6755) merged, `src/utils/cache/Cache.ts` and `test/utils/cache/Cache.test.ts` contain three brace-less one-line `if`/`for` bodies. oxlint's `curly` rule auto-fixes them, so every `bun run lint` (which runs `oxlint --fix`) rewrites the two files and leaves the tree dirty. CI stays green because the fix step exits 0, but every local validation run and every agent lane trips over the spurious diff.

## What

Brace the three bodies in oxfmt-canonical multi-line form. No behavior change.

## Verification

- `bun run format:check` clean
- `bunx oxlint src/utils/cache/Cache.ts test/utils/cache/Cache.test.ts` clean
- `bun test test/utils/cache/Cache.test.ts` 36 pass
- second `bun run lint` leaves `git status` clean